### PR TITLE
fix(studio): 상태 표시줄 쪽 표시가 문서 쪽번호(새 번호로 시작)를 따르게 한다 (#5749)

### DIFF
--- a/mydocs/working/task_5749_studio_status_page_number.md
+++ b/mydocs/working/task_5749_studio_status_page_number.md
@@ -1,0 +1,58 @@
+# #5749 상태 표시줄 쪽 표시가 문서 쪽번호를 따르게 한다
+
+## 목표
+
+한글과 같은 규칙으로, 상태 표시줄의 현재 쪽을 **문서가 매기는 쪽번호**(`쪽 > 새 번호로 시작`
+반영)로 보여준다. 분모(전체)는 물리 쪽수를 유지한다.
+
+## 문제
+
+`main.ts` 의 `current-page-changed` 핸들러가 `${pageIdx + 1} / ${total} 쪽` 으로 **물리 순번**만
+썼다. 앞 2쪽 뒤 1쪽부터 다시 시작하는 문서에서 한글은 세 번째 쪽을 `1쪽` 으로 보여주는데
+rhwp-studio 는 `3 / 33 쪽` 이었다.
+
+엔진은 이미 맞는 값을 갖고 있었다 — `PageContent.page_number` 가 NewNumber 를 반영하고,
+쪽 하단 렌더도 `- 1 -` 로 다시 시작한다. `rhwp dump-pages --json` 도 `pageNumber` 를 낸다.
+빠진 곳은 딱 하나, `get_page_info_native` 의 JSON 이었다. studio 쪽 타입
+(`PageInfo.pageNumber?`)과 문서 비교(`compare/diff-engine.ts` 의 `pi.pageNumber ?? (page + 1)`)는
+이미 이 필드를 기대하고 있었으므로, 필드를 채우자 그쪽 폴백도 함께 해소된다.
+
+## 구현
+
+1. `src/document_core/queries/rendering.rs` — `get_page_info_native` 응답에
+   `"pageNumber"`(= `page_content.page_number`)를 추가한다. 기존 필드는 그대로 둔다.
+2. `rhwp-studio/src/view/page-indicator.ts` (신규) — 표시 문자열 조립을 순수 함수로 분리한다.
+   문서 쪽번호가 1 이상의 유한값일 때만 쓰고, 아니면 물리 순번으로 물러난다(구 WASM 대비).
+3. `rhwp-studio/src/main.ts` — 쪽 정보를 한 번만 조회해 쪽번호와 구역 표시에 함께 쓴다.
+4. `rhwp-studio/src/core/types.ts` — 이미 있던 `pageNumber?` 주석을 실제 계약에 맞게 고친다.
+
+페이지네이션(쪽 수 계산)과 쪽 하단 쪽번호 렌더는 건드리지 않았다. 찾아가기(`edit:goto`)의
+입력 해석도 이 변경 범위 밖이다.
+
+## 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `cargo fmt --all -- --check` | 통과 |
+| `cargo clippy --locked -- -D warnings` | 통과 |
+| `cargo test --test regression_suite_013 issue_5749_page_info_page_number` | 1개 통과 |
+| `cargo test --lib document_core::queries::rendering` | 22개 통과 |
+| `node scripts/rust-unit-test-tiers.mjs --check` | 4225 tests (증가 없음) |
+| `npx tsc --noEmit` (rhwp-studio) | 통과 |
+| `npm test` (rhwp-studio) | 1039개 중 1038 통과 · 0 실패 · 1 skip |
+| `npm run e2e:status-page-number` | 6개 단언 전부 PASS |
+| 실문서 브라우저 실측 | 아래 |
+
+실문서(교육부 보도자료 별첨 「2024학년도 대입전형시행계획 주요사항」, 로컬 코퍼스이므로
+저장소에 올리지 않는다)를 studio 에서 열고 물리 쪽마다 상태 표시줄을 읽은 결과:
+
+| 물리 쪽 | 문서 쪽번호 | 고치기 전 | 고친 뒤 |
+| --- | --- | --- | --- |
+| 1 | 1 | `1 / 33 쪽` | `1 / 33 쪽` |
+| 2 | 2 | `2 / 33 쪽` | `2 / 33 쪽` |
+| 3 | 1 | `3 / 33 쪽` | **`1 / 33 쪽`** |
+| 4 | 2 | `4 / 33 쪽` | **`2 / 33 쪽`** |
+| 33 | 31 | `33 / 33 쪽` | **`31 / 33 쪽`** |
+
+같은 문서에서 확인된 전체 쪽수 차이(rhwp 33쪽 vs 한글 43쪽)는 조판 정확도 문제로 #5750 에
+따로 등록했다. 이 변경의 범위가 아니다.

--- a/rhwp-studio/e2e/status-page-number.test.mjs
+++ b/rhwp-studio/e2e/status-page-number.test.mjs
@@ -1,0 +1,52 @@
+/**
+ * E2E 테스트 — 상태 표시줄 쪽 표시가 문서 쪽번호를 따른다 (#5749)
+ *
+ * 검증 항목:
+ * 1. 새 번호가 없는 문서는 물리 순번과 같은 숫자를 보여준다(회귀 없음)
+ * 2. `쪽 > 새 번호로 시작`(NewNumber)을 넣으면 상태 표시줄이 그 번호를 따른다
+ * 3. 전체 쪽수(분모)는 물리 쪽수를 유지한다
+ */
+
+import { runTest, loadHwpFile, assert } from './helpers.mjs';
+
+process.env.VITE_URL = process.env.VITE_URL || 'http://localhost:7700';
+
+const SAMPLE = '쪽기준.hwp';
+
+const readStatus = (pageIndex) => {
+  window.__eventBus.emit('current-page-changed', pageIndex, window.__wasm.pageCount);
+  const info = window.__wasm.getPageInfo(pageIndex);
+  return {
+    pageNumber: info.pageNumber,
+    statusBar: document.getElementById('sb-page').textContent,
+    pageCount: window.__wasm.pageCount,
+  };
+};
+
+runTest('상태 표시줄 쪽 표시', async ({ page }) => {
+  await loadHwpFile(page, SAMPLE);
+
+  // ── TC1: 새 번호가 없으면 물리 순번과 같다 ─────────────────
+  const before = await page.evaluate(readStatus, 0);
+  assert(before.pageNumber === 1,
+    `TC1: 첫 쪽의 문서 쪽번호는 1 (${before.pageNumber})`);
+  assert(before.statusBar === `1 / ${before.pageCount} 쪽`,
+    `TC1: 상태 표시줄이 물리 순번과 같음 (${before.statusBar})`);
+
+  // ── TC2: 새 번호로 시작을 넣으면 그 번호를 따른다 ──────────
+  const inserted = await page.evaluate(() => {
+    const res = window.__wasm.insertNewNumber(0, 0, 0, 7);
+    return typeof res === 'string' ? res.slice(0, 80) : String(res);
+  });
+  assert(inserted.includes('"ok":true'), `TC2: 새 번호 삽입 (${inserted})`);
+
+  const after = await page.evaluate(readStatus, 0);
+  assert(after.pageNumber === 7,
+    `TC2: 문서 쪽번호가 7로 다시 시작 (${after.pageNumber})`);
+  assert(after.statusBar.startsWith('7 / '),
+    `TC2: 상태 표시줄이 문서 쪽번호를 따름 (${after.statusBar})`);
+
+  // ── TC3: 분모는 물리 쪽수 ──────────────────────────────────
+  assert(after.statusBar === `7 / ${after.pageCount} 쪽`,
+    `TC3: 전체 쪽수는 물리 쪽수 유지 (${after.statusBar}, pageCount=${after.pageCount})`);
+});

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -25,6 +25,7 @@
     "e2e:form-edit-escape": "node e2e/form-edit-escape-cancel.test.mjs --mode=headless",
     "e2e:unsaved-guard": "node e2e/unsaved-changes-guard.test.mjs",
     "e2e:undo": "node e2e/undo-contracts.test.mjs",
+    "e2e:status-page-number": "node e2e/status-page-number.test.mjs --mode=headless",
     "e2e:undo-object-selection": "node e2e/undo-object-selection.test.mjs",
     "e2e:hwp-password-open": "node e2e/hwp-password-open.test.mjs --mode=headless",
     "e2e:clipboard-priority": "node e2e/task-871-clipboard-priority.test.mjs",

--- a/rhwp-studio/src/core/types.ts
+++ b/rhwp-studio/src/core/types.ts
@@ -14,7 +14,10 @@ export interface DocumentInfo {
 /** WASM getPageInfo() 반환 타입 */
 export interface PageInfo {
   pageIndex: number;
-  /** 조판 기준으로 계산된 표시용 쪽 번호(구역 설정 반영) */
+  /** 문서가 매기는 쪽번호 (1-based, `쪽 > 새 번호로 시작` 반영).
+   *
+   * 물리 순번(pageIndex + 1)과 다를 수 있다 — 상태 표시줄이 보여야 할 숫자는 이쪽이다.
+   * 구 WASM 은 이 필드를 내보내지 않으므로 optional 이다 (#5749). */
   pageNumber?: number;
   width: number;
   height: number;

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -1,5 +1,5 @@
 import { WasmBridge } from '@/core/wasm-bridge';
-import type { DocumentInfo } from '@/core/types';
+import type { DocumentInfo, PageInfo } from '@/core/types';
 import { EventBus } from '@/core/event-bus';
 import { assertRemoteDocumentBytes } from '@/core/document-signature';
 import { CanvasView } from '@/view/canvas-view';
@@ -77,6 +77,7 @@ import {
   type RenderBackendFallbackReason,
 } from '@/view/render-backend';
 import { calculateFitPageZoom, calculateFitWidthZoom } from '@/view/zoom-fit';
+import { formatPageIndicator } from '@/view/page-indicator';
 import { installEmbedRuntime } from '@/embed/runtime';
 import type { EmbedRendererRuntimeRequestV1 } from '@/embed/rpc-router';
 import { enrichFontDecisionTrace } from '@/core/font-decision-trace';
@@ -964,14 +965,21 @@ function setupEventListeners(): void {
 
   eventBus.on('current-page-changed', (page, _total) => {
     const pageIdx = page as number;
-    sbPage().textContent = `${pageIdx + 1} / ${_total} 쪽`;
-
-    // 구역 정보: 현재 페이지의 sectionIndex로 갱신
+    // 쪽 정보 한 번으로 쪽번호와 구역을 함께 갱신한다.
+    let pageInfo: PageInfo | null = null;
     if (wasm.pageCount > 0) {
       try {
-        const pageInfo = wasm.getPageInfo(pageIdx);
-        sbSection().textContent = `구역: ${pageInfo.sectionIndex + 1} / ${totalSections}`;
+        pageInfo = wasm.getPageInfo(pageIdx);
       } catch { /* 무시 */ }
+    }
+    // 현재 쪽은 문서가 매기는 쪽번호를 쓴다 — 한글과 같은 규칙이다 (#5749).
+    sbPage().textContent = formatPageIndicator({
+      pageIndex: pageIdx,
+      totalPages: _total as number,
+      documentPageNumber: pageInfo?.pageNumber,
+    });
+    if (pageInfo) {
+      sbSection().textContent = `구역: ${pageInfo.sectionIndex + 1} / ${totalSections}`;
     }
   });
 

--- a/rhwp-studio/src/view/page-indicator.ts
+++ b/rhwp-studio/src/view/page-indicator.ts
@@ -1,0 +1,36 @@
+/**
+ * 상태 표시줄 쪽 표시 문자열 조립.
+ *
+ * 한글과 같은 규칙이다 — 현재 쪽은 **문서가 매기는 쪽번호**(`쪽 > 새 번호로 시작` 반영)를,
+ * 전체는 **물리 쪽수**를 보여준다. 앞 2쪽 뒤에 1쪽부터 다시 시작하는 문서라면 세 번째 쪽에서
+ * 한글도 rhwp 도 `1` 을 보여야 한다 (#5749).
+ *
+ * 문서 쪽번호를 모르는 경우(구 WASM, 조회 실패)에는 물리 순번으로 물러난다 — 표시가 비거나
+ * `NaN` 이 되는 것보다 예전 동작이 낫다.
+ */
+
+export interface PageIndicatorInput {
+  /** 현재 쪽의 물리 순번 (0-based) */
+  pageIndex: number;
+  /** 전체 물리 쪽수 */
+  totalPages: number;
+  /** 문서가 매기는 쪽번호 (1-based). 모르면 null/undefined */
+  documentPageNumber?: number | null;
+}
+
+/** 문서 쪽번호로 쓸 수 있는 값인지 — 1 이상의 유한 정수만 받는다. */
+function usableDocumentPageNumber(value: number | null | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 1;
+}
+
+/** 상태 표시줄에 보일 현재 쪽 번호 */
+export function currentPageLabel(input: PageIndicatorInput): number {
+  return usableDocumentPageNumber(input.documentPageNumber)
+    ? Math.floor(input.documentPageNumber)
+    : input.pageIndex + 1;
+}
+
+/** 상태 표시줄 문자열 (`1 / 33 쪽`) */
+export function formatPageIndicator(input: PageIndicatorInput): string {
+  return `${currentPageLabel(input)} / ${input.totalPages} 쪽`;
+}

--- a/rhwp-studio/tests/page-indicator.test.ts
+++ b/rhwp-studio/tests/page-indicator.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { currentPageLabel, formatPageIndicator } from '../src/view/page-indicator.ts';
+
+test('문서 쪽번호가 있으면 그 숫자를 보여준다 (새 번호로 시작 반영)', () => {
+  // 앞 2쪽 뒤에 1쪽부터 다시 시작하는 문서: 세 번째 물리 쪽의 문서 쪽번호는 1이다.
+  assert.equal(
+    formatPageIndicator({ pageIndex: 2, totalPages: 33, documentPageNumber: 1 }),
+    '1 / 33 쪽',
+  );
+  assert.equal(
+    formatPageIndicator({ pageIndex: 3, totalPages: 33, documentPageNumber: 2 }),
+    '2 / 33 쪽',
+  );
+});
+
+test('전체 쪽수는 물리 쪽수를 유지한다', () => {
+  // 한글과 같은 규칙 — 현재 쪽만 문서 번호이고 분모는 실제 쪽 수다.
+  assert.match(
+    formatPageIndicator({ pageIndex: 32, totalPages: 33, documentPageNumber: 31 }),
+    /\/ 33 쪽$/,
+  );
+});
+
+test('새 번호가 없는 문서는 지금까지와 같은 숫자를 보여준다', () => {
+  for (let i = 0; i < 5; i++) {
+    assert.equal(
+      formatPageIndicator({ pageIndex: i, totalPages: 5, documentPageNumber: i + 1 }),
+      `${i + 1} / 5 쪽`,
+    );
+  }
+});
+
+test('문서 쪽번호를 모르면 물리 순번으로 물러난다', () => {
+  for (const unknown of [undefined, null, 0, -3, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.equal(
+      formatPageIndicator({ pageIndex: 4, totalPages: 10, documentPageNumber: unknown as number }),
+      '5 / 10 쪽',
+      `모르는 값(${String(unknown)})은 물리 순번으로 물러나야 한다`,
+    );
+  }
+});
+
+test('현재 쪽 번호는 정수로 자른다', () => {
+  assert.equal(currentPageLabel({ pageIndex: 2, totalPages: 9, documentPageNumber: 1.9 }), 1);
+});

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -2383,7 +2383,7 @@ impl DocumentCore {
             .collect::<Vec<_>>()
             .join(",");
         Ok(format!(
-            "{{\"pageIndex\":{},\"width\":{:.1},\"height\":{:.1},\"sectionIndex\":{},\
+            "{{\"pageIndex\":{},\"pageNumber\":{},\"width\":{:.1},\"height\":{:.1},\"sectionIndex\":{},\
             \"marginLeft\":{:.1},\"marginRight\":{:.1},\"marginTop\":{:.1},\"marginBottom\":{:.1},\
             \"marginHeader\":{:.1},\"marginFooter\":{:.1},\
             \"bodyLeft\":{:.1},\"bodyRight\":{:.1},\"marginGutter\":{:.1},\
@@ -2391,6 +2391,9 @@ impl DocumentCore {
             \"pageBorderLeft\":{:.1},\"pageBorderRight\":{:.1},\"pageBorderTop\":{:.1},\"pageBorderBottom\":{:.1},\
             \"columns\":[{}]}}",
             page_content.page_index,
+            // 문서가 매기는 쪽번호 — `쪽 > 새 번호로 시작`(NewNumber)을 반영한 값이다.
+            // 물리 순번(pageIndex + 1)과 다를 수 있고, 상태 표시줄·인쇄물이 보여야 할 숫자는 이쪽이다.
+            page_content.page_number,
             page_content.layout.page_width,
             page_content.layout.page_height,
             page_content.section_index,

--- a/tests/cases/issue_5749_page_info_page_number.rs
+++ b/tests/cases/issue_5749_page_info_page_number.rs
@@ -1,0 +1,67 @@
+//! #5749 — 쪽 정보가 문서 쪽번호(`쪽 > 새 번호로 시작` 반영)를 내보내는지 고정한다.
+//!
+//! 상태 표시줄이 보여야 할 숫자는 물리 순번(pageIndex + 1)이 아니라 문서가 매기는 쪽번호다.
+//! 둘은 NewNumber 컨트롤이 있을 때 갈라진다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+
+fn sample() -> String {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples/쪽기준.hwp")
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// JSON 문자열에서 정수 필드 하나를 읽는다(테스트용 최소 파서).
+fn json_int(json: &str, key: &str) -> i64 {
+    let needle = format!("\"{}\":", key);
+    let start = json
+        .find(&needle)
+        .unwrap_or_else(|| panic!("{key} 필드가 없다: {json}"))
+        + needle.len();
+    let end = json[start..]
+        .find([',', '}'])
+        .map(|idx| start + idx)
+        .unwrap_or(json.len());
+    json[start..end]
+        .trim()
+        .parse()
+        .unwrap_or_else(|e| panic!("{key} 파싱 실패({e}): {json}"))
+}
+
+#[test]
+fn page_info_reports_document_page_number() {
+    let data = std::fs::read(sample()).expect("샘플을 읽을 수 있어야 한다");
+    let mut core = DocumentCore::from_bytes(&data).expect("샘플을 열 수 있어야 한다");
+
+    let before = core
+        .get_page_info_native(0)
+        .expect("쪽 정보를 조회할 수 있어야 한다");
+    assert_eq!(json_int(&before, "pageIndex"), 0);
+    assert_eq!(
+        json_int(&before, "pageNumber"),
+        1,
+        "새 번호가 없으면 문서 쪽번호는 물리 순번과 같아야 한다: {before}"
+    );
+
+    // 쪽 > 새 번호로 시작 = 7
+    core.insert_new_number_native(0, 0, 0, 7)
+        .expect("새 번호 지정을 삽입할 수 있어야 한다");
+
+    let after = core
+        .get_page_info_native(0)
+        .expect("쪽 정보를 조회할 수 있어야 한다");
+    assert_eq!(
+        json_int(&after, "pageIndex"),
+        0,
+        "물리 순번은 그대로여야 한다: {after}"
+    );
+    assert_eq!(
+        json_int(&after, "pageNumber"),
+        7,
+        "문서 쪽번호는 새 번호를 따라야 한다: {after}"
+    );
+}


### PR DESCRIPTION
## 변경 요약

`쪽 > 새 번호로 시작`(NewNumber)으로 쪽번호를 다시 매기는 문서에서, rhwp-studio 하단 상태
표시줄이 **물리 순번**(`pageIndex + 1`)을 보여줘 한글과 다른 숫자가 나왔습니다. 앞 2쪽 뒤
1쪽부터 다시 시작하는 문서의 세 번째 쪽을 한글은 `1쪽` 으로 보여주는데 studio 는 `3 / 33 쪽`
이었습니다.

엔진은 이미 맞는 값을 갖고 있었습니다 — `PageContent.page_number`("실제 쪽 번호, NewNumber
반영")가 재시작을 반영하고, **쪽 하단에 찍히는 쪽번호도 `- 1 -` 로 정확히 다시 시작**합니다.
`rhwp dump-pages --json` 도 `pageNumber` 를 그대로 냅니다. 빠진 곳은 딱 하나,
`get_page_info_native` 의 JSON 이었습니다.

- `src/document_core/queries/rendering.rs` — 쪽 정보 응답에 `pageNumber`(문서 쪽번호)를 추가.
  studio 의 `PageInfo.pageNumber?` 타입과 문서 비교(`compare/diff-engine.ts` 의
  `pi.pageNumber ?? (page + 1)`)는 **이미 이 필드를 기대하고 있었으므로** 그쪽 폴백도 함께
  해소됩니다.
- `rhwp-studio/src/view/page-indicator.ts` (신규) — 표시 문자열 조립을 순수 함수로 분리.
  문서 쪽번호가 1 이상의 유한값일 때만 쓰고, 아니면 물리 순번으로 물러납니다(구 WASM 대비).
- `rhwp-studio/src/main.ts` — 쪽 정보를 한 번만 조회해 쪽번호·구역 표시에 함께 씁니다.
  현재 쪽만 문서 번호를 쓰고 **분모(전체)는 물리 쪽수를 유지**합니다 — 한글과 같은 규칙입니다.

페이지네이션(쪽 수 계산)과 쪽 하단 쪽번호 렌더는 건드리지 않았습니다. 찾아가기(`edit:goto`)의
입력 해석도 이 PR 범위 밖입니다.

## 관련 이슈

closes #5749

같은 문서에서 확인된 **전체 쪽수 차이**(rhwp 33쪽 vs 한글 43쪽)는 조판 정확도 문제로 #5750 에
따로 등록했습니다. 이 PR 은 그 숫자를 바꾸지 않습니다.

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (push·PR 직전 실행)
- [x] 새 integration test 원본은 `tests/cases/issue_5749_page_info_page_number.rs` 에만 추가했고 `tests/generated/`·`tests/suites/manifest.json`·Cargo generated test target 은 포함하지 않음
- [x] `src/**` 의 `#[cfg(test)]` 증가 없음 — `node scripts/rust-unit-test-tiers.mjs --check` 통과 (4225 tests, 변화 없음)
- [x] `cargo test` — 아래 focused 목록
- [x] `cargo clippy --locked -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 렌더 경로 변경 없음(해당 없음)
- [ ] 웹(WASM) 렌더링 확인 — `wasm-pack build --target web --out-dir pkg` 로 다시 빌드해 실제 브라우저에서 확인함(아래 실측)
- [x] rhwp-studio UI 변경: e2e 시나리오 추가 — `rhwp-studio/e2e/status-page-number.test.mjs`
      (`npm --prefix rhwp-studio run e2e:status-page-number`)
- [ ] 작업 증빙 `rhwp replay --capsule` — 문서를 편집·생성하지 않는 조회 계약 변경(해당 없음)
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 없음(해당 없음)

### 실행한 명령과 결과

~~~text
cargo fmt --all -- --check                                              # 통과
cargo clippy --locked -- -D warnings                                    # 통과
cargo test --test regression_suite_013 issue_5749_page_info_page_number # 1 passed
cargo test --lib document_core::queries::rendering                      # 22 passed
node scripts/rust-unit-test-tiers.mjs --check                           # 4225 tests (증가 없음)
(cd rhwp-studio && npx tsc --noEmit)                                    # 통과
npm --prefix rhwp-studio test                                           # 1038 pass / 0 fail / 1 skip
npm --prefix rhwp-studio run e2e:status-page-number                     # 단언 6건 PASS
git diff --check                                                        # 통과
~~~

focused test 선택 이유 — 변경은 `get_page_info_native` 의 응답 JSON 한 필드와 studio 표시
로직입니다. 새 계약은 `issue_5749_page_info_page_number`(새 번호 삽입 전후 `pageNumber` 고정),
기존 계약 회귀는 같은 함수를 쓰는 `document_core::queries::rendering` 단위 테스트로 덮었습니다.

### e2e 결과 (공개 샘플 `samples/쪽기준.hwp`)

~~~text
PASS: TC1: 첫 쪽의 문서 쪽번호는 1 (1)
PASS: TC1: 상태 표시줄이 물리 순번과 같음 (1 / 1 쪽)
PASS: TC2: 새 번호 삽입 ({"ok":true,"controlIdx":2})
PASS: TC2: 문서 쪽번호가 7로 다시 시작 (7)
PASS: TC2: 상태 표시줄이 문서 쪽번호를 따름 (7 / 1 쪽)
PASS: TC3: 전체 쪽수는 물리 쪽수 유지 (7 / 1 쪽, pageCount=1)
~~~

### 실문서 브라우저 실측

교육부 보도자료 별첨 「2024학년도 대입전형시행계획 주요사항」(로컬 코퍼스 파일이라 저장소에
올리지 않습니다). WASM 을 다시 빌드해 studio 에서 열고 물리 쪽마다 상태 표시줄을 읽었습니다.

| 물리 쪽 | 문서 쪽번호 | 쪽 하단 렌더 | 고치기 전 | 고친 뒤 |
| --- | --- | --- | --- | --- |
| 1 | 1 | (없음) | `1 / 33 쪽` | `1 / 33 쪽` |
| 2 | 2 | (없음) | `2 / 33 쪽` | `2 / 33 쪽` |
| 3 | 1 | `- 1 -` | `3 / 33 쪽` | **`1 / 33 쪽`** |
| 4 | 2 | `- 2 -` | `4 / 33 쪽` | **`2 / 33 쪽`** |
| 33 | 31 | `- 31 -` | `33 / 33 쪽` | **`31 / 33 쪽`** |

구역 표시(`구역: 1 / 4`)는 그대로입니다.

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음. 쪽 이동 때 하던 `getPageInfo` 호출을 **한 번으로 줄였고**(기존에는
  쪽번호·구역 갱신 경로가 따로 조회), JSON 필드 하나가 늘었습니다.
- 재현·측정: 별도 측정 없음(미측정).

## 스크린샷

상태 표시줄 텍스트 실측 표로 대체했습니다(위). 처리 결과 문서:
`mydocs/working/task_5749_studio_status_page_number.md`.
