### PR TITLE
feat(studio): 큰 문서 로딩 동안 대기 커서를 보여준다 (#5740)

### DIFF
--- a/mydocs/working/task_5740_studio_loading_busy_cursor.md
+++ b/mydocs/working/task_5740_studio_loading_busy_cursor.md
@@ -1,0 +1,50 @@
+# #5740 rhwp-studio 큰 문서 로딩 중 대기 커서
+
+## 목표
+
+큰 문서를 여는 동안 편집 영역이 빈 화면으로 오래 남는 구간에서, 마우스 커서로 "처리 중"을
+알린다. 로딩이 끝나거나 실패해도 커서는 반드시 되돌아가야 한다.
+
+## 문제
+
+10MB 급 `.hwp` 를 열면 파싱·쪽 계산 동안 상태바 텍스트만 바뀌고 커서는 평소 그대로였다.
+앱이 일하는 중인지 멈춘 것인지 구분되지 않아 사용자가 빈 화면을 클릭하거나 다시 열기를
+시도하게 된다.
+
+## 구현
+
+1. `src/view/busy-cursor.ts` 를 새로 두고 루트 클래스 `rhwp-busy` 토글만 담당하게 한다.
+   로딩 경로가 겹쳐 불릴 수 있어(`loadFile` → `loadBytes`) 깊이를 세고, 가장 바깥 처리가
+   끝날 때만 되돌린다. `withBusyCursor` 의 `finally` 가 실패 경로도 닫는다.
+   루트를 인자로 받아 전역 `document` 없이 검증한다.
+2. `src/style.css` 에 `:root.rhwp-busy, :root.rhwp-busy * { cursor: wait !important; }` 를 둔다.
+   편집 영역이 `style.cursor` 를 인라인으로 넣으므로(`input-handler-mouse.ts`) `!important`
+   없이는 지지 않는다.
+3. `main.ts` 의 문서 열기 경로를 감싼다.
+   - `loadBytes` — 바이트로 여는 모든 경로(파일 열기 · `?url=` · 자동저장 복구 · 호스트 API)의
+     공통 깔때기.
+   - `loadFile` — 파일 읽기(`arrayBuffer`)도 큰 파일에서는 시간이 걸린다. 단, 저장 여부 확인
+     모달(`canReplaceCurrentDocument`) 다음부터 든다 — 사용자가 답해야 하는 동안은 평소 커서다.
+   - `createNewDocument` — 새 문서 생성도 같은 처리 구간이다.
+
+빈 화면 자체를 없애는 오버레이·스피너는 이 변경의 범위 밖이다(별건).
+
+## 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `cargo fmt --all -- --check` | 통과 (Rust 변경 없음) |
+| `npx tsc --noEmit -p tsconfig.json` (rhwp-studio) | 통과 |
+| `npm test` (rhwp-studio) | 1038개 중 1037 통과 · 0 실패 · 1 skip |
+| `npm run e2e:loading-busy-cursor` | 5개 단언 전부 PASS |
+
+e2e 실측(헤드리스 Chrome, dev 서버, 샘플 `samples/2025 행정업무운영 편람(최종).hwp` 10MB):
+
+- 로딩 전: `rhwp-busy` 없음.
+- 실제 열기 경로(`#file-input` change → `loadFile` → `loadBytes`)를 태우고 프레임마다 샘플링:
+  **39프레임 중 37프레임**에서 루트에 `rhwp-busy` 가 걸려 있고 `getComputedStyle(body).cursor`
+  가 `wait` 로 계산됐다.
+- 로딩 후: `rhwp-busy` 해제, 커서 `auto` 로 복귀.
+
+단위 계약 테스트 `rhwp-studio/tests/busy-cursor.test.ts` 4건 — 처리 중 걸림/끝나면 복구,
+겹침 시 클래스 조작 1회, 실패해도 복구, CSS 가 인라인 커서를 덮는 `!important` 규칙 유지.

--- a/rhwp-studio/e2e/loading-busy-cursor.test.mjs
+++ b/rhwp-studio/e2e/loading-busy-cursor.test.mjs
@@ -1,0 +1,84 @@
+/**
+ * E2E 테스트 — 큰 문서 로딩 동안 대기 커서 (#5740)
+ *
+ * 검증 항목:
+ * 1. 로딩 시작 전에는 대기 커서가 아니다
+ * 2. 파싱·쪽 계산이 도는 동안 루트에 rhwp-busy 가 걸리고 커서가 wait 로 계산된다
+ * 3. 로딩이 끝나면 되돌아간다
+ */
+
+import { runTest, assert } from './helpers.mjs';
+
+process.env.VITE_URL = process.env.VITE_URL || 'http://localhost:7700';
+
+// 10MB 급 실제 샘플 — 빈 화면이 오래 보이는 상황을 그대로 재현한다.
+const SAMPLE = '2025 행정업무운영 편람(최종).hwp';
+
+runTest('큰 문서 로딩 중 대기 커서', async ({ page }) => {
+  // ── TC1: 로딩 전 ───────────────────────────────────────────
+  const before = await page.evaluate(() => ({
+    busy: document.documentElement.classList.contains('rhwp-busy'),
+    cursor: getComputedStyle(document.body).cursor,
+  }));
+  assert(before.busy === false, `TC1: 로딩 전에는 대기 커서가 아님 (busy=${before.busy})`);
+
+  // ── TC2/TC3: 실제 열기 경로(loadFile → loadBytes)를 태우며 샘플링 ──
+  const result = await page.evaluate(async ({ sample }) => {
+    const samples = [];
+    let running = true;
+    const tick = () => {
+      if (!running) return;
+      samples.push({
+        busy: document.documentElement.classList.contains('rhwp-busy'),
+        cursor: getComputedStyle(document.body).cursor,
+      });
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+
+    const resp = await fetch(`/samples/${encodeURIComponent(sample)}`);
+    if (!resp.ok) {
+      running = false;
+      return { error: `HTTP ${resp.status}` };
+    }
+    const bytes = new Uint8Array(await resp.arrayBuffer());
+    const file = new File([bytes], sample, { type: 'application/octet-stream' });
+    const input = document.getElementById('file-input');
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    input.files = dt.files;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+
+    // 로딩이 끝날 때까지 대기 — rhwp-busy 가 걸렸다가 풀리는 것을 관찰한다.
+    await new Promise((resolve) => {
+      const started = performance.now();
+      const poll = () => {
+        const busy = document.documentElement.classList.contains('rhwp-busy');
+        if (busy) window.__sawBusy = true;
+        if (window.__sawBusy && !busy) return resolve();
+        if (performance.now() - started > 120000) return resolve();
+        setTimeout(poll, 16);
+      };
+      poll();
+    });
+    running = false;
+
+    return {
+      samples: samples.length,
+      busyFrames: samples.filter(s => s.busy).length,
+      waitCursorFrames: samples.filter(s => s.cursor === 'wait').length,
+      after: {
+        busy: document.documentElement.classList.contains('rhwp-busy'),
+        cursor: getComputedStyle(document.body).cursor,
+      },
+    };
+  }, { sample: SAMPLE });
+
+  assert(!result.error, `TC2: 샘플 로드 (${result.error ?? 'ok'})`);
+  assert(result.busyFrames > 0,
+    `TC2: 로딩 동안 rhwp-busy 가 걸린 프레임 있음 (${result.busyFrames}/${result.samples})`);
+  assert(result.waitCursorFrames > 0,
+    `TC2: 로딩 동안 커서가 wait 로 계산된 프레임 있음 (${result.waitCursorFrames}/${result.samples})`);
+  assert(result.after.busy === false && result.after.cursor !== 'wait',
+    `TC3: 로딩이 끝나면 되돌아감 (busy=${result.after.busy}, cursor=${result.after.cursor})`);
+});

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -26,6 +26,7 @@
     "e2e:unsaved-guard": "node e2e/unsaved-changes-guard.test.mjs",
     "e2e:undo": "node e2e/undo-contracts.test.mjs",
     "e2e:undo-object-selection": "node e2e/undo-object-selection.test.mjs",
+    "e2e:loading-busy-cursor": "node e2e/loading-busy-cursor.test.mjs --mode=headless",
     "e2e:hwp-password-open": "node e2e/hwp-password-open.test.mjs --mode=headless",
     "e2e:clipboard-priority": "node e2e/task-871-clipboard-priority.test.mjs",
     "e2e:drag-autoscroll": "node e2e/drag-selection-autoscroll.test.mjs",

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -77,6 +77,7 @@ import {
   type RenderBackendFallbackReason,
 } from '@/view/render-backend';
 import { calculateFitPageZoom, calculateFitWidthZoom } from '@/view/zoom-fit';
+import { withBusyCursor } from '@/view/busy-cursor';
 import { installEmbedRuntime } from '@/embed/runtime';
 import type { EmbedRendererRuntimeRequestV1 } from '@/embed/rpc-router';
 import { enrichFontDecisionTrace } from '@/core/font-decision-trace';
@@ -1310,12 +1311,15 @@ async function loadFile(
 ): Promise<boolean> {
   try {
     if (!await canReplaceCurrentDocument(options.skipUnsavedGuard)) return false;
-    const startTime = performance.now();
-    await updateLoadProgress(0, '파일 읽는 중...');
-    const data = new Uint8Array(await file.arrayBuffer());
-    await updateLoadProgress(15, '파일 읽기 완료');
-    await loadBytes(data, file.name, options.fileHandle ?? null, startTime, { dataReadProgressShown: true });
-    return true;
+    // 대기 커서는 저장 여부 확인(모달) 다음부터 — 사용자가 답해야 하는 동안은 평소 커서다.
+    return await withBusyCursor(document.documentElement, async () => {
+      const startTime = performance.now();
+      await updateLoadProgress(0, '파일 읽는 중...');
+      const data = new Uint8Array(await file.arrayBuffer());
+      await updateLoadProgress(15, '파일 읽기 완료');
+      await loadBytes(data, file.name, options.fileHandle ?? null, startTime, { dataReadProgressShown: true });
+      return true;
+    });
   } catch (error) {
     showLoadErrorUnlessCancelled(error);
     return false;
@@ -1333,42 +1337,46 @@ async function loadBytes(
   startTime = performance.now(),
   options: { dataReadProgressShown?: boolean; skipRecent?: boolean; suppressDialogs?: boolean } = {},
 ): Promise<void> {
-  // 파싱 전에 먼저 빈 쪽 상태로 만든다 — 이전 문서를 붙잡고 있다가 한 번에 갈아치우면
-  // 화면이 튀어 보인다. 파싱이 실패하면 아래 catch가 이전 문서 뷰를 되살린다.
-  canvasView?.showBlankPage();
-  if (!options.dataReadProgressShown) {
-    await updateLoadProgress(0, '문서 데이터 준비 중...');
-  }
-  await updateLoadProgress(25, '문서 파싱 및 쪽 계산 중...');
-  const docInfo = await loadDocumentForOpen(data, fileName);
-  prepareCanvasRendererDocument();
-  // 문서가 갈렸다 — 빌린 핸들을 쥔 플러그인에 새 lease 를 준다. 알리지 않으면 그쪽만 옛
-  // 문서를 계속 만진다(세대 검사가 잡아 DOCUMENT_RELEASED 로 끊긴다).
-  plugins.notifyDocumentSwap();
-  await updateLoadProgress(45, '자동 저장 준비 중...');
-  forgetConvertedHmlSaveHandle(fileHandle);
-  wasm.currentFileHandle = fileHandle;
+  // 바이트로 여는 모든 경로(파일 열기 · ?url= · 자동저장 복구 · 호스트 API)의 공통 깔때기다.
+  // 파싱·쪽 계산 동안 빈 화면만 보이므로 여기서 대기 커서를 든다.
+  await withBusyCursor(document.documentElement, async () => {
+    // 파싱 전에 먼저 빈 쪽 상태로 만든다 — 이전 문서를 붙잡고 있다가 한 번에 갈아치우면
+    // 화면이 튀어 보인다. 파싱이 실패하면 아래 catch가 이전 문서 뷰를 되살린다.
+    canvasView?.showBlankPage();
+    if (!options.dataReadProgressShown) {
+      await updateLoadProgress(0, '문서 데이터 준비 중...');
+    }
+    await updateLoadProgress(25, '문서 파싱 및 쪽 계산 중...');
+    const docInfo = await loadDocumentForOpen(data, fileName);
+    prepareCanvasRendererDocument();
+    // 문서가 갈렸다 — 빌린 핸들을 쥔 플러그인에 새 lease 를 준다. 알리지 않으면 그쪽만 옛
+    // 문서를 계속 만진다(세대 검사가 잡아 DOCUMENT_RELEASED 로 끊긴다).
+    plugins.notifyDocumentSwap();
+    await updateLoadProgress(45, '자동 저장 준비 중...');
+    forgetConvertedHmlSaveHandle(fileHandle);
+    wasm.currentFileHandle = fileHandle;
 
-  // 최근 문서 기록 — 문서 로드 성공 직후, 폰트/모달 등 블로킹 UI 단계 이전에 기록한다.
-  // 핸들이 있으면 라이브 재열기용으로 함께 기록하고, 없으면(드롭/input/URL 로드)
-  // 메타-only 로 기록한다 — 목록에는 남기되 자동 재열기는 핸들 있는 항목만 가능하다.
-  // 자동저장 복구본은 options.skipRecent 로 제외.
-  if (!options.skipRecent) {
-    void addRecentDoc({
-      fileName: wasm.fileName,
-      sourceFormat: wasm.getSourceFormat(),
-      handle: fileHandle,
-    }).catch((err) => console.warn('[recent] 최근 문서 기록 실패:', err));
-  }
+    // 최근 문서 기록 — 문서 로드 성공 직후, 폰트/모달 등 블로킹 UI 단계 이전에 기록한다.
+    // 핸들이 있으면 라이브 재열기용으로 함께 기록하고, 없으면(드롭/input/URL 로드)
+    // 메타-only 로 기록한다 — 목록에는 남기되 자동 재열기는 핸들 있는 항목만 가능하다.
+    // 자동저장 복구본은 options.skipRecent 로 제외.
+    if (!options.skipRecent) {
+      void addRecentDoc({
+        fileName: wasm.fileName,
+        sourceFormat: wasm.getSourceFormat(),
+        handle: fileHandle,
+      }).catch((err) => console.warn('[recent] 최근 문서 기록 실패:', err));
+    }
 
-  await autosaveManager.beginDocument(
-    { fileName: wasm.fileName, sourceFormat: wasm.getSourceFormat() },
-    { discardPreviousDraft: true },
-  );
-  await updateLoadProgress(50, '문서 초기화 중...');
-  const elapsed = performance.now() - startTime;
-  await initializeDocument(docInfo, `${fileName} — ${docInfo.pageCount}페이지 (${elapsed.toFixed(1)}ms)`, {
-    suppressDialogs: options.suppressDialogs,
+    await autosaveManager.beginDocument(
+      { fileName: wasm.fileName, sourceFormat: wasm.getSourceFormat() },
+      { discardPreviousDraft: true },
+    );
+    await updateLoadProgress(50, '문서 초기화 중...');
+    const elapsed = performance.now() - startTime;
+    await initializeDocument(docInfo, `${fileName} — ${docInfo.pageCount}페이지 (${elapsed.toFixed(1)}ms)`, {
+      suppressDialogs: options.suppressDialogs,
+    });
   });
 }
 
@@ -1488,15 +1496,17 @@ async function restoreAutosaveDraft(draft: AutosaveDraft): Promise<void> {
 async function createNewDocument(): Promise<void> {
   const msg = sbMessage();
   try {
-    msg.textContent = '새 문서 생성 중...';
-    const docInfo = wasm.createNewDocument();
-    prepareCanvasRendererDocument();
-    plugins.notifyDocumentSwap();
-    await autosaveManager.beginDocument(
-      { fileName: wasm.fileName, sourceFormat: wasm.getSourceFormat() },
-      { discardPreviousDraft: true },
-    );
-    await initializeDocument(docInfo, `새 문서.hwp — ${docInfo.pageCount}페이지`);
+    await withBusyCursor(document.documentElement, async () => {
+      msg.textContent = '새 문서 생성 중...';
+      const docInfo = wasm.createNewDocument();
+      prepareCanvasRendererDocument();
+      plugins.notifyDocumentSwap();
+      await autosaveManager.beginDocument(
+        { fileName: wasm.fileName, sourceFormat: wasm.getSourceFormat() },
+        { discardPreviousDraft: true },
+      );
+      await initializeDocument(docInfo, `새 문서.hwp — ${docInfo.pageCount}페이지`);
+    });
   } catch (error) {
     msg.textContent = `새 문서 생성 실패: ${error}`;
     console.error('[main] 새 문서 생성 실패:', error);

--- a/rhwp-studio/src/style.css
+++ b/rhwp-studio/src/style.css
@@ -34,3 +34,10 @@
 .rhwp-chrome-no-toolbar #icon-toolbar,
 .rhwp-chrome-no-toolbar #style-bar { display: none; }
 .rhwp-chrome-no-status #status-bar { display: none; }
+
+/* ── 처리 중 대기 커서 ────────────────────────────────────
+   큰 문서 로딩처럼 빈 화면이 오래 보이는 동안 "일하는 중"을 커서로 알린다.
+   편집 영역이 인라인 style 로 커서를 바꾸므로 !important 로 덮는다.
+   토글은 view/busy-cursor.ts. */
+:root.rhwp-busy,
+:root.rhwp-busy * { cursor: wait !important; }

--- a/rhwp-studio/src/view/busy-cursor.ts
+++ b/rhwp-studio/src/view/busy-cursor.ts
@@ -1,0 +1,49 @@
+/**
+ * 문서 로딩처럼 오래 걸리는 처리 동안 대기 커서를 보여준다.
+ *
+ * 큰 문서는 파싱·쪽 계산 동안 빈 화면만 오래 보이고 커서는 평소 그대로여서, 앱이 멈춘 건지
+ * 일하는 중인지 구분되지 않았다. 루트에 클래스 하나를 걸고 CSS(`src/style.css`)가
+ * `cursor: wait` 를 덮는다 — 편집 영역이 인라인 style 로 커서를 바꾸므로 규칙은 `!important` 다.
+ *
+ * 로딩 경로는 겹쳐 불릴 수 있어(loadFile → loadBytes) 깊이를 센다. 바깥 것이 끝날 때까지
+ * 커서를 유지하고, 예외가 나도 `withBusyCursor` 의 finally 가 반드시 되돌린다.
+ * 루트는 인자로 받아 전역 `document` 없이 검증할 수 있다.
+ */
+
+/** 대기 커서를 켜는 루트 클래스 */
+export const BUSY_CLASS = 'rhwp-busy';
+
+/** 이 모듈이 쓰는 루트 요소 표면만 좁혀 받는다. */
+export interface BusyRoot {
+  classList: { add(token: string): void; remove(token: string): void };
+}
+
+let depth = 0;
+
+/** 대기 커서 시작 (겹침 허용) */
+export function beginBusy(root: BusyRoot): void {
+  depth += 1;
+  if (depth === 1) root.classList.add(BUSY_CLASS);
+}
+
+/** 대기 커서 종료 — 가장 바깥 처리가 끝날 때만 되돌린다. */
+export function endBusy(root: BusyRoot): void {
+  if (depth === 0) return;
+  depth -= 1;
+  if (depth === 0) root.classList.remove(BUSY_CLASS);
+}
+
+/** 현재 겹침 깊이 (0 이면 대기 커서 없음) */
+export function busyDepth(): number {
+  return depth;
+}
+
+/** 처리 하나를 대기 커서로 감싼다. 실패해도 커서를 반드시 되돌린다. */
+export async function withBusyCursor<T>(root: BusyRoot, task: () => Promise<T>): Promise<T> {
+  beginBusy(root);
+  try {
+    return await task();
+  } finally {
+    endBusy(root);
+  }
+}

--- a/rhwp-studio/tests/busy-cursor.test.ts
+++ b/rhwp-studio/tests/busy-cursor.test.ts
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  BUSY_CLASS,
+  busyDepth,
+  withBusyCursor,
+  type BusyRoot,
+} from '../src/view/busy-cursor.ts';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function fakeRoot() {
+  const tokens = new Set<string>();
+  const log: string[] = [];
+  const root: BusyRoot = {
+    classList: {
+      add(token: string) {
+        tokens.add(token);
+        log.push(`+${token}`);
+      },
+      remove(token: string) {
+        tokens.delete(token);
+        log.push(`-${token}`);
+      },
+    },
+  };
+  return { root, tokens, log };
+}
+
+test('처리 동안 대기 커서를 걸고 끝나면 되돌린다', async () => {
+  const { root, tokens, log } = fakeRoot();
+
+  const seen: boolean[] = [];
+  await withBusyCursor(root, async () => {
+    seen.push(tokens.has(BUSY_CLASS));
+  });
+
+  assert.deepEqual(seen, [true], '처리 중에는 대기 커서가 걸려 있어야 한다');
+  assert.equal(tokens.has(BUSY_CLASS), false, '끝나면 되돌려야 한다');
+  assert.deepEqual(log, [`+${BUSY_CLASS}`, `-${BUSY_CLASS}`]);
+  assert.equal(busyDepth(), 0);
+});
+
+test('겹쳐 불러도 가장 바깥 처리가 끝날 때 한 번만 되돌린다', async () => {
+  const { root, tokens, log } = fakeRoot();
+
+  await withBusyCursor(root, async () => {
+    // loadFile → loadBytes 처럼 안쪽에서 다시 감싸는 경우
+    await withBusyCursor(root, async () => {
+      assert.equal(busyDepth(), 2);
+    });
+    assert.equal(tokens.has(BUSY_CLASS), true, '안쪽이 끝나도 유지되어야 한다');
+  });
+
+  assert.equal(tokens.has(BUSY_CLASS), false);
+  assert.deepEqual(log, [`+${BUSY_CLASS}`, `-${BUSY_CLASS}`], '클래스 조작은 1회씩');
+  assert.equal(busyDepth(), 0);
+});
+
+test('처리가 실패해도 대기 커서를 반드시 되돌린다', async () => {
+  const { root, tokens } = fakeRoot();
+
+  await assert.rejects(
+    withBusyCursor(root, async () => {
+      throw new Error('파싱 실패');
+    }),
+    /파싱 실패/,
+  );
+
+  assert.equal(tokens.has(BUSY_CLASS), false);
+  assert.equal(busyDepth(), 0);
+});
+
+test('대기 커서 CSS 는 편집 영역의 인라인 커서까지 덮는다', () => {
+  const css = readFileSync(join(rootDir, 'src/style.css'), 'utf8');
+  // 편집 영역이 style.cursor 를 직접 넣으므로 !important 가 없으면 지지 않는다.
+  assert.match(css, new RegExp(`:root\\.${BUSY_CLASS}[^{]*\\{[^}]*cursor:\\s*wait\\s*!important`));
+  assert.match(css, new RegExp(`:root\\.${BUSY_CLASS}\\s*\\*`), '자식 요소까지 덮어야 한다');
+});


### PR DESCRIPTION
## 변경 요약

큰 문서(10MB 급 `.hwp`)를 열면 파싱·쪽 계산이 도는 동안 편집 영역이 빈 화면으로 오래 남습니다.
그동안 상태바 텍스트(`파일 로딩 25% - 문서 파싱 및 쪽 계산 중...`)만 바뀌고 마우스 커서는 평소
그대로라, 앱이 일하는 중인지 멈춘 것인지 구분되지 않았습니다. 데스크톱 워드프로세서의 관례대로
처리 중에는 대기 커서를 보여줍니다.

- 새 모듈 `src/view/busy-cursor.ts` 가 루트 클래스 `rhwp-busy` 토글만 담당합니다. 로딩 경로가
  겹쳐 불릴 수 있어(`loadFile` → `loadBytes`) **깊이를 세고**, 가장 바깥 처리가 끝날 때만
  되돌립니다. `withBusyCursor` 의 `finally` 가 **실패 경로도** 닫습니다. 루트를 인자로 받아
  전역 `document` 없이 단위 검증할 수 있습니다.
- `src/style.css` 에 `:root.rhwp-busy, :root.rhwp-busy * { cursor: wait !important; }`.
  편집 영역이 `style.cursor` 를 인라인으로 넣으므로(`input-handler-mouse.ts`) `!important`
  없이는 지지 않습니다.
- `main.ts` 의 문서 열기 경로를 감쌉니다.
  - `loadBytes` — 바이트로 여는 **모든** 경로(파일 열기 · `?url=` · 자동저장 복구 · 호스트 API)의
    공통 깔때기입니다.
  - `loadFile` — 큰 파일은 `arrayBuffer()` 도 시간이 걸립니다. 단, 저장 여부 확인 모달
    (`canReplaceCurrentDocument`) **다음부터** 듭니다 — 사용자가 답해야 하는 동안은 평소 커서입니다.
  - `createNewDocument` — 새 문서 생성도 같은 처리 구간입니다.

빈 화면 자체를 없애는 오버레이·스피너는 이 PR 의 범위 밖입니다(별건). 파서·렌더러·WASM 경계와
진행률 표시 자체는 건드리지 않았습니다.

## 관련 이슈

closes #5740

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (push·PR 직전 실행. Rust 변경 없음)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, Cargo generated test target을 포함하지 않음 (Rust 테스트 추가 없음 — 해당 없음)
- [x] `src/**`의 `#[cfg(test)]` 변경 없음 (`rust-unit-test-tiers.mjs` 해당 없음)
- [x] `npm --prefix rhwp-studio test` — 1038개 중 **1037 통과 · 0 실패 · 1 skip**
- [x] `(cd rhwp-studio && npx tsc --noEmit)` 통과
- [x] `cargo clippy -- -D warnings` — Rust 변경 없음(해당 없음)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 렌더 경로 변경 없음(해당 없음)
- [ ] 웹(WASM) 렌더링 확인 — WASM 경계 변경 없음(해당 없음)
- [x] rhwp-studio UI 변경: e2e 시나리오 추가 — `rhwp-studio/e2e/loading-busy-cursor.test.mjs`
      (`npm --prefix rhwp-studio run e2e:loading-busy-cursor`)
- [ ] 작업 증빙 `rhwp replay --capsule` — 문서를 편집·생성하지 않는 UI 변경(해당 없음)
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 없음(해당 없음)

변경 범위는 `local_validation.md` §4.3 의 **rhwp-studio만 변경** 행(TypeScript 검사 · npm test ·
실제 browser 동작)에 해당하며 세 가지를 모두 실행했습니다.

### 실행한 명령과 결과

~~~text
cargo fmt --all -- --check                              # 통과
(cd rhwp-studio && npx tsc --noEmit)                    # 통과 (이 브랜치 워크트리에서 실행)
npm --prefix rhwp-studio test                           # tests 1038 / pass 1037 / fail 0 / skip 1
VITE_URL=http://localhost:7700 \
  npm --prefix rhwp-studio run e2e:loading-busy-cursor  # 단언 5건 전부 PASS
git diff --check                                        # 통과
~~~

e2e(헤드리스 Chrome) 결과 — 샘플은 저장소의 `samples/2025 행정업무운영 편람(최종).hwp`(10MB),
실제 열기 경로(`#file-input` change → `loadFile` → `loadBytes`)를 태우고 프레임마다 샘플링했습니다.

~~~text
PASS: TC1: 로딩 전에는 대기 커서가 아님 (busy=false)
PASS: TC2: 샘플 로드 (ok)
PASS: TC2: 로딩 동안 rhwp-busy 가 걸린 프레임 있음 (37/39)
PASS: TC2: 로딩 동안 커서가 wait 로 계산된 프레임 있음 (37/39)
PASS: TC3: 로딩이 끝나면 되돌아감 (busy=false, cursor=auto)
~~~

새 단위 계약 테스트 `rhwp-studio/tests/busy-cursor.test.ts` 4건 — 처리 중 걸림/끝나면 복구,
겹침 시 클래스 조작 1회, **실패해도 복구**, CSS 가 인라인 커서를 덮는 `!important` 규칙 유지.

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음. 로딩 시작·종료에 클래스 토글 1회씩이고 렌더 루프에는 손대지 않았습니다.
- 재현·측정: 위 e2e 의 프레임 샘플링(39프레임)으로 확인했습니다.

## 스크린샷

커서는 스크린샷에 찍히지 않아 e2e 의 `getComputedStyle(body).cursor` 실측(37/39 프레임 `wait`)으로
대체했습니다. 처리 결과 문서: `mydocs/working/task_5740_studio_loading_busy_cursor.md`.
