### PR TITLE
fix(ci): CI 전용 wasm 스텁을 생성 타입과 맞춘다 — devel 의 Type-check Studio 실패 해소

### DIFF
--- a/rhwp-studio/types/wasm-ci-unit-stub.d.ts
+++ b/rhwp-studio/types/wasm-ci-unit-stub.d.ts
@@ -14,6 +14,11 @@ declare module '@wasm/rhwp.js' {
     constructor(data: Uint8Array);
     static createEmpty(): HwpDocument;
     static openWithPassword(data: Uint8Array, password: string): HwpDocument;
+    // 인덱스 시그니처는 이름 있는 프로퍼티를 대신하지 못한다 — 구조적 할당 검사에서
+    // `exportHwp` 를 요구하는 쪽(document-agent 의 ExportableDocument)에 닿지 않는다.
+    // 생성된 `pkg/rhwp.d.ts` 와 같은 시그니처로 명시한다.
+    exportHwp(): Uint8Array;
+    exportHwpx(): Uint8Array;
     [name: string]: any;
   }
 


### PR DESCRIPTION
관련 이슈: 없음 — `devel` 을 막고 있는 CI 결함이라 이슈 없이 올립니다. 별도 추적이 필요하면
이슈로 옮기겠습니다.

## 문제

`devel`(`c2a36398d`·`2d897ca04`)에서 **`Frontend unit gates` 의 Type-check Studio 단계가
실패합니다.** studio 소스를 건드리는 PR 은 내용과 무관하게 red 가 됩니다.

```
src/main.ts(577,7): error TS2322: Type 'WasmBridge' is not assignable to type 'DocumentAgentWasm'.
  The types returned by 'borrowDocumentHandle()' are incompatible between these types.
    Type 'HwpDocument | null' is not assignable to type 'ExportableDocument | null'.
      Type 'HwpDocument' is missing the following properties from type
        'ExportableDocument': exportHwp, exportHwpx
src/main.ts(578,7): error TS2322: Type 'InputHandler' is not assignable to type 'DocumentAgentInput'.
```

두 번째 오류는 첫 번째에서 파생됩니다(`executeDocumentAgentOperation` 의 `operation` 인자가
같은 `DocumentAgentWasm` 을 요구).

## 원인

이 단계는 `tsconfig.ci-unit.json` 으로 돕니다. 그 설정이 `@wasm/rhwp.js` 를 실제 생성물이
아니라 **CI 전용 스텁**으로 바꿔치기합니다.

```json
"paths": { "@wasm/rhwp.js": ["./types/wasm-ci-unit-stub.d.ts"] }
```

스텁의 `HwpDocument` 에 `exportHwp`·`exportHwpx` 가 없습니다. `[name: string]: any` 인덱스
시그니처가 있지만 **이름 있는 프로퍼티를 대신하지 못해** 구조적 할당 검사에서
`document-agent/controller.ts:21` 의 `ExportableDocument` 에 닿지 않습니다.

실제 생성 타입에는 둘 다 있습니다 — `pkg/rhwp.d.ts:331`·`:352`, 출처는 Rust
`impl HwpDocument` 의 `#[wasm_bindgen(js_name = exportHwp)]`(`src/wasm_api.rs:6414`·`:6455`).
**그래서 일반 `tsc --noEmit` 은 통과하고 ci-unit 만 실패합니다** — 기여자 로컬에서 재현되지
않아 원인을 찾기 어려운 형태입니다.

`ExportableDocument` 를 요구하는 `document-agent/controller.ts` 는 #5569(`b0c0a0839`,
2026-08-19)에서 들어왔고, 스텁의 마지막 변경은 2026-08-04(`fc1c10450`)입니다. 소비자가
추가되면서 거울이 함께 갱신되지 않았습니다.

## 변경

스텁은 생성 타입의 거울이므로 스텁을 맞춥니다. 생성물과 **같은 시그니처**로 두 메서드를
명시합니다.

```ts
export class HwpDocument {
  constructor(data: Uint8Array);
  static createEmpty(): HwpDocument;
  static openWithPassword(data: Uint8Array, password: string): HwpDocument;
  // 인덱스 시그니처는 이름 있는 프로퍼티를 대신하지 못한다 — 구조적 할당 검사에서
  // `exportHwp` 를 요구하는 쪽(document-agent 의 ExportableDocument)에 닿지 않는다.
  // 생성된 `pkg/rhwp.d.ts` 와 같은 시그니처로 명시한다.
  exportHwp(): Uint8Array;
  exportHwpx(): Uint8Array;
  [name: string]: any;
}
```

인덱스 시그니처는 그대로 둡니다 — 이 스텁이 덮는 표면 전체를 열거하는 것은 이 PR 의 범위가
아닙니다.

## 검증

devel `2d897ca04` 기준.

- **수정 전 실패 증명**: 이 브랜치의 스텁만 devel 판으로 되돌리면
  `npx tsc --project tsconfig.ci-unit.json --noEmit` 가 위 `TS2322` 두 건으로 실패합니다.
  수정 후 exit 0.
- `./node_modules/.bin/tsc --noEmit`(일반 설정) — exit 0. 수정 전에도 통과했습니다.
- `npm --prefix rhwp-studio run test` — **1017 tests, 0 fail**(skipped 1 은 기존 테스트).
- `npm --prefix rhwp-studio run build`(`tsc && vite build`) — exit 0.
- Rust 를 건드리지 않으므로 `cargo` 게이트는 영향 없습니다.

## 범위 외

- **스텁이 생성 타입과 어긋나지 않도록 강제하는 장치** — 지금은 사람이 맞춰야 합니다. 같은
  누락이 다시 나면 studio PR 이 전부 막히므로 가드가 있는 편이 낫지만, 생성물이 CI 에서
  빌드되는 시점과 스텁이 쓰이는 시점이 달라 설계가 필요합니다. 별건으로 두겠습니다.
- **`ExportableDocument` 쪽 설계** — 소비자가 요구하는 계약 자체는 실제 생성 타입이 만족하므로
  건드리지 않습니다.
