### PR TITLE
docs(review): PR #5758 검토 기록을 보존한다

### DIFF
--- a/mydocs/orders/20260820.md
+++ b/mydocs/orders/20260820.md
@@ -199,3 +199,18 @@ date: 2026-08-20
 - 첫 직접 push의 CI에서 monolithic `main.rs`를 전제한 `shadow_agree` 계약 검사가 실패했다.
   top-level·중첩 dispatch와 envelope field를 production Rust source 전체에서 확인하도록 테스트만
   보정했으며, shadow suite 31/31과 CI의 LLM verifier 계약 7개 명령을 로컬에서 전부 통과했다.
+
+## #5758 점유 Docker GID의 builder 소유권 보정 완료
+
+- [#5758](https://github.com/edwardkim/rhwp/pull/5758)은 Docker image 안에서 이미 사용 중인 숫자
+  GID를 인자로 넘기면 `groupadd`가 실패한 뒤 `chown builder:builder`도 실패하던 경로를
+  `chown builder:${GID}`로 보정했다.
+- Ubuntu 컨테이너에서 `UID=501, GID=20`을 재현해 기존 그룹 이름 방식의 실패와 숫자 GID
+  방식의 성공(`501:20`)을 확인했다. `UID=1001, GID=1000` 호환 경로도 `1001:1000`으로
+  확인했다. 전체 `rust:latest` image build는 registry pull 환경 문제로 완료하지 못했으므로
+  이 기록은 Dockerfile 소유권 명령의 컨테이너 검증만 근거로 한다.
+- code candidate CI에서 preflight, Lint, Native Skia, frontend package, archive builder,
+  slow/regular worker와 `Build & Test` aggregate가 성공했다. Rust CodeQL은 진행 중이었지만
+  작업지시자의 administrator merge 지시에 따라 대기 예외로 처리했다.
+- PR은 `cd761884c`로 병합됐으며 연결 이슈는 없다. 상세 판정은
+  [PR #5758 검토 기록](../pr/archives/pr_5758_review.md)에 남긴다.

--- a/mydocs/pr/archives/pr_5758_review.md
+++ b/mydocs/pr/archives/pr_5758_review.md
@@ -1,0 +1,60 @@
+---
+kind: pr-review
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+---
+
+# PR #5758 - 점유된 Docker GID에서도 builder 소유권을 설정한다
+
+## 라우팅과 메타데이터
+
+```text
+base route: collaborator external PR
+modifiers: intake_and_review.md, local_validation.md,
+  collaborator_external_pr.md, post_merge.md
+code candidate: 00e95071e2e5557baeddd53eec0a8d10482f27c5
+merge commit: cd761884cc580fa721961105043fa0b5b1a9c6b1
+```
+
+| 항목 | 결과 |
+| --- | --- |
+| PR | [#5758](https://github.com/edwardkim/rhwp/pull/5758) |
+| Issue | 연결된 이슈 없음 |
+| 작성자 | `kjh0523` (rhwp 첫 GitHub 기여) |
+| base / head | `devel` / `fix/docker-build-on-macos` |
+| 범위 | `Dockerfile` 1개, +6 / -2 |
+| 병합 | 2026-08-20, administrator merge, `cd761884c` |
+
+## 변경 범위와 판정
+
+- `groupadd -g ${GID} builder || true`는 지정한 숫자 GID가 이미지 안에서 이미 쓰이면
+  `builder` 그룹을 만들지 못한다. 기존 `chown builder:builder`는 이 경우 존재하지 않는
+  그룹 이름을 다시 참조해 실패했다.
+- 두 `chown`을 `builder:${GID}`로 바꿔, 새 그룹 생성 여부와 관계없이 숫자 GID에
+  소유권을 설정한다. `/home/builder`와 `.cargo`를 함께 보정해 후속 단계의 동일한 실패도
+  방지한다.
+- 기본 `1000:1000` 경로를 망가뜨리지 않고, macOS 기본 GID 20처럼 Debian 계열에서 이미
+  점유된 GID를 명시한 Docker 사용자 경로만 고친다.
+
+## 검증과 한계
+
+- Ubuntu 컨테이너에서 `UID=501, GID=20`을 재현했다. 기존 그룹 이름 방식은
+  `chown: invalid group: 'builder:builder'`로 실패했고, 숫자 GID 방식은
+  `uid=501(builder) gid=20(dialout)` 및 두 대상 경로의 `501:20` 소유권으로 성공했다.
+- 호환 경로는 `UID=1001, GID=1000`으로 확인했다. 두 대상 경로가 `1001:1000`이 되어
+  기본적인 비점유 GID 동작도 유지했다.
+- 전체 `rust:latest` Dockerfile build는 registry pull이 진행되지 않는 로컬 Docker 환경 문제로
+  완료하지 못했다. 이 기록은 위 Dockerfile 소유권 명령의 Linux 컨테이너 검증만 근거로 하며,
+  전체 이미지 빌드 성공을 주장하지 않는다.
+- [CI run 32350721366](https://github.com/edwardkim/rhwp/actions/runs/32350721366)는
+  preflight, Lint, Native Skia, frontend package, archive builder, slow/regular test worker와
+  `Build & Test` aggregate가 성공했다.
+- Rust CodeQL은 administrator merge 시점에도 진행 중이었다. 작업지시자의 명시적
+  `admin merge` 지시로 해당 대기를 예외 처리했으며, 성공으로 간주하지 않는다.
+
+## 최종 판정
+
+**병합 완료.** 실제 점유 GID 재현에서 실패 원인과 두 소유권 경로의 보정이 확인됐고, code CI의
+핵심 Rust aggregate도 성공했다. 이 검토 기록과 오늘할일은 구현 PR과 분리한 docs-only PR로
+보존한다.
+


### PR DESCRIPTION
## 목적

병합된 [#5758](https://github.com/edwardkim/rhwp/pull/5758)의 검토 근거와 2026-08-20 오늘할일을 구현 변경과 분리해 보존합니다.

## 포함 문서

- `mydocs/pr/archives/pr_5758_review.md`
- `mydocs/orders/20260820.md`

## 검토 기록 요약

- 점유된 GID 20에서 기존 그룹 이름 `chown` 실패와 숫자 GID 보정 성공을 Ubuntu 컨테이너로 재현했습니다.
- `Build & Test`, Lint, Native Skia, archive builder 및 test worker 성공을 기록했습니다.
- 전체 `rust:latest` image build는 registry pull 환경 문제로 완료하지 못한 한계를 명시했습니다.

구현 파일과 CI workflow는 변경하지 않는 docs-only PR입니다.