### PR TITLE
fix(test): 파생 suite 준비에서 Cargo 파일을 격리한다 (#5682)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ closes #
 ## 테스트
 
 - [ ] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
-- [ ] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, Cargo generated test target을 PR에 포함하지 않음
+- [ ] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음 (`--sync-cargo-targets` 메인터너 registry PR은 marker 블록만 예외)
 - [ ] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
 - [ ] `cargo test` 통과
 - [ ] `cargo clippy -- -D warnings` 통과

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,8 +53,10 @@
   남으며 커밋하지 않는다.
 - **review·maintainer worktree와 CI 전용**: 새 integration source는 `tests/cases/` 원본만 PR에
   포함한다. `node scripts/rust-test-suite-manifest.mjs --prepare`와 manifest `--check`는
-  파생 suite를 준비한 review worktree와 CI에서만 수행한다. generated suite·manifest·Cargo target은
-  검증 증적일 뿐 source PR에 stage하지 않는다. 세부 절차는 `CONTRIBUTING.md`와
+  파생 suite를 준비한 review worktree와 CI에서만 수행한다. generated suite·manifest는
+  검증 증적일 뿐 source PR에 stage하지 않는다. 기본 `--prepare`는 root `Cargo.toml`을 바꾸지 않으며,
+  통합 불가 예외 target registry를 갱신하는 메인터너 전용 PR만 `--sync-cargo-targets`로 Cargo marker
+  블록을 동기화할 수 있다. 세부 절차는 `CONTRIBUTING.md`와
   `mydocs/manual/pr_review/local_validation.md`의 integration test 절을 따른다.
 - 문서 역할·생명주기·canonical 관계는 `mydocs/README.md`의 manifest를 따른다.
 - 문서 이동·정보구조 리팩토링의 링크와 메타데이터 검사는

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ cargo fmt --all -- --check                       # CI와 같은 포맷 검증 �
 node --test scripts/tests/rust-test-suite-manifest.test.mjs
 # `src/**`의 `#[cfg(test)]`를 변경한 경우에만 실행한다. 파생 파일은 생성하지 않는다.
 node scripts/rust-unit-test-tiers.mjs --check
-cargo nextest run \
+cargo nextest run --locked \
   --cargo-profile release-test \
   --target-dir target/pr-review \
   --tests --test-threads <현재_환경에_맞는_값> --no-fail-fast                          # 통합 테스트 포함 전체
@@ -172,8 +172,10 @@ cargo clippy --all-targets --target-dir target/pr-review -- -D warnings # 린트
 
 새 통합 테스트는 `tests/cases/` 에만 둡니다. `tests/suites/suite-policy.json`,
 `tests/suites/unit-test-tier-policy.json`은 추적하는 정책이고, `tests/generated/`, `tests/suites/manifest.json`,
-`tests/generated/**`, Cargo의 generated test target 블록은 **PR에 넣지 않는 파생 산출물**입니다. 일반 기여자는 자신의 PR checkout에서 `--prepare`, `--generate`,
+`tests/generated/**`는 **PR에 넣지 않는 파생 산출물**입니다. 일반 기여자는 자신의 PR checkout에서 `--prepare`, `--generate`,
 `--sync`, `--rebalance`, 또는 `rust-test-suite-manifest.mjs --check`를 실행해 이를 등록하지 않습니다.
+`--prepare`는 root `Cargo.toml`을 수정하지 않습니다. Cargo의 generated test target 블록은 통합 불가 예외 target의
+추적 registry이므로, 예외 구조가 바뀌는 메인터너 전용 유지보수 PR에서만 `--sync-cargo-targets`로 동기화합니다.
 `rust-unit-test-tiers.mjs --check`는 source-side `#[cfg(test)]` 변경의 정책 검사로만 실행할 수 있으며
 파일을 생성하지 않습니다. 새 원본의 배정과 harness 검증은 PR review 전용 worktree 및 CI가
 `--prepare` 뒤 manifest `--check`로 수행합니다.
@@ -273,15 +275,20 @@ checks는 기존과 같이 merge gate입니다. 추가 환경 검증에서 심�
    않습니다. 검토자가 PR review 전용 worktree와 CI에서 `--prepare`를 실행하면, 생성기가 source
    weight를 계산해 기존 integration suite 중 가장 가벼운 곳에 자동 배정합니다.
 
-   `tests/generated/*.rs`, `tests/suites/manifest.json`, `Cargo.toml`의 generated test target 블록은
-   **PR에 포함하지 않습니다.** 이 파일들은 검토·CI checkout에서만 만드는 파생 산출물입니다. 이를
+   `tests/generated/*.rs`, `tests/suites/manifest.json`은 **PR에 포함하지 않습니다.** 이 파일들은 검토·CI
+   checkout에서만 만드는 파생 산출물입니다. 이를
    커밋하면 독립 PR끼리 같은 harness·manifest를 수정해 불필요한 충돌을 만들므로 CI가 거부합니다.
+   `Cargo.toml`의 generated test target 블록도 일반 PR에는 포함하지 않습니다. 단, 통합 불가 예외 target이
+   바뀐 메인터너 전용 registry 동기화 PR은 `--sync-cargo-targets`로 해당 marker 블록만 갱신할 수 있습니다.
+   `#[path]`·root `mod`·feature-gated test처럼 module harness와의 호환성을 판단해야 하는 원본은 일반 기여자가 registry를
+   늘리지 않습니다. 기존 source의 module 호환성이 확인된 경우에만 메인터너가 `suite-policy.json`의 좁은
+   `moduleIntegrationOverrides`에 blocker 이름을 명시해 suite 배정을 허용합니다.
    원본을 이름 변경·삭제해도 PR에는 `tests/cases/` 변경만 제출합니다. `--rebalance`는 일반 기여
    절차에 포함하지 않으며, 배정 정책 자체를 바꾸는 메인터너 전용 별도 작업에서만 검토합니다.
 
    원본을 커밋한 뒤 전체 integration 실행이 필요하면, PR branch와 분리된 review worktree에서만
-   `--prepare`와 `--check`를 차례로 실행합니다. 생성된 manifest·harness·Cargo 변경은 검증 증적일
-   뿐이므로 테스트가 끝나면 그 review worktree에서 복원하고 stage하지 않습니다.
+   `--prepare`와 `--check`를 차례로 실행합니다. 생성된 manifest·harness는 검증 증적일 뿐이므로 테스트가
+   끝나면 그 review worktree에서 복원하고 stage하지 않습니다. 이 기본 경로는 `Cargo.toml`을 변경하지 않습니다.
 
    제품 소스의 `#[cfg(test)]`에는 새 테스트 모듈이나 test support 항목을 추가하지 않습니다. 공개 API로
    재현할 수 있는 테스트는 `tests/cases/`에 작성하고, 기존 소스 테스트의 차등 이동 상태는 다음 명령으로
@@ -293,7 +300,8 @@ checks는 기존과 같이 merge gate입니다. 추가 환경 검증에서 심�
    ```
 
    CI는 PR base와 현재 source를 다시 비교하고, unit-tier inventory도 source에서 메모리로 재계산한다.
-   커밋된 generated harness·manifest·Cargo generated block도 거부한다. 새 integration source는 `tests/cases/`만 허용하며, source-side 테스트는 Git
+   커밋된 generated harness·manifest는 거부한다. Cargo generated block은 명시적 registry 동기화에서 marker
+   블록만 바꾼 경우에만 허용한다. 새 integration source는 `tests/cases/`만 허용하며, source-side 테스트는 Git
    rename으로 확인되는 순수 crate 이동처럼 개수가 늘지 않는 경로 변경만 허용한다.
 2. **수정 전 실패 증명 (권장)** — "수정 커밋만 원복한 상태에서 신규 테스트가 실제로 FAIL"
    함을 PR 본문에 기록해주세요. 테스트가 결함을 판별한다는 증명이 되어 리뷰 신뢰도가

--- a/mydocs/manual/dev_environment_guide.md
+++ b/mydocs/manual/dev_environment_guide.md
@@ -103,11 +103,12 @@ node scripts/rust-test-suite-manifest.mjs --prepare
 node scripts/run-rust-test.mjs <확장자를_뺀_test_source_이름>
 ```
 
-`tests/suites/suite-policy.json`과 `tests/suites/unit-test-tier-policy.json`은 추적 정책이고, `tests/generated/`, `tests/suites/manifest.json`, Cargo generated test target 블록은 파생 산출물이며
+`tests/suites/suite-policy.json`과 `tests/suites/unit-test-tier-policy.json`은 추적 정책이고, `tests/generated/`, `tests/suites/manifest.json`은 파생 산출물이며
 직접 수정하거나 PR에 포함하지 않는다. 일반 기여자는 `--prepare`를 실행해 파생 결과를 자신의 PR에
 등록하지 않으며, PR 전에는 `node --test scripts/tests/rust-test-suite-manifest.test.mjs`로 배정 규칙만
-확인한다. review worktree의 `--prepare`가 이름 변경·삭제와 신규 source를 한 번에 반영하고, 검증 뒤
-그 worktree에만 남은 파생 변경은 복원한다. 전체 배정 정책과 PR 검증 절차는
+확인한다. review worktree의 기본 `--prepare`는 이름 변경·삭제와 신규 source를 harness에만 반영하며
+root `Cargo.toml`은 바꾸지 않는다. 통합 불가 예외 target registry가 달라진 경우에만 메인터너 전용 PR에서
+`--sync-cargo-targets`로 Cargo marker 블록을 동기화한다. 검증 뒤 worktree에 남은 파생 변경은 복원한다. 전체 배정 정책과 PR 검증 절차는
 [로컬 사전 검증](pr_review/local_validation.md)의 "integration test source 추가와 자동 sharding"을 따른다.
 
 제품 소스의 기존 `#[cfg(test)]`는 의존성에 따라 `integration_ready`, `test_support`, `white_box`로

--- a/mydocs/manual/pr_review/local_validation.md
+++ b/mydocs/manual/pr_review/local_validation.md
@@ -33,6 +33,10 @@ pgrep -alf '(^|/)(cargo|rustc|wasm-pack)( |$)' || true
 전체 Rust 회귀의 기본 명령은 다음과 같다. 같은 `target/pr-review`를 사용하는 Cargo 계열 명령은 반드시
 앞 명령의 종료를 확인한 뒤 실행한다.
 
+검토 명령에는 `--locked`를 넣어 Cargo가 검토 checkout의 `Cargo.lock`을 갱신하지 못하게 한다.
+`run-rust-test.mjs`도 이를 기본 적용한다. lockfile 자체를 의도적으로 바꾸는 의존성 갱신 작업만 별도
+검증에서 이 규칙을 벗어날 수 있다.
+
 문서의 명령은 고정 `--test-threads` 값을 쓰지 않는다. nextest 기본 동시성을 먼저 사용하고, 현재
 host의 논리 CPU·메모리·동시 작업을 확인한 뒤에만 `--test-threads <현재 환경에 맞는 값>`으로 조정한다.
 논리 CPU 확인은 macOS `sysctl -n hw.logicalcpu`, Linux `getconf _NPROCESSORS_ONLN`, PowerShell
@@ -40,7 +44,7 @@ host의 논리 CPU·메모리·동시 작업을 확인한 뒤에만 `--test-thre
 부족하거나 다른 작업이 있으면 더 낮은 값을 선택하고 실제 실행 시간을 기록한다.
 
 ~~~bash
-cargo nextest run \
+cargo nextest run --locked \
   --cargo-profile release-test \
   --target-dir target/pr-review \
   --tests --test-threads <현재_환경에_맞는_값> --no-fail-fast
@@ -53,8 +57,8 @@ cargo nextest run \
 `--prepare`와 `--check`를 실행하지 않는다. `--check`는 준비된 파생 상태를 검사하므로 새 원본만 있는
 정상 PR checkout에서는 manifest 누락을 보고한다. Cargo는 이 원본 파일을 개별 binary로 자동 발견하지
 않으므로, **PR review 전용 worktree에서만** 다음 준비 단계를 실행한다. 이 단계는 삭제·이름변경을
-동기화하고 신규 source를 현재 weight가 가장 낮은 suite에 배정한 뒤 harness와 Cargo target 블록을 작업
-checkout에만 만든다.
+동기화하고 신규 source를 현재 weight가 가장 낮은 suite에 배정한 뒤 harness를 작업 checkout에만 만든다.
+기본 `--prepare`는 `Cargo.toml` registry를 바꾸지 않는다.
 
 ~~~bash
 node scripts/rust-test-suite-manifest.mjs --prepare
@@ -63,13 +67,16 @@ node scripts/run-rust-test.mjs issue_1234_short_description \
   -- --cargo-profile release-test --target-dir target/pr-review
 ~~~
 
-`tests/generated/*.rs`, unit-tier inventory, manifest·Cargo generated block은 직접 편집하거나 PR에 stage하지 않는다.
+`tests/generated/*.rs`, unit-tier inventory, manifest는 직접 편집하거나 PR에 stage하지 않는다. Cargo generated
+block은 통합 불가 예외 target이 바뀐 메인터너 전용 PR에서만 `--sync-cargo-targets`로 marker 블록만 동기화한다.
 검증이 끝나면 이 파생 변경은 review worktree에서 복원한다. `--prepare`가 이름 변경·삭제와 신규 source를
 함께 처리하므로 일반 PR에 `--generate`·`--sync`·`--rebalance` 결과를 포함하지 않는다. 기여자가
 PR 전 검증으로 실행할 명령은 `node --test scripts/tests/rust-test-suite-manifest.test.mjs`와 변경 범위의
 Rust test이며, source-side `#[cfg(test)]`를 바꾼 경우에는 `node scripts/rust-unit-test-tiers.mjs --check`도
 실행한다. 이 unit-tier 검사는 파생 파일을 만들지 않는다. 반면 manifest 파생 파일 일치 검사는 review
-worktree와 CI의 책임이다. 경로·crate-root 의존성이 탐지된 source는 생성기가 singleton exception으로 보존한다.
+worktree와 CI의 책임이다. 경로·crate-root·feature-gated 의존성이 탐지된 source는 기본적으로 singleton
+exception으로 보존한다. module harness 호환성을 실제 실행으로 확인한 경우에만 메인터너가
+`suite-policy.json`의 좁은 `moduleIntegrationOverrides`로 필요한 blocker만 허용해 suite에 배정한다.
 
 제품 소스의 `#[cfg(test)]`는 root `src/`와 내부 `crates/*/src/`의 기존 모듈별 테스트 수와 test
 support 항목을 기준선으로 관리한다.
@@ -283,18 +290,18 @@ merge 판단에서는 다음 경계를 적용한다.
 일반 Rust 검증 예시는 다음과 같다. 명령은 같은 checkout에서 동시에 실행하지 않는다.
 
 ~~~bash
-cargo nextest run \
+cargo nextest run --locked \
   --cargo-profile release-test \
   --target-dir target/pr-review \
   --tests --test-threads <현재_환경에_맞는_값> --no-fail-fast
 cargo fmt --all -- --check
-cargo clippy --all-targets -- -D warnings
+cargo clippy --locked --all-targets -- -D warnings
 ~~~
 
 renderer 영향 PR의 Native Skia 공식 회귀 범위는 다음 3종이다.
 
 ~~~bash
-cargo test --profile release-test --target-dir target/pr-review --features native-skia --lib
+cargo test --locked --profile release-test --target-dir target/pr-review --features native-skia --lib
 node scripts/run-rust-test.mjs issue_2225_missing_picture_placeholder -- \\
   --cargo-profile release-test --target-dir target/pr-review --features native-skia
 node scripts/run-rust-test.mjs render_p37_direct_pdf_export -- \\
@@ -320,7 +327,7 @@ draft 해제 전에 **두 baseline 절차**를 수행한다: ① IR field sweep(
 
 ~~~bash
 RHWP_IR_SWEEP_DUMP=/tmp/ir_field_sweep_current.tsv \
-  cargo test --profile release-test \
+  cargo test --locked --profile release-test \
   --test ir_field_sweep_baseline -- --nocapture
 diff -u tests/fixtures/ir_field_sweep_baseline.tsv /tmp/ir_field_sweep_current.tsv
 ~~~
@@ -340,7 +347,7 @@ diff -u tests/fixtures/ir_field_sweep_baseline.tsv /tmp/ir_field_sweep_current.t
 
 ~~~bash
 RHWP_OVERFLOW_CELL_DUMP=/tmp/overflow_cell_current.tsv \
-  cargo test --profile release-test \
+  cargo test --locked --profile release-test \
   --test overflow_cell_baseline -- --nocapture
 diff -u tests/fixtures/overflow_cell_baseline.tsv /tmp/overflow_cell_current.tsv
 ~~~
@@ -377,21 +384,21 @@ VITE_URL=http://127.0.0.1:7700 npm --prefix rhwp-studio run e2e:embed
 diff check, clippy, doc test, TypeScript, npm test, 표준 Docker WASM build를 이 순서로 실행한다.
 
 ~~~bash
-cargo build --release --target-dir target/pr-review
-cargo test --release --target-dir target/pr-review --lib
-cargo nextest run \
+cargo build --locked --release --target-dir target/pr-review
+cargo test --locked --release --target-dir target/pr-review --lib
+cargo nextest run --locked \
   --cargo-profile release-test \
   --target-dir target/pr-review \
   --tests --test-threads <현재_환경에_맞는_값> --no-fail-fast
-cargo test --profile release-test --target-dir target/pr-review --features native-skia --lib
+cargo test --locked --profile release-test --target-dir target/pr-review --features native-skia --lib
 node scripts/run-rust-test.mjs issue_2225_missing_picture_placeholder -- \
   --cargo-profile release-test --target-dir target/pr-review --features native-skia
 node scripts/run-rust-test.mjs render_p37_direct_pdf_export -- \
   --cargo-profile release-test --target-dir target/pr-review --features native-skia
 cargo fmt --all -- --check
 git diff --check
-cargo clippy --all-targets --target-dir target/pr-review -- -D warnings
-cargo test --doc --target-dir target/pr-review
+cargo clippy --locked --all-targets --target-dir target/pr-review -- -D warnings
+cargo test --locked --doc --target-dir target/pr-review
 (cd rhwp-studio && npx tsc --noEmit)
 npm --prefix rhwp-studio test
 docker compose --env-file .env.docker run --rm wasm

--- a/mydocs/orders/20260820.md
+++ b/mydocs/orders/20260820.md
@@ -13,3 +13,9 @@ date: 2026-08-20
 - q-kit의 하위 명령 `--help`가 handler 오류로 종료 코드 2를 내던 결함은 메인터너 보정으로 해결했다. 전역 목록 기반 50/50 help 실행과 focused contract 6/6이 통과했다.
 - 로컬 manifest·unit tier·fmt·clippy와 전체 release-test nextest 7,978/7,978건(38 skipped)이 통과했다. renderer·layout 변경이 없어 시각 검증은 적용하지 않는다.
 - 이 오늘할일과 [#5674 self-review](../pr/archives/pr_5674_review.md), 구현 기록을 trailing docs commit으로 push한다. 최신 head의 CI와 mergeability가 성공하면 병합하고, 원 PR·issue comment/close 및 review branch/worktree/전용 target 정리를 `post_merge.md` 순서로 수행한다.
+
+## #5682 파생 suite 준비의 Cargo 파일 격리
+
+- [#5683](https://github.com/edwardkim/rhwp/pull/5683)은 review/CI용 suite 준비와 루트 Cargo registry 동기화를 분리해 일반 `--prepare`가 `Cargo.toml`·`Cargo.lock`을 변경하지 않도록 한다.
+- manifest·Cargo 격리·`--locked` 계약 테스트 22건, `--prepare`/`--check`, prepare 전후 두 Cargo 파일 SHA-256 비교, fmt·diff 검증을 완료했다.
+- self-review 기록은 [pr_5683_review.md](../pr/archives/pr_5683_review.md)에 남겼다. 최신 trailing head의 CI와 mergeability가 통과하고 작업지시자 승인 후 merge한다.

--- a/mydocs/pr/archives/pr_5683_review.md
+++ b/mydocs/pr/archives/pr_5683_review.md
@@ -1,0 +1,41 @@
+---
+kind: pr-review
+status: active
+pr: 5683
+issue: 5682
+---
+
+# PR #5683 검토 - 파생 suite 준비의 Cargo 파일 격리
+
+| 항목 | 작성 시점 참고값 |
+| --- | --- |
+| PR | [#5683](https://github.com/edwardkim/rhwp/pull/5683) |
+| 작성자 | `jangster77` (collaborator self-review) |
+| base / head | `devel` / `codex/5682-derived-suite-cargo-isolation` |
+| 후보 head | `97c3534ea7464edb6f17b69dd6dc65d96b5bac3a` |
+| 관련 이슈 | [#5682](https://github.com/edwardkim/rhwp/issues/5682) |
+| 변경 범위 | manifest 준비, Rust test wrapper, suite policy, 계약 테스트, 개발·검토 문서 |
+
+## 변경 판정
+
+- 일반 `rust-test-suite-manifest --prepare`는 ignored generated harness와 manifest만 만든다.
+- 루트 Cargo test-target registry 갱신은 marker block만 허용하는 명시적
+  `--sync-cargo-targets` 경로로 분리한다.
+- test wrapper는 `--locked`로 `Cargo.lock` 갱신을 막는다.
+- review/CI 산출물과 기여자 source PR의 제출 경계를 문서화했다.
+
+## 완료한 로컬 검증
+
+- `node --test scripts/tests/rust-test-suite-manifest.test.mjs scripts/tests/rust-test-suite-cargo-isolation.test.mjs scripts/tests/run-rust-test-locking.test.mjs`: 22 passed
+- `node scripts/rust-test-suite-manifest.mjs --prepare` 및 `--check`: 통과
+- prepare 전후 SHA-256 비교: `Cargo.toml`, `Cargo.lock` 모두 불변
+- `cargo fmt --all -- --check`, `git diff --check`: 통과
+
+## 위험과 범위 밖
+
+- 명시적 `--sync-cargo-targets`는 maintainer registry 동기화 전용이며 일반 PR·review 준비에는 사용하지 않는다.
+- renderer, fixture, CI workflow 변경이 없으므로 시각 검증과 workflow 변경 등급 검증은 적용하지 않는다.
+
+## 결론
+
+**CI 검증 대기.** 최신 PR head의 required check 통과, mergeability 재확인, 작업지시자 승인 뒤 merge 후보로 판단한다.

--- a/mydocs/working/task_m100_5682_stage1_derived_suite_cargo_isolation.md
+++ b/mydocs/working/task_m100_5682_stage1_derived_suite_cargo_isolation.md
@@ -1,0 +1,36 @@
+# Task M100-5682 Stage 1 - 파생 suite Cargo 격리
+
+- Issue: #5682
+- 기준: `upstream/devel` `2d897ca04dc80819a9833cf96f2a971c3ae792a1`
+- 범위: integration suite 준비, Cargo registry 동기화, Rust test lockfile 보호, 관련 개발·검토 문서
+
+## 문제
+
+`rust-test-suite-manifest --prepare`가 review/CI용 harness와 manifest를 준비하면서 루트
+Cargo test-target registry도 함께 갱신하면, 검토자는 자신의 변경과 관계없이 `Cargo.toml`이
+dirty 상태가 된다. lockfile을 갱신할 수 있는 테스트 실행까지 겹치면 `Cargo.lock`도 검토
+산출물로 오인될 수 있다.
+
+## 설계
+
+1. 기본 `--prepare`는 ignored generated harness와 manifest만 준비한다.
+2. Cargo test-target registry 갱신은 `--sync-cargo-targets`를 명시한 maintainer 작업으로만
+   허용하며 marker block 밖 변경을 거부한다.
+3. `run-rust-test.mjs`가 nextest와 `cargo test`에 `--locked`를 한 번만 전달한다.
+4. 실제 module 호환성을 확인한 소수의 source는 `moduleIntegrationOverrides`로 generated suite에
+   편입하고, 남은 독립 target은 현재 Cargo registry와 일치시킨다.
+5. 기여자는 `tests/cases/` 원본만 제출하고, 파생 파일과 registry 동기화의 책임 경계를 문서에
+   명확히 기록한다.
+
+## 검증 근거
+
+- manifest/Cargo 격리 및 `--locked` 계약 테스트 22건 통과
+- `--prepare`, manifest `--check`, 자동 배정된 regression target 3건 실행 통과
+- 전후 SHA-256 비교로 루트 `Cargo.toml`과 `Cargo.lock` 불변 확인
+- `cargo fmt --all -- --check`, `git diff --check` 통과
+
+## 완료 기준
+
+- 일반 review worktree에서 파생 suite를 준비해도 루트 Cargo 파일이 변경되지 않는다.
+- Cargo registry 갱신이 필요할 때만 별도 명령과 marker 검증을 사용한다.
+- source PR과 파생 검토 산출물의 제출 경계가 문서와 PR 템플릿에서 일치한다.

--- a/scripts/run-rust-test.mjs
+++ b/scripts/run-rust-test.mjs
@@ -34,7 +34,8 @@ export function resolveCase(caseName, root = ROOT) {
 }
 
 export function nextestArguments(plan, extraArguments = []) {
-  const arguments_ = ['nextest', 'run', '--test', plan.target];
+  const locked = extraArguments.includes('--locked') ? [] : ['--locked'];
+  const arguments_ = ['nextest', 'run', ...locked, '--test', plan.target];
   if (plan.grouped) {
     arguments_.push('-E', `test(/(^|::)${plan.caseName}::/)`);
   }
@@ -42,7 +43,8 @@ export function nextestArguments(plan, extraArguments = []) {
 }
 
 export function cargoTestArguments(plan, extraArguments = []) {
-  const arguments_ = ['test', ...extraArguments, '--test', plan.target];
+  const locked = extraArguments.includes('--locked') ? [] : ['--locked'];
+  const arguments_ = ['test', ...locked, ...extraArguments, '--test', plan.target];
   if (plan.grouped) {
     arguments_.push(`${plan.caseName}::`);
   }

--- a/scripts/rust-test-suite-manifest.mjs
+++ b/scripts/rust-test-suite-manifest.mjs
@@ -110,6 +110,39 @@ export function loadManifest(root = ROOT) {
     }
   }
 
+  if (manifest.moduleIntegrationOverrides === undefined) {
+    manifest.moduleIntegrationOverrides = [];
+  }
+  if (!Array.isArray(manifest.moduleIntegrationOverrides)) {
+    throw new Error('moduleIntegrationOverrides는 배열이어야 합니다.');
+  }
+  const overridePaths = new Set();
+  for (const [index, override] of manifest.moduleIntegrationOverrides.entries()) {
+    assertRecord(override, `moduleIntegrationOverrides[${index}]`);
+    override.path = normalizeRelativePath(
+      override.path,
+      `moduleIntegrationOverrides[${index}].path`,
+    );
+    if (!override.path.endsWith('.rs')) {
+      throw new Error(
+        `moduleIntegrationOverrides[${index}].path는 Rust 파일이어야 합니다: ${override.path}`,
+      );
+    }
+    if (overridePaths.has(override.path)) {
+      throw new Error(`중복 moduleIntegrationOverride: ${override.path}`);
+    }
+    overridePaths.add(override.path);
+    if (
+      !Array.isArray(override.allowBlockers) ||
+      override.allowBlockers.length === 0 ||
+      override.allowBlockers.some((blocker) => typeof blocker !== 'string')
+    ) {
+      throw new Error(
+        `moduleIntegrationOverrides[${index}].allowBlockers는 비어 있지 않은 문자열 배열이어야 합니다.`,
+      );
+    }
+  }
+
   if (!Array.isArray(manifest.exceptions)) {
     throw new Error('exceptions는 배열이어야 합니다.');
   }
@@ -224,7 +257,11 @@ function addedPathsAgainstBase(root, ref) {
 
 export function validateDerivedArtifactChanges(
   changedPaths,
-  { baseCargoToml = null, headCargoToml = null } = {},
+  {
+    baseCargoToml = null,
+    headCargoToml = null,
+    allowCargoTargetRegistryChange = false,
+  } = {},
 ) {
   const errors = [];
   for (const changedPath of [...new Set(changedPaths)].sort()) {
@@ -246,10 +283,24 @@ export function validateDerivedArtifactChanges(
       const baseBlock = baseCargoToml.slice(baseBounds.start, baseBounds.end);
       const headBlock = headCargoToml.slice(headBounds.start, headBounds.end);
       if (baseBlock !== headBlock) {
-        errors.push(
-          'PR에는 Cargo.toml의 generated test target 블록 변경을 커밋하지 마세요 ' +
-            '(PR review/CI에서 --prepare로 생성)',
-        );
+        if (!allowCargoTargetRegistryChange) {
+          errors.push(
+            'PR에는 Cargo.toml의 generated test target 블록 변경을 커밋하지 마세요 ' +
+              '(명시적 --sync-cargo-targets 유지보수 PR만 허용)',
+          );
+        } else {
+          const baseOutsideBlock =
+            baseCargoToml.slice(0, baseBounds.start) +
+            baseCargoToml.slice(baseBounds.end);
+          const headOutsideBlock =
+            headCargoToml.slice(0, headBounds.start) +
+            headCargoToml.slice(headBounds.end);
+          if (baseOutsideBlock !== headOutsideBlock) {
+            errors.push(
+              'Cargo.toml generated test target registry 동기화에는 marker 블록 밖의 변경을 함께 커밋할 수 없습니다.',
+            );
+          }
+        }
       }
     } catch (error) {
       errors.push(
@@ -309,9 +360,14 @@ export function sourceMetrics(source, manifest, root = ROOT) {
   const caseAttributes = (text.match(CASE_ATTRIBUTE) ?? []).length;
   const staticTests = testAttributes + caseAttributes;
   const bytes = Buffer.byteLength(text);
-  const blockers = MODULE_BLOCKERS.filter(([, pattern]) => pattern.test(text)).map(
-    ([name]) => name,
+  const allowedBlockers = new Set(
+    (manifest.moduleIntegrationOverrides ?? [])
+      .find((override) => override.path === source)
+      ?.allowBlockers ?? [],
   );
+  const blockers = MODULE_BLOCKERS.filter(
+    ([name, pattern]) => !allowedBlockers.has(name) && pattern.test(text),
+  ).map(([name]) => name);
   return {
     source,
     caseName: caseNameForSource(source),
@@ -541,12 +597,19 @@ export function syncManifestSources(
   let removed = 0;
 
   manifest.exceptions = manifest.exceptions.filter((entry) => {
-    if (discovered.has(entry.path)) {
+    if (
+      discovered.has(entry.path) &&
+      (entry.manual || sourceMetrics(entry.path, manifest, root).blockers.length > 0)
+    ) {
       return true;
     }
     removed += 1;
     if (report) {
-      process.stdout.write(`[RustTestSuite] 제거 반영: ${entry.path}\n`);
+      process.stdout.write(
+        `[RustTestSuite] ${
+          discovered.has(entry.path) ? 'module 통합 전환' : '제거 반영'
+        }: ${entry.path}\n`,
+      );
     }
     return false;
   });
@@ -648,7 +711,7 @@ function cargoBlockBounds(cargoManifest) {
   return { start, end: endMarker + CARGO_BLOCK_END.length };
 }
 
-function updateCargoManifest(manifest, root = ROOT) {
+export function syncCargoTestTargets(manifest, root = ROOT) {
   const cargoPath = path.join(root, CARGO_MANIFEST_RELATIVE_PATH);
   const cargoManifest = readFileSync(cargoPath, 'utf8');
   const bounds = cargoBlockBounds(cargoManifest);
@@ -691,6 +754,7 @@ function inspectRepository(
           {
             baseCargoToml: textAtGitRef(root, baseRef, CARGO_MANIFEST_RELATIVE_PATH),
             headCargoToml: textAtGitRef(root, 'HEAD', CARGO_MANIFEST_RELATIVE_PATH),
+            allowCargoTargetRegistryChange: true,
           },
         ),
       );
@@ -884,7 +948,11 @@ export function validateRepository(
   }
 }
 
-export function generateArtifacts(manifest, root = ROOT) {
+export function generateArtifacts(
+  manifest,
+  root = ROOT,
+  { syncCargoTargets = false } = {},
+) {
   const inspection = inspectRepository(manifest, root, {
     checkGenerated: false,
     checkCargo: false,
@@ -914,7 +982,9 @@ export function generateArtifacts(manifest, root = ROOT) {
       'utf8',
     );
   }
-  updateCargoManifest(manifest, root);
+  if (syncCargoTargets) {
+    syncCargoTestTargets(manifest, root);
+  }
   process.stdout.write(
     `[RustTestSuite] 생성: ${Object.keys(manifest.suites).length} harnesses, ` +
       `${manifest.exceptions.length} exceptions\n`,
@@ -957,6 +1027,10 @@ if (process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH) {
       const manifest = prepareManifest(loadManifest());
       generateArtifacts(manifest);
       printValidation(validateRepository());
+    } else if (command === '--sync-cargo-targets') {
+      const manifest = prepareManifest(loadManifest());
+      generateArtifacts(manifest, ROOT, { syncCargoTargets: true });
+      printValidation(validateRepository());
     } else if (command === '--sync') {
       const manifest = loadManifest();
       syncManifestSources(manifest);
@@ -981,8 +1055,8 @@ if (process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH) {
     } else {
       process.stderr.write(
         '사용법: node scripts/rust-test-suite-manifest.mjs ' +
-          '--check [--base-ref <Git ref>]|--prepare|--generate|--sync|--rebalance|' +
-          '--adopt-new|--adopt <파일...>\n',
+        '--check [--base-ref <Git ref>]|--prepare|--generate|--sync|--rebalance|' +
+          '--adopt-new|--adopt <파일...>|--sync-cargo-targets\n',
       );
       process.exitCode = 2;
     }

--- a/scripts/tests/run-rust-test-locking.test.mjs
+++ b/scripts/tests/run-rust-test-locking.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  cargoTestArguments,
+  nextestArguments,
+} from '../run-rust-test.mjs';
+
+const GROUPED_PLAN = {
+  target: 'regression_suite_001',
+  grouped: true,
+  caseName: 'issue_1035_alignment',
+};
+
+test('run-rust-test nextest 명령은 Cargo.lock을 갱신하지 않는다', () => {
+  assert.deepEqual(
+    nextestArguments(GROUPED_PLAN, ['--cargo-profile', 'release-test']),
+    [
+      'nextest',
+      'run',
+      '--locked',
+      '--test',
+      'regression_suite_001',
+      '-E',
+      'test(/(^|::)issue_1035_alignment::/)',
+      '--cargo-profile',
+      'release-test',
+    ],
+  );
+});
+
+test('run-rust-test cargo test 명령은 중복 없이 --locked를 전달한다', () => {
+  assert.deepEqual(
+    cargoTestArguments(GROUPED_PLAN, ['--locked', '--features', 'native-skia']),
+    [
+      'test',
+      '--locked',
+      '--features',
+      'native-skia',
+      '--test',
+      'regression_suite_001',
+      'issue_1035_alignment::',
+    ],
+  );
+});

--- a/scripts/tests/rust-test-suite-cargo-isolation.test.mjs
+++ b/scripts/tests/rust-test-suite-cargo-isolation.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { validateDerivedArtifactChanges } from '../rust-test-suite-manifest.mjs';
+
+const CARGO_BLOCK_START = '# BEGIN RHWP GENERATED TEST TARGETS';
+const CARGO_BLOCK_END = '# END RHWP GENERATED TEST TARGETS';
+
+function cargoToml(targetName, beforeBlock = '') {
+  return [
+    '[package]',
+    'name = "fixture"',
+    beforeBlock,
+    CARGO_BLOCK_START,
+    '[[test]]',
+    `name = "${targetName}"`,
+    `path = "tests/${targetName}.rs"`,
+    CARGO_BLOCK_END,
+    '',
+  ].join('\n');
+}
+
+test('명시적 Cargo test target registry 동기화만 허용한다', () => {
+  const baseCargoToml = cargoToml('old_target');
+  const headCargoToml = cargoToml('new_target');
+
+  assert.equal(
+    validateDerivedArtifactChanges([], { baseCargoToml, headCargoToml }).length,
+    1,
+  );
+  assert.deepEqual(
+    validateDerivedArtifactChanges([], {
+      baseCargoToml,
+      headCargoToml,
+      allowCargoTargetRegistryChange: true,
+    }),
+    [],
+  );
+});
+
+test('Cargo registry 동기화에 marker 블록 밖 변경을 섞지 못한다', () => {
+  const baseCargoToml = cargoToml('old_target');
+  const headCargoToml = cargoToml('new_target', 'version = "2"');
+  const errors = validateDerivedArtifactChanges([], {
+    baseCargoToml,
+    headCargoToml,
+    allowCargoTargetRegistryChange: true,
+  });
+
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /marker 블록 밖/);
+});

--- a/scripts/tests/rust-test-suite-manifest.test.mjs
+++ b/scripts/tests/rust-test-suite-manifest.test.mjs
@@ -136,19 +136,22 @@ test('경로 의존 case는 기존 target 이름을 유지한다', () => {
   assert.equal(nextestArguments(plan).includes('-E'), false);
 });
 
-test('Native Skia 함수 게이트 case는 독립 target으로 실행한다', () => {
+test('명시적으로 허용한 CLI module blocker는 generated suite에 배정한다', () => {
+  for (const caseName of ['cli_json_contract', 'cli_catalog_contract']) {
+    const plan = resolveCasePlan(caseName);
+    assert.equal(plan.grouped, true, caseName);
+    assert.match(plan.target, /^regression_suite_\d{3}$/);
+  }
+});
+
+test('Native Skia 함수 게이트 case는 generated suite에서 feature별로 실행한다', () => {
   const plan = resolveCasePlan('issue_2225_missing_picture_placeholder');
-  assert.deepEqual(plan, {
-    caseName: 'issue_2225_missing_picture_placeholder',
-    target: 'issue_2225_missing_picture_placeholder',
-    grouped: false,
-  });
-  assert.deepEqual(nextestArguments(plan), [
-    'nextest',
-    'run',
-    '--test',
-    'issue_2225_missing_picture_placeholder',
-  ]);
+  assert.equal(plan.grouped, true);
+  assert.match(plan.target, /^regression_suite_\d{3}$/);
+  assert.match(
+    nextestArguments(plan).join(' '),
+    /issue_2225_missing_picture_placeholder::/,
+  );
 });
 
 test('CI slow archive case는 독립 target과 nextest 우선순위를 함께 유지한다', () => {
@@ -285,7 +288,7 @@ test('PR base 검사도 커밋된 manifest 산출물을 실제 Git diff에서 �
   );
 });
 
-test('PR base 검사는 Cargo generated target block의 커밋도 거부한다', (t) => {
+test('PR base 검사는 manifest와 맞지 않는 Cargo generated target registry를 거부한다', (t) => {
   const root = mkdtempSync(path.join(os.tmpdir(), 'rhwp-suite-base-cargo-'));
   t.after(() => rmSync(root, { recursive: true, force: true }));
   writeRepositoryFixture(root);
@@ -302,7 +305,7 @@ test('PR base 검사는 Cargo generated target block의 커밋도 거부한다',
 
   const validation = validateRepository(root, { baseRef: 'HEAD~1' });
   assert.ok(
-    validation.errors.some((error) => /Cargo\.toml의 generated test target 블록/.test(error)),
+    validation.errors.some((error) => /Cargo\.toml generated test target block drift/.test(error)),
     validation.errors.join('\n'),
   );
 });

--- a/tests/suites/suite-policy.json
+++ b/tests/suites/suite-policy.json
@@ -27,6 +27,28 @@
       "recursive": false
     }
   ],
+  "moduleIntegrationOverrides": [
+    {
+      "path": "tests/cli_json_contract.rs",
+      "allowBlockers": [
+        "path_attr",
+        "root_mod"
+      ]
+    },
+    {
+      "path": "tests/cases/cli_catalog_contract.rs",
+      "allowBlockers": [
+        "path_attr",
+        "root_mod"
+      ]
+    },
+    {
+      "path": "tests/issue_2225_missing_picture_placeholder.rs",
+      "allowBlockers": [
+        "function_gated_native_skia"
+      ]
+    }
+  ],
   "exceptions": [
     {
       "target": "cli_exit_codes",


### PR DESCRIPTION
## 관련 이슈

Closes #5682

## 변경

- 일반 `rust-test-suite-manifest --prepare`에서 루트 Cargo test-target registry 갱신을 제거했습니다.
- registry 갱신은 marker block만 허용하는 명시적 `--sync-cargo-targets` 경로로 분리했습니다.
- Rust test wrapper가 `--locked`를 사용해 `Cargo.lock` 갱신을 막습니다.
- 실제 module 호환이 확인된 source는 generated suite로 편입하고, source PR·review·CI의 산출물 책임 경계를 문서화했습니다.

## 검증

- `node --test scripts/tests/rust-test-suite-manifest.test.mjs scripts/tests/rust-test-suite-cargo-isolation.test.mjs scripts/tests/run-rust-test-locking.test.mjs` (22 passed)
- `node scripts/rust-test-suite-manifest.mjs --prepare`
- `node scripts/rust-test-suite-manifest.mjs --check`
- prepare 전후 SHA-256으로 `Cargo.toml`, `Cargo.lock` 불변 확인
- `cargo fmt --all -- --check`
- `git diff --check`