### PR TITLE
docs(review): #5672 검토와 보정 기록을 남긴다

### DIFF
--- a/mydocs/orders/20260820.md
+++ b/mydocs/orders/20260820.md
@@ -6,6 +6,18 @@ date: 2026-08-20
 
 # 2026-08-20 오늘할 일
 
+## #5671 rhwp-q-pack 조회 CLI 50개와 Control 필드 조회 코드 완료
+
+- [#5672](https://github.com/edwardkim/rhwp/pull/5672)는 최종 검토 head `47b2fab`의 CI 성공 뒤
+  `f9616a95fdffb917e9a5a74d4cdf4f4ad774b32e`로 `devel`에 squash merge되었다.
+- 메인터너 보정으로 `caption-tables`, `ctrl-kinds`, `page-starts-on`이 실제 문서 모델의 의미를
+  직렬화하도록 맞췄고, 50개 query command의 help/JSON/volume-probe 계약을 integration test로 고정했다.
+- focused contract 4건, 전체 release-test 7,995 passed (38 skipped), `clippy -D warnings`, suite/unit-test
+  정책 검사와 최신 CI의 Build & Test, Lint, Rust CodeQL, adapter inter-diff, proptest가 성공했다.
+- 연결 이슈 [#5671](https://github.com/edwardkim/rhwp/issues/5671)은 merge로 종료됐으며, 이슈와 기여자 PR에
+  해결 범위와 검증 근거를 안내했다. 상세 검토는 [PR #5672 기록](../pr/archives/pr_5672_review.md)과
+  [보정 기록](../pr/archives/pr_5672_review_impl.md)에 남긴다.
+
 ## #5674 kevin9327 조회 CLI 54개 누적 통합
 
 - 통합 PR은 [#5674](https://github.com/edwardkim/rhwp/pull/5674)이며, 최신 `upstream/devel@c2a36398d` 위에 [#5659](https://github.com/edwardkim/rhwp/pull/5659), [#5662](https://github.com/edwardkim/rhwp/pull/5662), [#5663](https://github.com/edwardkim/rhwp/pull/5663), [#5664](https://github.com/edwardkim/rhwp/pull/5664), [#5668](https://github.com/edwardkim/rhwp/pull/5668)을 `-x` 계보로 누적했다.

--- a/mydocs/pr/archives/pr_5672_review.md
+++ b/mydocs/pr/archives/pr_5672_review.md
@@ -1,0 +1,49 @@
+---
+kind: pr-review
+status: merged
+pr: 5672
+issue: 5671
+merged_at: 2026-08-19T17:54:04Z
+---
+
+# PR #5672 검토 기록 - rhwp-q-pack 조회 CLI 50개와 Control 필드 조회 코드
+
+## 결론
+
+**머지 완료.** 원 기여분과 메인터너 보정은 `f9616a95fdffb917e9a5a74d4cdf4f4ad774b32e`로
+`devel`에 squash merge되었다.
+
+## 검토 범위
+
+- 원 PR: [#5672](https://github.com/edwardkim/rhwp/pull/5672)
+- 관련 이슈: [#5671](https://github.com/edwardkim/rhwp/issues/5671)
+- 기여자: `kevin9327`
+- 원 source head: `d81d69b`
+- 최종 검토 head: `47b2fab503c3ce6d74528c09dbfefd0710c00afe`
+- 메인터너 보정: `47b2fab`의 `caption-tables`, `ctrl-kinds`, `page-starts-on` 계약 보정
+
+## 검토 결과
+
+- `caption-tables`는 실제 caption이 있는 표만 반환하고, 행·열·cell 수와 caption 문단 수를 공개한다.
+- `ctrl-kinds`는 문서 안의 Control variant를 빠짐없이 안정된 kind/count 집계로 반환한다.
+- `page-starts-on`은 저장된 section 시작 면의 `BOTH`, `EVEN`, `ODD` 값을 보존한다.
+- 50개 명령의 help/JSON/volume-probe 계약은 `tests/cases/agent_q_pack_contract.rs`로 회귀 범위를 고정했다.
+- 신규 source-side `#[cfg(test)]` 또는 source PR에 파생 suite/manifest를 추가하지 않았다.
+
+## 검증 근거
+
+- GitHub Actions 최신 head CI: Build & Test, Lint, Rust CodeQL, adapter inter-diff, proptest 성공.
+  archive build는 12분 37초, Lint는 17분 31초, Rust CodeQL은 20분 57초였다.
+- Focused `agent_q_pack_contract`: 4건 통과.
+- 전체 `cargo nextest run --locked --cargo-profile release-test --target-dir target/pr-review --tests --no-fail-fast`:
+  7,995 passed, 38 skipped.
+- `cargo clippy --locked --all-targets --target-dir target/pr-review -- -D warnings` 통과.
+- suite manifest prepare/check, unit-test tier 정책 검사, `cargo fmt --all -- --check`, `git diff --check` 통과.
+- CLI 조회 변경만 포함하므로 renderer/layout 시각 검증은 적용 대상이 아니다.
+
+## 후속 처리
+
+- #5671은 PR 본문의 close 연결로 자동 종료됐고, 해결 범위와 검증 결과를 이슈에 안내했다.
+- 기여자 PR에는 merge SHA, 보정 내역, CI 및 로컬 검증 결과를 코멘트로 안내했다.
+- 원 기여자 fork branch는 외부 소유이므로 삭제하지 않는다.
+

--- a/mydocs/pr/archives/pr_5672_review_impl.md
+++ b/mydocs/pr/archives/pr_5672_review_impl.md
@@ -1,0 +1,30 @@
+---
+kind: pr-review-implementation
+status: merged
+pr: 5672
+issue: 5671
+merged_at: 2026-08-19T17:54:04Z
+---
+
+# PR #5672 메인터너 보정 기록
+
+## 계보
+
+- contributor source head: `d81d69b`
+- maintainer correction head: `47b2fab503c3ce6d74528c09dbfefd0710c00afe`
+- merged squash commit: `f9616a95fdffb917e9a5a74d4cdf4f4ad774b32e`
+
+## 보정 내용
+
+- `caption-tables`의 결과를 caption이 있는 Table Control로 한정하고, 구조 요약과 caption 문단 수를
+  직렬화한다.
+- `ctrl-kinds`의 kind 이름을 Control enum 전체에 대해 명시하고 문서 전체에서 count를 집계한다.
+- `page-starts-on`에서 model의 page start 값을 JSON 계약 값으로 직접 직렬화한다.
+- 50개 query command의 help, JSON envelope, volume-probe 경로를 integration contract로 고정한다.
+
+## 검증 및 반영 방식
+
+- 보정은 contributor source branch에 direct push하여 원 PR #5672의 최신 head로 검증했다.
+- 최신 CI와 전체 release-test 회귀가 성공한 뒤 해당 PR을 squash merge했다.
+- 원 코드 PR을 다시 변경하지 않도록 이 문서와 review 기록은 merge 뒤 별도 review-only PR로 남긴다.
+


### PR DESCRIPTION
> **PR base 브랜치: `devel`**

## 변경 요약

머지된 [#5672](https://github.com/edwardkim/rhwp/pull/5672)의 검토 기록, 메인터너 보정 기록 및 오늘할일 완료 항목만 추가합니다. 코드, 테스트, workflow, Cargo 파일은 변경하지 않습니다.

## 관련 이슈

Refs #5671

## 테스트

- [x] review-only 문서 변경만 포함
- [ ] `cargo fmt --all -- --check` 미실행 (Rust 변경 없음)
- [ ] `cargo test` 미실행 (문서 전용 PR)
- [ ] `cargo clippy -- -D warnings` 미실행 (문서 전용 PR)
- [ ] 시각 검증 미적용 (renderer/layout 변경 없음)

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음
- 재현·측정: 코드 변경 없음
