### PR TITLE
fix: lpaiu-cs Studio 변경 3건을 통합한다

### DIFF
--- a/mydocs/orders/20260820.md
+++ b/mydocs/orders/20260820.md
@@ -13,3 +13,21 @@ date: 2026-08-20
 - q-kit의 하위 명령 `--help`가 handler 오류로 종료 코드 2를 내던 결함은 메인터너 보정으로 해결했다. 전역 목록 기반 50/50 help 실행과 focused contract 6/6이 통과했다.
 - 로컬 manifest·unit tier·fmt·clippy와 전체 release-test nextest 7,978/7,978건(38 skipped)이 통과했다. renderer·layout 변경이 없어 시각 검증은 적용하지 않는다.
 - 이 오늘할일과 [#5674 self-review](../pr/archives/pr_5674_review.md), 구현 기록을 trailing docs commit으로 push한다. 최신 head의 CI와 mergeability가 성공하면 병합하고, 원 PR·issue comment/close 및 review branch/worktree/전용 target 정리를 `post_merge.md` 순서로 수행한다.
+
+## #5685 lpaiu-cs Studio 변경 3건 통합
+
+- 통합 PR은 [#5685](https://github.com/edwardkim/rhwp/pull/5685)이며, 최신 `upstream/devel` 위에
+  [#5675](https://github.com/edwardkim/rhwp/pull/5675), [#5676](https://github.com/edwardkim/rhwp/pull/5676),
+  [#5684](https://github.com/edwardkim/rhwp/pull/5684)을 오래된 번호순으로 충돌 없이 체리픽했다.
+- 도형의 회전·대칭은 양식 모드 차단을 거치는 command 역연산으로, 그림·OLE는 저장 바이트 보존을 위해
+  snapshot으로 유지한다. 선택 범위의 실재성은 `CursorState.selectRange`가 소유하고, CI unit WASM stub은
+  생성 선언과 같은 `exportHwp`·`exportHwpx` 메서드를 명시한다.
+- `cargo fmt --all`, format check, `git diff --check`, Studio TypeScript, Studio 전체 test
+  `1,019 passed, 1 skipped`, 로컬 headless Chrome의 그림·표 undo/redo E2E를 통과했다. 원격 VM Chrome
+  CDP 주소의 도달 불가는 로컬 headless 재검증으로 환경 문제로 분리했다.
+- code candidate CI의 Build & Test, Lint, Frontend package gate, Native Skia, Canvas visual diff,
+  CodeQL, archive·regular/slow shard, Proptest, Adapter inter-diff가 모두 통과했다.
+- 이 오늘할일과 [#5685 통합 검토 기록](../pr/archives/pr_5685_review.md),
+  [구현 기록](../pr/archives/pr_5685_review_impl.md)을 하나의 trailing commit으로 push한다. 최신 문서
+  head의 fast-pass CI가 성공하면 작업지시자 승인 뒤 병합하며, 원 PR·관련 issue·통합 branch는
+  `post_merge.md` 순서로 정리한다.

--- a/mydocs/pr/archives/pr_5685_review.md
+++ b/mydocs/pr/archives/pr_5685_review.md
@@ -1,0 +1,39 @@
+# PR #5685 통합 검토 기록
+
+- 대상 PR: [#5685](https://github.com/edwardkim/rhwp/pull/5685)
+- 작성자: `jangster77` (maintainer integration)
+- 통합 원 PR: [#5675](https://github.com/edwardkim/rhwp/pull/5675),
+  [#5676](https://github.com/edwardkim/rhwp/pull/5676),
+  [#5684](https://github.com/edwardkim/rhwp/pull/5684)
+- code candidate: `960d7439bfa34b2b1eccbe7b7b2dafad1af21621`
+
+## 누적 범위와 검토 결론
+
+- #5675는 `d20647822438a2f869e08c7f15c214051d9bf31d` →
+  `c67c27da24beb5681acca87521ae16cdb1d33e99` →
+  `c63711e6f1d707fe8bd422680cfaa1295f1fe091` 순으로 적용했다. 도형의 회전·대칭만 command
+  역연산으로 전환하고, 저장 바이트가 달라질 수 있는 그림·OLE는 snapshot을 유지한다. 두 경로는
+  `executeOperation`을 거쳐 양식 모드 차단을 우회하지 않는다.
+- #5676의 `f22b676c4587a2733672535b3a9de6727d2f83c6`은 선택 범위 실재성 검사를
+  `CursorState.selectRange` 소유 계약으로 이동한다. 실제 호출은 undo 복원 한 곳뿐이어서 셀
+  선택 경로를 새로 제한하지 않는다.
+- #5684의 `db1fe3a3e006102f18efe8616c5b956f9f39ff0a`은 CI WASM stub에 `exportHwp`와
+  `exportHwpx`를 생성 `pkg/rhwp.d.ts`와 같은 `Uint8Array` 반환형으로 명시한다.
+- 체리픽 충돌과 차단 결함은 없었고, contributor 원 branch와 history는 변경하지 않았다.
+
+## 로컬 검증
+
+- `cargo fmt --all`, `cargo fmt --all -- --check`, `git diff --check`, Studio TypeScript 검사를 통과했다.
+- `npm --prefix rhwp-studio test`: `1,019 passed, 1 skipped`.
+- 로컬 headless Chrome에서 `e2e:undo-object-selection`의 그림·표 undo/redo 선택 해제 계약을 통과했다.
+- 이전 VM Chrome CDP 주소의 도달 불가는 로컬 headless 재검증으로 환경 문제로 분리했다.
+
+## GitHub CI
+
+- code candidate의 Build & Test, Lint, Frontend package gate, Native Skia, Canvas visual diff,
+  CodeQL, archive·regular/slow shard, Proptest, Adapter inter-diff가 통과했다.
+- 최종 병합 조건은 이 trailing head의 required CI 성공과 작업지시자 승인이다.
+
+## 결론
+
+- 통합 PR #5685는 최신 trailing head CI 성공 뒤 병합 권고다.

--- a/mydocs/pr/archives/pr_5685_review_impl.md
+++ b/mydocs/pr/archives/pr_5685_review_impl.md
@@ -1,0 +1,20 @@
+# PR #5685 통합 구현 기록
+
+## 적용 순서
+
+1. 최신 `upstream/devel`에서 `integration/lpaiu-cs-20260820`을 만들었다.
+2. #5675의 세 commit을 오래된 순서로 `-x` 체리픽했다.
+3. #5676, #5684의 각 고유 commit을 `-x` 체리픽했다.
+4. Studio 기본 검증과 code candidate Full CI를 통과한 뒤 이 review 기록을 trailing commit으로 추가한다.
+
+## 충돌과 보정 경계
+
+- 다섯 commit은 충돌 없이 누적됐다.
+- 메인터너 코드 보정은 추가하지 않았다. #5675의 그림·OLE snapshot 유지, #5676의 cell 좌표 보수적 거절,
+  #5684의 generated type 대조는 원 변경의 실제 범위 안에서 검토했다.
+- contributor fork branch에는 review 기록이나 보정 commit을 push하지 않는다.
+
+## 후속 단계
+
+- trailing 문서 head의 fast-pass CI가 성공하면 작업지시자 승인 뒤 #5685을 병합한다.
+- 병합 뒤 원 PR·관련 issue의 상태와 `edwardkim/rhwp` 통합 branch 정리는 `post_merge.md` 순서로 처리한다.

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -15,7 +15,7 @@ import type { CellPathLike } from '@/core/types';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { InputHandler } from '@/engine/input-handler';
 import { SetObjectPropsCommand, type RefreshPolicy } from '@/engine/command';
-import { getObjectProps, setObjectProps, type ObjectPropsRef } from '@/engine/object-props';
+import { getObjectProps, type ObjectPropsRef } from '@/engine/object-props';
 
 /** 스텁 커맨드 생성 헬퍼 */
 function stub(id: string, label: string, icon?: string, shortcut?: string): CommandDef {
@@ -693,31 +693,26 @@ function changeZOrder(
   ih.exitPictureObjectSelectionAndAfterEdit();
 }
 
-function setProps(services: import('../types').CommandServices, ref: PictureRef, props: Record<string, unknown>): any {
-  return setObjectProps(services.wasm, ref, props);
-}
-
 /**
- * [Task #3230] 절대 속성 하나를 바꾸고 **역연산으로** 기록한다.
+ * [Task #3230] 절대 속성 하나를 **역연산 커맨드로** 적용하고 기록한다.
  *
- * 스냅샷(`recordObjectMutation`)이 아니라 `kind:'record'` 를 쓴다 — 되돌릴 것이 스칼라 하나인데
+ * 스냅샷(`recordObjectMutation`) 대신 `kind:'command'`를 쓴다 — 되돌릴 것이 스칼라 하나인데
  * `Document` 통째 클론 2개(문서에 따라 최대 21 MB)를 스택에 얹을 이유가 없다. 호출부가 이미
- * 적용 전 값을 읽어 두었으므로 before 가 정확하다.
+ * 적용 전 값을 읽어 두었으므로 before 가 정확하다. setter를 라우터 전에 직접 호출하지 않아야
+ * 양식 모드의 편집 허용 검사가 실제 변경보다 먼저 실행된다.
  *
- * refresh 를 'full' 로 명시한다 — `kind:'record'` 의 기본은 'none' 이고, 종전 스냅샷 라우팅의
- * 'full' 이 `afterEdit()` → `document-changed` 를 대신 emit 해 주고 있었다(그래서 호출부의 수동
- * emit 이 [undo P3 정리] 에서 제거됐다). 명시하지 않으면 회전이 화면에 반영되지 않는다.
+ * refresh 를 'full' 로 명시한다 — command 라우팅의 자동 판정에 맡기면 개체 회전/대칭의 화면 반영이
+ * 보장되지 않는다. 종전 스냅샷 라우팅의 'full' 이 `afterEdit()` → `document-changed` 를 대신
+ * emit 해 주고 있었다(그래서 호출부의 수동 emit 이 [undo P3 정리] 에서 제거됐다).
  */
-function recordAbsolutePropChange(
-  services: import('../types').CommandServices,
+function executeAbsolutePropChange(
   ih: InputHandler,
   ref: PictureRef,
   before: Record<string, unknown>,
   after: Record<string, unknown>,
 ): void {
-  setProps(services, ref, after);
   ih.executeOperation({
-    kind: 'record',
+    kind: 'command',
     command: new SetObjectPropsCommand(ref, before, after),
     meta: { refresh: 'full' },
   });
@@ -738,7 +733,7 @@ function applyRotationDelta(services: import('../types').CommandServices, delta:
   if (next > 180) next -= 360;
   // [Task #3230] 스냅샷 → 역연산. `cur` 는 이미 위에서 읽은 적용 전 각도이고 setter 가
   // 절대값이라 되돌리기가 자명하다.
-  recordAbsolutePropChange(services, ih, ref, { rotationAngle: cur }, { rotationAngle: next });
+  executeAbsolutePropChange(ih, ref, { rotationAngle: cur }, { rotationAngle: next });
 }
 
 /** horzFlip/vertFlip을 토글한다 (shape + image 지원). */
@@ -751,5 +746,5 @@ function toggleFlip(services: import('../types').CommandServices, key: 'horzFlip
   if (props.sizeProtect) return;
   const cur = !!props[key];
   // 위 rotate 와 동일 — 토글이지만 setter 에 넘기는 값은 절대값(`!cur`)이라 역연산이 자명하다.
-  recordAbsolutePropChange(services, ih, ref, { [key]: cur }, { [key]: !cur });
+  executeAbsolutePropChange(ih, ref, { [key]: cur }, { [key]: !cur });
 }

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -721,6 +721,45 @@ function executeAbsolutePropChange(
   });
 }
 
+/**
+ * [Task #3230] 속성 왕복이 **참인 역연산인 대상**인지.
+ *
+ * 도형은 참이다 — `rotationAngle` 은 평범한 필드 대입이고 flip 은 비트를 대칭으로 set/clear
+ * 한다(`document_core/commands/object_ops/shape.rs`). 같은 값을 다시 넣으면 원래 상태다.
+ *
+ * **그림·OLE 는 아니다.** `rotationAngle` 이 섞이면 `refresh_picture_rotation_layout_for_save`
+ * 가 각도와 무관하게 — 0 으로 되돌리는 경우까지 — `rotate_image = true` 와
+ * `flip |= 0x0008_0000` 을 세운다(`object_ops/picture.rs:242-243`). 이 둘을 다시 내리는 경로는
+ * 저장소에 없어서, 90° 돌렸다 되돌린 그림은 화면은 같아도 저장 바이트가 원본과 달라진다
+ * (HWPX `hp:rotationInfo rotateimage`·HWP5 `HWPTAG_SHAPE_COMPONENT` 의 flip 비트).
+ * 대칭도 `TRANSFORM_KEYS`(picture.rs:176-184)에 걸려 `raw_rendering`·`render_*` 캐시를
+ * 기본값으로 리셋한다.
+ *
+ * 속성 bag 만으로는 이것들을 복원할 수 없다. 문서를 통째로 되돌리는 스냅샷이라야 정확하므로
+ * 그림·OLE 는 종전 경로를 유지한다 — 되돌리기의 정확성이 스냅샷 비용보다 앞선다.
+ */
+function absolutePropChangeIsInvertible(ref: PictureRef): boolean {
+  return ref.type === 'shape';
+}
+
+/** 역연산이 참이면 커맨드로, 아니면 종전 스냅샷으로 기록한다. */
+function applyAbsolutePropChange(
+  services: import('../types').CommandServices,
+  ih: InputHandler,
+  ref: PictureRef,
+  operationType: string,
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): void {
+  if (absolutePropChangeIsInvertible(ref)) {
+    executeAbsolutePropChange(ih, ref, before, after);
+    return;
+  }
+  recordObjectMutation(ih, operationType, (wasm) => {
+    setObjectProps(wasm, ref, after);
+  });
+}
+
 /** 현재 회전각에 delta(도)를 더한다 (shape + image 지원). */
 function applyRotationDelta(services: import('../types').CommandServices, delta: number): void {
   const ih = services.getInputHandler();
@@ -734,9 +773,11 @@ function applyRotationDelta(services: import('../types').CommandServices, delta:
   // -180 ~ 180 범위로 정규화
   next = ((next % 360) + 360) % 360;
   if (next > 180) next -= 360;
-  // [Task #3230] 스냅샷 → 역연산. `cur` 는 이미 위에서 읽은 적용 전 각도이고 setter 가
-  // 절대값이라 되돌리기가 자명하다.
-  executeAbsolutePropChange(ih, ref, { rotationAngle: cur }, { rotationAngle: next });
+  // [Task #3230] 도형은 역연산, 그림·OLE 는 스냅샷 유지(`absolutePropChangeIsInvertible`).
+  // `cur` 는 이미 위에서 읽은 적용 전 각도이고 setter 가 절대값이라 되돌리기가 자명하다.
+  applyAbsolutePropChange(
+    services, ih, ref, 'rotateObject', { rotationAngle: cur }, { rotationAngle: next },
+  );
 }
 
 /** horzFlip/vertFlip을 토글한다 (shape + image 지원). */
@@ -749,5 +790,5 @@ function toggleFlip(services: import('../types').CommandServices, key: 'horzFlip
   if (props.sizeProtect) return;
   const cur = !!props[key];
   // 위 rotate 와 동일 — 토글이지만 setter 에 넘기는 값은 절대값(`!cur`)이라 역연산이 자명하다.
-  executeAbsolutePropChange(ih, ref, { [key]: cur }, { [key]: !cur });
+  applyAbsolutePropChange(services, ih, ref, 'flipObject', { [key]: cur }, { [key]: !cur });
 }

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -15,7 +15,7 @@ import type { CellPathLike } from '@/core/types';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { InputHandler } from '@/engine/input-handler';
 import { SetObjectPropsCommand, type RefreshPolicy } from '@/engine/command';
-import { getObjectProps, type ObjectPropsRef } from '@/engine/object-props';
+import { getObjectProps, setObjectProps, type ObjectPropsRef } from '@/engine/object-props';
 
 /** 스텁 커맨드 생성 헬퍼 */
 function stub(id: string, label: string, icon?: string, shortcut?: string): CommandDef {
@@ -454,7 +454,10 @@ export const insertCommands: CommandDef[] = [
           captionIncludeMargin: false,
         };
         let result: any;
-        result = setProps(services, ref, captionProps);
+        // [Task #3230] `setProps` 래퍼가 사라져 공유 라우팅을 직접 부른다. 이 경로는 종전부터
+        // 라우터를 거치지 않고 직접 적용하고 `document-changed` 를 스스로 emit 한다 —
+        // 회전/대칭과 달리 이번 변경 대상이 아니라 종전 동작 그대로 둔다.
+        result = setObjectProps(services.wasm, ref, captionProps);
         // "그림 N " 끝 위치를 Rust가 반환
         charOffset = result?.captionCharOffset ?? 4;
         services.eventBus.emit('document-changed');

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -183,13 +183,37 @@ export class CursorState {
    * `setAnchor()` 는 "현재 위치에서 선택을 시작한다" 이고 이미 anchor 가 있으면 아무것도 하지
    * 않는다. undo 뒤 복원처럼 **범위 전체를 지정해야 하는** 자리에는 쓸 수 없어 따로 둔다.
    *
-   * 호출부가 범위의 유효성을 먼저 확인해야 한다 — 문서에 없는 범위를 세우면 이후 Bold·
-   * Backspace 가 유령 범위를 만지게 된다(#2339 가 막아 둔 그 경로).
+   * **두 끝이 모두 현재 문서에서 확인될 때만 세운다.** anchor/focus 의 소유자가 여기이므로
+   * "선택은 실재하는 위치를 가리킨다"(#2339)를 지키는 것도 여기 몫이다 — 호출부의 선의에
+   * 맡기면 호출부가 하나 늘 때마다 유령 범위가 되살아난다. 세우지 못하면 아무것도 바꾸지
+   * 않고 `false` 를 돌려준다(종전 선택 상태 그대로).
    */
-  selectRange(start: DocumentPosition, end: DocumentPosition): void {
+  selectRange(start: DocumentPosition, end: DocumentPosition): boolean {
+    if (!this.isVerifiedBodyPosition(start) || !this.isVerifiedBodyPosition(end)) return false;
     this.anchor = { ...start };
     this.position = { ...end };
     this.updateRect();
+    return true;
+  }
+
+  /**
+   * 본문 좌표계에서 **실재가 확인된** 위치인가 (Task #3416).
+   *
+   * 셀 안 위치(`parentParaIndex`)는 `false` 다 — 확인이 중첩 셀 경로(`cellPath`)를 따라가는
+   * 별도 축이라 이 산술로는 실재를 말할 수 없다. "없다" 가 아니라 "이 판정으로는 확인할 수
+   * 없다" 는 뜻이고, 확인할 수 없는 위치를 세우지 않는 것이 #2339 의 판단과 같다.
+   */
+  private isVerifiedBodyPosition(pos: DocumentPosition): boolean {
+    if (pos.parentParaIndex !== undefined) return false;
+    try {
+      const paraCount = this.wasm.getParagraphCount(pos.sectionIndex);
+      if (pos.paragraphIndex < 0 || pos.paragraphIndex >= paraCount) return false;
+      const len = this.wasm.getParagraphLength(pos.sectionIndex, pos.paragraphIndex);
+      return pos.charOffset >= 0 && pos.charOffset <= len;
+    } catch {
+      // 조회 자체가 실패하면 그 위치를 실재한다고 말할 수 없다.
+      return false;
+    }
   }
 
   /** 선택을 해제한다 */

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2661,32 +2661,12 @@ export class InputHandler {
   private restoreSelectionAfterUndo(cmd: EditCommand | null): void {
     const range = cmd?.selectionBefore?.();
     if (!range) return;
-    if (!this.isRestorableBodySelection(range.start, range.end)) return;
+    // 구역을 걸치는 범위는 되살리지 않는다 — 한컴 실측을 한 구역 안에서만 했다. 이건 실재
+    // 여부가 아니라 "어디까지 맞출지" 의 판단이라 여기 남는다.
+    if (range.start.sectionIndex !== range.end.sectionIndex) return;
+    // 범위가 현재 문서에 실재하는지는 `selectRange` 가 판정하고 거절한다(#2339 유령 범위
+    // 차단은 anchor/focus 소유자의 계약이다). 거절되면 해제된 상태 그대로 둔다.
     this.cursor.selectRange(range.start, range.end);
-  }
-
-  /**
-   * 되살려도 되는 본문 선택 범위인가 (Task #3416).
-   *
-   * 셀 안 범위(`parentParaIndex` 보유)는 되살리지 않는다 — 유효성 확인이 중첩 셀 경로
-   * (`cellPath`)를 따라가는 별도 축이고, 한컴 실측도 본문에서만 했다. 확인할 수 없는 범위를
-   * 세우느니 해제로 남기는 쪽이 #2339 의 판단과 같다.
-   */
-  private isRestorableBodySelection(start: DocumentPosition, end: DocumentPosition): boolean {
-    if (start.parentParaIndex !== undefined || end.parentParaIndex !== undefined) return false;
-    if (start.sectionIndex !== end.sectionIndex) return false;
-    try {
-      const paraCount = this.wasm.getParagraphCount(start.sectionIndex);
-      for (const pos of [start, end]) {
-        if (pos.paragraphIndex < 0 || pos.paragraphIndex >= paraCount) return false;
-        const len = this.wasm.getParagraphLength(pos.sectionIndex, pos.paragraphIndex);
-        if (pos.charOffset < 0 || pos.charOffset > len) return false;
-      }
-    } catch {
-      // 조회 자체가 실패하면 그 범위를 유효하다고 말할 수 없다.
-      return false;
-    }
-    return true;
   }
 
   /**

--- a/rhwp-studio/tests/issue-3416-selection-restore.test.ts
+++ b/rhwp-studio/tests/issue-3416-selection-restore.test.ts
@@ -19,8 +19,9 @@ import { functionBodyFrom } from './support/source-guard.ts';
 //  Redo 는 선택을 해제한다(삭제 직후 상태).
 //
 // 그래서 복원은 **선택 삭제 계열만** 이고, 나머지는 #2339 의 해제가 그대로 최종 상태다.
-// 그리고 복원 전에 현재 문서에서 유효한 범위인지 확인해야 한다 — #2339 가 해제를 넣은 이유가
-// 유령 범위이기 때문이다.
+// 그리고 실재하지 않는 범위는 서지 않아야 한다 — #2339 가 해제를 넣은 이유가 유령 범위이기
+// 때문이다. 그 판정은 anchor/focus 소유자인 `CursorState.selectRange` 가 하고, 호출부는
+// "어디까지 맞출지"(구역·커맨드 종류)만 정한다.
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 const src = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
@@ -60,15 +61,22 @@ test('[#3416] undo 경로가 선택을 되살린다 — redo 경로에는 없다
     '해제 뒤에 복원해야 한다');
 });
 
-test('[#3416] 복원 전에 유효성을 확인한다 (#2339 유령 범위 방지)', () => {
+test('[#3416] 유효성은 호출부가 아니라 selectRange 안에서 판정된다', () => {
+  const cursor = src('src/engine/cursor.ts');
+  const select = functionBodyFrom(cursor, 'selectRange(start: DocumentPosition, end: DocumentPosition)');
+
+  // 확인이 대입보다 먼저여야 한다 — 뒤면 유령 범위가 이미 선 뒤다.
+  const idxCheck = select.indexOf('isVerifiedBodyPosition');
+  const idxAssign = select.indexOf('this.anchor =');
+  assert.ok(idxCheck !== -1 && idxAssign !== -1 && idxCheck < idxAssign,
+    '두 끝을 확인한 뒤에 anchor/position 을 세워야 한다');
+  assert.match(select, /return false/, '세우지 못하면 그 사실을 돌려줘야 한다');
+
+  // 호출부에 같은 판정을 두면 계약이 두 곳으로 갈라진다 — 그때부터 한쪽만 고쳐진다.
   const handler = src('src/engine/input-handler.ts');
   const restore = functionBodyFrom(handler, 'private restoreSelectionAfterUndo');
-  assert.match(restore, /isRestorableBodySelection\(/, '유효성 확인을 거쳐야 한다');
-  // 확인보다 먼저 selectRange 를 부르면 유령 범위가 그대로 선다.
-  const idxCheck = restore.indexOf('isRestorableBodySelection');
-  const idxSelect = restore.indexOf('selectRange');
-  assert.ok(idxCheck !== -1 && idxSelect !== -1 && idxCheck < idxSelect,
-    '확인이 selectRange 보다 먼저여야 한다');
+  assert.doesNotMatch(restore, /getParagraphCount|getParagraphLength|parentParaIndex/,
+    '실재 판정을 호출부가 되풀이하면 안 된다');
 });
 
 test('[#3416] 해제는 그대로 남는다 — 복원은 그 위에 얹는 향상이다', () => {
@@ -79,43 +87,61 @@ test('[#3416] 해제는 그대로 남는다 — 복원은 그 위에 얹는 향�
   assert.match(reset, /exitPictureObjectSelection\(\)/);
 });
 
-test('[#3416] 범위 유효성 판정 — 실제 동작', async () => {
+test('[#3416] selectRange 는 실재하지 않는 범위를 거절한다 — 실제 동작', async () => {
   const vite = await createServer({
     root: rootDir, appType: 'custom', logLevel: 'silent', server: { middlewareMode: true },
   });
   try {
-    const mod = await vite.ssrLoadModule('/src/engine/input-handler.ts');
-    const InputHandler: any = mod.InputHandler;
-    // 판정은 wasm 조회에만 의존하므로 프로토타입 메서드를 최소 컨텍스트로 부른다.
-    const check = InputHandler.prototype['isRestorableBodySelection'];
-    assert.equal(typeof check, 'function', 'isRestorableBodySelection 이 있어야 함');
+    const { CursorState } = await vite.ssrLoadModule('/src/engine/cursor.ts');
+    const selectRange = CursorState.prototype.selectRange;
 
-    const ctx = (paraCount: number, len: number) => ({
-      wasm: {
-        getParagraphCount: () => paraCount,
-        getParagraphLength: () => len,
+    // 판정은 wasm 조회에만 의존한다. 생성자는 렌더러까지 요구하므로 프로토타입 위에
+    // 최소 상태만 얹어 부른다(내부 helper 도 프로토타입에서 찾아야 하므로 Object.create).
+    const ctx = (paraCount: number, len: number) => Object.assign(
+      Object.create(CursorState.prototype),
+      {
+        anchor: null, position: null,
+        wasm: { getParagraphCount: () => paraCount, getParagraphLength: () => len },
+        updateRect() { /* 기하 갱신은 이 판정과 무관 */ },
       },
-    });
+    );
     const p = (para: number, off: number) => ({ sectionIndex: 0, paragraphIndex: para, charOffset: off });
 
-    assert.equal(check.call(ctx(3, 10), p(0, 2), p(0, 6)), true, '문서 안 범위는 복원 가능');
-    assert.equal(check.call(ctx(3, 10), p(0, 2), p(5, 6)), false, '문단이 사라졌으면 불가');
-    assert.equal(check.call(ctx(3, 10), p(0, 2), p(0, 99)), false, '오프셋이 길이를 넘으면 불가');
-    assert.equal(
-      check.call(ctx(3, 10), p(0, 2), { sectionIndex: 1, paragraphIndex: 0, charOffset: 1 }),
-      false,
-      '구역이 다르면 불가',
-    );
-    // 셀 안 범위는 확인 축이 달라 복원하지 않는다.
-    assert.equal(
-      check.call(ctx(3, 10), { ...p(0, 2), parentParaIndex: 1 }, p(0, 6)),
-      false,
-      '셀 범위는 복원 대상이 아니다',
-    );
-    // 조회가 던지면 유효하다고 말할 수 없다.
-    const throwing = { wasm: { getParagraphCount: () => { throw new Error('gone'); } } };
-    assert.equal(check.call(throwing, p(0, 2), p(0, 6)), false, '조회 실패는 불가로 판정');
+    const ok = ctx(3, 10);
+    assert.equal(selectRange.call(ok, p(0, 2), p(0, 6)), true, '문서 안 범위는 세운다');
+    assert.deepEqual(ok.anchor, p(0, 2), 'anchor 는 start');
+    assert.deepEqual(ok.position, p(0, 6), '커서는 end');
+
+    // 거절할 때는 **아무것도 바꾸지 않아야** 한다 — 반쯤 세우면 그게 유령 범위다.
+    for (const [why, start, end] of [
+      ['문단이 사라졌으면', p(0, 2), p(5, 6)],
+      ['오프셋이 길이를 넘으면', p(0, 2), p(0, 99)],
+      ['셀 안 위치는', { ...p(0, 2), parentParaIndex: 1 }, p(0, 6)],
+    ] as Array<[string, any, any]>) {
+      const c = ctx(3, 10);
+      assert.equal(selectRange.call(c, start, end), false, `${why} 거절한다`);
+      assert.equal(c.anchor, null, `${why} anchor 를 건드리지 않는다`);
+      assert.equal(c.position, null, `${why} 커서를 건드리지 않는다`);
+    }
+
+    // 조회가 던지면 실재한다고 말할 수 없다.
+    const throwing = Object.assign(Object.create(CursorState.prototype), {
+      anchor: null, position: null,
+      wasm: { getParagraphCount: () => { throw new Error('gone'); } },
+      updateRect() {},
+    });
+    assert.equal(selectRange.call(throwing, p(0, 2), p(0, 6)), false, '조회 실패는 거절');
+    assert.equal(throwing.anchor, null, '조회 실패에도 상태를 건드리지 않는다');
   } finally {
     await vite.close();
   }
+});
+
+test('[#3416] 구역을 걸치는 범위는 복원 대상이 아니다 (실측 범위 밖)', () => {
+  const handler = src('src/engine/input-handler.ts');
+  const restore = functionBodyFrom(handler, 'private restoreSelectionAfterUndo');
+  assert.match(restore, /sectionIndex !== range\.end\.sectionIndex/, '구역 정책은 호출부가 갖는다');
+  const idxPolicy = restore.indexOf('sectionIndex !==');
+  const idxSelect = restore.indexOf('selectRange');
+  assert.ok(idxPolicy !== -1 && idxPolicy < idxSelect, '정책 판정이 먼저다');
 });

--- a/rhwp-studio/tests/undo-menu-object-ops.test.ts
+++ b/rhwp-studio/tests/undo-menu-object-ops.test.ts
@@ -77,19 +77,36 @@ test('services.wasm 을 별칭으로 빼내 가드를 우회할 수 없다', () 
 // "히스토리를 우회하지 않는다". 우회 형태만 달라졌으므로(직접 setProps 호출) 그것을 본다.
 test('회전/대칭은 역연산으로 기록한다', () => {
   const rot = balancedFrom(insertSrc, 'function applyRotationDelta', '{');
-  assert.match(rot, /executeAbsolutePropChange\(/, '회전을 히스토리에 기록');
+  assert.match(rot, /applyAbsolutePropChange\(/, '회전을 히스토리에 기록');
   assert.doesNotMatch(
     rot,
-    /\bsetProps\s*\(/,
+    /\bsetProps\s*\(|setObjectProps\s*\(/,
     '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
   );
   const flip = balancedFrom(insertSrc, 'function toggleFlip', '{');
-  assert.match(flip, /executeAbsolutePropChange\(/, '대칭을 히스토리에 기록');
+  assert.match(flip, /applyAbsolutePropChange\(/, '대칭을 히스토리에 기록');
   assert.doesNotMatch(
     flip,
-    /\bsetProps\s*\(/,
+    /\bsetProps\s*\(|setObjectProps\s*\(/,
     '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
   );
+});
+
+// [Task #3230 후속] 역연산은 **왕복이 참인 대상에만** 쓴다. 그림·OLE 는
+// `refresh_picture_rotation_layout_for_save` 가 각도와 무관하게 `rotate_image`·flip 0x80000 을
+// 세우고 되돌리는 경로가 없어(object_ops/picture.rs:242-243) 속성 bag 으로 복원되지 않는다.
+test('그림·OLE 는 스냅샷을 유지한다 — 속성 왕복이 참인 역연산이 아니다', () => {
+  const gate = functionBodyFrom(insertSrc, 'function absolutePropChangeIsInvertible');
+  assert.match(
+    gate,
+    /ref\.type === 'shape'/,
+    "역연산 대상은 도형뿐 — 그림·OLE 로 넓히면 rotate_image 가 되돌아가지 않는다",
+  );
+
+  const apply = functionBodyFrom(insertSrc, 'function applyAbsolutePropChange');
+  assert.match(apply, /absolutePropChangeIsInvertible\(ref\)/, '대상 판정을 거쳐야 한다');
+  assert.match(apply, /executeAbsolutePropChange\(/, '참이면 역연산 커맨드');
+  assert.match(apply, /recordObjectMutation\(/, '아니면 종전 스냅샷');
 });
 
 test('executeAbsolutePropChange 는 라우터에서 역연산 커맨드를 실행한다', () => {

--- a/rhwp-studio/tests/undo-menu-object-ops.test.ts
+++ b/rhwp-studio/tests/undo-menu-object-ops.test.ts
@@ -77,14 +77,14 @@ test('services.wasm 을 별칭으로 빼내 가드를 우회할 수 없다', () 
 // "히스토리를 우회하지 않는다". 우회 형태만 달라졌으므로(직접 setProps 호출) 그것을 본다.
 test('회전/대칭은 역연산으로 기록한다', () => {
   const rot = balancedFrom(insertSrc, 'function applyRotationDelta', '{');
-  assert.match(rot, /recordAbsolutePropChange\(/, '회전을 히스토리에 기록');
+  assert.match(rot, /executeAbsolutePropChange\(/, '회전을 히스토리에 기록');
   assert.doesNotMatch(
     rot,
     /\bsetProps\s*\(/,
     '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
   );
   const flip = balancedFrom(insertSrc, 'function toggleFlip', '{');
-  assert.match(flip, /recordAbsolutePropChange\(/, '대칭을 히스토리에 기록');
+  assert.match(flip, /executeAbsolutePropChange\(/, '대칭을 히스토리에 기록');
   assert.doesNotMatch(
     flip,
     /\bsetProps\s*\(/,
@@ -92,13 +92,14 @@ test('회전/대칭은 역연산으로 기록한다', () => {
   );
 });
 
-test('recordAbsolutePropChange 는 역연산 커맨드로 위임한다', () => {
-  const block = functionBodyFrom(insertSrc, 'function recordAbsolutePropChange');
-  assert.match(block, /kind:\s*'record'/, '스냅샷이 아니라 역연산 기록');
+test('executeAbsolutePropChange 는 라우터에서 역연산 커맨드를 실행한다', () => {
+  const block = functionBodyFrom(insertSrc, 'function executeAbsolutePropChange');
+  assert.match(block, /kind:\s*'command'/, '속성 적용도 편집 허용 검사를 거치는 command 라우터에서 실행');
   assert.match(block, /new SetObjectPropsCommand\(/, 'before/after 를 든 커맨드로 기록');
   assert.match(
     block,
     /refresh:\s*'full'/,
-    "kind:'record' 의 기본 refresh 는 'none' — 명시하지 않으면 회전이 화면에 반영되지 않는다",
+    '개체 회전/대칭 뒤 전체 화면 갱신을 유지한다',
   );
+  assert.doesNotMatch(block, /\bsetProps\s*\(/, 'setter를 라우터 전에 호출하면 양식 모드 편집 차단을 우회한다');
 });

--- a/rhwp-studio/types/wasm-ci-unit-stub.d.ts
+++ b/rhwp-studio/types/wasm-ci-unit-stub.d.ts
@@ -14,6 +14,11 @@ declare module '@wasm/rhwp.js' {
     constructor(data: Uint8Array);
     static createEmpty(): HwpDocument;
     static openWithPassword(data: Uint8Array, password: string): HwpDocument;
+    // 인덱스 시그니처는 이름 있는 프로퍼티를 대신하지 못한다 — 구조적 할당 검사에서
+    // `exportHwp` 를 요구하는 쪽(document-agent 의 ExportableDocument)에 닿지 않는다.
+    // 생성된 `pkg/rhwp.d.ts` 와 같은 시그니처로 명시한다.
+    exportHwp(): Uint8Array;
+    exportHwpx(): Uint8Array;
     [name: string]: any;
   }
 


### PR DESCRIPTION
## 통합 대상

- [#5675](https://github.com/edwardkim/rhwp/pull/5675): 양식 모드 개체 편집 차단과 그림 회전/대칭 undo 보존
- [#5676](https://github.com/edwardkim/rhwp/pull/5676): 선택 범위 유효성 검사를 `CursorState.selectRange` 소유 계약으로 이동
- [#5684](https://github.com/edwardkim/rhwp/pull/5684): CI WASM stub의 `exportHwp`·`exportHwpx` 생성 타입 정합

## 체리픽

최신 `upstream/devel` 위에서 `#5675 -> #5676 -> #5684` 순으로 고유 commit 5개를 충돌 없이 누적했습니다.

## 검토와 로컬 검증

- 그림·OLE 회전/대칭은 snapshot 경로를 유지하고, 양식 모드 차단은 `executeOperation`에서 계속 적용됨을 확인했습니다.
- `selectRange`의 실제 호출은 undo 복원 한 곳이며 셀 선택 경로를 새로 제한하지 않습니다.
- `cargo fmt --all`, `cargo fmt --all -- --check`, `git diff --check`, Studio TypeScript 검사를 통과했습니다.
- `npm --prefix rhwp-studio test`: `1,019 passed, 1 skipped`.
- 로컬 headless Chrome에서 `e2e:undo-object-selection`의 그림·표 undo/redo 계약을 통과했습니다. 기존 VM Chrome CDP 주소의 도달 불가는 환경 문제로 분리했습니다.

## 후속 조건

- 원 PR별 archive review와 오늘할일은 이 code candidate의 최신 CI가 통과한 뒤 하나의 trailing commit으로 추가합니다.
- 최종 병합 조건은 trailing head의 required CI 성공과 작업지시자 승인입니다.
