### PR TITLE
fix(#5690): F3 블록 선택 삭제 undo 가 확장 단계까지 되살리게 한다

### DIFF
--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -49,12 +49,19 @@ export interface EditCommand {
    *
    * 한컴 2024 실측: 선택을 지운 뒤 undo 하면 지우기 전 범위가 그대로 복원되고(캐럿은 선택 끝),
    * redo 하면 해제된다. 반면 선택 위에 타이핑해서 대체한 경우의 undo 는 복원하지 않는다.
+   * F3 블록 선택은 **확장 단계까지** 되돌아온다 — undo 뒤 F3 를 누르면 단어에서 문단으로
+   * 이어서 확장한다(단계가 초기화됐다면 다시 단어 범위에 머물렀을 것이다).
    * 그래서 이것은 **선택 삭제 계열만 구현한다** — 미구현이면 종전대로 해제된다.
    *
    * 반환값은 "그때 그랬다" 는 기록일 뿐 지금 유효하다는 보장이 아니다. 복원하는 쪽이 현재
    * 문서에서 유효한지 반드시 확인해야 한다(#2339).
    */
-  selectionBefore?(): { start: DocumentPosition; end: DocumentPosition } | null;
+  selectionBefore?(): {
+    start: DocumentPosition;
+    end: DocumentPosition;
+    /** F3 블록 선택이었으면 그 확장 단계, 아니면 `null` (실측: 한컴은 단계까지 되돌린다). */
+    blockPhase: number | null;
+  } | null;
 }
 
 /**
@@ -856,10 +863,14 @@ export class DeleteSelectionCommand implements EditCommand {
    * 양식 모드 선택 삭제가 게이트에서 드롭돼 무언 폐기가 된다.
    */
   private readonly snapshot: SnapshotCommand;
-  private readonly selection: { start: DocumentPosition; end: DocumentPosition };
+  private readonly selection: {
+    start: DocumentPosition;
+    end: DocumentPosition;
+    blockPhase: number | null;
+  };
 
-  constructor(start: DocumentPosition, end: DocumentPosition) {
-    this.selection = { start: { ...start }, end: { ...end } };
+  constructor(start: DocumentPosition, end: DocumentPosition, blockPhase: number | null = null) {
+    this.selection = { start: { ...start }, end: { ...end }, blockPhase };
     // 삭제 후 커서는 선택 시작으로 모이고, undo 후에는 선택 끝으로 되돌아간다.
     this.snapshot = new SnapshotCommand('deleteSelection', end, start, (wasm) => {
       if (isCell(start)) {
@@ -896,7 +907,7 @@ export class DeleteSelectionCommand implements EditCommand {
    * undo 가 돌려주는 커서가 이미 `end`(선택 끝)라, 여기에 anchor(`start`)만 더하면 한컴과
    * 같은 상태가 된다 — 실측에서 undo 후 선택은 `(0,0,18)~(0,0,22)`, 캐럿은 `(0,0,22)` 였다.
    */
-  selectionBefore(): { start: DocumentPosition; end: DocumentPosition } {
+  selectionBefore(): { start: DocumentPosition; end: DocumentPosition; blockPhase: number | null } {
     return this.selection;
   }
 

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -188,12 +188,31 @@ export class CursorState {
    * 맡기면 호출부가 하나 늘 때마다 유령 범위가 되살아난다. 세우지 못하면 아무것도 바꾸지
    * 않고 `false` 를 돌려준다(종전 선택 상태 그대로).
    */
-  selectRange(start: DocumentPosition, end: DocumentPosition): boolean {
+  selectRange(
+    start: DocumentPosition,
+    end: DocumentPosition,
+    blockPhase: number | null = null,
+  ): boolean {
     if (!this.isVerifiedBodyPosition(start) || !this.isVerifiedBodyPosition(end)) return false;
     this.anchor = { ...start };
     this.position = { ...end };
+    // 범위와 블록 상태를 **한 번에** 세운다. 따로 세우면 그 사이에 "단계는 있는데 범위가 없는"
+    // 상태가 생기고, 다음 F3 가 그 단계에서 이어 확장해 엉뚱한 범위를 만든다.
+    this._blockSelectionMode = blockPhase !== null;
+    this._expandPhase = blockPhase ?? 0;
     this.updateRect();
     return true;
+  }
+
+  /**
+   * 지금이 F3 블록 선택이면 그 확장 단계, 아니면 `null` (Task #3416).
+   *
+   * `null` 과 `0` 은 다르다 — `0` 은 "블록 모드인데 아직 확장 전"(F5 로 들어온 직후)이고
+   * `null` 은 "블록 모드가 아님"이다. 되살릴 때 이 둘을 같게 취급하면 평범한 드래그 선택이
+   * 블록 모드로 되살아난다.
+   */
+  blockSelectionPhase(): number | null {
+    return this._blockSelectionMode ? this._expandPhase : null;
   }
 
   /**

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2508,7 +2508,8 @@ export class InputHandler {
     if (!sel) return;
     if (!this.canDeleteSelectionInFormMode()) return;
 
-    const cmd = new DeleteSelectionCommand(sel.start, sel.end);
+    // [Task #3416] F3 블록이면 확장 단계도 함께 기록한다 — 한컴은 undo 뒤 단계까지 되돌린다.
+    const cmd = new DeleteSelectionCommand(sel.start, sel.end, this.cursor.blockSelectionPhase());
     this.cursor.clearSelection();
     this.executeOperation({ kind: 'command', command: cmd });
   }
@@ -2666,7 +2667,9 @@ export class InputHandler {
     if (range.start.sectionIndex !== range.end.sectionIndex) return;
     // 범위가 현재 문서에 실재하는지는 `selectRange` 가 판정하고 거절한다(#2339 유령 범위
     // 차단은 anchor/focus 소유자의 계약이다). 거절되면 해제된 상태 그대로 둔다.
-    this.cursor.selectRange(range.start, range.end);
+    // 블록 단계는 범위와 같은 호출로 세운다 — `resetDerivedStateAfterHistoryJump` 의
+    // `exitBlockSelectionMode()` 가 방금 0 으로 되돌린 것을 여기서 되살린다.
+    this.cursor.selectRange(range.start, range.end, range.blockPhase);
   }
 
   /**

--- a/rhwp-studio/tests/issue-3416-selection-restore.test.ts
+++ b/rhwp-studio/tests/issue-3416-selection-restore.test.ts
@@ -36,7 +36,7 @@ test('[#3416] 선택 삭제 커맨드가 지우기 전 범위를 들고 있다',
     const end = { sectionIndex: 0, paragraphIndex: 0, charOffset: 22 };
     const cmd: any = new DeleteSelectionCommand(start, end);
 
-    assert.deepEqual(cmd.selectionBefore(), { start, end });
+    assert.deepEqual(cmd.selectionBefore(), { start, end, blockPhase: null });
 
     // 호출부가 넘긴 객체를 그대로 들고 있으면 이후 변형이 기록을 오염시킨다.
     start.charOffset = 999;
@@ -63,7 +63,7 @@ test('[#3416] undo 경로가 선택을 되살린다 — redo 경로에는 없다
 
 test('[#3416] 유효성은 호출부가 아니라 selectRange 안에서 판정된다', () => {
   const cursor = src('src/engine/cursor.ts');
-  const select = functionBodyFrom(cursor, 'selectRange(start: DocumentPosition, end: DocumentPosition)');
+  const select = functionBodyFrom(cursor, 'selectRange(');
 
   // 확인이 대입보다 먼저여야 한다 — 뒤면 유령 범위가 이미 선 뒤다.
   const idxCheck = select.indexOf('isVerifiedBodyPosition');

--- a/rhwp-studio/tests/issue-5690-block-selection-phase.test.ts
+++ b/rhwp-studio/tests/issue-5690-block-selection-phase.test.ts
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'vite';
+import { functionBodyFrom } from './support/source-guard.ts';
+
+// [#5690] F3 블록 선택 삭제를 undo 하면 **확장 단계까지** 되돌아와야 한다.
+//
+// 한컴 오피스 2024 실측(COM, `HAction.Run("Select")` = F3):
+//
+//  | 단계                | 캐럿 | 선택            |
+//  |---------------------|------|-----------------|
+//  | F3 x2 (단어 단계)   | 27   | 16~27           |
+//  | 삭제 후             | 16   | 없음            |
+//  | Undo 후             | 27   | 16~27 복원      |
+//  | **Undo 후 F3 한 번**| 44   | **16~44 문단**  |
+//  | Redo 후             | 16   | 없음            |
+//
+// 마지막 줄이 판정이다 — 단어에서 **문단으로 이어서** 확장했다. 단계가 초기화됐다면 다시
+// 단어 범위(16~27)에 머물렀을 것이다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+
+test('[#5690] 삭제 커맨드가 블록 확장 단계를 함께 들고 있다', async () => {
+  const vite = await createServer({
+    root: rootDir, appType: 'custom', logLevel: 'silent', server: { middlewareMode: true },
+  });
+  try {
+    const { DeleteSelectionCommand } = await vite.ssrLoadModule('/src/engine/command.ts');
+    const start = { sectionIndex: 0, paragraphIndex: 0, charOffset: 2 };
+    const end = { sectionIndex: 0, paragraphIndex: 0, charOffset: 12 };
+
+    const block: any = new DeleteSelectionCommand(start, end, 1);
+    assert.equal(block.selectionBefore().blockPhase, 1, 'F3 블록은 단계를 보관한다');
+
+    // 드래그 선택은 블록이 아니다. 0 으로 적으면 되살릴 때 블록 모드로 부활한다.
+    const drag: any = new DeleteSelectionCommand(start, end);
+    assert.equal(drag.selectionBefore().blockPhase, null, '블록이 아니면 null');
+  } finally {
+    await vite.close();
+  }
+});
+
+test('[#5690] 호출부가 커서에서 단계를 읽어 커맨드에 넘긴다', () => {
+  const handler = src('src/engine/input-handler.ts');
+  const del = functionBodyFrom(handler, 'private deleteSelection()');
+  assert.match(del, /new DeleteSelectionCommand\(sel\.start, sel\.end, this\.cursor\.blockSelectionPhase\(\)\)/,
+    '삭제 시점의 블록 단계를 기록해야 한다');
+
+  const restore = functionBodyFrom(handler, 'private restoreSelectionAfterUndo');
+  assert.match(restore, /selectRange\(range\.start, range\.end, range\.blockPhase\)/,
+    '되살릴 때 범위와 단계를 같은 호출로 넘겨야 한다');
+});
+
+test('[#5690] selectRange 가 범위와 블록 상태를 한 번에 세운다', async () => {
+  const vite = await createServer({
+    root: rootDir, appType: 'custom', logLevel: 'silent', server: { middlewareMode: true },
+  });
+  try {
+    const { CursorState } = await vite.ssrLoadModule('/src/engine/cursor.ts');
+    const ctx = () => Object.assign(Object.create(CursorState.prototype), {
+      anchor: null, position: null, _blockSelectionMode: false, _expandPhase: 0,
+      wasm: { getParagraphCount: () => 3, getParagraphLength: () => 20 },
+      updateRect() { /* 기하 갱신은 이 판정과 무관 */ },
+    });
+    const p = (off: number) => ({ sectionIndex: 0, paragraphIndex: 0, charOffset: off });
+
+    const blk = ctx();
+    assert.equal(CursorState.prototype.selectRange.call(blk, p(2), p(12), 2), true);
+    assert.equal(blk._blockSelectionMode, true, '단계를 주면 블록 모드로 선다');
+    assert.equal(blk._expandPhase, 2, '그 단계 그대로 — 다음 F3 가 이어서 확장한다');
+    assert.equal(CursorState.prototype.blockSelectionPhase.call(blk), 2);
+
+    const drag = ctx();
+    assert.equal(CursorState.prototype.selectRange.call(drag, p(2), p(12)), true);
+    assert.equal(drag._blockSelectionMode, false, 'null 이면 블록 모드가 아니다');
+    assert.equal(CursorState.prototype.blockSelectionPhase.call(drag), null);
+
+    // 0 단계(F5 진입 직후)와 "블록 아님"은 다르다.
+    const zero = ctx();
+    CursorState.prototype.selectRange.call(zero, p(2), p(12), 0);
+    assert.equal(CursorState.prototype.blockSelectionPhase.call(zero), 0, '0 과 null 을 구분한다');
+
+    // 거절되는 범위는 블록 상태도 남기지 않는다 — 반쯤 선 상태가 곧 유령 범위다.
+    const bad = ctx();
+    assert.equal(CursorState.prototype.selectRange.call(bad, p(2), p(99), 3), false);
+    assert.equal(bad._blockSelectionMode, false, '거절이면 블록 모드도 세우지 않는다');
+    assert.equal(bad._expandPhase, 0);
+    assert.equal(bad.anchor, null);
+  } finally {
+    await vite.close();
+  }
+});
+
+test('[#5690] #2339 의 해제는 그대로 남는다 — 복원이 그 위에 얹힌다', () => {
+  const handler = src('src/engine/input-handler.ts');
+  const reset = functionBodyFrom(handler, 'private resetDerivedStateAfterHistoryJump');
+  assert.match(reset, /exitBlockSelectionMode\(\)/, '해제는 유지되어야 한다');
+
+  const undo = functionBodyFrom(handler, 'private handleUndo()');
+  const redo = functionBodyFrom(handler, 'private handleRedo()');
+  const idxReset = undo.indexOf('resetDerivedStateAfterHistoryJump');
+  const idxRestore = undo.indexOf('restoreSelectionAfterUndo');
+  assert.ok(idxReset !== -1 && idxRestore !== -1 && idxReset < idxRestore, '해제 뒤에 복원한다');
+  assert.doesNotMatch(redo, /restoreSelectionAfterUndo/, '한컴은 redo 에서 해제한다');
+});


### PR DESCRIPTION
관련 이슈: #5690

## 문제

F3 블록 선택으로 지운 뒤 되돌리면 **확장 단계가 사라집니다.** 범위는 돌아오는데 이어서 F3 를
누르면 확장이 처음부터 다시 시작합니다.

#3416 의 검증 목록 마지막 항목("F3 확장 단계·F5 셀 블록도 같은 규약")이 선결 조건인 한컴
실측이 없어 남아 있었습니다. 이 PR 은 실측을 마친 **F3 축**을 닫습니다.

## 한컴 오라클 — 실측

한컴 오피스 2024(Hwp 13.0) COM 자동화. `HAction.Run("Select")` 가 F3 이고, 캐럿은
`GetPosBySet()`, 선택은 `GetSelectedPosBySet(a, b)`(둘 다 `CreateSet("ListParaPos")`)로 읽었습니다.
문단 시작이 `Pos` 16 이라 21자 문단이 16~37 입니다.

| 단계 | 캐럿 | 선택 |
|---|---|---|
| F3 ×2 (단어) | 27 | 16~27 (`ABCDEFGHIJ`) |
| 삭제 후 | 16 | 없음 |
| **Undo 후** | 27 | **16~27 복원** |
| **Undo 후 F3 한 번 더** | 44 | **16~44 (문단 전체)** |
| Redo 후 | 16 | 없음 |

**마지막 줄이 판정입니다** — 단어에서 **문단으로 이어서** 확장했습니다. 단계가 초기화됐다면
다시 단어 범위(16~27)에 머물렀을 것입니다. 즉 한컴은 범위뿐 아니라 **확장 단계까지** 되돌리고,
redo 는 종전 규칙대로 해제합니다.

## 원인

`resetDerivedStateAfterHistoryJump` 의 `exitBlockSelectionMode()` 가 범위·모드·단계를 함께 0 으로
되돌립니다(#2339 의 안전 조치). #3416 의 복원은 그 뒤에 **범위만** 되살리므로, 되돌린 직후의
선택은 "블록이 아닌 평범한 선택" 이 되고 다음 F3 가 단계 0 부터 다시 시작합니다.

범위 복원 자체는 이미 동작합니다 — F3 선택 삭제도 `hasSelection()` 경로라
`DeleteSelectionCommand` 로 가고 그 커맨드가 `selectionBefore()` 를 구현합니다.
**빠진 것은 단계 하나뿐입니다.**

## 변경

- `DeleteSelectionCommand` 가 삭제 시점의 확장 단계를 함께 보관하고 `selectionBefore()` 로
  내줍니다. **`null` 과 `0` 을 구분합니다** — `0` 은 "블록인데 아직 확장 전", `null` 은
  "블록 아님" 입니다. 같게 취급하면 평범한 드래그 선택이 블록 모드로 되살아납니다.
- `cursor.blockSelectionPhase()` 가 그 값을 내주는 유일한 자리입니다 — `_blockSelectionMode`·
  `_expandPhase` 의 소유자가 커서이므로 판정도 거기 둡니다.
- `cursor.selectRange(start, end, blockPhase)` 가 범위와 블록 상태를 **한 호출로** 세웁니다.

```ts
selectRange(start, end, blockPhase: number | null = null): boolean {
  if (!this.isVerifiedBodyPosition(start) || !this.isVerifiedBodyPosition(end)) return false;
  this.anchor = { ...start };
  this.position = { ...end };
  this._blockSelectionMode = blockPhase !== null;
  this._expandPhase = blockPhase ?? 0;
  this.updateRect();
  return true;
}
```

따로 세우면 "단계는 있는데 범위가 없는" 중간 상태가 생기고, 다음 F3 가 그 단계에서 이어 확장해
엉뚱한 범위를 만듭니다. **거절되는 범위는 블록 상태도 남기지 않습니다** — 반쯤 선 상태가 곧
#2339 가 막아 둔 유령 범위입니다.

#2339 의 해제는 그대로 두고 그 위에 얹습니다. `handleRedo` 에는 넣지 않습니다.

### 테스트

`rhwp-studio/tests/issue-5690-block-selection-phase.test.ts` (4개)

- 커맨드가 단계를 보관하고 블록이 아니면 `null` 을 돌려준다
- 호출부가 커서에서 단계를 읽어 커맨드에 넘기고, 되살릴 때 범위와 단계를 같은 호출로 넘긴다
- `selectRange` 가 범위와 블록 상태를 한 번에 세우고, `0` 과 `null` 을 구분하며,
  **거절 시 anchor·position·블록 상태를 모두 건드리지 않는다**
- #2339 의 해제가 그대로 남아 있고 복원이 그 뒤에 오며 redo 에는 없다

기존 `issue-3416-selection-restore.test.ts` 의 가드 두 개는 계약이 넓어진 만큼 갱신했습니다
(`selectionBefore()` 반환에 `blockPhase` 추가, `selectRange` 시그니처가 여러 줄이 되어 슬라이스
기준 변경). 잠그는 불변식은 그대로입니다.

## 검증

devel `b914bdf4b` 기준.

- **수정 전 실패 증명**: 이 PR 의 테스트를 devel 소스에 그대로 걸면 **4개 중 3개 실패**
  (통과하는 1개는 "#2339 의 해제가 유지되는가" — 이 PR 이 그것을 건드리지 않는다는 확인이라
  양쪽에서 통과하는 것이 맞습니다). 이 브랜치에서 4개 전부 통과.
- `npm --prefix rhwp-studio run test` — **1023 tests, 0 fail**(skipped 1 은 기존 테스트).
- `./node_modules/.bin/tsc --noEmit` — exit 0.
- `./node_modules/.bin/tsc --project tsconfig.ci-unit.json --noEmit` — exit 0.
- `npm --prefix rhwp-studio run build`(`tsc && vite build`) — exit 0.
- Rust 를 건드리지 않으므로 `cargo` 게이트는 영향 없습니다.

한컴 측정 스크립트는 임시라 커밋하지 않았습니다. 재현은 `HWPFrame.HwpObject` COM 으로
`FileNew` → `CreateAction("InsertText")` 로 본문 입력 → `MoveDocBegin`/`MoveRight`×2 →
`HAction.Run("Select")` ×2 → `Run("Delete"/"Undo")` → `Run("Select")` 입니다.

## 범위 외

- **F5 셀 블록** — 같은 검증 항목의 나머지 절반이지만 오라클이 없습니다. `TableCellBlock` 계열은
  잡히는데(`ret=True`) 그 상태의 `Delete` 가 일관되게 `False` 를 돌려주고 문서가 바뀌지
  않습니다("셀 지우기" 대화상자 경로로 보입니다). `GetSelectedPosBySet` 도 셀 블록에는 선택
  없음을 주므로(셀마다 `List` 가 다름) 읽는 축부터 다시 찾아야 합니다.
- **F3 첫 타 동작 차이** — 한컴은 첫 F3 가 블록만 켜고 범위를 만들지 않는데 rhwp 는 곧바로
  단어까지 확장합니다. 이 PR 은 undo 복원만 다룹니다.
- **선택 위 타이핑 대체의 복원** — 한컴이 복원하지 않으므로 맞추지 않습니다.
