### PR TITLE
fix(dev): WASM 검증의 Cargo lockfile 오염을 막는다

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,6 +204,37 @@ cargo build --profile release-test --target-dir target/pr-review
 아래 범위에서 검증합니다. 메인터너용 PR review 문서를 읽거나 저장소에 검토 기록을 추가할 필요는 없습니다.
 PR 본문에 실제로 실행한 명령, 통과 결과, 수동 확인한 동작과 사용한 공개 sample만 적어주세요.
 
+WASM package를 다시 만들 때는 raw `wasm-pack build` 대신 아래 wrapper를 사용합니다. `wasm-pack`의 사전
+metadata 호출까지 `--locked`로 고정하므로, 검증 과정에서 루트 `Cargo.lock`이 갱신되는 것을 막습니다.
+
+```bash
+CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg
+```
+
+반복 실행할 때는 macOS/Linux 셸에서 아래 alias를 둘 수 있습니다.
+
+```bash
+alias rhwp-wasm-build='CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg'
+rhwp-wasm-build
+```
+
+Windows에서는 native wrapper를 사용합니다.
+
+```powershell
+$env:CARGO_TARGET_DIR = 'target\pr-review'
+.\scripts\wasm-pack-locked.ps1 --target web --out-dir pkg
+Remove-Item Env:CARGO_TARGET_DIR
+```
+
+`cmd.exe`에서는 아래처럼 `doskey` macro를 현재 세션에 등록할 수 있습니다. macro는 세션 종료 시 사라집니다.
+
+```bat
+doskey rhwp-wasm-build=scripts\wasm-pack-locked.cmd --target web --out-dir pkg $*
+set "CARGO_TARGET_DIR=target\pr-review"
+rhwp-wasm-build
+set "CARGO_TARGET_DIR="
+```
+
 먼저 의존성을 설치한 뒤 Studio의 타입·단위·번들을 확인합니다.
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
         trap 'exit 143' TERM
         trap finish EXIT
         rm -f pkg/*-opt.wasm
-        wasm-pack build --target web
+        scripts/wasm-pack-locked.sh --target web
 
 volumes:
   cargo-cache:

--- a/mydocs/manual/dev_environment_guide.md
+++ b/mydocs/manual/dev_environment_guide.md
@@ -173,8 +173,37 @@ Docker를 사용할 수 없는 호스트에서 원인을 분리하는 **진단�
 ```powershell
 Remove-Item -Force -ErrorAction SilentlyContinue pkg\*-opt.wasm
 $env:CARGO_TARGET_DIR = 'target\pr-review'
-wasm-pack build --target web --out-dir pkg --no-opt
+.\scripts\wasm-pack-locked.ps1 --target web --out-dir pkg --no-opt
 Remove-Item Env:CARGO_TARGET_DIR
+```
+
+macOS/Linux의 native WASM 검증은 `wasm-pack`을 직접 실행하지 않는다. 아래 wrapper는
+`cargo metadata`와 `cargo build` 모두에 `--locked`를 적용해 루트 `Cargo.lock`을
+갱신하지 못하게 한다.
+
+```bash
+CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg
+```
+
+반복 실행은 macOS/Linux 셸의 alias로 줄일 수 있습니다. alias는 현재 셸에만 적용하며, 영구 적용이 필요하면
+사용 중인 셸의 초기화 파일에 같은 줄을 넣습니다.
+
+```bash
+alias rhwp-wasm-build='CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg'
+rhwp-wasm-build
+# 예: 최적화를 생략한 진단 빌드
+rhwp-wasm-build --no-opt
+```
+
+Windows에서는 native PowerShell wrapper를 사용합니다. `cmd.exe`에서는 아래 `doskey` macro를 현재 세션에
+등록할 수 있습니다. 새 `cmd.exe`를 열면 다시 등록해야 합니다.
+
+```bat
+doskey rhwp-wasm-build=scripts\wasm-pack-locked.cmd --target web --out-dir pkg $*
+set "CARGO_TARGET_DIR=target\pr-review"
+rhwp-wasm-build
+rhwp-wasm-build --no-opt
+set "CARGO_TARGET_DIR="
 ```
 
 네이티브 `wasm-pack build`를 최적화까지 포함해 반복 검증해야 하면 먼저 표준 Docker 경로를

--- a/mydocs/manual/pr_review/README.md
+++ b/mydocs/manual/pr_review/README.md
@@ -24,7 +24,7 @@ last_verified: 2026-07-25
 | [collaborator_self_merge.md](collaborator_self_merge.md) | collaborator 자신의 PR을 준비·merge |
 | [collaborator_external_pr.md](collaborator_external_pr.md) | collaborator가 contributor PR head를 보정하거나 기록을 더함 |
 | [local_validation.md](local_validation.md) | local fetch, simulation, Cargo/npm/fixture 검증 |
-| [visual_fixture_evidence.md](visual_fixture_evidence.md) | renderer 또는 HWP/HWPX/PDF fixture·페이지·시각 검증 |
+| [visual_fixture_evidence.md](visual_fixture_evidence.md) | renderer 또는 HWP/HWPX/PDF fixture·페이지·시각 검증. 문서 비교 절차는 [Visual Sweep 가이드](../verification/visual_sweep_guide.md#github-merge-comment)를 정본으로 사용 |
 | [multi_pr_update_branch.md](multi_pr_update_branch.md) | 대량 유입, 다수 PR 누적 검토, update branch, stale CI |
 | [review_only_fast_pass.md](review_only_fast_pass.md) | code PR 뒤 review-only commit 또는 PR 전체가 허용된 review-only 범위 |
 | [post_merge.md](post_merge.md) | merge 이후 문서·asset·issue·comment·정리 |

--- a/mydocs/manual/pr_review/local_validation.md
+++ b/mydocs/manual/pr_review/local_validation.md
@@ -37,6 +37,38 @@ pgrep -alf '(^|/)(cargo|rustc|wasm-pack)( |$)' || true
 `run-rust-test.mjs`도 이를 기본 적용한다. lockfile 자체를 의도적으로 바꾸는 의존성 갱신 작업만 별도
 검증에서 이 규칙을 벗어날 수 있다.
 
+`wasm-pack`은 Cargo build 전에 별도 metadata를 실행하므로, WASM 검증은 raw `wasm-pack build` 대신
+아래 wrapper를 사용한다. wrapper는 두 Cargo 호출 모두에 `--locked`를 적용한다.
+
+```bash
+CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg
+```
+
+반복 검증에는 macOS/Linux 셸에서 다음 alias를 사용할 수 있습니다.
+
+```bash
+alias rhwp-wasm-build='CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg'
+rhwp-wasm-build
+```
+
+Windows PowerShell에서는 native wrapper를 사용합니다.
+
+```powershell
+$env:CARGO_TARGET_DIR = 'target\pr-review'
+.\scripts\wasm-pack-locked.ps1 --target web --out-dir pkg
+Remove-Item Env:CARGO_TARGET_DIR
+```
+
+`cmd.exe`에서는 아래 `doskey` macro로 같은 native wrapper를 현재 세션에 등록할 수 있습니다. 새 `cmd.exe`를
+열면 다시 등록해야 합니다.
+
+```bat
+doskey rhwp-wasm-build=scripts\wasm-pack-locked.cmd --target web --out-dir pkg $*
+set "CARGO_TARGET_DIR=target\pr-review"
+rhwp-wasm-build
+set "CARGO_TARGET_DIR="
+```
+
 문서의 명령은 고정 `--test-threads` 값을 쓰지 않는다. nextest 기본 동시성을 먼저 사용하고, 현재
 host의 논리 CPU·메모리·동시 작업을 확인한 뒤에만 `--test-threads <현재 환경에 맞는 값>`으로 조정한다.
 논리 CPU 확인은 macOS `sysctl -n hw.logicalcpu`, Linux `getconf _NPROCESSORS_ONLN`, PowerShell

--- a/mydocs/manual/pr_review/post_merge.md
+++ b/mydocs/manual/pr_review/post_merge.md
@@ -166,16 +166,24 @@ close 체크리스트: ① sub-issue close ② 가드 테스트 PR merge ③ 판
 원 PR에는 감사, merge 사실, 실제 검증 결과, 필요하면 후속 issue를 남긴다. issue·PR·comment는 평문 번호
 대신 Markdown direct link로 쓴다.
 
-시각 검증을 merge 판단 근거로 썼다면 실제 devel asset을 보이게 포함한다.
+시각 검증을 merge 판단 근거로 썼다면 [Visual Sweep의 GitHub merge comment 정본](../verification/visual_sweep_guide.md#github-merge-comment)을
+direct link로 남기고, merge commit에 포함된 실제 asset을 보이게 포함한다. raw URL은 이미지 표시용 증적이며,
+문서 비교 방법의 정본은 Visual Sweep 가이드다.
 
 ~~~markdown
 검토 및 머지 완료했습니다. 감사합니다.
 
 - CI: Build & Test, CodeQL, Render Diff의 최신 head 결과 확인
 - 로컬 검증: 실제 실행한 focused/release-test/Native Skia 등
+- 문서 비교: [PDF/SVG visual sweep 가이드](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/verification/visual_sweep_guide.md#github-merge-comment)를 따름
 - visual sweep: pN, flagged=0/N, pixel match NN.NNNNN%
 
-![PR N pN visual review](https://raw.githubusercontent.com/edwardkim/rhwp/devel/mydocs/pr/assets/<review>.png)
+코멘트: 내용 픽셀 중심 자동 일치율 보조값 = 약 NN.NN%.
+높을수록 좋음: 기준 PDF와 rhwp PNG가 더 비슷함
+낮을수록 나쁨/검토 필요: 잉크 위치나 형태 차이가 큼
+단, 사람 판정 정확도가 아니라 내용 픽셀 중심 자동 일치율 보조값입니다
+
+![PR N pN visual review](https://raw.githubusercontent.com/edwardkim/rhwp/<merge-commit-sha>/mydocs/pr/assets/<review>.png)
 ~~~
 
 이미지 link만 쓰거나 output 임시 경로만 남기지 않는다. review 문서에 기록된 실제 수치·페이지·결론만

--- a/mydocs/manual/pr_review/visual_fixture_evidence.md
+++ b/mydocs/manual/pr_review/visual_fixture_evidence.md
@@ -18,6 +18,8 @@ merge를 보류하지 않는다.
 
 visual sweep을 실제 검토 근거로 쓰면 review 문서에 다음을 모두 기록한다.
 
+- 문서 비교 절차의 정본인 [PDF/SVG visual sweep 가이드](../verification/visual_sweep_guide.md#github-merge-comment)와
+  적용한 command·판정 범위
 - compare, overlay, review PNG의 임시 output 경로
 - 검토한 페이지 수와 자동 후보 수
 - pixel match, visual_accuracy_proxy_percent
@@ -60,11 +62,15 @@ visual sweep을 실제 merge 판단에 썼으면 merge 가능 또는 승인 요�
 - review 문서에는 임시 output 경로와 최종 asset 경로를 둘 다 적는다.
 - 여러 페이지를 검증해도 모든 PNG를 기계적으로 보존할 필요는 없다. 결론을 증명하는 정상 page와
   보완 요청·후속 issue 판단에 필요한 후보 page를 대표 asset으로 남긴다.
-- GitHub comment에는 output 경로 link만 남기지 않는다. devel에 반영된 asset의 raw URL을 Markdown image로
-  실제 표시되게 넣는다.
+- GitHub merge comment에는 [Visual Sweep 정본](../verification/visual_sweep_guide.md#github-merge-comment)을
+  direct link로 남긴다. output 경로 link만 남기지 않고, merge commit에 반영된 asset의 **commit SHA 고정**
+  raw URL을 Markdown image로 실제 표시한다. raw URL은 PNG 표시용 증적이며 문서 비교 방법의 인용은
+  Visual Sweep 정본과 review 문서가 담당한다.
 
 ~~~markdown
-![PR N visual review](https://raw.githubusercontent.com/edwardkim/rhwp/devel/mydocs/pr/assets/<file>.png)
+- 문서 비교: [PDF/SVG visual sweep 가이드](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/verification/visual_sweep_guide.md#github-merge-comment)를 따름
+
+![PR N visual review](https://raw.githubusercontent.com/edwardkim/rhwp/<merge-commit-sha>/mydocs/pr/assets/<file>.png)
 ~~~
 
 ### asset 반영 경로

--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -287,8 +287,10 @@ review 문서에는 계획형이나 미래형으로 쓰지 않는다. 실행한 
 
 review 문서 경로, review_impl 작성 조건, 사전 판단 report의 범위는 선택한 기본 경로와
 [PR 접수와 리뷰 기록](pr_review/intake_and_review.md)을 따른다. 시각 검증을 실제 판단 근거로 사용하면
-임시 output 경로만 남기지 말고, 대표 review PNG를 mydocs/pr/assets 아래 안정 경로에 보존한 뒤
-그 경로를 review 문서와 실제 GitHub comment에 사용한다.
+문서 비교 절차의 정본으로 [PDF/SVG visual sweep 가이드](verification/visual_sweep_guide.md#github-merge-comment)를
+사용한다. 임시 output 경로만 남기지 말고, 대표 review PNG를 mydocs/pr/assets 아래 안정 경로에 보존한 뒤
+그 경로를 review 문서와 실제 GitHub comment에 사용한다. merge 후 comment에는 Visual Sweep 정본 link와
+review 문서의 실제 수치·결론을 함께 남기며, PNG는 merge commit SHA 고정 raw URL로 표시한다.
 
 ## 5. 기존 절 번호 대응
 

--- a/mydocs/manual/verification/visual_sweep_guide.md
+++ b/mydocs/manual/verification/visual_sweep_guide.md
@@ -311,6 +311,36 @@ jq '.pages[] | select(.page == 22) | {page, overlay_png, visual_accuracy_proxy_p
   output/task1274/<target>/overlay/overlay_metrics.json
 ```
 
+## GitHub merge comment
+
+renderer, layout, paint처럼 **문서 비교 결과를 merge 판단 근거로 쓴 PR**의 공식 비교 절차는 이
+Visual Sweep 가이드다. merge 후 GitHub comment는 이미지 하나 또는 raw URL만으로 판정하지 않고, 이 절의
+절차와 review 문서에 기록한 실제 결과를 함께 가리킨다.
+
+comment에는 다음을 포함한다.
+
+- 이 절의 [Visual Sweep 정본](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/verification/visual_sweep_guide.md#github-merge-comment)
+  direct link
+- review 문서에 기록된 실제 페이지, 후보 수, `pixel match`와 `visual_accuracy_proxy_percent`
+- 수치가 자동 일치율 보조값이며 사람의 최종 판정을 대체하지 않는다는 설명
+- merge commit SHA에 고정한 representative review PNG
+
+`raw.githubusercontent.com` URL은 GitHub comment에서 PNG를 표시하는 증적 전달 수단일 뿐, 문서 비교 절차의
+정본 링크가 아니다. branch URL 대신 asset을 포함한 merge commit SHA를 사용해, 이후 `devel`이 전진해도
+comment가 가리키는 증적을 고정한다.
+
+~~~markdown
+- 문서 비교: [PDF/SVG visual sweep 가이드](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/verification/visual_sweep_guide.md#github-merge-comment)를 따름
+- 대상: pN, flagged=0/N, pixel match NN.NNNNN%
+
+코멘트: 내용 픽셀 중심 자동 일치율 보조값 = 약 NN.NN%.
+높을수록 좋음: 기준 PDF와 rhwp PNG가 더 비슷함
+낮을수록 나쁨/검토 필요: 잉크 위치나 형태 차이가 큼
+단, 사람 판정 정확도가 아니라 내용 픽셀 중심 자동 일치율 보조값입니다
+
+![PR N pN visual review](https://raw.githubusercontent.com/edwardkim/rhwp/<merge-commit-sha>/mydocs/pr/assets/<review>.png)
+~~~
+
 ## PNG overlay 비교
 
 스크립트는 각 페이지에 대해 `rhwp_png`와 `pdf_png`를 같은 canvas 크기로 padding한 뒤, RGB 채널 차이가

--- a/mydocs/orders/20260820.md
+++ b/mydocs/orders/20260820.md
@@ -19,6 +19,8 @@ date: 2026-08-20
   개발·검토 가이드와 로컬 source bind-mount Docker Compose 경로를 같은 wrapper로 통일한다.
 - GitHub Actions workflow는 바꾸지 않는다. fresh runner의 실행 산출물은 폐기되므로 이 변경은 개발자
   로컬 작업 트리에서 의존성 변경과 검증 산출물을 명확히 분리하는 범위다.
+- 구현 PR은 [#5774](https://github.com/edwardkim/rhwp/pull/5774)다. 같은 branch의 trailing 문서는
+  문서 비교의 정본을 Visual Sweep으로 명확히 하고, 최신 head의 CI와 mergeability를 다시 확인한다.
 
 ## #5770 renderer bughunt r2: 표 폭, 글상자 vpos, 인라인 TAC 보정
 

--- a/mydocs/orders/20260820.md
+++ b/mydocs/orders/20260820.md
@@ -6,6 +6,20 @@ date: 2026-08-20
 
 # 2026-08-20 오늘할 일
 
+## #5773 로컬 WASM 검증의 Cargo lockfile 오염 차단
+
+- [`wasm-pack build --locked`](https://github.com/edwardkim/rhwp/issues/5773)는 Cargo build보다 앞서
+  실행하는 `cargo metadata`에는 `--locked`를 전달하지 않아, 검증만으로 루트 `Cargo.lock`을
+  재정렬하거나 갱신할 수 있다.
+- `devel`에서 manifest suite Node test 18건, `--prepare`/`--check`, unit-tier check와 focused
+  integration test를 재실행했다. `--prepare`는 ignored 파생 suite만 만들었고, 모든 명령 전후
+  `Cargo.toml`·`Cargo.lock` diff는 없었다. 원인은 일반 Node 검증이 아니라 raw `wasm-pack` metadata
+  호출이다.
+- POSIX, Windows PowerShell, `cmd.exe` wrapper가 metadata까지 `--locked`로 실행하도록 만들고,
+  개발·검토 가이드와 로컬 source bind-mount Docker Compose 경로를 같은 wrapper로 통일한다.
+- GitHub Actions workflow는 바꾸지 않는다. fresh runner의 실행 산출물은 폐기되므로 이 변경은 개발자
+  로컬 작업 트리에서 의존성 변경과 검증 산출물을 명확히 분리하는 범위다.
+
 ## #5770 renderer bughunt r2: 표 폭, 글상자 vpos, 인라인 TAC 보정
 
 - [#5770](https://github.com/edwardkim/rhwp/pull/5770)은 #5720의 병합 셀 표 폭 초과, #5721의

--- a/mydocs/pr/archives/pr_5774_review.md
+++ b/mydocs/pr/archives/pr_5774_review.md
@@ -1,0 +1,65 @@
+---
+kind: pr-review
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+---
+
+# PR #5774 - WASM 검증의 Cargo lockfile 오염을 막는다
+
+## 라우팅과 메타데이터
+
+```text
+base route: collaborator self-merge
+modifiers: intake_and_review.md, local_validation.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+  collaborator_self_merge.md, intake_and_review.md, local_validation.md,
+  docs_and_git_workflow.md, github_operations.md
+code candidate: 5feb13948dee6a5f1fb2051dca3d0a71619fe614
+```
+
+| 항목 | 작성 시점 참고값 |
+| --- | --- |
+| PR | [#5774](https://github.com/edwardkim/rhwp/pull/5774) |
+| Issue | [#5773](https://github.com/edwardkim/rhwp/issues/5773) |
+| 작성자 | `jangster77` self-review |
+| base / head | `devel` / `codex/wasm-pack-locked-metadata` |
+| code candidate 상태 | Open, non-draft. trailing 문서 head CI 대기 |
+
+최종 merge 전에는 trailing 문서를 포함한 최신 head의 SHA, mergeability, preflight와 `Build & Test`
+aggregate를 다시 확인한다.
+
+## 변경 범위와 판정
+
+- raw `wasm-pack build --locked`의 사전 `cargo metadata`는 lockfile을 갱신할 수 있다. POSIX wrapper는
+  shim `cargo`로 metadata에만 `--locked`를 더하고 나머지 호출은 원래 인수대로 위임한다.
+- Windows PowerShell wrapper는 임시 `cargo.exe` proxy와 sibling `wasm-pack.exe`를 사용해 Windows의 실행 파일
+  탐색 순서에서도 같은 metadata 보호를 적용한다. `cmd.exe` wrapper는 이를 native PowerShell로 위임한다.
+- `CONTRIBUTING.md`, 개발·PR 검토 가이드와 로컬 source bind-mount Docker Compose 경로를 wrapper로 통일했다.
+  GitHub Actions workflow와 의존성 갱신 정책은 변경하지 않았다.
+- trailing 문서는 renderer/layout 결과를 바꾸지 않는다. PR review에서 문서 비교가 필요한 경우의 공식
+  절차가 [PDF/SVG visual sweep 가이드](../../manual/verification/visual_sweep_guide.md#github-merge-comment)임을
+  라우터·fixture 증적·merge 후속 안내에 명시한다.
+
+## 로컬 검증
+
+- `node --test scripts/tests/rust-test-suite-manifest.test.mjs`: 18 passed.
+- suite `--prepare`/`--check`, `node scripts/rust-unit-test-tiers.mjs --check`, focused
+  `issue_1035_alignment`: 통과. `--prepare`는 ignored 파생 suite만 만들었고 `Cargo.toml`·`Cargo.lock`은
+  변경하지 않았다.
+- `python3 -m unittest scripts/tests/test_docker_wasm_compose.py`: 4 passed.
+- `cargo fmt --all`, `cargo fmt --all -- --check`, `git diff --check`: 통과.
+- `CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg`: 성공 후
+  `git diff --exit-code -- Cargo.toml Cargo.lock` 통과.
+- Windows `win10-ted`에서 PowerShell wrapper와 `cmd.exe` wrapper의 실제 WASM build 뒤에도 동일 Cargo
+  파일 diff 검사가 통과했다.
+- 변경 문서 6개의 `scripts/check_markdown_links.py` 상대 링크 검사가 통과했다. 전체
+  `check_document_metadata.py`는 이 PR과 무관한 기존 `mydocs/tech` 4개 파일의 front matter 누락 16건으로
+  실패했으며, 새 review 문서는 오류 목록에 없었다.
+- Visual Sweep 문서 규칙은 경로·comment template 정리만 다룬다. 이 PR 자체는 renderer 출력 변경이 없어
+  visual sweep 실행 대상이 아니다.
+
+## 최종 권고
+
+**병합 권고, trailing 문서 head 검증 대기.** wrapper의 macOS와 Windows 실측이 root Cargo 파일 무변경을
+확인했고, 문서 변경은 검토 시 문서 비교 절차와 PNG 증적 표시를 혼동하지 않도록 정본 경로를 고정한다.
+최신 PR head의 CI와 mergeability가 통과하면 merge할 수 있다.

--- a/mydocs/working/task_m100_5773_stage1_wasm_pack_lockfile_isolation.md
+++ b/mydocs/working/task_m100_5773_stage1_wasm_pack_lockfile_isolation.md
@@ -1,0 +1,34 @@
+# #5773 로컬 WASM 검증 Cargo lockfile 격리
+
+- 이슈: [#5773](https://github.com/edwardkim/rhwp/issues/5773)
+- 브랜치: `codex/wasm-pack-locked-metadata`
+- 기준: `upstream/devel@f26c2e7ca`
+
+## 배경
+
+`wasm-pack build --locked`는 Cargo build 호출에만 `--locked`를 전달한다. 앞선 `cargo metadata`가
+lockfile을 갱신할 수 있어, 의존성을 변경하지 않은 로컬 WASM 검증 뒤에도 루트 `Cargo.lock`이 dirty로
+남는다. 이는 의도적인 의존성 갱신 diff와 검증 산출물을 혼동하게 만든다.
+
+## 범위
+
+- POSIX shell, Windows PowerShell, `cmd.exe`용 native wrapper를 제공한다.
+- wrapper는 metadata 호출에도 `--locked`를 적용하고, 일반 Cargo 호출은 원래 인수대로 위임한다.
+- 개발·PR 검토 문서, 로컬 source bind-mount Docker Compose WASM 경로, WASM pkg 누락 진단을 wrapper
+  명령으로 갱신한다.
+- GitHub Actions workflow와 의존성 갱신 정책은 범위 밖이다.
+
+## 사전 재현·분리 결과
+
+- raw `wasm-pack build --target web --out-dir pkg --locked`는 root `Cargo.lock`을 변경했다.
+- `node --test scripts/tests/rust-test-suite-manifest.test.mjs` 18건, suite `--prepare`/`--check`,
+  unit-tier `--check`, focused `issue_1035_alignment`은 통과했고, 이후 `Cargo.toml`·`Cargo.lock` diff는
+  없었다.
+- `--prepare`가 만드는 32개 generated harness와 9개 exception은 ignored 검증 산출물이며, source PR에
+  포함하지 않는다.
+
+## 완료 기준
+
+- POSIX wrapper 실행 뒤 `git diff --exit-code -- Cargo.toml Cargo.lock`가 통과한다.
+- Windows PowerShell과 `cmd.exe` wrapper도 같은 검사를 통과한다.
+- raw `wasm-pack build`를 권장하는 로컬 개발·검토 문서와 진단 메시지가 남지 않는다.

--- a/scripts/svg_native_wasm_diff.mjs
+++ b/scripts/svg_native_wasm_diff.mjs
@@ -99,7 +99,7 @@ if (!fs.existsSync(opts.rhwp)) {
 }
 const wasmJs = path.join(opts.pkg, 'rhwp.js');
 if (!fs.existsSync(wasmJs)) {
-  console.error(`wasm pkg 없음: ${wasmJs} — wasm-pack build --target web --out-dir pkg 먼저 실행`);
+  console.error(`wasm pkg 없음: ${wasmJs} — scripts/wasm-pack-locked.sh --target web --out-dir pkg 먼저 실행`);
   process.exit(2);
 }
 

--- a/scripts/tests/test_docker_wasm_compose.py
+++ b/scripts/tests/test_docker_wasm_compose.py
@@ -24,7 +24,7 @@ class DockerWasmComposeContractTests(unittest.TestCase):
 
     def test_stale_wasm_opt_is_removed_before_build(self) -> None:
         cleanup = self.compose.index("rm -f pkg/*-opt.wasm")
-        build = self.compose.index("wasm-pack build --target web")
+        build = self.compose.index("scripts/wasm-pack-locked.sh --target web")
         self.assertLess(cleanup, build)
 
     def test_host_pkg_ownership_is_restored_even_after_a_failed_build(self) -> None:
@@ -38,7 +38,7 @@ class DockerWasmComposeContractTests(unittest.TestCase):
 
     def test_guide_makes_docker_primary_and_no_opt_diagnostic_only(self) -> None:
         docker = self.guide.index("docker compose --env-file .env.docker run --rm wasm")
-        native = self.guide.index("wasm-pack build --target web --out-dir pkg --no-opt")
+        native = self.guide.index(".\\scripts\\wasm-pack-locked.ps1 --target web --out-dir pkg --no-opt")
         self.assertLess(docker, native)
         self.assertIn("진단용", self.guide)
         self.assertIn("최적화된 배포 산출물을 대체하지 않는다", self.guide)

--- a/scripts/wasm-pack-locked.cmd
+++ b/scripts/wasm-pack-locked.cmd
@@ -1,0 +1,4 @@
+@echo off
+setlocal EnableExtensions
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0wasm-pack-locked.ps1" %*
+exit /b %ERRORLEVEL%

--- a/scripts/wasm-pack-locked.ps1
+++ b/scripts/wasm-pack-locked.ps1
@@ -1,0 +1,84 @@
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$WasmPackArguments
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Resolve-Application([string]$Name) {
+    return (Get-Command $Name -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
+}
+
+if ([string]::IsNullOrWhiteSpace($env:CARGO)) {
+    $realCargo = Resolve-Application 'cargo'
+} elseif ([System.IO.Path]::IsPathRooted($env:CARGO) -or $env:CARGO -match '[\\/]') {
+    $realCargo = $env:CARGO
+} else {
+    $realCargo = Resolve-Application $env:CARGO
+}
+$wasmPack = Resolve-Application 'wasm-pack'
+$rustc = Resolve-Application 'rustc'
+$shimDirectory = Join-Path ([System.IO.Path]::GetTempPath()) ("rhwp-wasm-pack-$([Guid]::NewGuid().ToString('N'))")
+$shimSource = Join-Path $shimDirectory 'cargo-proxy.rs'
+$shimCargo = Join-Path $shimDirectory 'cargo.exe'
+$shimWasmPack = Join-Path $shimDirectory (Split-Path -Leaf $wasmPack)
+$previousPath = $env:PATH
+$hadRealCargo = Test-Path Env:RHWP_WASM_PACK_REAL_CARGO
+$previousRealCargo = $env:RHWP_WASM_PACK_REAL_CARGO
+$exitCode = 1
+
+New-Item -ItemType Directory -Path $shimDirectory -Force | Out-Null
+@'
+use std::env;
+use std::process::{exit, Command};
+
+fn main() {
+    let real_cargo = env::var_os("RHWP_WASM_PACK_REAL_CARGO")
+        .expect("RHWP_WASM_PACK_REAL_CARGO must name the real cargo executable");
+    let mut arguments: Vec<_> = env::args_os().skip(1).collect();
+    let is_metadata = arguments
+        .first()
+        .map(|argument| argument == "metadata")
+        .unwrap_or(false);
+    let has_locked = arguments.iter().any(|argument| argument == "--locked");
+    if is_metadata && !has_locked {
+        arguments.push("--locked".into());
+    }
+
+    let status = Command::new(real_cargo)
+        .args(arguments)
+        .status()
+        .expect("failed to start the real cargo executable");
+    exit(status.code().unwrap_or(1));
+}
+'@ | Set-Content -LiteralPath $shimSource -Encoding Ascii
+& $rustc $shimSource '--edition=2021' '-O' '-o' $shimCargo
+if ($LASTEXITCODE -ne 0) {
+    throw "failed to build the temporary cargo.exe proxy: $LASTEXITCODE"
+}
+Copy-Item -LiteralPath $wasmPack -Destination $shimWasmPack
+
+try {
+    $arguments = @('build') + $WasmPackArguments
+    if ($arguments -notcontains '--locked') {
+        $arguments += '--locked'
+    }
+    $env:PATH = "$shimDirectory;$previousPath"
+    $env:RHWP_WASM_PACK_REAL_CARGO = $realCargo
+    # Windows searches the wasm-pack executable directory before PATH. Run a
+    # temporary sibling copy so cargo_metadata resolves this proxy cargo.exe.
+    & $shimWasmPack @arguments
+    $exitCode = $LASTEXITCODE
+} finally {
+    $env:PATH = $previousPath
+    if ($hadRealCargo) {
+        $env:RHWP_WASM_PACK_REAL_CARGO = $previousRealCargo
+    } else {
+        Remove-Item Env:RHWP_WASM_PACK_REAL_CARGO -ErrorAction SilentlyContinue
+    }
+    Remove-Item -LiteralPath $shimDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+exit $exitCode

--- a/scripts/wasm-pack-locked.sh
+++ b/scripts/wasm-pack-locked.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+# wasm-pack passes extra arguments only to cargo build. Its earlier cargo
+# metadata call can otherwise rewrite the workspace lockfile.
+set -eu
+
+real_cargo="${CARGO:-}"
+if [ -z "${real_cargo}" ]; then
+  real_cargo="$(command -v cargo)"
+elif [ "${real_cargo#*/}" = "${real_cargo}" ]; then
+  real_cargo="$(command -v "${real_cargo}")"
+fi
+
+shim_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${shim_dir}"
+}
+trap cleanup EXIT HUP INT TERM
+
+cat > "${shim_dir}/cargo" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+
+if [ "${1:-}" = "metadata" ]; then
+  for arg in "$@"; do
+    if [ "${arg}" = "--locked" ]; then
+      exec "${RHWP_WASM_PACK_REAL_CARGO}" "$@"
+    fi
+  done
+  exec "${RHWP_WASM_PACK_REAL_CARGO}" "$@" --locked
+fi
+
+exec "${RHWP_WASM_PACK_REAL_CARGO}" "$@"
+EOF
+chmod +x "${shim_dir}/cargo"
+
+PATH="${shim_dir}:${PATH}" \
+  RHWP_WASM_PACK_REAL_CARGO="${real_cargo}" \
+  wasm-pack build "$@" --locked


### PR DESCRIPTION
## 요약

- 로컬 `wasm-pack`의 사전 `cargo metadata` 호출까지 `--locked`로 고정하는 POSIX 및 Windows native wrapper를 추가했습니다.
- 기여·개발·PR 검토 문서과 로컬 source bind-mount Docker Compose WASM 경로를 wrapper로 통일했습니다.
- 이 변경은 개발자 로컬 작업 트리 보호만 다루며 GitHub Actions workflow나 의존성 갱신 정책은 바꾸지 않습니다.

## 검증

- `node --test scripts/tests/rust-test-suite-manifest.test.mjs`: 18 passed
- suite `--prepare`/`--check`, unit-tier `--check`, focused `issue_1035_alignment`: 통과
- `python3 -m unittest scripts/tests/test_docker_wasm_compose.py`: 4 passed
- `cargo fmt --all` 및 `cargo fmt --all -- --check`: 통과
- `CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg`: 통과
- 위 WASM 검증 뒤 `git diff --exit-code -- Cargo.toml Cargo.lock`: 통과
- Windows PowerShell wrapper 및 `cmd.exe` wrapper 실제 WASM build 뒤 동일 Cargo 파일 diff 검사: 통과

Closes #5773
