### PR TITLE
fix: 한글 IME에서 Ctrl+Z/Y 실행취소·다시실행 매칭 보정

### DIFF
--- a/rhwp-studio/src/command/shortcut-map.ts
+++ b/rhwp-studio/src/command/shortcut-map.ts
@@ -17,9 +17,11 @@ export interface ShortcutDef {
 /** 기본 단축키 → 커맨드 ID 매핑 */
 export const defaultShortcuts: [ShortcutDef, string][] = [
   // 편집
-  [{ key: 'z', ctrl: true }, 'edit:undo'],
-  [{ key: 'z', ctrl: true, shift: true }, 'edit:redo'],
-  [{ key: 'y', ctrl: true }, 'edit:redo'],
+  // 한글 IME에서는 e.key가 자모('ㅋ' 등) 또는 조합 중 'Process'가 되므로 물리 키로 보정한다
+  // (#3950 select-all 과 동일한 결함 — undo/redo 도 같은 경로로 매칭이 실패했다).
+  [{ key: 'z', code: 'KeyZ', ctrl: true }, 'edit:undo'],
+  [{ key: 'z', code: 'KeyZ', ctrl: true, shift: true }, 'edit:redo'],
+  [{ key: 'y', code: 'KeyY', ctrl: true }, 'edit:redo'],
   // 한글 IME에서는 e.key가 'ㅁ' 또는 조합 중 'Process'가 되므로 물리 KeyA로 보정한다.
   [{ key: 'a', code: 'KeyA', ctrl: true }, 'edit:select-all'],
 


### PR DESCRIPTION
## 문제

한글 IME 상태에서 Ctrl+Z(실행취소)·Ctrl+Y/Ctrl+Shift+Z(다시실행)가 무반응입니다.

## 원인

#3950(Ctrl+A select-all)과 동일한 결함입니다 — 한글 IME에서는 `e.key`가 자모('ㅋ')나 조합 중 'Process'로 오는데, undo/redo 항목은 key 문자 비교만 있어 매칭이 실패합니다.

## 수정

bcb65ed6(select-all 수정)과 같은 방식으로 물리 키 `code` 병행 매칭을 추가했습니다.

## 검증

Windows Chrome + 한글 IME 상태에서 문서·표 셀 양쪽에서 Ctrl+Z/Ctrl+Y 동작 확인. 실사용(대학 행정 서식 편집) 중 발견해 자체 포크에서 검증 후 올립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)