### PR TITLE
fix(studio): 마스터 페이지 이미지가 본문 입력을 가로채지 않게 한다

### DIFF
--- a/mydocs/orders/20260820.md
+++ b/mydocs/orders/20260820.md
@@ -48,3 +48,14 @@ date: 2026-08-20
 - [#5683](https://github.com/edwardkim/rhwp/pull/5683)은 review/CI용 suite 준비와 루트 Cargo registry 동기화를 분리해 일반 `--prepare`가 `Cargo.toml`·`Cargo.lock`을 변경하지 않도록 한다.
 - manifest·Cargo 격리·`--locked` 계약 테스트 22건, `--prepare`/`--check`, prepare 전후 두 Cargo 파일 SHA-256 비교, fmt·diff 검증을 완료했다.
 - self-review 기록은 [pr_5683_review.md](../pr/archives/pr_5683_review.md)에 남겼다. 최신 trailing head의 CI와 mergeability가 통과하고 작업지시자 승인 후 merge한다.
+
+## #5692 마스터 페이지 그림의 본문 입력 가로채기 보정
+
+- [#5693](https://github.com/edwardkim/rhwp/pull/5693)은 `plane: 1` master-page 장식의 직렬화된
+  `inFrontOfText` 값이 본문 클릭을 그림 선택으로 전환하던 결함을 보정한다.
+- 물리 37쪽에서 재현한 전체 배경 이미지 hit-test를 입력 경로에서 제외하고, 일반 본문 foreground 및
+  header/footer 그림 선택은 유지하는 회귀 테스트를 추가했다.
+- Studio TypeScript, 정책 test 2건, Studio 전체 test 1,021 passed/1 skipped, fmt·diff check를 완료했다.
+  출력 렌더링 변경은 없으므로 PDF/SVG visual sweep은 적용하지 않는다.
+- 상세 판정은 [PR #5693 self-review](../pr/archives/pr_5693_review.md)에 남겼다. 최신 trailing head의
+  CI가 통과하고 작업지시자 승인을 받은 뒤 merge하며, #5692와 branch 정리는 `post_merge.md`를 따른다.

--- a/mydocs/pr/archives/pr_5693_review.md
+++ b/mydocs/pr/archives/pr_5693_review.md
@@ -1,0 +1,43 @@
+---
+kind: review
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-20
+---
+
+# PR #5693 검토: 마스터 페이지 이미지가 본문 입력을 가로채지 않게 한다
+
+## Metadata
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#5693](https://github.com/edwardkim/rhwp/pull/5693) |
+| 작성자·self-review | `jangster77` |
+| base / head | `devel` / `task_m100_5692` |
+| code candidate | `04c91180d6c42fc9ed49628546ba03c706415753` |
+| 규모 | 4 files, +63/-1 (문서 포함) |
+| 관련 이슈 | [#5692](https://github.com/edwardkim/rhwp/issues/5692) |
+| 작성 시점 상태 | `MERGEABLE`, `BLOCKED`; merge 전에 최신 head와 CI 재확인 필요 |
+
+## 범위와 판정
+
+- `plane: 1`의 header/footer가 아닌 master-page 장식은 직렬화된
+  `inFrontOfText` 값과 관계없이 본문 그림 hit-test 후보에서 제외한다.
+- CanvasKit 재생의 master-page behind-text 처리와 입력 hit-test를 일치시켜,
+  물리 37쪽의 전체 배경 이미지가 본문 캐럿을 가로채지 않게 한다.
+- 일반 본문 foreground 및 header/footer 그림은 선택 후보로 유지한다.
+- 렌더 출력·페이지네이션·fixture를 변경하지 않는다. PDF/SVG visual sweep은 적용하지 않으며,
+  Studio TypeScript·전체 test와 hit-test 정책 회귀 테스트로 입력 경로를 검증했다.
+
+## 완료한 로컬 검증
+
+- `cd rhwp-studio && npx tsc --noEmit`이 통과했다.
+- `cd rhwp-studio && node --test tests/master-page-picture-hit.test.ts`가 2건 통과했다.
+- `cd rhwp-studio && npm test`가 1,021 passed, 1 skipped로 통과했다.
+- `cargo fmt --all`, `cargo fmt --all -- --check`, `git diff --check`이 통과했다.
+
+## 결론
+
+**merge 권고.** 최신 PR head의 GitHub Actions가 모두 통과하고 작업지시자 승인을 받은 뒤에만
+merge한다. merge 뒤 #5692가 자동 종료됐는지와 remote/local branch 정리 대상은
+`post_merge.md` 절차로 확인한다.

--- a/mydocs/working/task_m100_5692_stage1_master_page_picture_hit.md
+++ b/mydocs/working/task_m100_5692_stage1_master_page_picture_hit.md
@@ -1,0 +1,37 @@
+---
+kind: investigation
+status: active
+canonical: mydocs/manual/codex/docs_and_git_workflow.md
+last_verified: 2026-08-20
+---
+
+# #5692 마스터 페이지 그림 hit-test 보정
+
+Issue: #5692
+
+## 재현
+
+`samples/2025 행정업무운영 편람(최종).hwp`의 물리 37쪽에서 본문을 클릭하면
+캐럿이 나타나지 않고 입력할 수 있다. 물리 38쪽의 같은 본문 클릭은 정상이다.
+
+## 원인
+
+37쪽의 페이지 전체 이미지가 `plane: 1`, `wrap: inFrontOfText`로 직렬화되어
+`findPictureAtClick`의 foreground 후보가 되었다. CanvasKit 재생은 master-page
+레이어를 본문 뒤에 그리므로, 렌더 순서와 입력 hit-test의 해석이 서로 달랐다.
+
+## 보정
+
+header/footer 개체가 아닌 `plane: 1` master-page 장식은 그림 선택 후보에서 제외한다.
+일반 본문 foreground 이미지는 기존처럼 선택하도록 별도 회귀 테스트로 고정한다.
+
+## 검증 결과
+
+- `cd rhwp-studio && npx tsc --noEmit`이 통과했다.
+- `cd rhwp-studio && node --test tests/master-page-picture-hit.test.ts`가 2건 통과했다.
+- `cd rhwp-studio && npm test`가 1,021건 통과와 기존 skip 1건으로 종료했다.
+- `cargo fmt --all`, `cargo fmt --all -- --check`, `git diff --check`이 통과했다.
+
+원본 HWP를 브라우저 파일 선택기로 재주입하는 동작은 로컬 파일 업로드이므로 자동화하지 않았다.
+원인 재현에서 확인한 page 37의 master-page control과 hit-test 결과, 그리고 동일 정책을 실행하는
+회귀 테스트로 보정 범위를 검증했다.

--- a/rhwp-studio/src/engine/input-handler-picture.ts
+++ b/rhwp-studio/src/engine/input-handler-picture.ts
@@ -5,6 +5,7 @@ import { MovePictureCommand, MoveShapeCommand, ResizeObjectCommand } from './com
 import type { ObjectResizeTarget } from './command';
 import { computeArrowResize, MIN_SIZE_HWP, type ArrowKey } from './picture-resize';
 import { computeRotationRecord } from './object-drag-record';
+import { isMasterPageDecoration } from './picture-hit-policy';
 import type { CellPathLike } from '@/core/types';
 import { showToast } from '@/ui/toast';
 
@@ -225,7 +226,7 @@ export function findPictureAtClick(this: any,
       let shapeHit = false;
       let nestedPic: any = null;
       for (const ctrl of layout.controls) {
-        if (ctrl.secIdx === undefined || ctrl.wrap === 'behindText') continue;
+        if (ctrl.secIdx === undefined || ctrl.wrap === 'behindText' || isMasterPageDecoration(ctrl)) continue;
         const inBox = pageX >= ctrl.x && pageX <= ctrl.x + ctrl.w &&
           pageY >= ctrl.y && pageY <= ctrl.y + ctrl.h;
         if (!inBox) continue;
@@ -249,6 +250,7 @@ export function findPictureAtClick(this: any,
     for (const ctrl of layout.controls) {
       if (ctrl.type !== 'image' && ctrl.type !== 'shape' && ctrl.type !== 'equation' && ctrl.type !== 'group' && ctrl.type !== 'line' && ctrl.type !== 'ole') continue;
       if (ctrl.secIdx === undefined || ctrl.paraIdx === undefined || ctrl.controlIdx === undefined) continue;
+      if (isMasterPageDecoration(ctrl)) continue;
       // [Task #825] 머리말/꼬리말 그림: headerFooter marker 가 함께 있어야 lookup 가능.
       // (없으면 본문 picture 동작 그대로.)
 

--- a/rhwp-studio/src/engine/picture-hit-policy.ts
+++ b/rhwp-studio/src/engine/picture-hit-policy.ts
@@ -1,0 +1,10 @@
+/**
+ * Master-page drawings decorate document pages. CanvasKit replays them behind
+ * document text, so a serialized foreground wrap must not capture body clicks.
+ */
+export function isMasterPageDecoration(control: {
+  plane?: number;
+  headerFooter?: unknown;
+}): boolean {
+  return control.plane === 1 && !control.headerFooter;
+}

--- a/rhwp-studio/tests/master-page-picture-hit.test.ts
+++ b/rhwp-studio/tests/master-page-picture-hit.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isMasterPageDecoration } from '../src/engine/picture-hit-policy.ts';
+
+test('master-page front image does not capture a body-text click', () => {
+  assert.equal(isMasterPageDecoration({ plane: 1 }), true);
+});
+
+test('document and header/footer foreground images remain selectable', () => {
+  assert.equal(isMasterPageDecoration({ plane: 2 }), false);
+  assert.equal(isMasterPageDecoration({ plane: 1, headerFooter: { kind: 'header' } }), false);
+});


### PR DESCRIPTION
## 요약

- `plane: 1` master-page 장식이 직렬화된 foreground wrap을 따라 본문 클릭을 가로채지 않게 했습니다.
- header/footer와 일반 본문 foreground 개체 선택은 유지합니다.
- 해당 선택 정책의 회귀 테스트와 #5692 원인·검증 기록을 추가했습니다.

## 검증

- `cd rhwp-studio && npx tsc --noEmit`
- `cd rhwp-studio && node --test tests/master-page-picture-hit.test.ts`
- `cd rhwp-studio && npm test` (1,021 passed, 1 skipped)
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #5692