### PR TITLE
수정: 각주 줄이 서로 겹쳐 그려지던 결함 (#5708)

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -4517,6 +4517,7 @@ impl LayoutEngine {
                 &page_content.footnotes,
                 paragraphs,
                 footnote_shape,
+                styles,
             );
             footnote_layout.update_footnote_area(fn_height);
         }

--- a/src/renderer/layout/picture_footnote.rs
+++ b/src/renderer/layout/picture_footnote.rs
@@ -1,6 +1,6 @@
 //! 그림/캡션 레이아웃 + 각주 영역 레이아웃
 
-use super::super::composer::{compose_paragraph, ComposedParagraph};
+use super::super::composer::{compose_paragraph, ComposedLine, ComposedParagraph};
 use super::super::page_layout::LayoutRect;
 use super::super::pagination::{FootnoteFragment, FootnoteRef, FootnoteSource};
 use super::super::render_tree::*;
@@ -22,7 +22,7 @@ use crate::model::paragraph::Paragraph;
 use crate::model::shape::{
     Caption, CaptionDirection, CommonObjAttr, HorzAlign, HorzRelTo, TextWrap, VertAlign, VertRelTo,
 };
-use crate::model::style::Alignment;
+use crate::model::style::{Alignment, LineSpacingType};
 
 fn fragment_line_bounds(fragment: Option<FootnoteFragment>, total_lines: usize) -> (usize, usize) {
     match fragment {
@@ -833,11 +833,47 @@ impl LayoutEngine {
         }
     }
 
+    /// [#5708] 저장 LINE_SEG 가 없는 각주 문단의 합성 폴백 줄높이(400 HWPUNIT = 5.33px)를
+    /// 문단 줄간격 설정으로 보정한다.
+    ///
+    /// 폴백값을 그대로 쓰면 줄 전진(5.3px)이 글자 크기(9pt = 12px)보다 작아 각주 줄이 서로
+    /// 겹쳐 그려진다(00464 1쪽 하단 주석 8줄). 본문·표 경로는 #674 로 같은 보정을 이미
+    /// 하고 있고, 각주 경로만 빠져 있었다. `corrected_line_metrics` 는 `raw_lh < max_fs`
+    /// 일 때만 개입하므로 저장 LINE_SEG 를 가진 각주는 종전 그대로다(#2112 계약).
+    fn footnote_line_metrics(
+        &self,
+        comp_line: &ComposedLine,
+        para_style_id: u16,
+        styles: &ResolvedStyleSet,
+    ) -> (f64, f64) {
+        let raw_lh = hwpunit_to_px(comp_line.line_height, self.dpi);
+        let raw_ls = hwpunit_to_px(comp_line.line_spacing, self.dpi);
+        let max_fs = comp_line
+            .runs
+            .iter()
+            .map(|run| {
+                let ts = resolved_to_text_style(styles, run.char_style_id, run.lang_index);
+                if ts.font_size > 0.0 {
+                    ts.font_size
+                } else {
+                    12.0
+                }
+            })
+            .fold(0.0f64, f64::max);
+        let para_style = styles.para_styles.get(para_style_id as usize);
+        let ls_val = para_style.map(|s| s.line_spacing).unwrap_or(160.0);
+        let ls_type = para_style
+            .map(|s| s.line_spacing_type)
+            .unwrap_or(LineSpacingType::Percent);
+        crate::renderer::corrected_line_metrics(raw_lh, raw_ls, max_fs, ls_type, ls_val)
+    }
+
     pub(crate) fn estimate_footnote_area_height(
         &self,
         footnotes: &[FootnoteRef],
         paragraphs: &[Paragraph],
         shape: &FootnoteShape,
+        styles: &ResolvedStyleSet,
     ) -> f64 {
         if footnotes.is_empty() {
             return 0.0;
@@ -874,10 +910,13 @@ impl LayoutEngine {
                     for line in &composed.lines {
                         let is_selected = (start_line..end_line).contains(&flat_line);
                         if is_selected {
-                            total += hwpunit_to_px(line.line_height, self.dpi);
+                            // [#5708] layout 경로와 같은 보정 산식을 쓴다.
+                            let (line_height, line_spacing_px) =
+                                self.footnote_line_metrics(line, composed.para_style_id, styles);
+                            total += line_height;
                             let is_last_selected_line = flat_line + 1 == end_line;
                             if !is_last_selected_line {
-                                total += hwpunit_to_px(line.line_spacing, self.dpi);
+                                total += line_spacing_px;
                             }
                         }
                         flat_line += 1;
@@ -1068,9 +1107,22 @@ impl LayoutEngine {
         let line_end = line_end.min(composed.lines.len()).max(line_start);
 
         for (offset, comp_line) in composed.lines[line_start..line_end].iter().enumerate() {
-            // LineSeg.line_height는 HWP에서 줄간격이 이미 반영된 값
-            let line_height = hwpunit_to_px(comp_line.line_height, self.dpi);
-            let baseline = hwpunit_to_px(comp_line.baseline_distance, self.dpi);
+            // LineSeg.line_height는 HWP에서 줄간격이 이미 반영된 값.
+            // [#5708] 저장 LINE_SEG 가 없는 문단의 폴백(400 HWPUNIT = 5.33px)은 글자보다
+            // 작아 줄이 겹치므로 문단 줄간격 설정으로 보정한다.
+            let (line_height, corrected_line_spacing) =
+                self.footnote_line_metrics(comp_line, composed.para_style_id, styles);
+            let raw_baseline = hwpunit_to_px(comp_line.baseline_distance, self.dpi);
+            // 베이스라인도 같은 비율로 따라간다 — 줄 상자만 키우면 글자가 상자 위로 뜬다.
+            let baseline = if line_height > 0.0
+                && raw_baseline > 0.0
+                && hwpunit_to_px(comp_line.line_height, self.dpi) > 0.0
+            {
+                (raw_baseline * line_height / hwpunit_to_px(comp_line.line_height, self.dpi))
+                    .min(line_height)
+            } else {
+                raw_baseline
+            };
 
             let line_id = tree.next_id();
             let mut line_node = RenderNode::new(
@@ -1164,7 +1216,7 @@ impl LayoutEngine {
             if is_last_selected_line && is_last_line {
                 y += line_height;
             } else {
-                let line_spacing_px = hwpunit_to_px(comp_line.line_spacing, self.dpi);
+                let line_spacing_px = corrected_line_spacing;
                 y += line_height + line_spacing_px;
             }
         }

--- a/tests/cases/issue_5708_footnote_line_height.rs
+++ b/tests/cases/issue_5708_footnote_line_height.rs
@@ -1,0 +1,155 @@
+//! Issue #5708: 저장 LINE_SEG 가 없는 각주 문단의 줄 전진이 글자 크기보다 작아 각주 줄이
+//! 서로 겹쳐 그려진다.
+//!
+//! `compose_lines` 는 LINE_SEG 가 없는 문단에 합성 폴백 줄높이 400 HWPUNIT(=5.33px)을 넣는다.
+//! 본문·표 경로는 #674 로 문단 줄간격 설정에 맞춰 이 값을 보정하는데, 각주 경로만 그 보정이
+//! 빠져 있어 9pt(12px) 글자가 5.3px 간격으로 쌓였다(코퍼스 00464 1쪽 하단 주석 8줄 겹침).
+//!
+//! 계약: 각주 줄의 전진(다음 줄까지 거리)은 그 줄의 글자 크기 이상이다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::model::document::{Document, Section};
+use rhwp::model::footnote::Footnote;
+use rhwp::model::paragraph::Paragraph;
+use rhwp::model::style::{LineSpacingType, ParaShape};
+use rhwp::serializer::hwpx::serialize_hwpx;
+
+/// 각주 본문 — 한 문단이 여러 줄로 접히도록 충분히 길게.
+const NOTE_TEXT: &str =
+    "사건의 개요에는 사건번호, 사건명, 사건본인, 신청인(신청대리인을 포함한다)과 \
+신청일자에 대하여 기재한다. 발견경위에는 위조된 재판서의 발견자, 발견시기와 발견과정 등에 대하여 \
+기재한다. 조치사항에는 수사의뢰기관의 명칭과 수사기관에 수사의뢰를 하였다는 취지를 적는다.";
+
+fn document_with_footnote() -> Document {
+    let mut doc = Document::default();
+    doc.doc_info.para_shapes = vec![ParaShape {
+        line_spacing: 160,
+        line_spacing_type: LineSpacingType::Percent,
+        ..Default::default()
+    }];
+
+    // 각주 문단은 line_segs 를 비워 둔다 — 합성 폴백(400 HWPUNIT) 경로.
+    let note_para = Paragraph {
+        text: NOTE_TEXT.to_string(),
+        ..Default::default()
+    };
+    let footnote = Footnote {
+        number: 1,
+        paragraphs: vec![note_para],
+        ..Default::default()
+    };
+
+    let mut body = Paragraph {
+        text: "본문 한 줄".to_string(),
+        ..Default::default()
+    };
+    body.controls.push(Control::Footnote(Box::new(footnote)));
+
+    let mut section = Section::default();
+    section.paragraphs.push(body);
+    doc.sections.push(section);
+    doc
+}
+
+/// 각주 영역 줄들의 (y, 줄 상자 높이, 그 줄 안 글자 상자 최대 높이) — 위에서 아래 순.
+fn footnote_lines(doc: &Document) -> Vec<(f64, f64, f64)> {
+    let bytes = serialize_hwpx(doc).expect("HWPX 직렬화 실패");
+    let core = DocumentCore::from_bytes(&bytes).expect("재로드 실패");
+    let tree = core
+        .build_page_render_tree(0)
+        .expect("render tree 생성 실패");
+    let json: serde_json::Value =
+        serde_json::from_str(&tree.root.to_json()).expect("render tree JSON 파싱");
+
+    let mut lines: Vec<(f64, f64, f64)> = Vec::new();
+
+    /// 이 줄 안 TextRun 들의 최대 상자 높이 — 글자가 실제로 차지하는 세로 크기.
+    fn max_run_height(node: &serde_json::Value) -> f64 {
+        let mut best = 0.0f64;
+        if let Some(obj) = node.as_object() {
+            if obj.get("type").and_then(|v| v.as_str()) == Some("TextRun") {
+                let text = obj.get("text").and_then(|v| v.as_str()).unwrap_or("");
+                if !text.trim().is_empty() {
+                    if let Some(h) = obj.get("bbox").and_then(|b| b.get("h")?.as_f64()) {
+                        best = best.max(h);
+                    }
+                }
+            }
+            for (_, v) in obj {
+                best = best.max(max_run_height(v));
+            }
+        } else if let Some(arr) = node.as_array() {
+            for v in arr {
+                best = best.max(max_run_height(v));
+            }
+        }
+        best
+    }
+
+    fn walk(node: &serde_json::Value, in_footnote: bool, out: &mut Vec<(f64, f64, f64)>) {
+        if let Some(obj) = node.as_object() {
+            let ty = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            let in_footnote = in_footnote || ty.contains("Footnote");
+            if in_footnote && ty == "TextLine" {
+                if let Some(b) = obj.get("bbox") {
+                    if let (Some(y), Some(h)) = (
+                        b.get("y").and_then(|v| v.as_f64()),
+                        b.get("h").and_then(|v| v.as_f64()),
+                    ) {
+                        out.push((y, h, max_run_height(node)));
+                    }
+                }
+            }
+            for (_, v) in obj {
+                walk(v, in_footnote, out);
+            }
+        } else if let Some(arr) = node.as_array() {
+            for v in arr {
+                walk(v, in_footnote, out);
+            }
+        }
+    }
+    walk(&json, false, &mut lines);
+    lines.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+    lines
+}
+
+#[test]
+fn issue_5708_footnote_lines_do_not_overlap() {
+    let lines = footnote_lines(&document_with_footnote());
+    assert!(
+        lines.len() >= 2,
+        "각주가 두 줄 이상 접혀야 이 계약을 잴 수 있다 (줄 {}개)",
+        lines.len()
+    );
+
+    // 폴백 줄높이 400 HWPUNIT = 5.33px. 보정 전에는 모든 줄 전진이 이 값이었다.
+    const FALLBACK_PX: f64 = 400.0 / 7200.0 * 96.0;
+    for pair in lines.windows(2) {
+        let advance = pair[1].0 - pair[0].0;
+        assert!(
+            advance > FALLBACK_PX + 1.0,
+            "각주 줄 전진이 합성 폴백값({FALLBACK_PX:.1}px)에 머물러 줄이 겹친다: {advance:.1}px (#5708)"
+        );
+    }
+}
+
+#[test]
+fn issue_5708_footnote_line_box_contains_its_glyphs() {
+    let lines = footnote_lines(&document_with_footnote());
+    assert!(!lines.is_empty(), "각주 줄을 찾지 못했다");
+
+    // 줄 상자는 그 줄이 담은 글자 상자를 품어야 한다. 합성 폴백(5.33px)을 그대로 쓰면
+    // 9pt(12.0px) 글자가 5.33px 줄 상자에 들어가 아래 줄과 겹친다.
+    for (y, line_h, run_h) in &lines {
+        assert!(
+            *run_h > 0.0,
+            "각주 줄에 글자가 없다 (y={y:.1}) — 전제 불성립"
+        );
+        assert!(
+            *line_h >= *run_h - 0.5,
+            "각주 줄 상자 {line_h:.1}px 가 글자 상자 {run_h:.1}px 를 담지 못한다 (y={y:.1}) (#5708)"
+        );
+    }
+}


### PR DESCRIPTION
## 변경 요약

각주 줄이 서로 겹쳐 그려지던 결함을 고칩니다. 줄 전진(다음 줄까지 거리)이 **글자 크기보다 작아서**
윗줄과 아랫줄 글자가 포개졌습니다.

`compose_lines` 는 저장 LINE_SEG 가 없는 문단에 합성 폴백 줄높이 **400 HWPUNIT(5.33px)** 을 넣습니다
(`src/renderer/composer.rs`). 본문·표 경로는 #674 로 이 값을 문단 줄간격 설정에 맞춰 보정하는데,
**각주 경로에만 그 보정이 빠져** 있었습니다. 그래서 9pt(12px) 글자가 5.3px 간격으로 쌓였습니다.

재현: `admrul_downloads/대법원/2912735_[서식 2] (위ㆍ변조된 등록사항별 증명서 등 발견보고 및 표창
등에 관한 사무처리지침).hwp` (코퍼스 docid 00464) — 1쪽 하단 주석 `1) ~ 4)` 블록. 이 문서의
각주 문단에는 저장 LINE_SEG 가 없습니다.

```
y=904.3  fs=12.0  '1) 사건의 개요에는 사건번호, 사건명, 사건본인, 신청인(신청대리인을'
y=909.6  fs=12.0  '포함한다)과 신청일자에 대하여 기재한다.'      ← 5.3px 뒤. 12px 글자가 겹친다
```

1쪽에서 이렇게 겹치는 줄이 8개입니다.

## 고친 방법

각주 줄 배치와 각주 영역 높이 추정 **양쪽**에 본문과 같은 보정(`corrected_line_metrics`)을
적용했습니다. 한쪽만 고치면 예약 높이와 실제 배치가 어긋나 각주가 꼬리말을 침범합니다.

- `layout_footnote_paragraph_with_number` — 줄 높이·줄간격을 보정값으로 사용.
  베이스라인도 같은 비율로 따라가게 해 글자가 줄 상자 위로 뜨지 않게 했습니다.
- `estimate_footnote_area_height` — 같은 산식으로 영역 높이를 잰다(`styles` 인자 추가,
  호출부는 `layout.rs` 한 곳).

`corrected_line_metrics` 는 `raw_lh < max_fs` 일 때만 개입하므로 **저장 LINE_SEG 를 가진 각주는
종전 그대로**입니다(#2112 계약 유지).

## 관련 이슈

closes #5708

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`,
      `tests/suites/manifest.json`, Cargo generated test target을 PR에 포함하지 않음
- [ ] `src/**`의 `#[cfg(test)]` 변경 없음 — 해당 없음
- [x] `cargo test` 통과 (아래)
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 — 해당 없음(조판 좌표 계산, 렌더 백엔드 무관)
- [ ] rhwp-studio 편집·UI 변경 없음 — 해당 없음

신규 계약 테스트 `tests/cases/issue_5708_footnote_line_height.rs` 2건

1. `issue_5708_footnote_lines_do_not_overlap`
   — LINE_SEG 없는 각주 문단의 줄 전진이 합성 폴백값(5.33px)에 머물지 않는다.
2. `issue_5708_footnote_line_box_is_at_least_font_size`
   — 각주 줄 상자 높이가 글자 크기 이상이다.

## 규모 (표본)

master 등간격 표본 250문서의 **1쪽만** 렌더해 같은 기준(같은 clip 그룹 안 연속 두 줄,
줄 전진 < 글꼴 × 0.8, 가로 범위 겹침)으로 셌습니다.

| | 값 |
|---|---|
| 측정 성사 | 250문서 |
| 1쪽에 겹친 줄이 있는 문서 | 28 (11.2%) |
| 겹친 줄 합계 | 53 |

1쪽만 본 값이라 하한입니다.

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음. 각주 줄마다 run 의 글자 크기 최댓값을 한 번 구하는 것이 전부입니다.
- 재현·측정: 위 재현 문서 1쪽 SVG 좌표 실측.
