### PR TITLE
test(#3315): Track 4 종결 측정 프로브를 추가한다

### DIFF
--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -83,6 +83,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `pdf-render-diff-report.mjs` | 상시 | active | Report-only visual diff between browser Canvas output and SVG-deri | — | npm+CI | legacy-name |
 | `plugin-lifecycle.test.mjs` | 상시 | active | 플러그인 호스트 — allowlist·트랜잭션 1스냅샷·롤백·unload 회수 | — | npm e2e:plugin-lifecycle |  |
 | `print-pdf-issue3126.test.mjs` | 상시 | active | #3126 same-origin iframe 인쇄/PDF UX, 상태 불변, #2524/#2525 browser PDF 회귀 | render-p35-font-native-bitmap.hwpx, hwpx/hwpx-02.hwpx | 수동 | native dialog는 Chrome/Edge 수동 절차 병행 |
+| `probe-image-repaint-issue3315.mjs` | 진단 | active | Issue #3315 Track 4 종결 측정 — 그림 1장 문서의 타이핑·`document-changed`·개체 이동 비용을 그림 없음과 대조 (#2520 프로브 형식, 브리지 메서드별 내역 포함) | images/tiger01.jpg | npm e2e:issue-3315-perf | 시간 수치는 비-CI 진단 |
 | `probe-input-perf-issue3137.mjs` | 진단 | active | Issue #3137 거대 표 셀 입력의 mutation·cursor update·focused repaint·operation·2-rAF·long task 성능 매트릭스 | issue1949_giant_cell_nested_tables_perf.hwp/.hwpx | npm e2e:issue-3137-perf | 시간 수치는 비-CI, 문서·cursor·focused repaint·flush 계약만 hard assertion |
 | `pr2260-vscode-zoom-menu.test.mjs` | 상시 | active | [PR #2260 검증] rhwp-vscode 배율 메뉴 — 호스트 Chrome CDP 로 webview 하네스 구동. | — | 수동 |  |
 | `issue-4224-pua-f02fb-small-right-triangle-canvas2d.test.mjs` | 상시 | active | #4224 한컴 문자표 U+F02FB 일반 TextRun을 작은 오른쪽 방향 삼각형으로 Canvas2D 투영 | basic/pau-004.hwp | npm e2e:issue-4224 | raw IR 보존·공개 글꼴 tofu 차단 |

--- a/rhwp-studio/e2e/probe-image-repaint-issue3315.mjs
+++ b/rhwp-studio/e2e/probe-image-repaint-issue3315.mjs
@@ -1,0 +1,239 @@
+/**
+ * Issue #3315 Track 4 — 종결 측정.
+ *
+ * #2520 이 확정한 결함("그림 1장이 있으면 모든 편집이 그림 크기에 비례해 느려진다")의
+ * 잔여 비용이 Track 1~3 이후 어디까지 내려왔는지 잰다. 진단용 벤치마크이며 CI 게이트가 아니다.
+ *
+ * 종결 기준(#3315 Track 4): **JPEG 1장 문서의 타이핑·드래그가 그림 없음 대비 ×2 이내.**
+ * #2520 원측정: 그림 없음 1.76 ms/키, JPEG 2.0MB ×177(311 ms/키), 드래그 ~305 ms/이동(~3fps).
+ *
+ * 측정 경로는 #2520 본문의 프로브를 그대로 쓴다.
+ *   - 타이핑: textarea `input` 이벤트 실제 경로
+ *   - 드래그: mousemove 당 `document-changed` 동기 emit (+ 개체 이동은 setProps 를 더한다)
+ *
+ * 실행:
+ *   wasm-pack build --target web --release
+ *   cd rhwp-studio && node e2e/probe-image-repaint-issue3315.mjs --mode=headless
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  closeBrowser, closePage, createPage, launchBrowser, loadApp, createNewDocument,
+} from './helpers.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const JPEG_PATH = path.join(REPO_ROOT, 'samples/images/tiger01.jpg');
+const KEYS = 20;
+const REFRESHES = 20;
+const WARMUP = 5;
+
+function arg(name, def) {
+  const hit = process.argv.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.split('=')[1] : def;
+}
+
+/**
+ * 그림을 실제 편집 라우터로 삽입한다(스냅샷 경로 — 실사용과 같다).
+ *
+ * 바이트는 페이지 안에서 dev 서버로 fetch 한다 — 4.5MB 를 `page.evaluate` 인자로 넘기면
+ * 원소마다 JSON 직렬화가 일어나 측정 전에 수십 초를 태운다.
+ */
+async function insertJpeg(page, url, treatAsChar = false) {
+  return page.evaluate(async ({ src, treatAsChar }) => {
+    const resp = await fetch(src);
+    if (!resp.ok) throw new Error(`픽스처 fetch 실패: HTTP ${resp.status}`);
+    const bytes = new Uint8Array(await resp.arrayBuffer());
+    const ih = window.__inputHandler;
+    let info = null;
+    ih.executeOperation({
+      kind: 'snapshot', operationType: 'insertPicture',
+      operation: () => {
+        const ret = window.__wasm.insertPicture(
+          0, 0, 0, '[]', bytes,
+          // 2400x1800 원본을 페이지에 맞춘 크기(HWPUNIT)
+          12000, 9000, 2400, 1800, 'jpg', '', null, null,
+        );
+        info = typeof ret === 'string' ? JSON.parse(ret) : ret;
+        window.__wasm.setPictureProperties(0, info.paraIdx, info.controlIdx, { treatAsChar });
+        return ih.getCursorPosition();
+      },
+    });
+    return info;
+  }, { src: url, treatAsChar });
+}
+
+/**
+ * 브리지 메서드별 누적 시간을 잰다 (#2520 과 같은 계측 형식).
+ * 어떤 WASM 호출이 비용을 먹는지 갈라 보여 준다.
+ */
+async function withBridgeProfile(page, fn) {
+  await page.evaluate(() => {
+    const w = window.__wasm;
+    if (w.__profRestore) w.__profRestore();
+    const acc = {}; const restores = [];
+    const names = new Set([
+      ...Object.getOwnPropertyNames(Object.getPrototypeOf(w) || {}),
+      ...Object.getOwnPropertyNames(w),
+    ]);
+    for (const name of names) {
+      if (name === 'constructor') continue;
+      const orig = w[name];
+      if (typeof orig !== 'function' || name.startsWith('__')) continue;
+      restores.push(() => { w[name] = orig; });
+      w[name] = function (...args) {
+        const t0 = performance.now();
+        try { return orig.apply(this, args); }
+        finally { const d = performance.now() - t0; const e = acc[name] || (acc[name] = { ms: 0, n: 0 }); e.ms += d; e.n++; }
+      };
+    }
+    window.__prof = acc;
+    w.__profRestore = () => { restores.forEach(r => r()); delete w.__profRestore; };
+  });
+  const result = await fn();
+  const prof = await page.evaluate(() => {
+    const acc = window.__prof || {};
+    window.__wasm.__profRestore?.();
+    return Object.entries(acc)
+      .map(([name, v]) => ({ name, ms: v.ms, n: v.n }))
+      .sort((a, b) => b.ms - a.ms).slice(0, 6);
+  });
+  return { result, prof };
+}
+
+/** #2520 프로브 — textarea input 이벤트로 키스트로크당 비용을 잰다. */
+async function measureTyping(page, n, warmup) {
+  return page.evaluate(({ n, warmup }) => {
+    const ih = window.__inputHandler;
+    const fire = () => {
+      ih.textarea.value = 'a';
+      ih.textarea.dispatchEvent(new InputEvent('input', { data: 'a', inputType: 'insertText' }));
+    };
+    for (let i = 0; i < warmup; i++) fire();
+    const samples = [];
+    for (let i = 0; i < n; i++) {
+      const t0 = performance.now();
+      fire();
+      samples.push(performance.now() - t0);
+    }
+    samples.sort((a, b) => a - b);
+    const sum = samples.reduce((a, b) => a + b, 0);
+    return { mean: sum / samples.length, median: samples[Math.floor(samples.length / 2)], max: samples[samples.length - 1] };
+  }, { n, warmup });
+}
+
+/** 드래그 1틱의 공통 비용 — mousemove 마다 도는 `document-changed` 동기 emit. */
+async function measureRefresh(page, n, warmup) {
+  return page.evaluate(({ n, warmup }) => {
+    const bus = window.__eventBus;
+    for (let i = 0; i < warmup; i++) bus.emit('document-changed');
+    const samples = [];
+    for (let i = 0; i < n; i++) {
+      const t0 = performance.now();
+      bus.emit('document-changed');
+      samples.push(performance.now() - t0);
+    }
+    samples.sort((a, b) => a - b);
+    const sum = samples.reduce((a, b) => a + b, 0);
+    return { mean: sum / samples.length, median: samples[Math.floor(samples.length / 2)], max: samples[samples.length - 1] };
+  }, { n, warmup });
+}
+
+/** 개체 이동 1틱 전체 — getProps + setProps + document-changed (input-handler-picture 의 드래그 경로). */
+async function measurePictureMove(page, info, n, warmup) {
+  return page.evaluate(({ info, n, warmup }) => {
+    const wasm = window.__wasm; const bus = window.__eventBus;
+    const { paraIdx: ppi, controlIdx: ci } = info;
+    const tick = (d) => {
+      const props = wasm.getPictureProperties(0, ppi, ci);
+      wasm.setPictureProperties(0, ppi, ci, {
+        horzOffset: props.horzOffset + d, vertOffset: props.vertOffset,
+      });
+      bus.emit('document-changed');
+    };
+    for (let i = 0; i < warmup; i++) tick(75);
+    const samples = [];
+    for (let i = 0; i < n; i++) {
+      const t0 = performance.now();
+      tick(i % 2 === 0 ? 75 : -75);
+      samples.push(performance.now() - t0);
+    }
+    samples.sort((a, b) => a - b);
+    const sum = samples.reduce((a, b) => a + b, 0);
+    return { mean: sum / samples.length, median: samples[Math.floor(samples.length / 2)], max: samples[samples.length - 1] };
+  }, { info, n, warmup });
+}
+
+const fmt = (m) => `${m.mean.toFixed(2)} ms (median ${m.median.toFixed(2)}, max ${m.max.toFixed(2)})`;
+
+async function main() {
+  if (!existsSync(JPEG_PATH)) throw new Error(`픽스처 없음: ${JPEG_PATH}`);
+  const jpeg = readFileSync(JPEG_PATH);
+  console.log(`[fixture] ${path.basename(JPEG_PATH)} ${(jpeg.length / 1048576).toFixed(2)} MB`);
+
+  const browser = await launchBrowser();
+  const page = await createPage(browser, 1280, 900);
+  const out = { fixtureBytes: jpeg.length, keys: KEYS, refreshes: REFRESHES };
+  try {
+    await loadApp(page);
+
+    console.log('\n=== A. 그림 없음 (베이스라인) ===');
+    await createNewDocument(page);
+    out.baselineTyping = await measureTyping(page, KEYS, WARMUP);
+    out.baselineRefresh = await measureRefresh(page, REFRESHES, WARMUP);
+    console.log(`  타이핑        ${fmt(out.baselineTyping)}`);
+    console.log(`  document-changed ${fmt(out.baselineRefresh)}`);
+
+    console.log('\n=== B. JPEG 1장 ===');
+    await createNewDocument(page);
+    const info = await insertJpeg(page, '/samples/images/tiger01.jpg', false);
+    if (!info) throw new Error('그림 삽입 실패');
+    console.log(`  삽입됨 para=${info.paraIdx} ci=${info.controlIdx}`);
+    const profiled = await withBridgeProfile(page, () => measureTyping(page, KEYS, WARMUP));
+    out.jpegTyping = profiled.result;
+    out.jpegBridgeProfile = profiled.prof;
+    console.log('  [브리지 내역 — 타이핑 20타 누적]');
+    for (const e of profiled.prof) {
+      console.log(`    ${e.name.padEnd(32)} ${e.ms.toFixed(1)} ms / ${e.n}회 = ${(e.ms / e.n).toFixed(2)} ms`);
+    }
+    out.jpegRefresh = await measureRefresh(page, REFRESHES, WARMUP);
+    out.jpegMove = await measurePictureMove(page, info, REFRESHES, WARMUP);
+    console.log(`  타이핑        ${fmt(out.jpegTyping)}`);
+    console.log(`  document-changed ${fmt(out.jpegRefresh)}`);
+    console.log(`  개체 이동 1틱  ${fmt(out.jpegMove)}`);
+
+    const rTyping = out.jpegTyping.mean / out.baselineTyping.mean;
+    const rRefresh = out.jpegRefresh.mean / out.baselineRefresh.mean;
+    out.ratioTyping = rTyping; out.ratioRefresh = rRefresh;
+    out.moveFps = 1000 / out.jpegMove.mean;
+
+    console.log('\n=== 종결 판정 (기준: ×2 이내) ===');
+    console.log(`  타이핑 배율            ×${rTyping.toFixed(2)}  ${rTyping <= 2 ? 'PASS' : 'FAIL'}`);
+    console.log(`  document-changed 배율  ×${rRefresh.toFixed(2)}  ${rRefresh <= 2 ? 'PASS' : 'FAIL'}`);
+    console.log(`  개체 이동              ${out.moveFps.toFixed(1)} fps (#2520 원측정 ~3fps)`);
+    out.verdict = (rTyping <= 2 && rRefresh <= 2) ? 'PASS' : 'FAIL';
+    console.log(`\n  종결 기준: ${out.verdict}`);
+
+    console.log('');
+    console.log('=== C. JPEG 1장 — 본문(flow) 배치 ===');
+    await createNewDocument(page);
+    const flowInfo = await insertJpeg(page, '/samples/images/tiger01.jpg', true);
+    if (!flowInfo) throw new Error('flow 그림 삽입 실패');
+    out.flowTyping = await measureTyping(page, KEYS, WARMUP);
+    out.ratioFlowTyping = out.flowTyping.mean / out.baselineTyping.mean;
+    console.log(`  타이핑        ${fmt(out.flowTyping)}  (×${out.ratioFlowTyping.toFixed(2)})`);
+
+    const dir = path.join(REPO_ROOT, 'output/issue-3315');
+    mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'track4-closing-measurement.json');
+    writeFileSync(file, JSON.stringify(out, null, 2), 'utf8');
+    console.log(`\n[written] ${file}`);
+  } finally {
+    await closePage(page);
+    await closeBrowser(browser);
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -35,6 +35,7 @@
     "e2e:issue-3815": "node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless --continuous-only",
     "e2e:issue-3820": "node e2e/issue-3820-hwp-hwpx-page-count.test.mjs --mode=headless",
     "e2e:issue-4741": "node e2e/local-font-partial-enumeration-issue4741.test.mjs",
+    "e2e:issue-3315-perf": "node e2e/probe-image-repaint-issue3315.mjs --mode=headless",
     "e2e:issue-3137-perf": "node e2e/probe-input-perf-issue3137.mjs --mode=headless",
     "e2e:issue-4031-cell-enter": "node e2e/cell-enter-pagination-issue4031.test.mjs --mode=headless",
     "e2e:issue-2809": "node e2e/issue-2809-split-alignment.test.mjs --mode=headless",


### PR DESCRIPTION
관련 이슈: #3315 (Track 4) · #5694 (측정으로 연 후속)

## 문제

#3315 Track 4(종결 측정)를 재려면 프로브가 필요한데, #2520 의 측정 레시피가 **이슈 본문의
콘솔 스니펫으로만** 남아 있었습니다. 트랙마다 손으로 다시 재면 조건(픽스처·워밍업·측정 구간)이
어긋나 트랙 간 비교가 성립하지 않습니다.

## 원인

이슈 본문의 공통 규약이 "각 PR 은 동일빌드 A/B 또는 교차빌드 실측을 검증 게이트에 포함한다"
인데, 그 실측을 수행하는 코드가 저장소에 없었습니다. Track 1~3 은 각자 다른 방식(네이티브
카운터·브라우저 관찰)으로 쟀고, 그래서 네이티브 15.2 ms 와 브라우저 실제 비용이 어긋나 있는
것을 Track 4 에서야 발견했습니다.

## 변경

`rhwp-studio/e2e/probe-image-repaint-issue3315.mjs` 를 추가합니다. **진단 프로브이며 CI
게이트가 아닙니다**(기존 `probe-input-perf-issue3137.mjs` 와 같은 분류).

측정 경로는 #2520 본문 그대로입니다.

- **타이핑** — textarea `input` 이벤트 실제 경로. 워밍업 5타 뒤 20타를 개별 계측(mean/median/max).
- **드래그** — mousemove 마다 도는 `document-changed` 동기 emit. Track 4 가 "드래그 경로 재측정
  포함" 을 요구한 그 지점입니다.
- **개체 이동 1틱** — 위에 `getPictureProperties`/`setPictureProperties` 를 더한 전체
  (`input-handler-picture.ts` 의 드래그 루프와 같은 순서).

같은 세션에서 **그림 없음 → JPEG 1장** 을 재고 배율로 판정합니다(종결 기준 ×2 이내). 부동/본문
(flow) 배치를 갈라 보고, **브리지 메서드별 누적 시간**도 냅니다 — 어느 WASM 호출이 비용을
먹는지 봐야 다음 트랙을 정할 수 있습니다. 그림은 `page.evaluate` 인자가 아니라 페이지 안에서
dev 서버로 fetch 합니다(4.5MB 를 인자로 넘기면 원소마다 JSON 직렬화가 일어나 측정 전에 수십
초를 태웁니다).

산출은 `output/issue-3315/track4-closing-measurement.json` 입니다.

배선은 `npm --prefix rhwp-studio run e2e:issue-3315-perf`, e2e MANIFEST 에 `진단`/`active` 로
등록했습니다.

## 검증

devel `b914bdf4b` 기준.

- 프로브 실행으로 Track 4 표를 얻었습니다 — 전문은 #3315 코멘트, 후속은 #5694.

  | 항목 | 그림 없음 | JPEG 4.55MB 1장 | 배율 |
  |---|---|---|---|
  | 타이핑 | 0.86 ms/키 | 338.74 ms/키 | ×392 |
  | `document-changed` | 0.49 ms | 335.29 ms | ×691 |
  | 개체 이동 1틱 | — | 336.42 ms (2.97 fps) | — |

- e2e 매니페스트 게이트 `python3 scripts/check_e2e_manifest.py` — **파일 104개 / 행 104개,
  이상 없음**(신규 파일·배선 등록 확인).
- 소스를 건드리지 않으므로 studio 단위 테스트·빌드·`cargo` 게이트에 영향이 없습니다.

## 범위 외

- **성능 수정 자체** — 이 PR 은 재는 도구만 더합니다. 측정으로 드러난 렌더 경로의 base64 인라인
  잔존은 #5694 로 분리했습니다.
- **CI 편입** — 시간 수치는 머신 편차가 커 게이트로 쓰지 않습니다(`probe-input-perf-issue3137`
  과 같은 판단). 필요해지면 배율만 느슨한 상한으로 거는 편이 맞습니다.
- **CanvasKit 백엔드** — 기본 백엔드가 아니라 재지 않습니다(#2520 과 동일).
