### PR TITLE
수정: 음수 줄간격 문단에서 아래 테두리가 글자를 가로지르던 결함 (#5711)

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -3040,6 +3040,11 @@ impl LayoutEngine {
         let mut endnote_line_vpos_y_end: Option<f64> = None;
         let mut endnote_auto_wrap_y_end: Option<f64> = None;
         let mut prev_line_reserved_tac_picture_height: Option<f64> = None;
+        // [#5711] 마지막으로 그린 줄 상자의 아래 경계. 문단 테두리의 아래 변은 이 값을
+        // 따라야 한다 — 줄간격이 음수인 문단에서는 전진값 `y` 가 줄 상자 아래보다 위로
+        // 올라가, 테두리가 글자를 가로지른다(3143955 제목: 줄 상자 아래 171.6px, 전진 y
+        // 162.0px, 실제로 그려진 선 159.7/163.7).
+        let mut last_line_box_bottom: Option<f64> = None;
         for line_idx in start_line..end {
             let comp_line = &composed.lines[line_idx];
             let mut current_line_reserved_tac_picture_height: Option<f64> = None;
@@ -4449,10 +4454,12 @@ impl LayoutEngine {
                 }
                 y = next_y;
             } else if is_cell_last_line && cell_ctx.is_some() {
+                last_line_box_bottom = Some(y + line_flow_height);
                 y += line_flow_height;
             } else if skip_advance_empty_line {
                 // no advance
             } else {
+                last_line_box_bottom = Some(y + render_line_flow_height);
                 y += render_line_flow_height + render_line_spacing_px + tac_picture_label_extra;
             }
             prev_line_reserved_tac_picture_height = current_line_reserved_tac_picture_height;
@@ -4464,7 +4471,11 @@ impl LayoutEngine {
         // 셀 외곽선은 별도 경로(table_layout/border_rendering)에서 처리되므로
         // 본문 단락의 연속 외곽선 merge 가 셀 단락 좌표/시그니처에 의해 깨지지 않게 한다.
         if para_border_fill_id > 0 && cell_ctx.is_none() {
-            let bg_height = y - bg_y_start;
+            // [#5711] 줄간격이 음수인 문단은 전진값 `y` 가 마지막 줄 상자 아래보다 위에
+            // 있다. 그 값을 테두리 아래 변으로 쓰면 테두리가 글자를 가로지른다. 다음 문단
+            // 시작 y 는 종전대로 두어 문단 간 간격 계약은 바꾸지 않는다.
+            let border_bottom = last_line_box_bottom.map_or(y, |bottom| y.max(bottom));
+            let bg_height = border_bottom - bg_y_start;
             if bg_height > 0.0 {
                 // margin_left/margin_right는 이미 px 단위 (style_resolver에서 변환됨)
                 // border_spacing[2]/[3] (top/bottom) 을 inset 으로 전달 — 병합 그룹의 첫/마지막 range 에서만 적용됨.
@@ -4493,7 +4504,7 @@ impl LayoutEngine {
                     box_x,
                     bg_y_start,
                     box_w,
-                    y,
+                    border_bottom,
                     top_inset,
                     bottom_inset,
                     is_partial_start,

--- a/tests/cases/issue_5711_para_border_negative_spacing.rs
+++ b/tests/cases/issue_5711_para_border_negative_spacing.rs
@@ -1,0 +1,126 @@
+//! Issue #5711: 줄간격이 음수인 문단에서 문단 아래 테두리가 줄 상자 아래가 아니라 글자 위에
+//! 그려진다.
+//!
+//! 테두리 범위의 아래 경계로 줄 전진값 `y` 를 썼다. 줄 배치는 `y += line_height + line_spacing`
+//! 으로 나아가는데, 저장 줄간격이 음수면 그 값이 마지막 줄 상자 아래보다 위에 놓인다.
+//! 재현 문서(3143955 제목 `안과ㆍ정신건강의학과 …`)는 줄 상자 147.6~171.6px 에 줄간격
+//! −720(−9.6px) 이라, 이중선이 기준선(168.0) 위인 159.7 / 163.7 에 그려졌다.
+//!
+//! 계약: 문단 테두리의 아래 변은 마지막 줄 상자 아래 경계 아래에 있다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::document::{Document, Section};
+use rhwp::model::paragraph::{LineSeg, Paragraph};
+use rhwp::model::style::{BorderFill, BorderLine, BorderLineType, ParaShape};
+use rhwp::serializer::hwpx::serialize_hwpx;
+
+/// 줄 높이(HWPUNIT) — 24.0px.
+const LINE_H: i32 = 1800;
+/// 음수 줄간격(HWPUNIT) — −9.6px.
+const NEG_SPACING: i32 = -720;
+
+fn document_with_bordered_paragraph(line_spacing: i32) -> Document {
+    let mut doc = Document::default();
+
+    let mut shape = ParaShape::default();
+    shape.border_fill_id = 1;
+    doc.doc_info.para_shapes = vec![shape];
+
+    // 아래 변만 있는 문단 테두리.
+    let mut fill = BorderFill::default();
+    fill.borders[3] = BorderLine {
+        line_type: BorderLineType::Solid,
+        width: 1,
+        color: 0,
+    };
+    doc.doc_info.border_fills = vec![fill];
+
+    let mut para = Paragraph {
+        text: "안과ㆍ정신건강의학과 질환자 취득 제한 자격ㆍ면허".to_string(),
+        ..Default::default()
+    };
+    para.para_shape_id = 0;
+    para.line_segs = vec![LineSeg {
+        text_start: 0,
+        vertical_pos: 0,
+        line_height: LINE_H,
+        text_height: LINE_H,
+        baseline_distance: LINE_H * 85 / 100,
+        line_spacing,
+        segment_width: 48188,
+        ..Default::default()
+    }];
+
+    let mut section = Section::default();
+    section.paragraphs.push(para);
+    doc.sections.push(section);
+    doc
+}
+
+/// (테두리 선들의 최대 y, 글자 줄 상자의 아래 끝).
+fn border_bottom_vs_line_box(doc: &Document) -> (f64, f64) {
+    let bytes = serialize_hwpx(doc).expect("HWPX 직렬화 실패");
+    let core = DocumentCore::from_bytes(&bytes).expect("재로드 실패");
+    let tree = core
+        .build_page_render_tree(0)
+        .expect("render tree 생성 실패");
+    let json: serde_json::Value =
+        serde_json::from_str(&tree.root.to_json()).expect("render tree JSON 파싱");
+
+    let mut border_max = f64::MIN;
+    let mut line_bottom = f64::MIN;
+    fn walk(node: &serde_json::Value, border_max: &mut f64, line_bottom: &mut f64) {
+        if let Some(obj) = node.as_object() {
+            let ty = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            let bbox = obj
+                .get("bbox")
+                .and_then(|b| Some((b.get("y")?.as_f64()?, b.get("h")?.as_f64()?)));
+            if let Some((y, h)) = bbox {
+                match ty {
+                    "Line" | "Rect" => *border_max = border_max.max(y + h),
+                    "TextLine" => *line_bottom = line_bottom.max(y + h),
+                    _ => {}
+                }
+            }
+            for (_, v) in obj {
+                walk(v, border_max, line_bottom);
+            }
+        } else if let Some(arr) = node.as_array() {
+            for v in arr {
+                walk(v, border_max, line_bottom);
+            }
+        }
+    }
+    walk(&json, &mut border_max, &mut line_bottom);
+    (border_max, line_bottom)
+}
+
+#[test]
+fn issue_5711_border_stays_below_the_line_box() {
+    let (border_bottom, line_bottom) =
+        border_bottom_vs_line_box(&document_with_bordered_paragraph(NEG_SPACING));
+    assert!(
+        line_bottom > f64::MIN,
+        "글자 줄 상자를 찾지 못했다 — 전제 불성립"
+    );
+    assert!(
+        border_bottom > f64::MIN,
+        "문단 테두리 노드를 찾지 못했다 — 전제 불성립"
+    );
+    assert!(
+        border_bottom >= line_bottom - 1.0,
+        "음수 줄간격 문단에서 테두리가 줄 상자 안({border_bottom:.1} < {line_bottom:.1})으로 \
+         올라와 글자를 가로지른다 (#5711)"
+    );
+}
+
+#[test]
+fn issue_5711_positive_spacing_is_unchanged() {
+    // 양수 줄간격이면 전진값이 줄 상자 아래보다 아래라 종전과 같아야 한다.
+    let (border_bottom, line_bottom) =
+        border_bottom_vs_line_box(&document_with_bordered_paragraph(600));
+    assert!(
+        border_bottom >= line_bottom - 1.0,
+        "양수 줄간격 문단에서 테두리가 줄 상자 위로 올라갔다 ({border_bottom:.1} < {line_bottom:.1})"
+    );
+}


### PR DESCRIPTION
## 변경 요약

줄간격이 음수인 문단에서 **문단 아래 테두리가 글자를 가로지르던** 결함을 고칩니다.

테두리 범위의 아래 경계로 줄 전진값 `y` 를 썼습니다. 줄 배치는 `y += line_height + line_spacing`
으로 나아가는데, 저장 줄간격이 음수면 그 값이 마지막 줄 상자 아래보다 **위**에 놓입니다.

재현 문서(`admrul_downloads/병무청/3143955_[별표 1] 안과·정신건강의학과 …`)의 제목 문단:

```xml
<hp:lineseg vertpos="5400" vertsize="1800" baseline="1530" spacing="-720" …/>
```

- 줄 상자 = 147.6 ~ **171.6px**
- 저장 줄간격 −720 = **−9.6px** → 전진값 `y` = **162.0px**
- 실제로 그려진 이중선 = 159.7 / 163.7 (가운데 161.7) — 글자 기준선(168.0)보다 **위**

글자 모양의 밑줄은 꺼져 있고(`<hh:underline type="NONE"/>`), 선의 출처는 문단 모양의 테두리
(`<hh:border borderFillIDRef="3" …/>`)입니다. 선이 글자 폭(107.4~661.6)보다 넓은 94.5~699.2 로
그려지는 것도 문단 테두리라는 근거입니다.

## 고친 방법

마지막으로 그린 줄 상자의 아래 경계를 따로 들고, 테두리 아래 변은 그 값과 전진값 `y` 중
**아래쪽**을 씁니다. 다음 문단 시작 y 는 종전대로 두어 문단 간 간격 계약은 바꾸지 않습니다.

## 관련 이슈

closes #5711

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`,
      `tests/suites/manifest.json`, Cargo generated test target을 PR에 포함하지 않음
- [ ] `src/**`의 `#[cfg(test)]` 변경 없음 — 해당 없음
- [x] `cargo test` 통과 (아래)
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 없음 — 해당 없음

신규 계약 테스트 `tests/cases/issue_5711_para_border_negative_spacing.rs` 2건

1. 음수 줄간격 문단에서 테두리 아래 변이 줄 상자 아래에 있다.
2. 양수 줄간격 문단은 종전과 같다(대조군).

돌린 스위트: `regression_suite_024`(신규) · `022` · `026` · `023` · `005`.

> 이 변경과 #5708 · #5702 · #5717 은 서로 다른 파일을 건드리며, 검증은 네 수정을 함께 얹은
> 통합 트리에서 한 번에 돌렸습니다.

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음. 줄 배치 루프에서 마지막 줄 상자 아래 경계 하나를 들고 다닐 뿐입니다.
- 재현·측정: 위 좌표(3143955 SVG 실측).
