### PR TITLE
fix(docker): 이미 쓰이는 GID 를 넘기면 이미지 빌드가 실패한다

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,19 @@ RUN rustup target add wasm32-unknown-unknown \
 # 호스트 사용자 UID/GID로 실행 (빌드 산출물 소유권 문제 방지)
 ARG UID=1000
 ARG GID=1000
+# `builder` 그룹은 만들어지지 않을 수 있다. GID 가 이미 쓰이고 있으면
+# `groupadd` 가 실패하고 `|| true` 가 그것을 삼킨다 — macOS 의 기본 GID 20 이
+# 데비안에서는 `dialout` 이라 정확히 그 경우가 된다. 그래서 소유자를 그룹
+# **이름**이 아니라 GID 로 지정한다.
 RUN groupadd -g ${GID} builder 2>/dev/null || true \
     && useradd -m -u ${UID} -g ${GID} builder \
     && mkdir -p /home/builder/.cache/.wasm-pack \
-    && chown -R builder:builder /home/builder
+    && chown -R builder:${GID} /home/builder
 
 ENV CARGO_HOME=/home/builder/.cargo
 RUN mkdir -p /home/builder/.cargo \
     && cp -r /usr/local/cargo/* /home/builder/.cargo/ \
-    && chown -R builder:builder /home/builder/.cargo
+    && chown -R builder:${GID} /home/builder/.cargo
 
 USER builder
 WORKDIR /app


### PR DESCRIPTION
> **정정 (2026-08-20).** 처음에 「macOS 에서 100% 실패」로 적었는데 **틀렸습니다.**
> `.env.docker.example` 이 `GID=1000` 을 박아 두므로 README 대로 하면 맥에서도
> 정상입니다. @humdrum00001010 님이 잡아 주셨습니다. 본문을 사실에 맞게 고칩니다.

## 언제 실패하나

`.env.docker` 에 **이미 쓰이고 있는 GID** 를 넣으면 이미지 빌드가 죽습니다.

```
$ printf 'UID=501\nGID=20\n' > .env.docker      # macOS 의 실제 값
$ docker compose --env-file .env.docker build wasm
chown: invalid group: 'builder:builder'
... returned a non-zero code: 1
```

## 원인

```dockerfile
RUN groupadd -g ${GID} builder 2>/dev/null || true \
    && useradd -m -u ${UID} -g ${GID} builder \
    && chown -R builder:builder /home/builder
```

GID 가 이미 쓰이고 있으면 `groupadd` 가 실패하고, **`|| true` 가 그 실패를 삼킨 뒤**,
있지도 않은 `builder` 그룹에 `chown` 을 걸어 죽습니다.

macOS 의 기본 그룹이 `staff`(20) 인데 데비안에서 GID 20 은 `dialout` 이라 자주
만나지만, **맥만의 일은 아닙니다** — 시스템 GID 와 겹치면 리눅스에서도 같습니다.

`.env.docker.example` 의 주석이 이 값을 「호스트 사용자 UID/GID」라고 설명하고
있어서, 설명대로 자기 값을 넣는 분이 걸립니다.

## 고침

소유자를 그룹 **이름**이 아니라 **GID** 로 지정합니다. 그룹이 만들어졌는지와
무관하게 돕니다. **두 곳입니다** — 앞의 것만 고치면 `.cargo` 단계에서 다시 죽습니다.

## 확인

```bash
docker build --build-arg UID=501  --build-arg GID=20   .   # 겹치는 GID  ✅
docker build --build-arg UID=1000 --build-arg GID=1000 .   # 기본값      ✅
```

기본값 경로가 안 깨지는 것도 함께 봤습니다.

```
uid=501(builder) gid=20(dialout) groups=20(dialout)
drwx------ 1 builder dialout /home/builder
drwxr-xr-x 4 builder dialout /home/builder/.cargo
```

그룹 이름이 `dialout` 으로 보이는 것은 GID 20 이 데비안에서 그 이름이기 때문이고,
**UID·GID 숫자가 맞으므로 소유권 일치라는 목적은 이뤄집니다.**

## 값어치 판단은 맡깁니다

기본값으로 쓰는 분께는 **아무 차이가 없습니다.** 굳이 넣을 것 없다고 보시면 닫아
주셔도 됩니다.

---

`KayaPDF` 라는 문서 변환 도구를 만들면서 rhwp 를 쓰고 있습니다. 좋은 프로젝트
만들어 주셔서 고맙습니다.