### PR TITLE
feat: Ctrl+A 모두 선택을 한컴처럼 셀 범위 우선으로

### DIFF
--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -1446,6 +1446,36 @@ export function handleCtrlKey(this: any, e: KeyboardEvent): void {
 }
 
 export function handleSelectAll(this: any): void {
+  // 한컴 정합: 표 셀 안에서는 셀 내용만 전체 선택하고, 본문에서는 문서 전체를 선택한다.
+  // 중첩 표(표 안의 표)는 cellPath(ByPath) 경유 — moveToParagraphBoundary 의 셀 분기와
+  // 동일한 이중 모드 패턴.
+  const pos = this.cursor.getPosition();
+  if (this.cursor.isInCell() && pos.parentParaIndex !== undefined) {
+    try {
+      const sec = pos.sectionIndex;
+      const ppi = pos.parentParaIndex;
+      const cellPath = pos.cellPath;
+      const useCellPath = (cellPath?.length ?? 0) > 0;
+      const n = useCellPath
+        ? this.wasm.getCellParagraphCountByPath(sec, ppi, JSON.stringify(cellPath))
+        : this.wasm.getCellParagraphCount(sec, ppi, pos.controlIndex!, pos.cellIndex!);
+      const pathAt = (cpi: number) => useCellPath
+        ? cellPath!.map((e: any, i: number) => i < cellPath!.length - 1 ? e : { ...e, cellParaIndex: cpi })
+        : cellPath;
+      const lastLen = useCellPath
+        ? this.wasm.getCellParagraphLengthByPath(sec, ppi, JSON.stringify(pathAt(n - 1)))
+        : this.wasm.getCellParagraphLength(sec, ppi, pos.controlIndex!, pos.cellIndex!, n - 1);
+      this.cursor.moveTo({
+        ...pos, paragraphIndex: 0, cellParaIndex: 0, cellPath: pathAt(0), charOffset: 0,
+      });
+      this.cursor.setAnchor();
+      this.cursor.moveTo({
+        ...pos, paragraphIndex: n - 1, cellParaIndex: n - 1, cellPath: pathAt(n - 1), charOffset: lastLen,
+      });
+      this.updateCaret();
+      return;
+    } catch { /* 셀 정보 조회 실패 → 문서 전체 선택으로 계속 */ }
+  }
   // anchor를 문서 시작, focus를 문서 끝으로 설정
   this.cursor.moveTo({ sectionIndex: 0, paragraphIndex: 0, charOffset: 0 });
   this.cursor.setAnchor();


### PR DESCRIPTION
## 문제

한컴 한글은 표 셀 안에서 Ctrl+A를 누르면 **그 셀의 내용만** 선택하지만, rhwp는 항상 문서 전체를 선택해 커서·화면이 문서 끝으로 이동합니다. 표 위주 문서(행정 서식 등)에서 셀 하나 고쳐 쓰려다 문서 끝으로 튀는 경험이 반복됩니다.

## 수정

`handleSelectAll`에 셀 분기를 추가했습니다:

- **셀 안**: 셀의 첫 문단 처음 ~ 마지막 문단 끝 선택
- **본문**: 기존대로 문서 전체 선택
- **중첩 표(표 안의 표)**: cellPath(ByPath API) 경유 — `moveToParagraphBoundary`의 셀 분기와 동일한 이중 모드(평면/ByPath) 패턴을 그대로 따랐습니다
- 셀 정보 조회 실패 시 기존 문서 전체 선택으로 폴백

## 검증

일반 셀·중첩 표 셀(서명란류)·본문 각각에서 동작 확인. 특히 중첩 표에서 평면 API만 쓰면 조회가 실패해 문서 끝으로 튀는 문제를 실사용 중 발견해 ByPath 경유로 해결했습니다.

## 비고

한컴은 셀 안에서 Ctrl+A 반복 시 셀 → 표 → 문서로 확장되는데, 이번 범위는 1단계(셀)까지입니다. 확장 선택이 필요하면 후속으로 나누겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)