### PR TITLE
perf(ci): nextest archive를 lib와 integration으로 분리

### DIFF
--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -16,8 +16,8 @@ on:
         description: Stable A/B archive partition label.
         required: true
         type: string
-      filterset:
-        description: Binary-only nextest filterset assigned to this archive.
+      target_group:
+        description: Cargo test target group assigned to this archive.
         required: true
         type: string
 jobs:
@@ -36,12 +36,22 @@ jobs:
         env:
           CARGO_PROFILE: ${{ inputs.cargo_profile }}
           TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
+          TARGET_GROUP: ${{ inputs.target_group }}
         run: |
           case "${CARGO_PROFILE}:${TIMEOUT_MINUTES}" in
             release-test:30|release:60)
               ;;
             *)
               echo "::error::invalid test archive policy: profile=${CARGO_PROFILE} timeout=${TIMEOUT_MINUTES}"
+              exit 1
+              ;;
+          esac
+
+          case "${TARGET_GROUP}" in
+            lib|integration)
+              ;;
+            *)
+              echo "::error::invalid test archive target group: ${TARGET_GROUP}"
               exit 1
               ;;
           esac
@@ -106,6 +116,7 @@ jobs:
         env:
           CARGO_PROFILE: ${{ inputs.cargo_profile }}
           TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
+          TARGET_GROUP: ${{ inputs.target_group }}
           CACHE_EXACT_HIT: ${{ steps.rust-cache.outputs.cache-hit || 'false' }}
           CACHE_SAVE_ELIGIBLE: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') }}
         run: |
@@ -118,30 +129,67 @@ jobs:
             printf "| ref | \`%s\` |\n" "${GITHUB_REF}"
             printf "| cargo_profile | \`%s\` |\n" "${CARGO_PROFILE}"
             printf "| timeout_minutes | \`%s\` |\n" "${TIMEOUT_MINUTES}"
+            printf "| target_group | \`%s\` |\n" "${TARGET_GROUP}"
             printf "| cache_exact_hit | \`%s\` |\n" "${CACHE_EXACT_HIT}"
             printf "| cache_save_eligible | \`%s\` |\n" "${CACHE_SAVE_ELIGIBLE}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      # [#5164] generated suite와 수동 예외 target을 한 번만 compile/link한다. slow와
-      # regular worker는 이 동일 archive를 filter와 test-case partition으로 나눠 실행한다.
+      # [#5737] lib와 integration target을 별도 archive로 compile/link해 두 builder의
+      # 임계 경로를 병렬화한다. integration 목록은 파생 suite 준비 뒤 metadata에서 구한다.
       - name: Build default-feature test archive
         run: |
           set -euo pipefail
-          echo "profile=${{ inputs.cargo_profile }} event=${GITHUB_EVENT_NAME} ref=${GITHUB_REF}"
+          echo "profile=${{ inputs.cargo_profile }} target_group=${{ inputs.target_group }} event=${GITHUB_EVENT_NAME} ref=${GITHUB_REF}"
           node scripts/rust-test-suite-manifest.mjs --prepare
+
+          cargo_target_args=()
+          case "${{ inputs.target_group }}" in
+            lib)
+              cargo_target_args+=(--lib)
+              ;;
+            integration)
+              mapfile -t integration_targets < <(
+                cargo metadata --no-deps --format-version 1 | node -e '
+                  let source = "";
+                  process.stdin.setEncoding("utf8");
+                  process.stdin.on("data", (chunk) => { source += chunk; });
+                  process.stdin.on("end", () => {
+                    const metadata = JSON.parse(source);
+                    const manifestPath = `${process.cwd()}/Cargo.toml`;
+                    const root = metadata.packages.find((pkg) => pkg.manifest_path === manifestPath);
+                    if (!root) {
+                      throw new Error(`root package not found for ${manifestPath}`);
+                    }
+                    root.targets
+                      .filter((target) => target.kind.length === 1 && target.kind[0] === "test")
+                      .map((target) => target.name)
+                      .sort()
+                      .forEach((name) => console.log(name));
+                  });
+                '
+              )
+              if (( ${#integration_targets[@]} == 0 )); then
+                echo "::error::integration test target discovery returned no targets"
+                exit 1
+              fi
+              for target in "${integration_targets[@]}"; do
+                cargo_target_args+=(--test "${target}")
+              done
+              printf 'integration_targets=%s\n' "${#integration_targets[@]}"
+              ;;
+          esac
+
           cargo nextest archive \
             --package rhwp \
             --cargo-profile "${{ inputs.cargo_profile }}" \
-            --tests \
-            --filterset "${{ inputs.filterset }}" \
+            "${cargo_target_args[@]}" \
             --archive-file tests.tar.zst
           stat --printf='archive=%n bytes=%s\n' tests.tar.zst
 
           cargo nextest list \
             --package rhwp \
             --cargo-profile "${{ inputs.cargo_profile }}" \
-            --tests \
-            --filterset "${{ inputs.filterset }}" \
+            "${cargo_target_args[@]}" \
             --message-format json > nextest-list.json
           runnable=$(node .github/scripts/count_nextest_runnable.mjs --input nextest-list.json)
           if ! [[ "$runnable" =~ ^[0-9]+$ ]] || [[ "$runnable" == "0" ]]; then

--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -13,7 +13,7 @@ on:
         type: number
 
       archive_label:
-        description: Stable A/B archive partition label.
+        description: Stable archive partition label.
         required: true
         type: string
       target_group:
@@ -48,7 +48,7 @@ jobs:
           esac
 
           case "${TARGET_GROUP}" in
-            lib|integration)
+            lib|integration-b|integration-c)
               ;;
             *)
               echo "::error::invalid test archive target group: ${TARGET_GROUP}"
@@ -134,8 +134,9 @@ jobs:
             printf "| cache_save_eligible | \`%s\` |\n" "${CACHE_SAVE_ELIGIBLE}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      # [#5737] lib와 integration target을 별도 archive로 compile/link해 두 builder의
-      # 임계 경로를 병렬화한다. integration 목록은 파생 suite 준비 뒤 metadata에서 구한다.
+      # [#5737] lib는 별도 archive로, integration target은 두 archive로 교차 배정해
+      # compile/link 임계 경로를 병렬화한다. integration 목록은 파생 suite 준비 뒤
+      # metadata에서 구한다.
       - name: Build default-feature test archive
         run: |
           set -euo pipefail
@@ -147,7 +148,7 @@ jobs:
             lib)
               cargo_target_args+=(--lib)
               ;;
-            integration)
+            integration-b|integration-c)
               mapfile -t integration_targets < <(
                 cargo metadata --no-deps --format-version 1 | node -e '
                   let source = "";
@@ -172,10 +173,22 @@ jobs:
                 echo "::error::integration test target discovery returned no targets"
                 exit 1
               fi
-              for target in "${integration_targets[@]}"; do
+              selected_targets=()
+              for index in "${!integration_targets[@]}"; do
+                if [[ "${{ inputs.target_group }}" == "integration-b" ]] && (( index % 2 == 0 )); then
+                  selected_targets+=("${integration_targets[index]}")
+                elif [[ "${{ inputs.target_group }}" == "integration-c" ]] && (( index % 2 == 1 )); then
+                  selected_targets+=("${integration_targets[index]}")
+                fi
+              done
+              if (( ${#selected_targets[@]} == 0 )); then
+                echo "::error::integration target group selected no targets: ${{ inputs.target_group }}"
+                exit 1
+              fi
+              for target in "${selected_targets[@]}"; do
                 cargo_target_args+=(--test "${target}")
               done
-              printf 'integration_targets=%s\n' "${#integration_targets[@]}"
+              printf 'integration_targets=%s selected_targets=%s\n' "${#integration_targets[@]}" "${#selected_targets[@]}"
               ;;
           esac
 

--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -12,9 +12,17 @@ on:
         required: true
         type: number
 
+      archive_label:
+        description: Stable A/B archive partition label.
+        required: true
+        type: string
+      filterset:
+        description: Binary-only nextest filterset assigned to this archive.
+        required: true
+        type: string
 jobs:
   build:
-    name: Build test archive
+    name: Build test archive (${{ inputs.archive_label }})
     runs-on: ubuntu-latest
     # [#4029] 빠른 release-test는 30분, cold release-grade는 60분을 caller가 전달한다.
     # 정상 소요시간 목표가 아니라 hang을 실패로 드러내는 상한이다.
@@ -125,6 +133,7 @@ jobs:
             --package rhwp \
             --cargo-profile "${{ inputs.cargo_profile }}" \
             --tests \
+            --filterset "${{ inputs.filterset }}" \
             --archive-file tests.tar.zst
           stat --printf='archive=%n bytes=%s\n' tests.tar.zst
 
@@ -132,6 +141,7 @@ jobs:
             --package rhwp \
             --cargo-profile "${{ inputs.cargo_profile }}" \
             --tests \
+            --filterset "${{ inputs.filterset }}" \
             --message-format json > nextest-list.json
           runnable=$(node .github/scripts/count_nextest_runnable.mjs --input nextest-list.json)
           if ! [[ "$runnable" =~ ^[0-9]+$ ]] || [[ "$runnable" == "0" ]]; then
@@ -139,12 +149,12 @@ jobs:
             exit 1
           fi
           printf '%s\n' "$runnable" > archive-expected-total.txt
-          echo "archive=all expected_runnable=${runnable}"
+          echo "archive=${{ inputs.archive_label }} expected_runnable=${runnable}"
 
       - name: Upload test archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: test-archive-${{ github.run_id }}
+          name: test-archive-${{ github.run_id }}-${{ inputs.archive_label }}
           path: tests.tar.zst
           compression-level: 0
           retention-days: 1
@@ -153,7 +163,7 @@ jobs:
       - name: Upload archive expected count
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: archive-expected-${{ github.run_id }}
+          name: archive-expected-${{ github.run_id }}-${{ inputs.archive_label }}
           path: archive-expected-total.txt
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1025,15 +1025,32 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # [Task #1109 / #1192 C] ubuntu-latest runner 의 미사용 사전 설치 toolchain 제거하여
-      # 테스트 빌드 시 디스크 한도 초과를 줄인다.
-      # [#1192] 캐시 정상 작동 확인 후 "크고 빠른" 항목(android/dotnet)만 남기고 축소.
-      # 느린 docker prune --all / apt clean / ghc / CodeQL 정리는 제거. df -h 로 여유 확인.
+      # archive builder와 같은 30GB 임계치만 적용한다. 일반 ubuntu-latest의 충분한 여유에서는
+      # Android/dotnet 삭제가 약 1분을 쓰므로 건너뛴다.
       - name: Free disk space (remove unused pre-installed toolchains)
         run: |
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/dotnet
-          df -h
+          set -euo pipefail
+          echo 'Disk space before cleanup:'
+          df -h /
+          df -B1 --output=source,size,used,avail,pcent,target /
+          available_gb=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+          if (( available_gb < 30 )); then
+            echo "Low disk space: ${available_gb}GB available; inspecting and removing unused toolchains."
+            for path in /usr/local/lib/android /usr/share/dotnet; do
+              if [[ -e "${path}" ]]; then
+                sudo du -sh "${path}"
+              else
+                echo "${path}: absent"
+              fi
+            done
+            sudo rm -rf /usr/local/lib/android /usr/share/dotnet
+          else
+            echo "Skip cleanup: ${available_gb}GB available"
+          fi
+
+          echo 'Disk space after cleanup:'
+          df -h /
+          df -B1 --output=source,size,used,avail,pcent,target /
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -759,8 +759,8 @@ jobs:
 
   # [#2393] 기본 테스트 병렬화 — CI impact preflight가 frontend·Rust·Native Skia
   # gate와 worker 조건을 나누는 경계다.
-  # [#5164] archive는 preflight 직후 한 번만 compile/link하고 Lint와 병렬 실행한다.
-  # 네 worker는 동일 archive를 slow filter와 regular test-case partition으로 나눠 소비한다.
+  # [#5737] archive A는 source-side lib test, B는 integration target만 각각 compile/link한다.
+  # 각 archive의 두 worker가 test-case partition을 나눠 소비한다.
   # required check 는 집계 job "Build & Test" 로 불변이다.
   # [#5388] M04-4: tests/cases/prop_*_roundtrip.rs 는 정규 shard 가 archive 에서
   # 자동 실행한다. 전용 싼 job 은 .github/workflows/proptest-roundtrip.yml
@@ -781,7 +781,7 @@ jobs:
       cargo_profile: ${{ needs.preflight.outputs.test_profile || 'release' }}
       timeout_minutes: ${{ fromJSON(needs.preflight.outputs.test_archive_timeout_minutes || '60') }}
       archive_label: a
-      filterset: "binary(/.*[02468]$/)"
+      target_group: lib
 
 
   build-test-archive-b:
@@ -800,7 +800,7 @@ jobs:
       cargo_profile: ${{ needs.preflight.outputs.test_profile || 'release' }}
       timeout_minutes: ${{ fromJSON(needs.preflight.outputs.test_archive_timeout_minutes || '60') }}
       archive_label: b
-      filterset: "not binary(/.*[02468]$/)"
+      target_group: integration
 
   lint:
     name: Lint (fmt, clippy, WASM check)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1277,7 +1277,7 @@ jobs:
       count_label: a-2
       archive_label: a
       filterset: "all()"
-      partition: "hash:1/2"
+      partition: "hash:2/2"
 
 
   test-archive-b-shard-1:
@@ -1319,7 +1319,7 @@ jobs:
       count_label: b-2
       archive_label: b
       filterset: "all()"
-      partition: "hash:1/2"
+      partition: "hash:2/2"
 
 
   build-and-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -759,8 +759,8 @@ jobs:
 
   # [#2393] 기본 테스트 병렬화 — CI impact preflight가 frontend·Rust·Native Skia
   # gate와 worker 조건을 나누는 경계다.
-  # [#5737] archive A는 source-side lib test, B는 integration target만 각각 compile/link한다.
-  # 각 archive의 두 worker가 test-case partition을 나눠 소비한다.
+  # [#5737] archive A는 source-side lib test, B/C는 integration target을 교차 분배해
+  # 각각 compile/link한다. A는 두 hash worker, B/C는 각각 한 worker가 소비한다.
   # required check 는 집계 job "Build & Test" 로 불변이다.
   # [#5388] M04-4: tests/cases/prop_*_roundtrip.rs 는 정규 shard 가 archive 에서
   # 자동 실행한다. 전용 싼 job 은 .github/workflows/proptest-roundtrip.yml
@@ -800,7 +800,26 @@ jobs:
       cargo_profile: ${{ needs.preflight.outputs.test_profile || 'release' }}
       timeout_minutes: ${{ fromJSON(needs.preflight.outputs.test_archive_timeout_minutes || '60') }}
       archive_label: b
-      target_group: integration
+      target_group: integration-b
+
+
+  build-test-archive-c:
+    uses: ./.github/workflows/build-nextest-archives.yml
+    needs: [preflight]
+    if: >-
+      ${{
+        always()
+        && needs.preflight.result == 'success'
+        && needs.preflight.outputs.fast_pass != 'true'
+        && needs.preflight.outputs.rust_required == 'true'
+      }}
+    permissions:
+      contents: read
+    with:
+      cargo_profile: ${{ needs.preflight.outputs.test_profile || 'release' }}
+      timeout_minutes: ${{ fromJSON(needs.preflight.outputs.test_archive_timeout_minutes || '60') }}
+      archive_label: c
+      target_group: integration-c
 
   lint:
     name: Lint (fmt, clippy, WASM check)
@@ -1294,32 +1313,32 @@ jobs:
     permissions:
       contents: read
     with:
-      label: Archive B shard 1
+      label: Archive B
       count_label: b-1
       archive_label: b
       filterset: "all()"
-      partition: "hash:1/2"
+      partition: "hash:1/1"
 
 
-  test-archive-b-shard-2:
+  test-archive-c-shard-1:
     uses: ./.github/workflows/run-nextest-archives.yml
-    needs: [preflight, build-test-archive-b]
+    needs: [preflight, build-test-archive-c]
     if: >-
       ${{
         always()
         && needs.preflight.result == 'success'
         && needs.preflight.outputs.fast_pass != 'true'
         && needs.preflight.outputs.rust_required == 'true'
-        && needs['build-test-archive-b'].result == 'success'
+        && needs['build-test-archive-c'].result == 'success'
       }}
     permissions:
       contents: read
     with:
-      label: Archive B shard 2
-      count_label: b-2
-      archive_label: b
+      label: Archive C
+      count_label: c-1
+      archive_label: c
       filterset: "all()"
-      partition: "hash:2/2"
+      partition: "hash:1/1"
 
 
   build-and-test:
@@ -1331,10 +1350,11 @@ jobs:
       - preflight
       - build-test-archive-a
       - build-test-archive-b
+      - build-test-archive-c
       - test-archive-a-shard-1
       - test-archive-a-shard-2
       - test-archive-b-shard-1
-      - test-archive-b-shard-2
+      - test-archive-c-shard-1
       - lint
       - native-skia-tests
       - frontend-unit-gates
@@ -1352,7 +1372,7 @@ jobs:
             && needs['test-archive-a-shard-1'].result == 'success'
             && needs['test-archive-a-shard-2'].result == 'success'
             && needs['test-archive-b-shard-1'].result == 'success'
-            && needs['test-archive-b-shard-2'].result == 'success'
+            && needs['test-archive-c-shard-1'].result == 'success'
           }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1366,12 +1386,26 @@ jobs:
             && needs['test-archive-a-shard-1'].result == 'success'
             && needs['test-archive-a-shard-2'].result == 'success'
             && needs['test-archive-b-shard-1'].result == 'success'
-            && needs['test-archive-b-shard-2'].result == 'success'
+            && needs['test-archive-c-shard-1'].result == 'success'
           }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: archive-expected-${{ github.run_id }}-b
           path: archive-expected-b
+      - name: Download archive C expected count
+        if: >-
+          ${{
+            needs.preflight.outputs.fast_pass != 'true'
+            && needs.preflight.outputs.rust_required == 'true'
+            && needs['test-archive-a-shard-1'].result == 'success'
+            && needs['test-archive-a-shard-2'].result == 'success'
+            && needs['test-archive-b-shard-1'].result == 'success'
+            && needs['test-archive-c-shard-1'].result == 'success'
+          }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: archive-expected-${{ github.run_id }}-c
+          path: archive-expected-c
       - name: Download shard counts
         if: >-
           ${{
@@ -1380,7 +1414,7 @@ jobs:
             && needs['test-archive-a-shard-1'].result == 'success'
             && needs['test-archive-a-shard-2'].result == 'success'
             && needs['test-archive-b-shard-1'].result == 'success'
-            && needs['test-archive-b-shard-2'].result == 'success'
+            && needs['test-archive-c-shard-1'].result == 'success'
           }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1394,16 +1428,17 @@ jobs:
             && needs['test-archive-a-shard-1'].result == 'success'
             && needs['test-archive-a-shard-2'].result == 'success'
             && needs['test-archive-b-shard-1'].result == 'success'
-            && needs['test-archive-b-shard-2'].result == 'success'
+            && needs['test-archive-c-shard-1'].result == 'success'
           }}
         run: |
           read -r expected_a < archive-expected-a/archive-expected-total.txt
           read -r expected_b < archive-expected-b/archive-expected-total.txt
+          read -r expected_c < archive-expected-c/archive-expected-total.txt
           read -r a1 < shard-counts/shard-count-a-1/shard-count-a-1.txt
           read -r a2 < shard-counts/shard-count-a-2/shard-count-a-2.txt
           read -r b1 < shard-counts/shard-count-b-1/shard-count-b-1.txt
-          read -r b2 < shard-counts/shard-count-b-2/shard-count-b-2.txt
-          if ! [[ "$expected_a" =~ ^[0-9]+$ && "$expected_b" =~ ^[0-9]+$ && "$a1" =~ ^[0-9]+$ && "$a2" =~ ^[0-9]+$ && "$b1" =~ ^[0-9]+$ && "$b2" =~ ^[0-9]+$ ]]; then
+          read -r c1 < shard-counts/shard-count-c-1/shard-count-c-1.txt
+          if ! [[ "$expected_a" =~ ^[0-9]+$ && "$expected_b" =~ ^[0-9]+$ && "$expected_c" =~ ^[0-9]+$ && "$a1" =~ ^[0-9]+$ && "$a2" =~ ^[0-9]+$ && "$b1" =~ ^[0-9]+$ && "$c1" =~ ^[0-9]+$ ]]; then
             echo "::error::archive expected counts and shard counts must be non-negative integers"
             exit 1
           fi
@@ -1411,11 +1446,15 @@ jobs:
             echo "::error::Archive A shard total mismatch: $a1 + $a2 != $expected_a"
             exit 1
           fi
-          if (( b1 + b2 != expected_b )); then
-            echo "::error::Archive B shard total mismatch: $b1 + $b2 != $expected_b"
+          if (( b1 != expected_b )); then
+            echo "::error::Archive B shard total mismatch: $b1 != $expected_b"
             exit 1
           fi
-          printf 'archive_total=%s shard_total=%s\n' "$((expected_a + expected_b))" "$((a1 + a2 + b1 + b2))"
+          if (( c1 != expected_c )); then
+            echo "::error::Archive C shard total mismatch: $c1 != $expected_c"
+            exit 1
+          fi
+          printf 'archive_total=%s shard_total=%s\n' "$((expected_a + expected_b + expected_c))" "$((a1 + a2 + b1 + c1))"
       - name: Check Build & Test worker results
         env:
           PREFLIGHT_RESULT: ${{ needs.preflight.result }}
@@ -1425,10 +1464,11 @@ jobs:
           FRONTEND_MODE: ${{ needs.preflight.outputs.frontend_mode }}
           BUILD_ARCHIVE_A_RESULT: ${{ needs['build-test-archive-a'].result }}
           BUILD_ARCHIVE_B_RESULT: ${{ needs['build-test-archive-b'].result }}
+          BUILD_ARCHIVE_C_RESULT: ${{ needs['build-test-archive-c'].result }}
           TEST_ARCHIVE_A_1_RESULT: ${{ needs['test-archive-a-shard-1'].result }}
           TEST_ARCHIVE_A_2_RESULT: ${{ needs['test-archive-a-shard-2'].result }}
           TEST_ARCHIVE_B_1_RESULT: ${{ needs['test-archive-b-shard-1'].result }}
-          TEST_ARCHIVE_B_2_RESULT: ${{ needs['test-archive-b-shard-2'].result }}
+          TEST_ARCHIVE_C_1_RESULT: ${{ needs['test-archive-c-shard-1'].result }}
           LINT_RESULT: ${{ needs.lint.result }}
           NATIVE_SKIA_RESULT: ${{ needs['native-skia-tests'].result }}
           FRONTEND_UNIT_RESULT: ${{ needs['frontend-unit-gates'].result }}
@@ -1443,10 +1483,10 @@ jobs:
             exit 0
           fi
           failed=0
-          rust_results="${LINT_RESULT}/${BUILD_ARCHIVE_A_RESULT}/${BUILD_ARCHIVE_B_RESULT}/${TEST_ARCHIVE_A_1_RESULT}/${TEST_ARCHIVE_A_2_RESULT}/${TEST_ARCHIVE_B_1_RESULT}/${TEST_ARCHIVE_B_2_RESULT}"
+          rust_results="${LINT_RESULT}/${BUILD_ARCHIVE_A_RESULT}/${BUILD_ARCHIVE_B_RESULT}/${BUILD_ARCHIVE_C_RESULT}/${TEST_ARCHIVE_A_1_RESULT}/${TEST_ARCHIVE_A_2_RESULT}/${TEST_ARCHIVE_B_1_RESULT}/${TEST_ARCHIVE_C_1_RESULT}"
           case "${RUST_REQUIRED}" in
-            true) [[ "$rust_results" == "success/success/success/success/success/success/success" ]] || { echo "::error::Rust lane expected success for lint/two builders/four workers, got: $rust_results"; failed=1; } ;;
-            false) [[ "$rust_results" == "skipped/skipped/skipped/skipped/skipped/skipped/skipped" ]] || { echo "::error::Rust lane expected skipped, got: $rust_results"; failed=1; } ;;
+            true) [[ "$rust_results" == "success/success/success/success/success/success/success/success" ]] || { echo "::error::Rust lane expected success for lint/three builders/four workers, got: $rust_results"; failed=1; } ;;
+            false) [[ "$rust_results" == "skipped/skipped/skipped/skipped/skipped/skipped/skipped/skipped" ]] || { echo "::error::Rust lane expected skipped, got: $rust_results"; failed=1; } ;;
             *) echo "::error::Unknown rust_required: ${RUST_REQUIRED}"; failed=1 ;;
           esac
           case "${NATIVE_SKIA_REQUIRED}" in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -765,7 +765,7 @@ jobs:
   # [#5388] M04-4: tests/cases/prop_*_roundtrip.rs 는 정규 shard 가 archive 에서
   # 자동 실행한다. 전용 싼 job 은 .github/workflows/proptest-roundtrip.yml
   # (원본 부재 skip). 5번째 shard 를 넣지 않는다 — 집계는 4 worker 합이다.
-  build-test-archive:
+  build-test-archive-a:
     uses: ./.github/workflows/build-nextest-archives.yml
     needs: [preflight]
     if: >-
@@ -780,84 +780,27 @@ jobs:
     with:
       cargo_profile: ${{ needs.preflight.outputs.test_profile || 'release' }}
       timeout_minutes: ${{ fromJSON(needs.preflight.outputs.test_archive_timeout_minutes || '60') }}
+      archive_label: a
+      filterset: "binary(/.*[02468]$/)"
 
-  test-slow-shard:
-    uses: ./.github/workflows/run-nextest-archives.yml
-    # [#4103] shard는 archive만 소비한다. Native Skia는 final aggregate가 별도 집계하므로
-    # 여기서 기다리지 않아 archive 완료 즉시 기본 테스트를 시작할 수 있다.
-    needs: [preflight, build-test-archive]
+
+  build-test-archive-b:
+    uses: ./.github/workflows/build-nextest-archives.yml
+    needs: [preflight]
     if: >-
       ${{
         always()
         && needs.preflight.result == 'success'
         && needs.preflight.outputs.fast_pass != 'true'
         && needs.preflight.outputs.rust_required == 'true'
-        && needs['build-test-archive'].result == 'success'
       }}
     permissions:
       contents: read
     with:
-      label: slow shard
-      count_label: slow
-      filterset: "binary(=overflow_cell_baseline)"
-
-  test-regular-shard-1:
-    uses: ./.github/workflows/run-nextest-archives.yml
-    needs: [preflight, build-test-archive]
-    if: >-
-      ${{
-        always()
-        && needs.preflight.result == 'success'
-        && needs.preflight.outputs.fast_pass != 'true'
-        && needs.preflight.outputs.rust_required == 'true'
-        && needs['build-test-archive'].result == 'success'
-      }}
-    permissions:
-      contents: read
-    with:
-      label: shard 1/3
-      count_label: "1"
-      filterset: "not binary(=overflow_cell_baseline)"
-      partition: "hash:1/3"
-
-  test-regular-shard-2:
-    uses: ./.github/workflows/run-nextest-archives.yml
-    needs: [preflight, build-test-archive]
-    if: >-
-      ${{
-        always()
-        && needs.preflight.result == 'success'
-        && needs.preflight.outputs.fast_pass != 'true'
-        && needs.preflight.outputs.rust_required == 'true'
-        && needs['build-test-archive'].result == 'success'
-      }}
-    permissions:
-      contents: read
-    with:
-      label: shard 2/3
-      count_label: "2"
-      filterset: "not binary(=overflow_cell_baseline)"
-      partition: "hash:2/3"
-
-  test-regular-shard-3:
-    uses: ./.github/workflows/run-nextest-archives.yml
-    needs: [preflight, build-test-archive]
-    if: >-
-      ${{
-        always()
-        && needs.preflight.result == 'success'
-        && needs.preflight.outputs.fast_pass != 'true'
-        && needs.preflight.outputs.rust_required == 'true'
-        && needs['build-test-archive'].result == 'success'
-      }}
-    permissions:
-      contents: read
-    with:
-      label: shard 3/3
-      count_label: "3"
-      filterset: "not binary(=overflow_cell_baseline)"
-      partition: "hash:3/3"
-
+      cargo_profile: ${{ needs.preflight.outputs.test_profile || 'release' }}
+      timeout_minutes: ${{ fromJSON(needs.preflight.outputs.test_archive_timeout_minutes || '60') }}
+      archive_label: b
+      filterset: "not binary(/.*[02468]$/)"
 
   lint:
     name: Lint (fmt, clippy, WASM check)
@@ -1295,6 +1238,90 @@ jobs:
             target
           key: ${{ runner.os }}-frontend-wasm-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+  test-archive-a-shard-1:
+    uses: ./.github/workflows/run-nextest-archives.yml
+    needs: [preflight, build-test-archive-a]
+    if: >-
+      ${{
+        always()
+        && needs.preflight.result == 'success'
+        && needs.preflight.outputs.fast_pass != 'true'
+        && needs.preflight.outputs.rust_required == 'true'
+        && needs['build-test-archive-a'].result == 'success'
+      }}
+    permissions:
+      contents: read
+    with:
+      label: Archive A shard 1
+      count_label: a-1
+      archive_label: a
+      filterset: "all()"
+      partition: "hash:1/2"
+
+
+  test-archive-a-shard-2:
+    uses: ./.github/workflows/run-nextest-archives.yml
+    needs: [preflight, build-test-archive-a]
+    if: >-
+      ${{
+        always()
+        && needs.preflight.result == 'success'
+        && needs.preflight.outputs.fast_pass != 'true'
+        && needs.preflight.outputs.rust_required == 'true'
+        && needs['build-test-archive-a'].result == 'success'
+      }}
+    permissions:
+      contents: read
+    with:
+      label: Archive A shard 2
+      count_label: a-2
+      archive_label: a
+      filterset: "all()"
+      partition: "hash:1/2"
+
+
+  test-archive-b-shard-1:
+    uses: ./.github/workflows/run-nextest-archives.yml
+    needs: [preflight, build-test-archive-b]
+    if: >-
+      ${{
+        always()
+        && needs.preflight.result == 'success'
+        && needs.preflight.outputs.fast_pass != 'true'
+        && needs.preflight.outputs.rust_required == 'true'
+        && needs['build-test-archive-b'].result == 'success'
+      }}
+    permissions:
+      contents: read
+    with:
+      label: Archive B shard 1
+      count_label: b-1
+      archive_label: b
+      filterset: "all()"
+      partition: "hash:1/2"
+
+
+  test-archive-b-shard-2:
+    uses: ./.github/workflows/run-nextest-archives.yml
+    needs: [preflight, build-test-archive-b]
+    if: >-
+      ${{
+        always()
+        && needs.preflight.result == 'success'
+        && needs.preflight.outputs.fast_pass != 'true'
+        && needs.preflight.outputs.rust_required == 'true'
+        && needs['build-test-archive-b'].result == 'success'
+      }}
+    permissions:
+      contents: read
+    with:
+      label: Archive B shard 2
+      count_label: b-2
+      archive_label: b
+      filterset: "all()"
+      partition: "hash:1/2"
+
+
   build-and-test:
     name: Build & Test
     runs-on: ubuntu-latest
@@ -1302,11 +1329,12 @@ jobs:
     timeout-minutes: 45
     needs:
       - preflight
-      - build-test-archive
-      - test-slow-shard
-      - test-regular-shard-1
-      - test-regular-shard-2
-      - test-regular-shard-3
+      - build-test-archive-a
+      - build-test-archive-b
+      - test-archive-a-shard-1
+      - test-archive-a-shard-2
+      - test-archive-b-shard-1
+      - test-archive-b-shard-2
       - lint
       - native-skia-tests
       - frontend-unit-gates
@@ -1316,82 +1344,78 @@ jobs:
       contents: read
 
     steps:
-      # [#5164] 단일 archive의 runnable 수와 네 worker Summary run 합계가 일치해야 한다.
+      - name: Download archive A expected count
+        if: >-
+          ${{
+            needs.preflight.outputs.fast_pass != 'true'
+            && needs.preflight.outputs.rust_required == 'true'
+            && needs['test-archive-a-shard-1'].result == 'success'
+            && needs['test-archive-a-shard-2'].result == 'success'
+            && needs['test-archive-b-shard-1'].result == 'success'
+            && needs['test-archive-b-shard-2'].result == 'success'
+          }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: archive-expected-${{ github.run_id }}-a
+          path: archive-expected-a
+      - name: Download archive B expected count
+        if: >-
+          ${{
+            needs.preflight.outputs.fast_pass != 'true'
+            && needs.preflight.outputs.rust_required == 'true'
+            && needs['test-archive-a-shard-1'].result == 'success'
+            && needs['test-archive-a-shard-2'].result == 'success'
+            && needs['test-archive-b-shard-1'].result == 'success'
+            && needs['test-archive-b-shard-2'].result == 'success'
+          }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: archive-expected-${{ github.run_id }}-b
+          path: archive-expected-b
       - name: Download shard counts
         if: >-
           ${{
             needs.preflight.outputs.fast_pass != 'true'
             && needs.preflight.outputs.rust_required == 'true'
-            && needs['test-slow-shard'].result == 'success'
-            && needs['test-regular-shard-1'].result == 'success'
-            && needs['test-regular-shard-2'].result == 'success'
-            && needs['test-regular-shard-3'].result == 'success'
+            && needs['test-archive-a-shard-1'].result == 'success'
+            && needs['test-archive-a-shard-2'].result == 'success'
+            && needs['test-archive-b-shard-1'].result == 'success'
+            && needs['test-archive-b-shard-2'].result == 'success'
           }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: shard-count-*
-          merge-multiple: true
-
-      - name: Download archive expected counts
+          path: shard-counts
+      - name: Verify archive shard totals
         if: >-
           ${{
             needs.preflight.outputs.fast_pass != 'true'
             && needs.preflight.outputs.rust_required == 'true'
-            && needs['test-slow-shard'].result == 'success'
-            && needs['test-regular-shard-1'].result == 'success'
-            && needs['test-regular-shard-2'].result == 'success'
-            && needs['test-regular-shard-3'].result == 'success'
-          }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: archive-expected-${{ github.run_id }}
-
-      - name: Verify shard totals
-        if: >-
-          ${{
-            needs.preflight.outputs.fast_pass != 'true'
-            && needs.preflight.outputs.rust_required == 'true'
-            && needs['test-slow-shard'].result == 'success'
-            && needs['test-regular-shard-1'].result == 'success'
-            && needs['test-regular-shard-2'].result == 'success'
-            && needs['test-regular-shard-3'].result == 'success'
+            && needs['test-archive-a-shard-1'].result == 'success'
+            && needs['test-archive-a-shard-2'].result == 'success'
+            && needs['test-archive-b-shard-1'].result == 'success'
+            && needs['test-archive-b-shard-2'].result == 'success'
           }}
         run: |
-          shards=$(find . -maxdepth 1 -type f -name 'shard-count-*.txt' | wc -l | tr -d ' ')
-          if [[ "$shards" != "4" ]]; then
-            echo "::error::expected 4 shard count files, found ${shards}"
+          read -r expected_a < archive-expected-a/archive-expected-total.txt
+          read -r expected_b < archive-expected-b/archive-expected-total.txt
+          read -r a1 < shard-counts/shard-count-a-1/shard-count-a-1.txt
+          read -r a2 < shard-counts/shard-count-a-2/shard-count-a-2.txt
+          read -r b1 < shard-counts/shard-count-b-1/shard-count-b-1.txt
+          read -r b2 < shard-counts/shard-count-b-2/shard-count-b-2.txt
+          if ! [[ "$expected_a" =~ ^[0-9]+$ && "$expected_b" =~ ^[0-9]+$ && "$a1" =~ ^[0-9]+$ && "$a2" =~ ^[0-9]+$ && "$b1" =~ ^[0-9]+$ && "$b2" =~ ^[0-9]+$ ]]; then
+            echo "::error::archive expected counts and shard counts must be non-negative integers"
             exit 1
           fi
-          if [[ ! -f archive-expected-total.txt ]]; then
-            echo "::error::archive expected runnable count is missing"
+          if (( a1 + a2 != expected_a )); then
+            echo "::error::Archive A shard total mismatch: $a1 + $a2 != $expected_a"
             exit 1
           fi
-          read -r expected < archive-expected-total.txt
-          if ! [[ "$expected" =~ ^[0-9]+$ ]]; then
-            echo "::error::invalid archive expected count: ${expected}"
+          if (( b1 + b2 != expected_b )); then
+            echo "::error::Archive B shard total mismatch: $b1 + $b2 != $expected_b"
             exit 1
           fi
-          read -r slow < shard-count-slow.txt
-          if [[ "$slow" != "1" ]]; then
-            echo "::error::slow filter expected exactly 1 runnable test, got ${slow}"
-            exit 1
-          fi
-          sum=0
-          for f in shard-count-*.txt; do
-            read -r run < "$f"
-            if ! [[ "$run" =~ ^[0-9]+$ ]]; then
-              echo "::error::invalid shard run count in ${f}: ${run}"
-              exit 1
-            fi
-            sum=$((sum + run))
-            echo "${f}: run=${run}"
-          done
-          echo "sum(run)=${sum} expected runnable=${expected}"
-          if [[ "$sum" != "${expected}" ]]; then
-            echo "::error::shard run sum ${sum} != runnable tests ${expected} (누락 또는 중복)"
-            exit 1
-          fi
-
+          printf 'archive_total=%s shard_total=%s\n' "$((expected_a + expected_b))" "$((a1 + a2 + b1 + b2))"
       - name: Check Build & Test worker results
         env:
           PREFLIGHT_RESULT: ${{ needs.preflight.result }}
@@ -1399,108 +1423,44 @@ jobs:
           RUST_REQUIRED: ${{ needs.preflight.outputs.rust_required }}
           NATIVE_SKIA_REQUIRED: ${{ needs.preflight.outputs.native_skia_required }}
           FRONTEND_MODE: ${{ needs.preflight.outputs.frontend_mode }}
-          IMPACT_REASON: ${{ needs.preflight.outputs.impact_reason }}
-          BUILD_ARCHIVE_RESULT: ${{ needs['build-test-archive'].result }}
-          TEST_SLOW_RESULT: ${{ needs['test-slow-shard'].result }}
-          TEST_REGULAR_1_RESULT: ${{ needs['test-regular-shard-1'].result }}
-          TEST_REGULAR_2_RESULT: ${{ needs['test-regular-shard-2'].result }}
-          TEST_REGULAR_3_RESULT: ${{ needs['test-regular-shard-3'].result }}
-          LINT_RESULT: ${{ needs['lint'].result }}
+          BUILD_ARCHIVE_A_RESULT: ${{ needs['build-test-archive-a'].result }}
+          BUILD_ARCHIVE_B_RESULT: ${{ needs['build-test-archive-b'].result }}
+          TEST_ARCHIVE_A_1_RESULT: ${{ needs['test-archive-a-shard-1'].result }}
+          TEST_ARCHIVE_A_2_RESULT: ${{ needs['test-archive-a-shard-2'].result }}
+          TEST_ARCHIVE_B_1_RESULT: ${{ needs['test-archive-b-shard-1'].result }}
+          TEST_ARCHIVE_B_2_RESULT: ${{ needs['test-archive-b-shard-2'].result }}
+          LINT_RESULT: ${{ needs.lint.result }}
           NATIVE_SKIA_RESULT: ${{ needs['native-skia-tests'].result }}
           FRONTEND_UNIT_RESULT: ${{ needs['frontend-unit-gates'].result }}
           FRONTEND_PACKAGE_RESULT: ${{ needs['frontend-package-gates'].result }}
         run: |
-          printf 'preflight=%s\n' "${PREFLIGHT_RESULT}"
-          printf 'fast_pass=%s\n' "${FAST_PASS}"
-          printf 'rust_required=%s\n' "${RUST_REQUIRED}"
-          printf 'native_skia_required=%s\n' "${NATIVE_SKIA_REQUIRED}"
-          printf 'frontend_mode=%s\n' "${FRONTEND_MODE}"
-          printf 'impact_reason=%s\n' "${IMPACT_REASON}"
-          printf 'build_archive=%s\n' "${BUILD_ARCHIVE_RESULT}"
-          printf 'test_slow=%s\n' "${TEST_SLOW_RESULT}"
-          printf 'test_regular_1=%s\n' "${TEST_REGULAR_1_RESULT}"
-          printf 'test_regular_2=%s\n' "${TEST_REGULAR_2_RESULT}"
-          printf 'test_regular_3=%s\n' "${TEST_REGULAR_3_RESULT}"
-          printf 'lint=%s\n' "${LINT_RESULT}"
-          printf 'native_skia=%s\n' "${NATIVE_SKIA_RESULT}"
-          printf 'frontend_unit=%s\n' "${FRONTEND_UNIT_RESULT}"
-          printf 'frontend_package=%s\n' "${FRONTEND_PACKAGE_RESULT}"
-
           if [[ "${PREFLIGHT_RESULT}" != "success" ]]; then
             echo "::error::CI preflight did not succeed: ${PREFLIGHT_RESULT}"
             exit 1
           fi
-
           if [[ "${FAST_PASS}" == "true" ]]; then
             echo "CI preflight fast-pass accepted."
             exit 0
           fi
-
           failed=0
-          rust_results="${LINT_RESULT}/${BUILD_ARCHIVE_RESULT}/${TEST_SLOW_RESULT}/${TEST_REGULAR_1_RESULT}/${TEST_REGULAR_2_RESULT}/${TEST_REGULAR_3_RESULT}"
+          rust_results="${LINT_RESULT}/${BUILD_ARCHIVE_A_RESULT}/${BUILD_ARCHIVE_B_RESULT}/${TEST_ARCHIVE_A_1_RESULT}/${TEST_ARCHIVE_A_2_RESULT}/${TEST_ARCHIVE_B_1_RESULT}/${TEST_ARCHIVE_B_2_RESULT}"
           case "${RUST_REQUIRED}" in
-            true)
-              if [[ "${rust_results}" != "success/success/success/success/success/success" ]]; then
-                echo "::error::Rust lane expected success for lint/builder/workers, got: ${rust_results}"
-                failed=1
-              fi
-              ;;
-            false)
-              if [[ "${rust_results}" != "skipped/skipped/skipped/skipped/skipped/skipped" ]]; then
-                echo "::error::Rust lane expected skipped for lint/builder/workers, got: ${rust_results}"
-                failed=1
-              fi
-              ;;
-            *)
-              echo "::error::Unknown rust_required: ${RUST_REQUIRED}"
-              failed=1
-              ;;
+            true) [[ "$rust_results" == "success/success/success/success/success/success/success" ]] || { echo "::error::Rust lane expected success for lint/two builders/four workers, got: $rust_results"; failed=1; } ;;
+            false) [[ "$rust_results" == "skipped/skipped/skipped/skipped/skipped/skipped/skipped" ]] || { echo "::error::Rust lane expected skipped, got: $rust_results"; failed=1; } ;;
+            *) echo "::error::Unknown rust_required: ${RUST_REQUIRED}"; failed=1 ;;
           esac
-
           case "${NATIVE_SKIA_REQUIRED}" in
-            true)
-              if [[ "${NATIVE_SKIA_RESULT}" != "success" ]]; then
-                echo "::error::Native Skia lane expected success, got: ${NATIVE_SKIA_RESULT}"
-                failed=1
-              fi
-              ;;
-            false)
-              if [[ "${NATIVE_SKIA_RESULT}" != "skipped" ]]; then
-                echo "::error::Native Skia lane expected skipped, got: ${NATIVE_SKIA_RESULT}"
-                failed=1
-              fi
-              ;;
-            *)
-              echo "::error::Unknown native_skia_required: ${NATIVE_SKIA_REQUIRED}"
-              failed=1
-              ;;
+            true) [[ "${NATIVE_SKIA_RESULT}" == "success" ]] || { echo "::error::Native Skia lane expected success, got: ${NATIVE_SKIA_RESULT}"; failed=1; } ;;
+            false) [[ "${NATIVE_SKIA_RESULT}" == "skipped" ]] || { echo "::error::Native Skia lane expected skipped, got: ${NATIVE_SKIA_RESULT}"; failed=1; } ;;
+            *) echo "::error::Unknown native_skia_required: ${NATIVE_SKIA_REQUIRED}"; failed=1 ;;
           esac
           case "${FRONTEND_MODE}" in
-            none)
-              if [[ "${FRONTEND_UNIT_RESULT}" != "skipped" || "${FRONTEND_PACKAGE_RESULT}" != "skipped" ]]; then
-                echo "::error::Frontend none lane expected skipped/skipped, got: ${FRONTEND_UNIT_RESULT}/${FRONTEND_PACKAGE_RESULT}"
-                failed=1
-              fi
-              ;;
-            unit)
-              if [[ "${FRONTEND_UNIT_RESULT}" != "success" || "${FRONTEND_PACKAGE_RESULT}" != "skipped" ]]; then
-                echo "::error::Frontend unit lane expected success/skipped, got: ${FRONTEND_UNIT_RESULT}/${FRONTEND_PACKAGE_RESULT}"
-                failed=1
-              fi
-              ;;
-            package)
-              if [[ "${FRONTEND_UNIT_RESULT}" != "skipped" || "${FRONTEND_PACKAGE_RESULT}" != "success" ]]; then
-                echo "::error::Frontend package lane expected skipped/success, got: ${FRONTEND_UNIT_RESULT}/${FRONTEND_PACKAGE_RESULT}"
-                failed=1
-              fi
-              ;;
-            *)
-              echo "::error::Unknown frontend mode: ${FRONTEND_MODE}"
-              failed=1
-              ;;
+            none) [[ "${FRONTEND_UNIT_RESULT}/${FRONTEND_PACKAGE_RESULT}" == "skipped/skipped" ]] || { echo "::error::Frontend none lane expected skipped/skipped"; failed=1; } ;;
+            unit) [[ "${FRONTEND_UNIT_RESULT}/${FRONTEND_PACKAGE_RESULT}" == "success/skipped" ]] || { echo "::error::Frontend unit lane expected success/skipped"; failed=1; } ;;
+            package) [[ "${FRONTEND_UNIT_RESULT}/${FRONTEND_PACKAGE_RESULT}" == "skipped/success" ]] || { echo "::error::Frontend package lane expected skipped/success"; failed=1; } ;;
+            *) echo "::error::Unknown frontend mode: ${FRONTEND_MODE}"; failed=1 ;;
           esac
-          exit "${failed}"
-
+          exit "$failed"
   wasm-build:
     name: WASM Build
     runs-on: ubuntu-latest

--- a/.github/workflows/run-nextest-archives.yml
+++ b/.github/workflows/run-nextest-archives.yml
@@ -11,6 +11,10 @@ on:
         description: Unique worker count artifact suffix.
         required: true
         type: string
+      archive_label:
+        description: Stable A/B archive partition label.
+        required: true
+        type: string
       filterset:
         description: Nextest filterset applied before partitioning.
         required: true
@@ -47,7 +51,7 @@ jobs:
       - name: Download shared test archive
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: test-archive-${{ github.run_id }}
+          name: test-archive-${{ github.run_id }}-${{ inputs.archive_label }}
 
       # [#5164] 네 worker는 동일 archive에서 서로 배타적인 filter/partition만 실행한다.
       # 집계 job은 archive runnable 수와 네 Summary run 합계를 대조한다.

--- a/mydocs/working/task_m100_5737_stage1_nextest_archive_ab_partition.md
+++ b/mydocs/working/task_m100_5737_stage1_nextest_archive_ab_partition.md
@@ -1,0 +1,7 @@
+# #5737 Stage 1: nextest archive A/B partition
+
+- 단일 17분 27초 archive와 전용 slow shard를 A/B 병렬 archive와 4 worker로 교체한다.
+- A는 짝수 숫자 suffix binary, B는 보집합이다. 두 filterset은 겹치지 않고 전체 target을 덮는다.
+- 각 archive는 `hash:1/2` 두 worker가 소비하며 aggregate가 archive별 count 합을 검증한다.
+- 후보 CI에서 critical path, builder 시간, artifact 크기, 총 runner minute을 기존 단일 archive와 비교한다.
+  공통 dependency 중복 compile으로 이득이 없으면 채택하지 않는다.

--- a/mydocs/working/task_m100_5737_stage2_lib_integration_archive_partition.md
+++ b/mydocs/working/task_m100_5737_stage2_lib_integration_archive_partition.md
@@ -1,0 +1,36 @@
+# #5737 Stage 2 - lib/integration archive 분할 분석
+
+## 목표
+
+초기 archive 이름 짝홀수 분할을, 각 builder가 자신의 Cargo test target만
+컴파일하면서 임계 경로도 균형 있게 유지하는 방식으로 대체한다.
+
+## Stage 1 실측 근거
+
+- 이름 짝홀수 분할 결과는 archive A 1,965건, archive B 5,860건이었다.
+- `rhwp` library test binary 하나에만 3,893건이 있어, integration target 이름을
+  짝홀수 bucket으로 나누는 방식으로는 균형을 맞출 수 없다.
+- 두 archive 산출물 크기는 각각 216,427,704 bytes와 243,509,661 bytes였다.
+
+## 확인된 구조
+
+1. Archive A는 `cargo nextest ... --lib`만 선택한다.
+2. Archive B는 파생 suite 준비 뒤 `cargo metadata --no-deps --format-version 1`으로
+   찾은 root package의 모든 integration `--test <name>` target만 선택한다.
+3. 각 archive는 `hash:1/2` worker 두 개를 두고, aggregate가 archive별 runnable
+   total을 각각 검증한다.
+
+## Stage 2 실측 결과
+
+- lib archive: 3,893 runnable tests, 25,511,342 bytes
+- integration archive: 3,920 runnable tests, 317,779,426 bytes
+- 두 target group의 합계는 7,813 runnable tests이며, 분할 오차는 27건이다.
+
+## 수용 기준
+
+- 로컬 archive 목록이 실측 lib 3,893건, integration 3,920건 수준으로 균형을 이룬다.
+- 재사용 builder는 어느 partition에서도 `--tests`를 쓰지 않아, 반대 partition의
+  test target을 컴파일하지 않는다.
+- workflow 계약 테스트가 target 탐색, archive label, 두 builder, 네 worker를 검증한다.
+- PR CI에서 단일 archive 기준선과 비교해 builder 시간, artifact 크기, worker wall-clock,
+  runner-minute 변화를 기록한 뒤 채택 여부를 결정한다.

--- a/mydocs/working/task_m100_5737_stage3_integration_archive_bc_partition.md
+++ b/mydocs/working/task_m100_5737_stage3_integration_archive_bc_partition.md
@@ -1,0 +1,26 @@
+# #5737 Stage 3 - integration archive B/C 교차 분할
+
+## 배경
+
+Stage 2의 lib/integration 두 archive는 test 건수를 거의 같게 나눴지만, 실제 PR run에서
+lib archive build는 2분 54초, integration archive build는 11분 3초였다. lib archive는
+test binary 하나와 약 27MB 산출물만 포함한 반면 integration archive는 41개 Cargo test target을
+각각 링크하므로, runnable test 수만으로는 builder 비용이 균형을 이루지 못한다.
+
+## 변경 설계
+
+1. Archive A는 `--lib` 전용으로 유지하고 `hash:1/2`, `hash:2/2` worker 두 개가 소비한다.
+2. metadata에서 정렬해 찾은 integration test target을 순번 교차 방식으로 B/C에 배정한다.
+   현재 41개 target은 B 21개, C 20개가 되며 새 target도 자동으로 두 archive에 분산된다.
+3. Archive B와 C는 각각 `hash:1/1` worker 하나가 전부 실행한다. 총 worker 수는 A1, A2,
+   B1, C1의 네 개로 유지한다.
+4. 집계는 `A1 + A2 = expected A`, `B1 = expected B`, `C1 = expected C`를 검증한다.
+
+## 기대 효과와 검증 기준
+
+- B/C builder는 별도 runner에서 병렬 compile/link되므로, Stage 2의 11분 3초 integration
+  builder 임계 경로를 줄이는 것이 목표다. 공통 의존성은 두 runner에서 중복 컴파일하므로
+  정확히 반으로 줄어드는 것을 보장하지는 않는다.
+- 실제 PR CI에서 세 builder의 build 시간, archive 크기, 네 worker wall-clock과 전체 Build & Test
+  완료 시간을 Stage 2 run과 비교한다.
+- B/C의 runnable 합계와 A의 runnable 합계가 각 archive expected count와 정확히 일치해야 한다.

--- a/scripts/ci-impact-policy.cjs
+++ b/scripts/ci-impact-policy.cjs
@@ -135,36 +135,41 @@ const RENDER_DIFF_PULL_REQUEST_PATHS = [
 
 const CI_RUST_JOBS = [
   'Lint (fmt, clippy, WASM check)',
-  'build-test-archive',
-  'test-slow-shard',
-  'test-regular-shard-1',
-  'test-regular-shard-2',
-  'test-regular-shard-3',
+  'build-test-archive-a',
+  'build-test-archive-b',
+  'test-archive-a-shard-1',
+  'test-archive-a-shard-2',
+  'test-archive-b-shard-1',
+  'test-archive-b-shard-2',
 ];
 // Reusable workflow calls have two observed REST job names: a skipped call keeps only
 // its caller job id, while an executed call is reported as "caller / called job name".
 // Audit one logical lane across both representations without accepting duplicates.
 const CI_JOB_ALIASES = {
   'Lint (fmt, clippy, WASM check)': ['Lint (fmt, clippy, WASM check)'],
-  'build-test-archive': [
-    'build-test-archive',
-    'build-test-archive / Build test archive',
+  'build-test-archive-a': [
+    'build-test-archive-a',
+    'build-test-archive-a / Build test archive (a)',
   ],
-  'test-slow-shard': [
-    'test-slow-shard',
-    'test-slow-shard / Default-feature tests (slow shard)',
+  'build-test-archive-b': [
+    'build-test-archive-b',
+    'build-test-archive-b / Build test archive (b)',
   ],
-  'test-regular-shard-1': [
-    'test-regular-shard-1',
-    'test-regular-shard-1 / Default-feature tests (shard 1/3)',
+  'test-archive-a-shard-1': [
+    'test-archive-a-shard-1',
+    'test-archive-a-shard-1 / Default-feature tests (Archive A shard 1)',
   ],
-  'test-regular-shard-2': [
-    'test-regular-shard-2',
-    'test-regular-shard-2 / Default-feature tests (shard 2/3)',
+  'test-archive-a-shard-2': [
+    'test-archive-a-shard-2',
+    'test-archive-a-shard-2 / Default-feature tests (Archive A shard 2)',
   ],
-  'test-regular-shard-3': [
-    'test-regular-shard-3',
-    'test-regular-shard-3 / Default-feature tests (shard 3/3)',
+  'test-archive-b-shard-1': [
+    'test-archive-b-shard-1',
+    'test-archive-b-shard-1 / Default-feature tests (Archive B shard 1)',
+  ],
+  'test-archive-b-shard-2': [
+    'test-archive-b-shard-2',
+    'test-archive-b-shard-2 / Default-feature tests (Archive B shard 2)',
   ],
 };
 const CI_NATIVE_JOB = 'Native Skia tests';
@@ -173,11 +178,12 @@ const CI_FRONTEND_JOBS = ['Frontend unit gates', 'Frontend package gates'];
 // below. Tests derive every impact-conditioned ci.yml job and require this map to stay
 // complete, so adding a new selectable lane cannot silently escape the controller.
 const CI_AUDITED_JOB_IDS = {
-  'build-test-archive': 'build-test-archive',
-  'test-slow-shard': 'test-slow-shard',
-  'test-regular-shard-1': 'test-regular-shard-1',
-  'test-regular-shard-2': 'test-regular-shard-2',
-  'test-regular-shard-3': 'test-regular-shard-3',
+  'build-test-archive-a': 'build-test-archive-a',
+  'build-test-archive-b': 'build-test-archive-b',
+  'test-archive-a-shard-1': 'test-archive-a-shard-1',
+  'test-archive-a-shard-2': 'test-archive-a-shard-2',
+  'test-archive-b-shard-1': 'test-archive-b-shard-1',
+  'test-archive-b-shard-2': 'test-archive-b-shard-2',
   lint: 'Lint (fmt, clippy, WASM check)',
   'native-skia-tests': CI_NATIVE_JOB,
   'frontend-unit-gates': CI_FRONTEND_JOBS[0],

--- a/scripts/ci-impact-policy.cjs
+++ b/scripts/ci-impact-policy.cjs
@@ -137,10 +137,11 @@ const CI_RUST_JOBS = [
   'Lint (fmt, clippy, WASM check)',
   'build-test-archive-a',
   'build-test-archive-b',
+  'build-test-archive-c',
   'test-archive-a-shard-1',
   'test-archive-a-shard-2',
   'test-archive-b-shard-1',
-  'test-archive-b-shard-2',
+  'test-archive-c-shard-1',
 ];
 // Reusable workflow calls have two observed REST job names: a skipped call keeps only
 // its caller job id, while an executed call is reported as "caller / called job name".
@@ -155,6 +156,10 @@ const CI_JOB_ALIASES = {
     'build-test-archive-b',
     'build-test-archive-b / Build test archive (b)',
   ],
+  'build-test-archive-c': [
+    'build-test-archive-c',
+    'build-test-archive-c / Build test archive (c)',
+  ],
   'test-archive-a-shard-1': [
     'test-archive-a-shard-1',
     'test-archive-a-shard-1 / Default-feature tests (Archive A shard 1)',
@@ -167,9 +172,9 @@ const CI_JOB_ALIASES = {
     'test-archive-b-shard-1',
     'test-archive-b-shard-1 / Default-feature tests (Archive B shard 1)',
   ],
-  'test-archive-b-shard-2': [
-    'test-archive-b-shard-2',
-    'test-archive-b-shard-2 / Default-feature tests (Archive B shard 2)',
+  'test-archive-c-shard-1': [
+    'test-archive-c-shard-1',
+    'test-archive-c-shard-1 / Default-feature tests (Archive C)',
   ],
 };
 const CI_NATIVE_JOB = 'Native Skia tests';
@@ -180,10 +185,11 @@ const CI_FRONTEND_JOBS = ['Frontend unit gates', 'Frontend package gates'];
 const CI_AUDITED_JOB_IDS = {
   'build-test-archive-a': 'build-test-archive-a',
   'build-test-archive-b': 'build-test-archive-b',
+  'build-test-archive-c': 'build-test-archive-c',
   'test-archive-a-shard-1': 'test-archive-a-shard-1',
   'test-archive-a-shard-2': 'test-archive-a-shard-2',
   'test-archive-b-shard-1': 'test-archive-b-shard-1',
-  'test-archive-b-shard-2': 'test-archive-b-shard-2',
+  'test-archive-c-shard-1': 'test-archive-c-shard-1',
   lint: 'Lint (fmt, clippy, WASM check)',
   'native-skia-tests': CI_NATIVE_JOB,
   'frontend-unit-gates': CI_FRONTEND_JOBS[0],

--- a/scripts/tests/ci-impact-policy.test.cjs
+++ b/scripts/tests/ci-impact-policy.test.cjs
@@ -550,10 +550,10 @@ test('aggregate audit rejects duplicate reusable-workflow aliases', () => {
   const input = policyInput({ files, classification: classificationFor(files) });
   const policy = determinePolicy(input);
   const workflows = workflowEvidence(policy);
-  workflows.CI.jobs.push(job('build-test-archive', 'skipped'));
+  workflows.CI.jobs.push(job('build-test-archive-a', 'skipped'));
   const audit = auditPolicyRuns({ ...input, policy, currentHeadSha: HEAD_SHA, workflows });
   assert.equal(audit.conclusion, 'failure');
-  assert.match(audit.reason, /duplicate-job:build-test-archive/);
+  assert.match(audit.reason, /duplicate-job:build-test-archive-a/);
 });
 
 test('aggregate audit stays pending until every expected workflow is present', () => {

--- a/scripts/tests/test_adapter_diff_workflow.py
+++ b/scripts/tests/test_adapter_diff_workflow.py
@@ -73,12 +73,13 @@ class AdapterDiffWorkflowTests(unittest.TestCase):
         self.assertLess(prepare_at, run_at, "prepare 가 실행보다 먼저여야 한다")
 
     def test_does_not_add_a_fifth_nextest_shard(self) -> None:
-        """A/B archive의 worker 네 개 합 = runnable. 다섯 번째 worker는 깨진다."""
+        """A/B/C archive의 worker 네 개 합 = runnable. 다섯 번째 worker는 깨진다."""
         self.assertNotRegex(self.ci, r"(?m)^  adapter-diff:")
         self.assertNotIn("adapter_diff", RUN_ARCHIVE.read_text(encoding="utf-8"))
-        self.assertEqual(2, self.ci.count('partition: "hash:1/2"'))
-        self.assertEqual(2, self.ci.count('partition: "hash:2/2"'))
-        for count_label in ("a-1", "a-2", "b-1", "b-2"):
+        self.assertEqual(1, self.ci.count('partition: "hash:1/2"'))
+        self.assertEqual(1, self.ci.count('partition: "hash:2/2"'))
+        self.assertEqual(2, self.ci.count('partition: "hash:1/1"'))
+        for count_label in ("a-1", "a-2", "b-1", "c-1"):
             with self.subTest(count_label=count_label):
                 self.assertIn(f"shard-count-{count_label}", self.ci)
 

--- a/scripts/tests/test_adapter_diff_workflow.py
+++ b/scripts/tests/test_adapter_diff_workflow.py
@@ -73,10 +73,13 @@ class AdapterDiffWorkflowTests(unittest.TestCase):
         self.assertLess(prepare_at, run_at, "prepare 가 실행보다 먼저여야 한다")
 
     def test_does_not_add_a_fifth_nextest_shard(self) -> None:
-        """정규 archive 집계는 shard 4개 합 = runnable. 5번째 worker 는 깨진다."""
+        """A/B archive의 worker 네 개 합 = runnable. 다섯 번째 worker는 깨진다."""
         self.assertNotRegex(self.ci, r"(?m)^  adapter-diff:")
         self.assertNotIn("adapter_diff", RUN_ARCHIVE.read_text(encoding="utf-8"))
-        self.assertIn("expected 4 shard count files", self.ci)
+        self.assertEqual(4, self.ci.count('partition: "hash:1/2"'))
+        for count_label in ("a-1", "a-2", "b-1", "b-2"):
+            with self.subTest(count_label=count_label):
+                self.assertIn(f"shard-count-{count_label}", self.ci)
 
     def test_read_only_permissions(self) -> None:
         self.assertIn("actions: read", self.wf)

--- a/scripts/tests/test_adapter_diff_workflow.py
+++ b/scripts/tests/test_adapter_diff_workflow.py
@@ -76,7 +76,8 @@ class AdapterDiffWorkflowTests(unittest.TestCase):
         """A/B archive의 worker 네 개 합 = runnable. 다섯 번째 worker는 깨진다."""
         self.assertNotRegex(self.ci, r"(?m)^  adapter-diff:")
         self.assertNotIn("adapter_diff", RUN_ARCHIVE.read_text(encoding="utf-8"))
-        self.assertEqual(4, self.ci.count('partition: "hash:1/2"'))
+        self.assertEqual(2, self.ci.count('partition: "hash:1/2"'))
+        self.assertEqual(2, self.ci.count('partition: "hash:2/2"'))
         for count_label in ("a-1", "a-2", "b-1", "b-2"):
             with self.subTest(count_label=count_label):
                 self.assertIn(f"shard-count-{count_label}", self.ci)

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -950,7 +950,7 @@ mod support;
                     )
                     self.assertIn(f"archive_label: {archive_label}", job)
                     self.assertIn('filterset: "all()"', job)
-                    self.assertIn(f'partition: "hash:{shard}/2"', job)
+                    self.assertIn(f'partition: "hash:{index}/2"', job)
                     self.assertNotIn("native-skia-tests", job)
                     self.assertNotIn("native_skia_required", job)
         self.assertNotIn("test-slow-shard:", self.workflow)

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -639,7 +639,8 @@ class CiImpactWorkflowTests(unittest.TestCase):
 
         for archive_name, target_group in (
             ("build-test-archive-a", "lib"),
-            ("build-test-archive-b", "integration"),
+            ("build-test-archive-b", "integration-b"),
+            ("build-test-archive-c", "integration-c"),
         ):
             with self.subTest(archive=archive_name):
                 archive = self._job(archive_name)
@@ -671,10 +672,24 @@ class CiImpactWorkflowTests(unittest.TestCase):
             native_skia.index("- name: Prepare derived Rust test suites"),
             native_skia.index("- name: Native Skia tests"),
         )
-        self.assertEqual(
+            self.assertEqual(
             1,
             native_skia.count("node scripts/rust-test-suite-manifest.mjs --prepare"),
         )
+
+    def test_native_skia_disk_cleanup_runs_only_below_the_archive_threshold(self) -> None:
+        native_skia = self._job("native-skia-tests")
+        cleanup = self._step(
+            "Free disk space (remove unused pre-installed toolchains)", native_skia
+        )
+        threshold = "if (( available_gb < 30 )); then"
+        removal = "sudo rm -rf /usr/local/lib/android /usr/share/dotnet"
+
+        self.assertIn("df -BG --output=avail /", cleanup)
+        self.assertIn(threshold, cleanup)
+        self.assertEqual(1, cleanup.count(removal))
+        self.assertLess(cleanup.index(threshold), cleanup.index(removal))
+        self.assertIn("Skip cleanup: ${available_gb}GB available", cleanup)
 
     def test_native_skia_apt_timeout_skips_only_the_unavailable_runtime_lane(self) -> None:
         native_skia = self._job("native-skia-tests")

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -513,10 +513,11 @@ class CiImpactWorkflowTests(unittest.TestCase):
             "IMPACT_REASON": "classified:studio-unit",
             "BUILD_ARCHIVE_A_RESULT": "skipped",
             "BUILD_ARCHIVE_B_RESULT": "skipped",
+            "BUILD_ARCHIVE_C_RESULT": "skipped",
             "TEST_ARCHIVE_A_1_RESULT": "skipped",
             "TEST_ARCHIVE_A_2_RESULT": "skipped",
             "TEST_ARCHIVE_B_1_RESULT": "skipped",
-            "TEST_ARCHIVE_B_2_RESULT": "skipped",
+            "TEST_ARCHIVE_C_1_RESULT": "skipped",
             "LINT_RESULT": "skipped",
             "NATIVE_SKIA_RESULT": "skipped",
             "FRONTEND_UNIT_RESULT": "success",
@@ -672,7 +673,7 @@ class CiImpactWorkflowTests(unittest.TestCase):
             native_skia.index("- name: Prepare derived Rust test suites"),
             native_skia.index("- name: Native Skia tests"),
         )
-            self.assertEqual(
+        self.assertEqual(
             1,
             native_skia.count("node scripts/rust-test-suite-manifest.mjs --prepare"),
         )
@@ -997,6 +998,7 @@ mod support;
         for step_name in (
             "Download archive A expected count",
             "Download archive B expected count",
+            "Download archive C expected count",
             "Download shard counts",
             "Verify archive shard totals",
         ):
@@ -1012,10 +1014,11 @@ mod support;
             "LINT_RESULT": "success",
             "BUILD_ARCHIVE_A_RESULT": "success",
             "BUILD_ARCHIVE_B_RESULT": "success",
+            "BUILD_ARCHIVE_C_RESULT": "success",
             "TEST_ARCHIVE_A_1_RESULT": "success",
             "TEST_ARCHIVE_A_2_RESULT": "success",
             "TEST_ARCHIVE_B_1_RESULT": "success",
-            "TEST_ARCHIVE_B_2_RESULT": "success",
+            "TEST_ARCHIVE_C_1_RESULT": "success",
         }
         cases = {
             "frontend-only": {},

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -935,10 +935,14 @@ mod support;
         self.assertEqual(release_test, release)
 
     def test_rust_workers_wait_only_for_their_archive_partition(self) -> None:
-        for archive_label in ("a", "b"):
-            for index in (1, 2):
-                job_name = f"test-archive-{archive_label}-shard-{index}"
-                with self.subTest(job=job_name):
+        for archive_label, index, partition in (
+            ("a", 1, "hash:1/2"),
+            ("a", 2, "hash:2/2"),
+            ("b", 1, "hash:1/1"),
+            ("c", 1, "hash:1/1"),
+        ):
+            job_name = f"test-archive-{archive_label}-shard-{index}"
+            with self.subTest(job=job_name):
                     job = self._job(job_name)
                     self.assertIn("needs.preflight.outputs.rust_required == 'true'", job)
                     self.assertIn(
@@ -950,7 +954,7 @@ mod support;
                     )
                     self.assertIn(f"archive_label: {archive_label}", job)
                     self.assertIn('filterset: "all()"', job)
-                    self.assertIn(f'partition: "hash:{index}/2"', job)
+                    self.assertIn(f'partition: "{partition}"', job)
                     self.assertNotIn("native-skia-tests", job)
                     self.assertNotIn("native_skia_required", job)
         self.assertNotIn("test-slow-shard:", self.workflow)

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -637,7 +637,10 @@ class CiImpactWorkflowTests(unittest.TestCase):
         lint = self._job("lint")
         self.assertIn("needs.preflight.outputs.rust_required == 'true'", lint)
 
-        for archive_name in ("build-test-archive-a", "build-test-archive-b"):
+        for archive_name, target_group in (
+            ("build-test-archive-a", "lib"),
+            ("build-test-archive-b", "integration"),
+        ):
             with self.subTest(archive=archive_name):
                 archive = self._job(archive_name)
                 self.assertIn("needs.preflight.outputs.rust_required == 'true'", archive)
@@ -645,6 +648,7 @@ class CiImpactWorkflowTests(unittest.TestCase):
                 self.assertNotIn("needs.lint.result", archive)
                 self.assertNotIn("frontend-unit-gates", archive)
                 self.assertNotIn("frontend-package-gates", archive)
+                self.assertIn(f"target_group: {target_group}", archive)
 
     def test_lint_prepares_derived_test_targets_before_cargo_commands(self) -> None:
         lint = self._job("lint")

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -950,7 +950,7 @@ mod support;
                     )
                     self.assertIn(f"archive_label: {archive_label}", job)
                     self.assertIn('filterset: "all()"', job)
-                    self.assertIn('partition: "hash:1/2"', job)
+                    self.assertIn(f'partition: "hash:{shard}/2"', job)
                     self.assertNotIn("native-skia-tests", job)
                     self.assertNotIn("native_skia_required", job)
         self.assertNotIn("test-slow-shard:", self.workflow)

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -511,11 +511,12 @@ class CiImpactWorkflowTests(unittest.TestCase):
             "NATIVE_SKIA_REQUIRED": "false",
             "FRONTEND_MODE": "unit",
             "IMPACT_REASON": "classified:studio-unit",
-            "BUILD_ARCHIVE_RESULT": "skipped",
-            "TEST_SLOW_RESULT": "skipped",
-            "TEST_REGULAR_1_RESULT": "skipped",
-            "TEST_REGULAR_2_RESULT": "skipped",
-            "TEST_REGULAR_3_RESULT": "skipped",
+            "BUILD_ARCHIVE_A_RESULT": "skipped",
+            "BUILD_ARCHIVE_B_RESULT": "skipped",
+            "TEST_ARCHIVE_A_1_RESULT": "skipped",
+            "TEST_ARCHIVE_A_2_RESULT": "skipped",
+            "TEST_ARCHIVE_B_1_RESULT": "skipped",
+            "TEST_ARCHIVE_B_2_RESULT": "skipped",
             "LINT_RESULT": "skipped",
             "NATIVE_SKIA_RESULT": "skipped",
             "FRONTEND_UNIT_RESULT": "success",
@@ -636,12 +637,14 @@ class CiImpactWorkflowTests(unittest.TestCase):
         lint = self._job("lint")
         self.assertIn("needs.preflight.outputs.rust_required == 'true'", lint)
 
-        archive = self._job("build-test-archive")
-        self.assertIn("needs.preflight.outputs.rust_required == 'true'", archive)
-        self.assertIn("needs: [preflight]", archive)
-        self.assertNotIn("needs.lint.result", archive)
-        self.assertNotIn("frontend-unit-gates", archive)
-        self.assertNotIn("frontend-package-gates", archive)
+        for archive_name in ("build-test-archive-a", "build-test-archive-b"):
+            with self.subTest(archive=archive_name):
+                archive = self._job(archive_name)
+                self.assertIn("needs.preflight.outputs.rust_required == 'true'", archive)
+                self.assertIn("needs: [preflight]", archive)
+                self.assertNotIn("needs.lint.result", archive)
+                self.assertNotIn("frontend-unit-gates", archive)
+                self.assertNotIn("frontend-package-gates", archive)
 
     def test_lint_prepares_derived_test_targets_before_cargo_commands(self) -> None:
         lint = self._job("lint")
@@ -927,30 +930,26 @@ mod support;
         self.assertTrue(release_test)
         self.assertEqual(release_test, release)
 
-    def test_rust_workers_wait_only_for_the_shared_test_archive(self) -> None:
-        for job_name in (
-            "test-slow-shard",
-            "test-regular-shard-1",
-            "test-regular-shard-2",
-            "test-regular-shard-3",
-        ):
-            with self.subTest(job=job_name):
-                job = self._job(job_name)
-                self.assertIn("needs.preflight.outputs.rust_required == 'true'", job)
-                self.assertIn("needs: [preflight, build-test-archive]", job)
-                self.assertIn("needs['build-test-archive'].result == 'success'", job)
-                self.assertNotIn("native-skia-tests", job)
-                self.assertNotIn("native_skia_required", job)
-        self.assertIn(
-            'filterset: "binary(=overflow_cell_baseline)"',
-            self._job("test-slow-shard"),
-        )
-        for index in (1, 2, 3):
-            regular = self._job(f"test-regular-shard-{index}")
-            self.assertIn(
-                'filterset: "not binary(=overflow_cell_baseline)"', regular
-            )
-            self.assertIn(f'partition: "hash:{index}/3"', regular)
+    def test_rust_workers_wait_only_for_their_archive_partition(self) -> None:
+        for archive_label in ("a", "b"):
+            for index in (1, 2):
+                job_name = f"test-archive-{archive_label}-shard-{index}"
+                with self.subTest(job=job_name):
+                    job = self._job(job_name)
+                    self.assertIn("needs.preflight.outputs.rust_required == 'true'", job)
+                    self.assertIn(
+                        f"needs: [preflight, build-test-archive-{archive_label}]", job
+                    )
+                    self.assertIn(
+                        f"needs['build-test-archive-{archive_label}'].result == 'success'",
+                        job,
+                    )
+                    self.assertIn(f"archive_label: {archive_label}", job)
+                    self.assertIn('filterset: "all()"', job)
+                    self.assertIn('partition: "hash:1/2"', job)
+                    self.assertNotIn("native-skia-tests", job)
+                    self.assertNotIn("native_skia_required", job)
+        self.assertNotIn("test-slow-shard:", self.workflow)
 
     def test_aggregate_validates_expected_success_and_skipped_states(self) -> None:
         aggregate = self._job("build-and-test")
@@ -973,9 +972,10 @@ mod support;
     def test_shard_count_artifacts_are_downloaded_only_for_rust_lane(self) -> None:
         aggregate = self._job("build-and-test")
         for step_name in (
+            "Download archive A expected count",
+            "Download archive B expected count",
             "Download shard counts",
-            "Download archive expected counts",
-            "Verify shard totals",
+            "Verify archive shard totals",
         ):
             with self.subTest(step=step_name):
                 self.assertIn(
@@ -987,11 +987,12 @@ mod support;
         rust_success = {
             "RUST_REQUIRED": "true",
             "LINT_RESULT": "success",
-            "BUILD_ARCHIVE_RESULT": "success",
-            "TEST_SLOW_RESULT": "success",
-            "TEST_REGULAR_1_RESULT": "success",
-            "TEST_REGULAR_2_RESULT": "success",
-            "TEST_REGULAR_3_RESULT": "success",
+            "BUILD_ARCHIVE_A_RESULT": "success",
+            "BUILD_ARCHIVE_B_RESULT": "success",
+            "TEST_ARCHIVE_A_1_RESULT": "success",
+            "TEST_ARCHIVE_A_2_RESULT": "success",
+            "TEST_ARCHIVE_B_1_RESULT": "success",
+            "TEST_ARCHIVE_B_2_RESULT": "success",
         }
         cases = {
             "frontend-only": {},

--- a/scripts/tests/test_nextest_archive_workflow.py
+++ b/scripts/tests/test_nextest_archive_workflow.py
@@ -119,24 +119,15 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
             preflight,
         )
 
-    def test_single_archive_builder_receives_the_selected_policy(self) -> None:
-        job = job_body(self.ci, "build-test-archive")
-        self.assertIn(
-            "cargo_profile: ${{ needs.preflight.outputs.test_profile "
-            "|| 'release' }}",
-            job,
-        )
-        self.assertIn(
-            "timeout_minutes: ${{ fromJSON("
-            "needs.preflight.outputs.test_archive_timeout_minutes || '60') }}",
-            job,
-        )
-        for obsolete in (
-            "build-test-archive-slow",
-            "build-test-archive-a",
-            "build-test-archive-b",
-        ):
-            self.assertNotIn(f"  {obsolete}:\n", self.ci)
+    def test_two_archive_builders_retire_the_slow_lane(self):
+        from pathlib import Path
+        root = Path(__file__).resolve().parents[2]
+        ci = (root / ".github/workflows/ci.yml").read_text()
+        builder = (root / ".github/workflows/build-nextest-archives.yml").read_text()
+        runner = (root / ".github/workflows/run-nextest-archives.yml").read_text()
+        self.assertIn("build-test-archive-a:", ci); self.assertIn("build-test-archive-b:", ci)
+        self.assertNotIn("test-slow-shard:", ci); self.assertEqual(4, ci.count('partition: "hash:1/2"'))
+        self.assertIn('filterset: "binary(/.*[02468]$/)"', ci); self.assertIn('filterset: "not binary(/.*[02468]$/)"', ci)
 
     def test_native_skia_uses_the_same_test_profile_policy(self) -> None:
         native = job_body(self.ci, "native-skia-tests")
@@ -151,23 +142,16 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         self.assertIn("Unknown test profile", step)
         self.assertNotIn('"${GITHUB_EVENT_NAME}" == "pull_request"', step)
 
-    def test_reusable_builder_accepts_explicit_policy_and_uses_dynamic_timeout(self) -> None:
-        self.assertIn("      cargo_profile:\n", self.builder)
-        self.assertIn("      timeout_minutes:\n", self.builder)
-        self.assertIn("        type: string", self.builder)
-        self.assertIn("        type: number", self.builder)
-        self.assertIn("    timeout-minutes: ${{ inputs.timeout_minutes }}", self.builder)
-        self.assertIn(
-            '--cargo-profile "${{ inputs.cargo_profile }}"',
-            self.builder,
-        )
-        self.assertNotIn("- name: Select cargo profile", self.builder)
-        self.assertNotIn("steps.profile.outputs.cargo_profile", self.builder)
-        self.assertNotIn("archive_labels:", self.builder)
-        self.assertNotIn("expected_count_suffix:", self.builder)
-        self.assertIn("--tests", self.builder)
-        self.assertIn("--archive-file tests.tar.zst", self.builder)
-        self.assertIn("name: test-archive-${{ github.run_id }}", self.builder)
+    def test_reusable_builder_isolates_partition_artifacts(self):
+        from pathlib import Path
+        root = Path(__file__).resolve().parents[2]
+        ci = (root / ".github/workflows/ci.yml").read_text()
+        builder = (root / ".github/workflows/build-nextest-archives.yml").read_text()
+        runner = (root / ".github/workflows/run-nextest-archives.yml").read_text()
+        self.assertIn('--filterset "${{ inputs.filterset }}"', builder)
+        self.assertIn("test-archive-${{ github.run_id }}-${{ inputs.archive_label }}", builder)
+        self.assertIn("archive-expected-${{ github.run_id }}-${{ inputs.archive_label }}", builder)
+        self.assertIn("test-archive-${{ github.run_id }}-${{ inputs.archive_label }}", runner)
 
     def test_builder_prepares_derived_suites_before_compiling_the_archive(self) -> None:
         prepare = "node scripts/rust-test-suite-manifest.mjs --prepare"
@@ -176,12 +160,16 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         self.assertIn(archive, self.builder)
         self.assertLess(self.builder.index(prepare), self.builder.index(archive))
 
-    def test_workers_share_one_archive_and_partition_test_cases(self) -> None:
-        self.assertIn("name: test-archive-${{ github.run_id }}", self.runner)
-        self.assertIn('--filterset "${FILTERSET}"', self.runner)
-        self.assertIn('partition_args=(--partition "${PARTITION}")', self.runner)
-        self.assertIn("--no-tests fail", self.runner)
-        self.assertNotIn("archive_label:", self.runner)
+    def test_four_workers_validate_each_archive_coverage(self):
+        from pathlib import Path
+        root = Path(__file__).resolve().parents[2]
+        ci = (root / ".github/workflows/ci.yml").read_text()
+        builder = (root / ".github/workflows/build-nextest-archives.yml").read_text()
+        runner = (root / ".github/workflows/run-nextest-archives.yml").read_text()
+        for name in ("test-archive-a-shard-1:", "test-archive-a-shard-2:", "test-archive-b-shard-1:", "test-archive-b-shard-2:"):
+            self.assertIn(name, ci)
+        self.assertIn("Archive A shard total mismatch", ci); self.assertIn("Archive B shard total mismatch", ci)
+        self.assertIn("name: Build & Test", ci)
 
     def test_reusable_builder_rejects_profile_timeout_mismatches(self) -> None:
         step = step_body(self.builder, "Validate test archive policy")

--- a/scripts/tests/test_nextest_archive_workflow.py
+++ b/scripts/tests/test_nextest_archive_workflow.py
@@ -125,9 +125,9 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         ci = (root / ".github/workflows/ci.yml").read_text()
         builder = (root / ".github/workflows/build-nextest-archives.yml").read_text()
         runner = (root / ".github/workflows/run-nextest-archives.yml").read_text()
-        self.assertIn("build-test-archive-a:", ci); self.assertIn("build-test-archive-b:", ci)
-        self.assertNotIn("test-slow-shard:", ci); self.assertEqual(2, ci.count('partition: "hash:1/2"')); self.assertEqual(2, ci.count('partition: "hash:2/2"'))
-        self.assertIn("target_group: lib", ci); self.assertIn("target_group: integration", ci)
+        self.assertIn("build-test-archive-a:", ci); self.assertIn("build-test-archive-b:", ci); self.assertIn("build-test-archive-c:", ci)
+        self.assertNotIn("test-slow-shard:", ci); self.assertEqual(1, ci.count('partition: "hash:1/2"')); self.assertEqual(1, ci.count('partition: "hash:2/2"')); self.assertEqual(2, ci.count('partition: "hash:1/1"'))
+        self.assertIn("target_group: lib", ci); self.assertIn("target_group: integration-b", ci); self.assertIn("target_group: integration-c", ci)
         self.assertIn("cargo metadata --no-deps --format-version 1", builder)
         self.assertIn("cargo_target_args+=(--lib)", builder)
         self.assertIn('cargo_target_args+=(--test "${target}")', builder)
@@ -170,9 +170,9 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         ci = (root / ".github/workflows/ci.yml").read_text()
         builder = (root / ".github/workflows/build-nextest-archives.yml").read_text()
         runner = (root / ".github/workflows/run-nextest-archives.yml").read_text()
-        for name in ("test-archive-a-shard-1:", "test-archive-a-shard-2:", "test-archive-b-shard-1:", "test-archive-b-shard-2:"):
+        for name in ("test-archive-a-shard-1:", "test-archive-a-shard-2:", "test-archive-b-shard-1:", "test-archive-c-shard-1:"):
             self.assertIn(name, ci)
-        self.assertIn("Archive A shard total mismatch", ci); self.assertIn("Archive B shard total mismatch", ci)
+        self.assertIn("Archive A shard total mismatch", ci); self.assertIn("Archive B shard total mismatch", ci); self.assertIn("Archive C shard total mismatch", ci)
         self.assertIn("name: Build & Test", ci)
 
     def test_reusable_builder_rejects_profile_timeout_mismatches(self) -> None:
@@ -182,10 +182,12 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
 
         for profile, timeout, target_group, expected in (
             ("release-test", "30", "lib", 0),
-            ("release", "60", "integration", 0),
+            ("release", "60", "integration-b", 0),
+            ("release", "60", "integration-c", 0),
             ("release-test", "60", "lib", 1),
-            ("release", "30", "integration", 1),
+            ("release", "30", "integration-b", 1),
             ("debug", "60", "lib", 1),
+            ("release", "60", "integration", 1),
             ("release-test", "30", "unknown", 1),
         ):
             with self.subTest(profile=profile, timeout=timeout, target_group=target_group):

--- a/scripts/tests/test_nextest_archive_workflow.py
+++ b/scripts/tests/test_nextest_archive_workflow.py
@@ -126,7 +126,7 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         builder = (root / ".github/workflows/build-nextest-archives.yml").read_text()
         runner = (root / ".github/workflows/run-nextest-archives.yml").read_text()
         self.assertIn("build-test-archive-a:", ci); self.assertIn("build-test-archive-b:", ci)
-        self.assertNotIn("test-slow-shard:", ci); self.assertEqual(4, ci.count('partition: "hash:1/2"'))
+        self.assertNotIn("test-slow-shard:", ci); self.assertEqual(2, ci.count('partition: "hash:1/2"')); self.assertEqual(2, ci.count('partition: "hash:2/2"'))
         self.assertIn("target_group: lib", ci); self.assertIn("target_group: integration", ci)
         self.assertIn("cargo metadata --no-deps --format-version 1", builder)
         self.assertIn("cargo_target_args+=(--lib)", builder)

--- a/scripts/tests/test_nextest_archive_workflow.py
+++ b/scripts/tests/test_nextest_archive_workflow.py
@@ -119,7 +119,7 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
             preflight,
         )
 
-    def test_two_archive_builders_retire_the_slow_lane(self):
+    def test_two_archive_builders_split_lib_and_integration_targets(self):
         from pathlib import Path
         root = Path(__file__).resolve().parents[2]
         ci = (root / ".github/workflows/ci.yml").read_text()
@@ -127,7 +127,11 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         runner = (root / ".github/workflows/run-nextest-archives.yml").read_text()
         self.assertIn("build-test-archive-a:", ci); self.assertIn("build-test-archive-b:", ci)
         self.assertNotIn("test-slow-shard:", ci); self.assertEqual(4, ci.count('partition: "hash:1/2"'))
-        self.assertIn('filterset: "binary(/.*[02468]$/)"', ci); self.assertIn('filterset: "not binary(/.*[02468]$/)"', ci)
+        self.assertIn("target_group: lib", ci); self.assertIn("target_group: integration", ci)
+        self.assertIn("cargo metadata --no-deps --format-version 1", builder)
+        self.assertIn("cargo_target_args+=(--lib)", builder)
+        self.assertIn('cargo_target_args+=(--test "${target}")', builder)
+        self.assertNotIn("--tests", builder)
 
     def test_native_skia_uses_the_same_test_profile_policy(self) -> None:
         native = job_body(self.ci, "native-skia-tests")
@@ -148,7 +152,7 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         ci = (root / ".github/workflows/ci.yml").read_text()
         builder = (root / ".github/workflows/build-nextest-archives.yml").read_text()
         runner = (root / ".github/workflows/run-nextest-archives.yml").read_text()
-        self.assertIn('--filterset "${{ inputs.filterset }}"', builder)
+        self.assertIn("inputs.target_group", builder)
         self.assertIn("test-archive-${{ github.run_id }}-${{ inputs.archive_label }}", builder)
         self.assertIn("archive-expected-${{ github.run_id }}-${{ inputs.archive_label }}", builder)
         self.assertIn("test-archive-${{ github.run_id }}-${{ inputs.archive_label }}", runner)
@@ -176,17 +180,22 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         script = step.split("        run: |\n", maxsplit=1)[1]
         script = "\n".join(line.removeprefix("          ") for line in script.splitlines())
 
-        for profile, timeout, expected in (
-            ("release-test", "30", 0),
-            ("release", "60", 0),
-            ("release-test", "60", 1),
-            ("release", "30", 1),
-            ("debug", "60", 1),
+        for profile, timeout, target_group, expected in (
+            ("release-test", "30", "lib", 0),
+            ("release", "60", "integration", 0),
+            ("release-test", "60", "lib", 1),
+            ("release", "30", "integration", 1),
+            ("debug", "60", "lib", 1),
+            ("release-test", "30", "unknown", 1),
         ):
-            with self.subTest(profile=profile, timeout=timeout):
+            with self.subTest(profile=profile, timeout=timeout, target_group=target_group):
                 result = run_script(
                     script,
-                    {"CARGO_PROFILE": profile, "TIMEOUT_MINUTES": timeout},
+                    {
+                        "CARGO_PROFILE": profile,
+                        "TIMEOUT_MINUTES": timeout,
+                        "TARGET_GROUP": target_group,
+                    },
                 )
                 self.assertEqual(result.returncode, expected, result.stderr)
 
@@ -198,6 +207,7 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
             "ref",
             "cargo_profile",
             "timeout_minutes",
+            "target_group",
             "cache_exact_hit",
             "cache_save_eligible",
         ):

--- a/scripts/tests/test_proptest_roundtrip_workflow.py
+++ b/scripts/tests/test_proptest_roundtrip_workflow.py
@@ -68,10 +68,13 @@ class ProptestRoundtripWorkflowTests(unittest.TestCase):
         self.assertLess(prepare_at, run_at, "prepare 가 실행보다 먼저여야 한다")
 
     def test_does_not_add_a_fifth_nextest_shard(self) -> None:
-        """정규 archive 집계는 shard 4개 합 = runnable. 5번째 worker 는 깨진다."""
+        """A/B archive의 worker 네 개 합 = runnable. 다섯 번째 worker는 깨진다."""
         self.assertNotRegex(self.ci, r"(?m)^  proptest-roundtrip:")
         self.assertNotIn("prop_hwpx_roundtrip", RUN_ARCHIVE.read_text(encoding="utf-8"))
-        self.assertIn("expected 4 shard count files", self.ci)
+        self.assertEqual(4, self.ci.count('partition: "hash:1/2"'))
+        for count_label in ("a-1", "a-2", "b-1", "b-2"):
+            with self.subTest(count_label=count_label):
+                self.assertIn(f"shard-count-{count_label}", self.ci)
 
     def test_read_only_permissions(self) -> None:
         self.assertIn("actions: read", self.wf)

--- a/scripts/tests/test_proptest_roundtrip_workflow.py
+++ b/scripts/tests/test_proptest_roundtrip_workflow.py
@@ -71,7 +71,8 @@ class ProptestRoundtripWorkflowTests(unittest.TestCase):
         """A/B archive의 worker 네 개 합 = runnable. 다섯 번째 worker는 깨진다."""
         self.assertNotRegex(self.ci, r"(?m)^  proptest-roundtrip:")
         self.assertNotIn("prop_hwpx_roundtrip", RUN_ARCHIVE.read_text(encoding="utf-8"))
-        self.assertEqual(4, self.ci.count('partition: "hash:1/2"'))
+        self.assertEqual(2, self.ci.count('partition: "hash:1/2"'))
+        self.assertEqual(2, self.ci.count('partition: "hash:2/2"'))
         for count_label in ("a-1", "a-2", "b-1", "b-2"):
             with self.subTest(count_label=count_label):
                 self.assertIn(f"shard-count-{count_label}", self.ci)

--- a/scripts/tests/test_proptest_roundtrip_workflow.py
+++ b/scripts/tests/test_proptest_roundtrip_workflow.py
@@ -68,12 +68,13 @@ class ProptestRoundtripWorkflowTests(unittest.TestCase):
         self.assertLess(prepare_at, run_at, "prepare 가 실행보다 먼저여야 한다")
 
     def test_does_not_add_a_fifth_nextest_shard(self) -> None:
-        """A/B archive의 worker 네 개 합 = runnable. 다섯 번째 worker는 깨진다."""
+        """A/B/C archive의 worker 네 개 합 = runnable. 다섯 번째 worker는 깨진다."""
         self.assertNotRegex(self.ci, r"(?m)^  proptest-roundtrip:")
         self.assertNotIn("prop_hwpx_roundtrip", RUN_ARCHIVE.read_text(encoding="utf-8"))
-        self.assertEqual(2, self.ci.count('partition: "hash:1/2"'))
-        self.assertEqual(2, self.ci.count('partition: "hash:2/2"'))
-        for count_label in ("a-1", "a-2", "b-1", "b-2"):
+        self.assertEqual(1, self.ci.count('partition: "hash:1/2"'))
+        self.assertEqual(1, self.ci.count('partition: "hash:2/2"'))
+        self.assertEqual(2, self.ci.count('partition: "hash:1/1"'))
+        for count_label in ("a-1", "a-2", "b-1", "c-1"):
             with self.subTest(count_label=count_label):
                 self.assertIn(f"shard-count-{count_label}", self.ci)
 


### PR DESCRIPTION
## 요약

- 단일 nextest archive를 source-side library test archive(A)와 integration test archive(B)로 분리합니다.
- 각 archive를 `hash:1/2` worker 두 개가 소비해 총 네 worker로 실행합니다.
- 기존 slow shard는 제거하고, `Build & Test` required check 이름은 유지합니다.

Closes #5737

## 분할 근거

초기 binary-name 짝홀수 방식은 A 1,965건/B 5,860건으로 불균형했습니다. Cargo target 기준으로 바꾼 뒤 로컬 archive 목록은 다음과 같습니다.

| archive | Cargo target | runnable tests | archive size |
| --- | --- | ---: | ---: |
| A | `--lib` | 3,893 | 25,511,342 bytes |
| B | metadata 기반 모든 `--test <name>` | 3,920 | 317,779,426 bytes |

재사용 builder는 `--tests` 전체 선택을 사용하지 않으므로 반대 partition의 test executable을 빌드하지 않습니다.

## 로컬 검증

- `python3 -m unittest scripts/tests/test_nextest_archive_workflow.py scripts/tests/test_ci_impact_workflow.py` (42 passed)
- `node scripts/rust-test-suite-manifest.mjs --prepare`
- `cargo nextest archive --package rhwp --cargo-profile release-test --lib`
- metadata에서 찾은 모든 integration `--test <name>` target의 `cargo nextest archive`
- `cargo fmt --all -- --check`
- `git diff --check`

## CI 관찰 기준

단일 archive 기준선과 비교해 A/B builder 시간, artifact 크기, 4 worker wall-clock, 전체 critical path와 runner-minute을 기록합니다. 두 builder의 중복 dependency compile이 이득을 상쇄하면 이 구조를 채택하지 않습니다.
