### PR TITLE
feat(studio): 보기 > 도구 상자(기본/서식) 표시 상태 저장·복원과 켜짐/꺼짐 표시 (#5738)

### DIFF
--- a/mydocs/working/task_5738_studio_toolbox_visibility.md
+++ b/mydocs/working/task_5738_studio_toolbox_visibility.md
@@ -1,0 +1,57 @@
+# #5738 rhwp-studio 도구 상자(기본/서식) 표시 상태 저장·복원
+
+## 목표
+
+`보기 > 도구 상자 > 기본/서식` 의 보이기/숨기기를 사용자 설정으로 저장해 다음 실행에서
+복원하고, 메뉴에서 현재 켜짐/꺼짐을 알 수 있게 한다. 숨김 상태로 재시작할 때 도구 모음이
+잠깐 보였다 사라지는 깜빡임이 없어야 한다.
+
+## 문제
+
+- 두 커맨드가 인라인 `style.display` 와 커맨드 모듈의 지역 변수(`visible`)에만 상태를 두어
+  창을 닫으면 사라졌다. 재시작하면 항상 둘 다 보임이었다.
+- `index.html` 의 두 항목이 `md-item disabled` 로 굳어 있어 비활성으로 보였고, 현재 상태를
+  나타내는 표시가 없었다.
+
+## 구현
+
+1. `user-settings.ts` 의 `view` 절에 `toolbarBasic` / `toolbarFormat` 을 추가한다. 기본값은
+   둘 다 `true`(보임)이고, 저장값이 없거나 boolean 이 아니면 기존 `normalizeBoolean` 경로로
+   기본값을 채운다. 저장은 기존 단일 키 `rhwp-settings` 를 그대로 쓴다.
+2. `src/view/toolbox-visibility.ts` 를 새로 두고 "설정값 → 루트 표시 상태 + 메뉴 체크 표시"
+   한 방향만 담당하게 한다. `document` 를 인자로 받아 전역 없이 검증할 수 있다.
+3. 숨김을 인라인 `style.display` 가 아니라 루트 data 속성
+   (`data-toolbox-basic` / `data-toolbox-format` = `shown` | `hidden`)으로 표현하고,
+   `src/style.css` 에 **숨김만** 하는 규칙을 둔다. 보임일 때 인라인 값을 남기지 않으므로
+   스킨·뷰어 모드 CSS(`.rhwp-chrome-no-toolbar` 등)와 충돌하지 않는다.
+4. 같은 속성을 `public/theme-init.js`(번들보다 먼저 동기 실행되는 기존 테마 FOUC 방지
+   스크립트)가 저장값을 읽어 첫 페인트 전에 찍는다. 이것이 깜빡임을 없애는 자리다.
+5. `view:toolbox-basic` / `view:toolbox-format` 은 설정을 토글하고 `syncToolboxMenu()` 로
+   같은 경로를 태운다. `main.ts` 는 시작 시 같은 함수로 복원한다.
+6. 메뉴 항목의 `disabled` 를 걷어내고 `role="menuitemcheckbox"` 로 두어, 켜짐이면
+   `active` 클래스 + `aria-checked="true"` 로 상태를 표시한다(앞쪽 체크 글리프는 두지 않는다).
+
+## 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `cargo fmt --all -- --check` | 통과 (Rust 변경 없음) |
+| `npx tsc --noEmit -p tsconfig.json` (rhwp-studio) | 통과 |
+| `npm test` (rhwp-studio) | 1039개 중 1038 통과 · 0 실패 · 1 skip |
+| `npm run e2e:toolbox-visibility` (rhwp-studio) | 10개 단언 전부 PASS |
+
+헤드리스 Chrome(dev 서버 `:7700`) e2e 실측:
+
+- 첫 방문(저장값 없음): `data-toolbox-basic="shown"`, `#icon-toolbar` / `#style-bar`
+  `display: flex` — 기본값 보임.
+- 숨기기로 저장 후 reload: `DOMContentLoaded` 부터 60프레임을 샘플링해
+  **도구 모음이 보인 프레임 0**. 첫 샘플부터 `display: none`.
+- 메뉴 상태: 숨김이면 `active=false` · `aria-checked="false"`, `disabled` 아님.
+- 다시 보이기로 토글: `localStorage.rhwp-settings.view` 가
+  `{ toolbarBasic: true, toolbarFormat: false }` 로 저장되고 메뉴 체크 상태가 따라간다.
+
+e2e 는 `rhwp-studio/e2e/toolbox-visibility.test.mjs`(TC1 기본값 · TC2 메뉴 체크 표시 ·
+TC3 토글 저장 · TC4 리로드 복원과 깜빡임 0프레임)다. 단위 계약 테스트는
+`rhwp-studio/tests/toolbox-visibility.test.ts` 3건(설정 → 루트 상태·메뉴 체크
+동기화, 메뉴 항목이 체크형 활성 항목, 숨김 규칙과 첫 페인트 초기화가 같은 data 속성 사용)과
+`rhwp-studio/tests/user-settings.test.ts` 2건(저장·기본값, 새 모듈 인스턴스에서 복원)이다.

--- a/rhwp-studio/e2e/toolbox-visibility.test.mjs
+++ b/rhwp-studio/e2e/toolbox-visibility.test.mjs
@@ -1,0 +1,101 @@
+/**
+ * E2E 테스트 — 보기 > 도구 상자(기본/서식) 표시 상태 저장·복원 (#5738)
+ *
+ * 검증 항목:
+ * 1. 저장값이 없으면 기본값은 보임
+ * 2. 숨기기로 저장한 뒤 리로드하면 숨김이 복원되고, 첫 페인트부터 숨겨져 깜빡임이 없다
+ * 3. 메뉴 항목이 활성이고 현재 켜짐/꺼짐을 active + aria-checked 로 표시한다
+ * 4. 토글이 rhwp-settings 의 view.toolbarBasic / view.toolbarFormat 에 저장된다
+ */
+
+import { runTest, loadApp, assert } from './helpers.mjs';
+
+process.env.VITE_URL = process.env.VITE_URL || 'http://localhost:7700';
+
+const readBars = () => ({
+  rootBasic: document.documentElement.dataset.toolboxBasic,
+  rootFormat: document.documentElement.dataset.toolboxFormat,
+  icon: getComputedStyle(document.getElementById('icon-toolbar')).display,
+  style: getComputedStyle(document.getElementById('style-bar')).display,
+});
+
+const readMenu = () => ['view:toolbox-basic', 'view:toolbox-format'].map(cmd => {
+  const el = document.querySelector(`[data-cmd="${cmd}"]`);
+  return {
+    cmd,
+    active: el?.classList.contains('active'),
+    checked: el?.getAttribute('aria-checked'),
+    disabled: el?.classList.contains('disabled'),
+  };
+});
+
+runTest('도구 상자 표시 상태 저장·복원', async ({ page }) => {
+  // ── TC1: 저장값 없음 → 기본값 보임 ─────────────────────────
+  await page.evaluate(() => localStorage.removeItem('rhwp-settings'));
+  await loadApp(page);
+  const first = await page.evaluate(readBars);
+  assert(first.rootBasic === 'shown' && first.rootFormat === 'shown',
+    `TC1: 저장값이 없으면 기본값은 보임 (${first.rootBasic}/${first.rootFormat})`);
+  assert(first.icon !== 'none' && first.style !== 'none',
+    `TC1: 두 도구 모음이 그려짐 (${first.icon}/${first.style})`);
+
+  // ── TC2: 메뉴 항목은 활성이고 켜짐을 표시한다 ──────────────
+  const menuShown = await page.evaluate(readMenu);
+  assert(menuShown.every(m => m.disabled === false),
+    'TC2: 두 메뉴 항목이 비활성이 아님');
+  assert(menuShown.every(m => m.active === true && m.checked === 'true'),
+    `TC2: 보임 상태가 체크로 표시됨 (${JSON.stringify(menuShown)})`);
+
+  // ── TC3: 토글이 설정에 저장된다 ────────────────────────────
+  const toggled = await page.evaluate(async () => {
+    const a = window.rhwpStudio?.automation;
+    await a.execute('view:toolbox-basic');
+    await a.execute('view:toolbox-format');
+    return {
+      stored: JSON.parse(localStorage.getItem('rhwp-settings')).view,
+      bars: {
+        rootBasic: document.documentElement.dataset.toolboxBasic,
+        icon: getComputedStyle(document.getElementById('icon-toolbar')).display,
+        style: getComputedStyle(document.getElementById('style-bar')).display,
+      },
+    };
+  });
+  assert(toggled.stored.toolbarBasic === false && toggled.stored.toolbarFormat === false,
+    `TC3: 숨김이 rhwp-settings 에 저장됨 (${JSON.stringify(toggled.stored)})`);
+  assert(toggled.bars.icon === 'none' && toggled.bars.style === 'none',
+    `TC3: 토글 즉시 두 도구 모음이 숨겨짐 (${JSON.stringify(toggled.bars)})`);
+
+  // ── TC4: 리로드 복원 + 첫 페인트부터 숨김(깜빡임 없음) ─────
+  await page.evaluateOnNewDocument(() => {
+    window.__toolboxSamples = [];
+    const sample = () => {
+      const icon = document.getElementById('icon-toolbar');
+      const style = document.getElementById('style-bar');
+      if (icon && style) {
+        window.__toolboxSamples.push({
+          icon: getComputedStyle(icon).display,
+          style: getComputedStyle(style).display,
+        });
+      }
+      if (window.__toolboxSamples.length < 60) requestAnimationFrame(sample);
+    };
+    document.addEventListener('DOMContentLoaded', sample);
+  });
+  await loadApp(page);
+  const restored = await page.evaluate(readBars);
+  assert(restored.rootBasic === 'hidden' && restored.rootFormat === 'hidden',
+    `TC4: 재시작 후 숨김이 복원됨 (${restored.rootBasic}/${restored.rootFormat})`);
+
+  const samples = await page.evaluate(() => window.__toolboxSamples ?? []);
+  const flashes = samples.filter(s => s.icon !== 'none' || s.style !== 'none');
+  assert(samples.length > 0, `TC4: 프레임 샘플 확보 (${samples.length}개)`);
+  assert(flashes.length === 0,
+    `TC4: 숨긴 도구 모음이 보인 프레임 없음 (${flashes.length}/${samples.length})`);
+
+  const menuHidden = await page.evaluate(readMenu);
+  assert(menuHidden.every(m => m.active === false && m.checked === 'false'),
+    `TC4: 숨김 상태가 체크 해제로 표시됨 (${JSON.stringify(menuHidden)})`);
+
+  // 다음 실행에 영향을 주지 않도록 되돌린다.
+  await page.evaluate(() => localStorage.removeItem('rhwp-settings'));
+});

--- a/rhwp-studio/index.html
+++ b/rhwp-studio/index.html
@@ -115,8 +115,8 @@
           <div class="md-sub">
             <span class="md-label">도구 상자</span><span class="md-arrow">▶</span>
             <div class="md-sub-panel">
-              <div class="md-item disabled" data-cmd="view:toolbox-basic"><span class="md-label">기본</span></div>
-              <div class="md-item disabled" data-cmd="view:toolbox-format"><span class="md-label">서식</span></div>
+              <div class="md-item" role="menuitemcheckbox" aria-checked="true" data-cmd="view:toolbox-basic"><span class="md-label">기본</span></div>
+              <div class="md-item" role="menuitemcheckbox" aria-checked="true" data-cmd="view:toolbox-format"><span class="md-label">서식</span></div>
             </div>
           </div>
         </div>

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -22,6 +22,7 @@
     "e2e:bridge-perf": "node e2e/bridge-perf.test.mjs --mode=headless",
     "gate:bridge:quick": "node ../scripts/gate_bridge.mjs --no-e2e --no-hwpctrl-gate",
     "e2e": "node e2e/text-flow.test.mjs",
+    "e2e:toolbox-visibility": "node e2e/toolbox-visibility.test.mjs --mode=headless",
     "e2e:form-edit-escape": "node e2e/form-edit-escape-cancel.test.mjs --mode=headless",
     "e2e:unsaved-guard": "node e2e/unsaved-changes-guard.test.mjs",
     "e2e:undo": "node e2e/undo-contracts.test.mjs",

--- a/rhwp-studio/public/theme-init.js
+++ b/rhwp-studio/public/theme-init.js
@@ -1,4 +1,4 @@
-// 다크테마 FOUC(Flash of Unstyled Content) 방지 — 페이지 렌더 전에 테마를 즉시 적용한다.
+// 다크테마·도구 상자 FOUC(Flash of Unstyled Content) 방지 — 페이지 렌더 전에 즉시 적용한다.
 //
 // 브라우저 확장 CSP(`script-src 'self' 'wasm-unsafe-eval'`)는 인라인 스크립트를 금지하므로,
 // 이 로직은 인라인이 아니라 외부 파일로 두고 index.html <head> 최상단에서
@@ -30,4 +30,21 @@
   if (colorSchemeMeta) colorSchemeMeta.setAttribute('content', scheme);
   const themeColorMeta = document.querySelector('meta[name="theme-color"]');
   if (themeColorMeta) themeColorMeta.setAttribute('content', effective === 'dark' ? '#2b3037' : '#f5f5f5');
+
+  // 도구 상자(기본/서식) 숨김도 같은 시점에 찍는다 — 숨기기로 저장해 두면 첫 페인트부터
+  // 숨긴 상태로 그려져 도구 모음이 잠깐 보였다 사라지지 않는다.
+  // 속성·기본값은 src/view/toolbox-visibility.ts, 규칙은 src/style.css 와 함께 갱신한다.
+  let toolbarBasic = true;
+  let toolbarFormat = true;
+  try {
+    const settings = JSON.parse(localStorage.getItem('rhwp-settings') || '{}');
+    const view = (settings && settings.view) || {};
+    if (view.toolbarBasic === false) toolbarBasic = false;
+    if (view.toolbarFormat === false) toolbarFormat = false;
+  } catch {
+    toolbarBasic = true;
+    toolbarFormat = true;
+  }
+  root.dataset.toolboxBasic = toolbarBasic ? 'shown' : 'hidden';
+  root.dataset.toolboxFormat = toolbarFormat ? 'shown' : 'hidden';
 })();

--- a/rhwp-studio/src/command/commands/view.ts
+++ b/rhwp-studio/src/command/commands/view.ts
@@ -11,6 +11,7 @@ import {
 } from '../../view/grid-settings';
 import { HWPUNIT_PER_MM } from '../../core/hwp-constants';
 import { calculateFitPageZoom, calculateFitWidthZoom } from '../../view/zoom-fit';
+import { applyToolboxVisibility } from '../../view/toolbox-visibility';
 
 const PX_TO_MM = 25.4 / 96;
 
@@ -77,6 +78,15 @@ export function syncClipMenu(enabled: boolean): void {
   document.querySelectorAll('[data-cmd="view:toggle-clip"]').forEach(el => {
     el.classList.toggle('active', !enabled);
   });
+}
+
+/**
+ * 저장된 도구 상자(기본/서식) 보이기·숨기기 설정을 도구 모음과 메뉴 체크 표시에 반영한다.
+ * 시작 시 설정 복원과 토글 직후 양쪽이 같은 경로를 쓴다.
+ */
+export function syncToolboxMenu(): void {
+  const view = userSettings.getViewSettings();
+  applyToolboxVisibility(document, { basic: view.toolbarBasic, format: view.toolbarFormat });
 }
 
 function refreshCaretAfterViewChange(services: Parameters<CommandDef['execute']>[0]): void {
@@ -329,38 +339,20 @@ export const viewCommands: CommandDef[] = [
       ).show();
     },
   },
-  (() => {
-    let visible: boolean | null = null;
-    return {
-      id: 'view:toolbox-basic',
-      label: '기본',
-      execute() {
-        const el = document.getElementById('icon-toolbar');
-        if (!el) return;
-        if (visible === null) visible = getComputedStyle(el).display !== 'none';
-        visible = !visible;
-        el.style.display = visible ? '' : 'none';
-        document.querySelectorAll('[data-cmd="view:toolbox-basic"]').forEach(btn => {
-          btn.classList.toggle('active', visible!);
-        });
-      },
-    } satisfies CommandDef;
-  })(),
-  (() => {
-    let visible: boolean | null = null;
-    return {
-      id: 'view:toolbox-format',
-      label: '서식',
-      execute() {
-        const el = document.getElementById('style-bar');
-        if (!el) return;
-        if (visible === null) visible = getComputedStyle(el).display !== 'none';
-        visible = !visible;
-        el.style.display = visible ? '' : 'none';
-        document.querySelectorAll('[data-cmd="view:toolbox-format"]').forEach(btn => {
-          btn.classList.toggle('active', visible!);
-        });
-      },
-    } satisfies CommandDef;
-  })(),
+  {
+    id: 'view:toolbox-basic',
+    label: '기본',
+    execute() {
+      userSettings.setToolbarBasic(!userSettings.getViewSettings().toolbarBasic);
+      syncToolboxMenu();
+    },
+  } satisfies CommandDef,
+  {
+    id: 'view:toolbox-format',
+    label: '서식',
+    execute() {
+      userSettings.setToolbarFormat(!userSettings.getViewSettings().toolbarFormat);
+      syncToolboxMenu();
+    },
+  } satisfies CommandDef,
 ];

--- a/rhwp-studio/src/core/user-settings.ts
+++ b/rhwp-studio/src/core/user-settings.ts
@@ -62,6 +62,10 @@ export interface ViewSettings {
   showControlCodes: boolean;
   /** 짤림보기(잘림 보기) 켜짐 여부. true = 편집용지 경계 밖 오버플로 내용을 보임(잘림 미적용). */
   clipView: boolean;
+  /** 기본 도구 상자(아이콘 도구 모음) 표시 여부 */
+  toolbarBasic: boolean;
+  /** 서식 도구 상자(서식 도구 모음) 표시 여부 */
+  toolbarFormat: boolean;
 }
 
 /** 복구용 자동저장 설정 */
@@ -152,6 +156,8 @@ function defaultSettings(): AppSettings {
       showParagraphMarks: false,
       showControlCodes: false,
       clipView: true,
+      toolbarBasic: true,
+      toolbarFormat: true,
     },
     autosave: {
       recoveryEnabled: true,
@@ -251,6 +257,14 @@ class UserSettingsService {
           clipView: normalizeBoolean(
             view.clipView,
             defaults.view.clipView,
+          ),
+          toolbarBasic: normalizeBoolean(
+            view.toolbarBasic,
+            defaults.view.toolbarBasic,
+          ),
+          toolbarFormat: normalizeBoolean(
+            view.toolbarFormat,
+            defaults.view.toolbarFormat,
           ),
         },
         autosave: {
@@ -375,6 +389,18 @@ class UserSettingsService {
   /** 짤림보기(잘림 보기) 켜짐 설정. true = 오버플로 내용 표시(잘림 미적용). */
   setClipView(value: boolean): void {
     this.data.view.clipView = value;
+    this.save();
+  }
+
+  /** 기본 도구 상자 표시 설정 */
+  setToolbarBasic(value: boolean): void {
+    this.data.view.toolbarBasic = value;
+    this.save();
+  }
+
+  /** 서식 도구 상자 표시 설정 */
+  setToolbarFormat(value: boolean): void {
+    this.data.view.toolbarFormat = value;
     this.save();
   }
 

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -20,7 +20,7 @@ import type { EditorContext, CommandServices, EditorEditMode } from '@/command/t
 import { defaultShortcuts, matchShortcut } from '@/command/shortcut-map';
 import { confirmSaveBeforeReplacingDocument, fileCommands } from '@/command/commands/file';
 import { editCommands } from '@/command/commands/edit';
-import { syncClipMenu, syncTextMarkMenu, viewCommands } from '@/command/commands/view';
+import { syncClipMenu, syncTextMarkMenu, syncToolboxMenu, viewCommands } from '@/command/commands/view';
 import { formatCommands } from '@/command/commands/format';
 import { insertCommands } from '@/command/commands/insert';
 import { tableCommands } from '@/command/commands/table';
@@ -96,6 +96,9 @@ initThemeSync((effective, mode) => {
   eventBus.emit('theme-changed', { mode, effective });
   eventBus.emit('command-state-changed');
 });
+// 저장된 도구 상자(기본/서식) 보이기·숨기기 복원 — 문서 로드와 무관하고, WASM 초기화보다
+// 먼저 반영해야 숨긴 도구 모음이 잠깐 보였다 사라지지 않는다(모듈 스크립트라 DOM 은 이미 파싱됨).
+syncToolboxMenu();
 
 /**
  * 호스트 저장 완료 통지 (#2660).

--- a/rhwp-studio/src/style.css
+++ b/rhwp-studio/src/style.css
@@ -34,3 +34,9 @@
 .rhwp-chrome-no-toolbar #icon-toolbar,
 .rhwp-chrome-no-toolbar #style-bar { display: none; }
 .rhwp-chrome-no-status #status-bar { display: none; }
+
+/* ── 도구 상자 보이기/숨기기 (보기 > 도구 상자) ──────────────
+   숨김만 표현한다. 값은 저장된 설정에서 오고, public/theme-init.js 가 번들보다 먼저
+   찍어 첫 페인트부터 숨긴 상태로 그린다(깜빡임 방지). 동기화는 view/toolbox-visibility.ts. */
+:root[data-toolbox-basic="hidden"] #icon-toolbar { display: none; }
+:root[data-toolbox-format="hidden"] #style-bar { display: none; }

--- a/rhwp-studio/src/view/toolbox-visibility.ts
+++ b/rhwp-studio/src/view/toolbox-visibility.ts
@@ -1,0 +1,69 @@
+/**
+ * 도구 상자(보기 > 도구 상자 > 기본/서식) 표시 상태를 DOM 에 반영한다.
+ *
+ * 저장·복원은 `userSettings` 의 `view.toolbarBasic` / `view.toolbarFormat` 가 맡고,
+ * 이 모듈은 "설정값 → 루트 표시 상태 + 메뉴 체크 표시" 한 방향만 책임진다.
+ *
+ * 숨김을 인라인 style 이 아니라 루트 data 속성으로 표현하는 이유는 첫 페인트다 —
+ * 같은 속성을 `public/theme-init.js` 가 번들보다 먼저 찍어 숨긴 도구 모음이
+ * 잠깐 보였다 사라지는 깜빡임을 없앤다. 규칙은 `src/style.css` 에 있다.
+ * DOM 은 인자로 받아 전역 `document` 없이 검증할 수 있게 둔다.
+ */
+
+/** 도구 상자 표시 상태 (기본/서식) */
+export interface ToolboxVisibility {
+  basic: boolean;
+  format: boolean;
+}
+
+/** 도구 상자 항목: 설정 키 ↔ 메뉴 커맨드 ↔ 루트 data 속성 ↔ 도구 모음 요소 id */
+export const TOOLBOX_TARGETS = [
+  {
+    key: 'basic',
+    cmd: 'view:toolbox-basic',
+    datasetKey: 'toolboxBasic',
+    attribute: 'data-toolbox-basic',
+    elementId: 'icon-toolbar',
+  },
+  {
+    key: 'format',
+    cmd: 'view:toolbox-format',
+    datasetKey: 'toolboxFormat',
+    attribute: 'data-toolbox-format',
+    elementId: 'style-bar',
+  },
+] as const satisfies ReadonlyArray<{
+  key: keyof ToolboxVisibility;
+  cmd: string;
+  datasetKey: string;
+  attribute: string;
+  elementId: string;
+}>;
+
+interface ToolboxMenuItem {
+  classList: { toggle(token: string, force: boolean): void };
+  setAttribute(name: string, value: string): void;
+}
+
+/** 이 모듈이 쓰는 `document` 표면만 좁혀 받는다. */
+export interface ToolboxDom {
+  documentElement: { dataset: Record<string, string | undefined> };
+  querySelectorAll(selectors: string): Iterable<ToolboxMenuItem>;
+}
+
+/** 루트 data 속성 값 — CSS 는 'hidden' 일 때만 숨긴다. */
+export function toolboxState(visible: boolean): 'shown' | 'hidden' {
+  return visible ? 'shown' : 'hidden';
+}
+
+/** 도구 모음 표시 여부와 메뉴 체크 상태(active 클래스 + aria-checked)를 함께 맞춘다. */
+export function applyToolboxVisibility(dom: ToolboxDom, visibility: ToolboxVisibility): void {
+  for (const target of TOOLBOX_TARGETS) {
+    const visible = visibility[target.key];
+    dom.documentElement.dataset[target.datasetKey] = toolboxState(visible);
+    for (const item of dom.querySelectorAll(`[data-cmd="${target.cmd}"]`)) {
+      item.classList.toggle('active', visible);
+      item.setAttribute('aria-checked', String(visible));
+    }
+  }
+}

--- a/rhwp-studio/tests/toolbox-visibility.test.ts
+++ b/rhwp-studio/tests/toolbox-visibility.test.ts
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  TOOLBOX_TARGETS,
+  applyToolboxVisibility,
+  type ToolboxDom,
+} from '../src/view/toolbox-visibility.ts';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+interface FakeItem {
+  cmd: string;
+  active: boolean | null;
+  ariaChecked: string | null;
+  classList: { toggle(token: string, force: boolean): void };
+  setAttribute(name: string, value: string): void;
+}
+
+function fakeItem(cmd: string): FakeItem {
+  const item: FakeItem = {
+    cmd,
+    active: null,
+    ariaChecked: null,
+    classList: {
+      toggle(token: string, force: boolean) {
+        if (token === 'active') item.active = force;
+      },
+    },
+    setAttribute(name: string, value: string) {
+      if (name === 'aria-checked') item.ariaChecked = value;
+    },
+  };
+  return item;
+}
+
+function fakeDom() {
+  const dataset: Record<string, string | undefined> = {};
+  const items = TOOLBOX_TARGETS.map(target => fakeItem(target.cmd));
+  const dom: ToolboxDom = {
+    documentElement: { dataset },
+    querySelectorAll: (selector) => items.filter(item => selector === `[data-cmd="${item.cmd}"]`),
+  };
+  return { dom, dataset, items };
+}
+
+test('도구 상자 설정은 루트 표시 상태와 메뉴 체크 상태를 함께 맞춘다', () => {
+  const { dom, dataset, items } = fakeDom();
+
+  applyToolboxVisibility(dom, { basic: false, format: true });
+  assert.equal(dataset.toolboxBasic, 'hidden');
+  assert.equal(dataset.toolboxFormat, 'shown');
+  assert.deepEqual(
+    items.map(i => [i.cmd, i.active, i.ariaChecked]),
+    [
+      ['view:toolbox-basic', false, 'false'],
+      ['view:toolbox-format', true, 'true'],
+    ],
+  );
+
+  applyToolboxVisibility(dom, { basic: true, format: false });
+  assert.equal(dataset.toolboxBasic, 'shown');
+  assert.equal(dataset.toolboxFormat, 'hidden');
+  assert.deepEqual(
+    items.map(i => [i.cmd, i.active, i.ariaChecked]),
+    [
+      ['view:toolbox-basic', true, 'true'],
+      ['view:toolbox-format', false, 'false'],
+    ],
+  );
+});
+
+test('도구 상자 메뉴 항목은 체크 상태를 가진 활성 항목이다', () => {
+  const html = source('index.html');
+  for (const target of TOOLBOX_TARGETS) {
+    const line = html.split('\n').find(l => l.includes(`data-cmd="${target.cmd}"`));
+    assert.ok(line, `메뉴 항목이 있어야 한다: ${target.cmd}`);
+    assert.match(line!, /role="menuitemcheckbox"/, `체크형 항목이어야 한다: ${target.cmd}`);
+    assert.doesNotMatch(line!, /md-item disabled/, `비활성으로 두면 안 된다: ${target.cmd}`);
+  }
+});
+
+test('숨김 규칙과 첫 페인트 초기화는 같은 data 속성을 쓴다', () => {
+  const css = source('src/style.css');
+  const init = source('public/theme-init.js');
+  for (const target of TOOLBOX_TARGETS) {
+    assert.match(
+      css,
+      new RegExp(`\\[${target.attribute}="hidden"\\]\\s*#${target.elementId}\\s*\\{[^}]*display:\\s*none`),
+      `숨김 규칙이 있어야 한다: ${target.attribute}`,
+    );
+    assert.match(
+      init,
+      new RegExp(`root\\.dataset\\.${target.datasetKey}\\s*=`),
+      `첫 페인트 전 초기화가 있어야 한다: ${target.datasetKey}`,
+    );
+  }
+  // 저장 키(user-settings 의 view.toolbar*)를 theme-init 이 그대로 읽어야 복원이 맞다.
+  assert.match(init, /view\.toolbarBasic === false/);
+  assert.match(init, /view\.toolbarFormat === false/);
+});

--- a/rhwp-studio/tests/user-settings.test.ts
+++ b/rhwp-studio/tests/user-settings.test.ts
@@ -175,6 +175,91 @@ test('짤림보기(clipView) 설정은 rhwp-settings에 저장되고 기본값�
   }
 });
 
+test('도구 상자(기본/서식) 표시 설정은 rhwp-settings에 저장되고 기본값은 보임이다', () => {
+  const originalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+  const store = new Map<string, string>();
+  const mockStorage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  } as Storage;
+
+  (globalThis as { localStorage?: Storage }).localStorage = mockStorage;
+  try {
+    assert.equal(userSettings.getViewSettings().toolbarBasic, true);
+    assert.equal(userSettings.getViewSettings().toolbarFormat, true);
+
+    userSettings.setToolbarBasic(false);
+    userSettings.setToolbarFormat(false);
+    let stored = JSON.parse(store.get('rhwp-settings') ?? '{}');
+    assert.equal(stored.view.toolbarBasic, false);
+    assert.equal(stored.view.toolbarFormat, false);
+
+    userSettings.setToolbarFormat(true);
+    stored = JSON.parse(store.get('rhwp-settings') ?? '{}');
+    assert.equal(stored.view.toolbarBasic, false);
+    assert.equal(stored.view.toolbarFormat, true);
+  } finally {
+    userSettings.setToolbarBasic(true);
+    userSettings.setToolbarFormat(true);
+    (globalThis as { localStorage?: Storage }).localStorage = originalStorage;
+  }
+});
+
+test('저장된 도구 상자 설정은 다시 시작해도 복원된다', async () => {
+  const originalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+  const store = new Map<string, string>([
+    ['rhwp-settings', JSON.stringify({ view: { toolbarBasic: false } })],
+  ]);
+  const mockStorage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  } as Storage;
+
+  (globalThis as { localStorage?: Storage }).localStorage = mockStorage;
+  try {
+    // 새 모듈 인스턴스 = 새 실행. 생성자의 load() 가 저장값을 읽는 경로를 그대로 태운다.
+    const fresh = await import('../src/core/user-settings.ts?restart=toolbox');
+    const view = fresh.userSettings.getViewSettings();
+    assert.equal(view.toolbarBasic, false);
+    // 저장값에 없는 항목은 기본값(보임)으로 채운다.
+    assert.equal(view.toolbarFormat, true);
+  } finally {
+    (globalThis as { localStorage?: Storage }).localStorage = originalStorage;
+  }
+});
+
 test('복구용 자동저장 설정은 rhwp-settings에 저장된다', () => {
   const originalStorage = (globalThis as { localStorage?: Storage }).localStorage;
   const store = new Map<string, string>();


### PR DESCRIPTION
## 변경 요약

rhwp-studio 의 `보기 > 도구 상자 > 기본/서식` 이 두 가지로 막혀 있었습니다.

1. **저장되지 않음** — 토글이 인라인 `style.display` 와 커맨드 모듈의 지역 변수에만 남아,
   창을 닫았다 다시 열면 항상 둘 다 보임으로 돌아갔습니다.
2. **켜짐/꺼짐을 알 수 없음** — 두 항목이 `index.html` 에서 `md-item disabled` 로 굳어 있어
   비활성으로 보였고, 현재 상태 표시가 없었습니다.

이 PR 은 표시 상태를 사용자 설정으로 저장·복원하고, 메뉴에 현재 상태를 표시합니다.

- `user-settings` 의 `view` 절에 `toolbarBasic` / `toolbarFormat` 추가. 기본값은 둘 다 **보임**이고,
  저장값이 없거나 boolean 이 아니면 기존 `normalizeBoolean` 경로로 기본값을 채웁니다.
  저장은 기존 단일 키 `rhwp-settings` 를 그대로 씁니다.
- 새 모듈 `src/view/toolbox-visibility.ts` 가 "설정값 → 루트 표시 상태 + 메뉴 체크 표시"
  한 방향만 담당합니다. `document` 를 인자로 받아 전역 없이 단위 검증할 수 있습니다.
- 숨김을 인라인 `display` 가 아니라 루트 data 속성(`data-toolbox-basic` / `data-toolbox-format`)
  으로 표현하고, `src/style.css` 에 **숨김만** 하는 규칙을 둡니다. 보임일 때 인라인 값을 남기지
  않으므로 스킨·뷰어 모드 CSS(`.rhwp-chrome-no-toolbar` 등)와 충돌하지 않습니다.
- 같은 속성을 `public/theme-init.js`(번들보다 먼저 동기 실행되는 기존 테마 FOUC 방지 스크립트)가
  저장값을 읽어 **첫 페인트 전에** 찍습니다. 숨김으로 저장한 뒤 리로드할 때 도구 모음이 잠깐
  보였다 사라지는 깜빡임을 없애는 자리입니다.
- 메뉴 항목의 `disabled` 를 걷고 `role="menuitemcheckbox"` 로 두어, 켜짐이면 `active` 클래스 +
  `aria-checked="true"` 로 상태를 표시합니다(항목 앞 체크 글리프는 두지 않았습니다).

동작이 바뀌는 것은 이 두 항목뿐입니다. 다른 보기 설정(조판/문단 부호, 짤림보기, 격자)의 기존
경로와 Rust 쪽은 건드리지 않았습니다.

## 관련 이슈

closes #5738

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (push·PR 직전 실행. Rust 변경 없음)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, Cargo generated test target을 포함하지 않음 (Rust 테스트 추가 없음 — 해당 없음)
- [x] `src/**`의 `#[cfg(test)]` 변경 없음 (`rust-unit-test-tiers.mjs` 해당 없음)
- [x] `npm --prefix rhwp-studio test` — 1039개 중 **1038 통과 · 0 실패 · 1 skip**
- [x] `(cd rhwp-studio && npx tsc --noEmit)` 통과
- [x] `cargo clippy -- -D warnings` — Rust 변경 없음(해당 없음)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 렌더 경로 변경 없음(해당 없음)
- [ ] 웹(WASM) 렌더링 확인 — WASM 경계 변경 없음(해당 없음)
- [x] rhwp-studio UI 변경: e2e 시나리오 추가 — `rhwp-studio/e2e/toolbox-visibility.test.mjs`
      (`npm --prefix rhwp-studio run e2e:toolbox-visibility`)
- [ ] 작업 증빙 `rhwp replay --capsule` — 문서를 편집·생성하지 않는 UI 변경(해당 없음)
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 없음(해당 없음)

변경 범위는 `local_validation.md` §4.3 의 **rhwp-studio만 변경** 행(TypeScript 검사 · npm test ·
실제 browser 동작)에 해당하며, 세 가지를 모두 실행했습니다.

### 실행한 명령과 결과

~~~text
cargo fmt --all -- --check                        # 통과
(cd rhwp-studio && npx tsc --noEmit)              # 통과
npm --prefix rhwp-studio test                     # tests 1039 / pass 1038 / fail 0 / skip 1
VITE_URL=http://localhost:7700 \
  npm --prefix rhwp-studio run e2e:toolbox-visibility   # 단언 10건 전부 PASS
git diff --check                                  # 통과
~~~

e2e(헤드리스 Chrome) 결과:

~~~text
PASS: TC1: 저장값이 없으면 기본값은 보임 (shown/shown)
PASS: TC1: 두 도구 모음이 그려짐 (flex/flex)
PASS: TC2: 두 메뉴 항목이 비활성이 아님
PASS: TC2: 보임 상태가 체크로 표시됨
PASS: TC3: 숨김이 rhwp-settings 에 저장됨 ({"toolbarBasic":false,"toolbarFormat":false ...})
PASS: TC3: 토글 즉시 두 도구 모음이 숨겨짐
PASS: TC4: 재시작 후 숨김이 복원됨 (hidden/hidden)
PASS: TC4: 프레임 샘플 확보 (33개)
PASS: TC4: 숨긴 도구 모음이 보인 프레임 없음 (0/33)
PASS: TC4: 숨김 상태가 체크 해제로 표시됨
~~~

새 단위 계약 테스트

- `rhwp-studio/tests/toolbox-visibility.test.ts` — 설정 → 루트 상태·메뉴 체크 동기화,
  메뉴 항목이 체크형 활성 항목인지, 숨김 CSS 규칙과 첫 페인트 초기화가 **같은 data 속성**을 쓰는지
- `rhwp-studio/tests/user-settings.test.ts` — 저장·기본값, 새 모듈 인스턴스(= 재시작)에서 복원

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음. 시작 경로에 localStorage 읽기 1회(기존 테마 초기화와 같은 스크립트)와
  data 속성 2개 설정이 더해질 뿐이고, 렌더 루프에는 손대지 않았습니다.
- 재현·측정: e2e 의 프레임 샘플링(33프레임)에서 숨김 상태가 첫 프레임부터 유지됨을 확인했습니다.

## 스크린샷

정적 스크린샷 대신 위 e2e 의 프레임 샘플링 수치로 대체했습니다(리로드 직후 60프레임까지
샘플링해 숨긴 도구 모음이 보인 프레임 0). 처리 결과 문서:
`mydocs/working/task_5738_studio_toolbox_visibility.md`.
