### PR TITLE
ci: 검토 PDF fast-pass를 독립 워크플로에 적용

### DIFF
--- a/.github/workflows/adapter-diff.yml
+++ b/.github/workflows/adapter-diff.yml
@@ -33,9 +33,9 @@ jobs:
       adapter_required: ${{ steps.classify.outputs.adapter_required || 'true' }}
       reason: ${{ steps.classify.outputs.reason || 'preflight-unavailable' }}
     steps:
-      # 문서 전용 PR 또는 검증된 코드 후보 뒤의 mydocs review tail에서는 stable check
+      # 문서 전용 PR 또는 검증된 코드 후보 뒤의 review-only tail에서는 stable check
       # 이름을 유지하고 worker만 skip한다. API·계보·후보 run 판정은 fail-closed다.
-      - name: Classify documentation-only or trusted trailing review tail
+      - name: Classify review-only or trusted trailing review tail
         id: classify
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -53,11 +53,31 @@ jobs:
               return;
             }
 
-            function isMydocsOnly(files) {
-              return files.length > 0 && files.every((file) => (
-                file.filename.startsWith('mydocs/')
-                && (!file.previous_filename || file.previous_filename.startsWith('mydocs/'))
-              ));
+            function isAllowedReviewPath(file) {
+              const filename = file.filename;
+              if (filename.startsWith('mydocs/')) {
+                return true;
+              }
+              if (file.status !== 'added') {
+                return false;
+              }
+              return isReviewReferencePath(filename);
+            }
+
+            function isReviewReferencePath(filename) {
+              const pdfPrefixes = ['pdf/', 'pdf-2020/', 'pdf-large/'];
+              return (
+                filename.startsWith('samples/')
+                && (
+                  filename.endsWith('.hwp')
+                  || filename.endsWith('.hwpx')
+                  || filename.endsWith('.pdf')
+                  || filename.endsWith('.png')
+                )
+              ) || (
+                pdfPrefixes.some((prefix) => filename.startsWith(prefix))
+                && filename.endsWith('.pdf')
+              );
             }
 
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -66,8 +86,8 @@ jobs:
               pull_number: pr.number,
               per_page: 100,
             });
-            if (isMydocsOnly(files)) {
-              setResult(false, 'skip-mydocs-only-pr');
+            if (files.length > 0 && files.every((file) => isAllowedReviewPath(file))) {
+              setResult(false, 'skip-review-only-pr');
               return;
             }
 
@@ -86,7 +106,8 @@ jobs:
                 ref: commit.sha,
               });
               const commitFiles = detail.data.files || [];
-              if (commitFiles.length === 0 || commitFiles.length >= 300 || !isMydocsOnly(commitFiles)) {
+              if (commitFiles.length === 0 || commitFiles.length >= 300
+                || !commitFiles.every((file) => isAllowedReviewPath(file))) {
                 break;
               }
               tailStart = index;
@@ -108,17 +129,23 @@ jobs:
               repo: context.repo.repo,
               workflow_id: 'adapter-diff.yml',
               event: 'pull_request',
-              head_sha: candidate.sha,
               per_page: 100,
             });
             const latestCandidateRun = candidateRuns
               .filter((run) => (
                 run.event === 'pull_request'
                 && run.head_sha === candidate.sha
-                && (run.pull_requests || []).some((runPr) => Number(runPr.number) === Number(pr.number))
+                && run.head_branch === pr.head.ref
+                && run.head_repository?.id === pr.head.repo?.id
               ))
               .sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at))[0];
-            if (!latestCandidateRun || latestCandidateRun.status !== 'completed' || latestCandidateRun.conclusion !== 'success') {
+            const runCreatedAt = Date.parse(latestCandidateRun?.created_at || '');
+            const pullCreatedAt = Date.parse(pr.created_at || '');
+            if (!latestCandidateRun || latestCandidateRun.status !== 'completed'
+              || latestCandidateRun.conclusion !== 'success'
+              || !Number.isFinite(runCreatedAt)
+              || !Number.isFinite(pullCreatedAt)
+              || runCreatedAt < pullCreatedAt) {
               setResult(true, 'review-tail-candidate-run-unavailable');
               return;
             }

--- a/.github/workflows/proptest-roundtrip.yml
+++ b/.github/workflows/proptest-roundtrip.yml
@@ -35,10 +35,10 @@ jobs:
       fast_pass: ${{ steps.finalize.outputs.fast_pass || 'false' }}
       reason: ${{ steps.finalize.outputs.reason || 'preflight-unavailable' }}
     steps:
-      # 문서 전용 devel PR과 검증된 코드 후보 뒤의 mydocs review tail도 `prop roundtrip`
+      # 문서 전용 devel PR과 검증된 코드 후보 뒤의 review-only tail도 `prop roundtrip`
       # check 이름은 남겨야 한다. workflow-level paths-ignore를 쓰면 required check가
       # 사라질 수 있으므로 job 조건으로 skip한다.
-      - name: Detect mydocs-only or trusted trailing review tail
+      - name: Detect review-only or trusted trailing review tail
         id: detect
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -60,11 +60,31 @@ jobs:
               return;
             }
 
-            function isMydocsOnly(files) {
-              return files.length > 0 && files.every((file) => (
-                file.filename.startsWith('mydocs/')
-                && (!file.previous_filename || file.previous_filename.startsWith('mydocs/'))
-              ));
+            function isAllowedReviewPath(file) {
+              const filename = file.filename;
+              if (filename.startsWith('mydocs/')) {
+                return true;
+              }
+              if (file.status !== 'added') {
+                return false;
+              }
+              return isReviewReferencePath(filename);
+            }
+
+            function isReviewReferencePath(filename) {
+              const pdfPrefixes = ['pdf/', 'pdf-2020/', 'pdf-large/'];
+              return (
+                filename.startsWith('samples/')
+                && (
+                  filename.endsWith('.hwp')
+                  || filename.endsWith('.hwpx')
+                  || filename.endsWith('.pdf')
+                  || filename.endsWith('.png')
+                )
+              ) || (
+                pdfPrefixes.some((prefix) => filename.startsWith(prefix))
+                && filename.endsWith('.pdf')
+              );
             }
 
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -73,8 +93,8 @@ jobs:
               pull_number: pr.number,
               per_page: 100,
             });
-            if (isMydocsOnly(files)) {
-              setResult(true, 'mydocs-only-devel-pr');
+            if (files.length > 0 && files.every((file) => isAllowedReviewPath(file))) {
+              setResult(true, 'review-only-devel-pr');
               return;
             }
 
@@ -93,7 +113,8 @@ jobs:
                 ref: commit.sha,
               });
               const commitFiles = detail.data.files || [];
-              if (commitFiles.length === 0 || commitFiles.length >= 300 || !isMydocsOnly(commitFiles)) {
+              if (commitFiles.length === 0 || commitFiles.length >= 300
+                || !commitFiles.every((file) => isAllowedReviewPath(file))) {
                 break;
               }
               tailStart = index;
@@ -115,17 +136,23 @@ jobs:
               repo: context.repo.repo,
               workflow_id: 'proptest-roundtrip.yml',
               event: 'pull_request',
-              head_sha: candidate.sha,
               per_page: 100,
             });
             const latestCandidateRun = candidateRuns
               .filter((run) => (
                 run.event === 'pull_request'
                 && run.head_sha === candidate.sha
-                && (run.pull_requests || []).some((runPr) => Number(runPr.number) === Number(pr.number))
+                && run.head_branch === pr.head.ref
+                && run.head_repository?.id === pr.head.repo?.id
               ))
               .sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at))[0];
-            if (!latestCandidateRun || latestCandidateRun.status !== 'completed' || latestCandidateRun.conclusion !== 'success') {
+            const runCreatedAt = Date.parse(latestCandidateRun?.created_at || '');
+            const pullCreatedAt = Date.parse(pr.created_at || '');
+            if (!latestCandidateRun || latestCandidateRun.status !== 'completed'
+              || latestCandidateRun.conclusion !== 'success'
+              || !Number.isFinite(runCreatedAt)
+              || !Number.isFinite(pullCreatedAt)
+              || runCreatedAt < pullCreatedAt) {
               setResult(false, 'review-tail-candidate-run-unavailable');
               return;
             }

--- a/mydocs/manual/pr_review/review_only_fast_pass.md
+++ b/mydocs/manual/pr_review/review_only_fast_pass.md
@@ -20,6 +20,11 @@ review-only인 경우에 적용하는 공용 modifier다. maintainer·collaborat
 기존 samples 또는 세 PDF 디렉터리 파일의 수정·삭제·rename, source, test, workflow, Cargo.lock,
 golden, baseline은 허용 범위가 아니다.
 
+Proptest roundtrip과 Adapter inter-diff도 같은 허용 경로 정책을 사용한다. 이 두 required check가 code
+candidate의 결과를 재사용할 때는 PR 번호 배열 유무가 아니라 candidate SHA, 현재 PR head branch, source
+repository id와 PR 생성 이후 실행 여부를 함께 확인한다. 따라서 fork PR의 `listWorkflowRuns` 응답에
+`pull_requests` 배열이 비어 있어도, 다른 PR·다른 fork·PR 생성 전 실행 결과는 재사용하지 않는다.
+
 ## A. code PR 뒤의 trailing review-only commit
 
 contributor code PR의 뒤에 review 문서·오늘할일·허용된 신규 기준 자료를 추가하면 workflow는 현재 head에서

--- a/mydocs/orders/20260820.md
+++ b/mydocs/orders/20260820.md
@@ -6,6 +6,21 @@ date: 2026-08-20
 
 # 2026-08-20 오늘할 일
 
+## #5777 검토 PDF 증적의 Proptest·Adapter fast-pass 정합성
+
+- [#5778](https://github.com/edwardkim/rhwp/pull/5778)은 #5772의 review evidence tail에서 중앙 CI만
+  fast-pass하고 `Proptest roundtrip` 및 `Adapter inter-diff`가 full worker를 실행한 경로를 보정한다.
+- 두 워크플로는 중앙 CI와 동일하게 `mydocs/**`, 새 `samples/` HWP/HWPX/PDF/PNG, 새
+  `pdf/`·`pdf-2020/`·`pdf-large/` PDF를 review-only로 허용한다. 기존 reference file 수정은 허용하지
+  않아 full 검증을 유지한다.
+- fork PR의 trailing candidate는 비어 있을 수 있는 `pull_requests` 배열 대신 event, SHA, branch,
+  repository ID와 PR 생성 시각으로 식별한다. 다른 fork 및 PR 생성 전 run은 재사용하지 않는다.
+- workflow contract test 37건, `cargo fmt --all`, format check, diff check를 완료했다. Rust와 렌더 경로가
+  바뀌지 않아 전체 Rust 회귀 및 시각 검토는 적용하지 않는다. 상세 근거는
+  [PR #5778 검토 기록](../pr/archives/pr_5778_review.md)에 보존했다.
+- 이 문서가 포함된 최신 source head의 GitHub Actions와 mergeability가 통과하면 작업지시자 승인 뒤 merge하고,
+  #5777의 해결 근거 comment·close 및 review branch/worktree 정리는 `post_merge.md` 절차를 따른다.
+
 ## #5773 로컬 WASM 검증의 Cargo lockfile 오염 차단
 
 - [`wasm-pack build --locked`](https://github.com/edwardkim/rhwp/issues/5773)는 Cargo build보다 앞서

--- a/mydocs/pr/archives/pr_5778_review.md
+++ b/mydocs/pr/archives/pr_5778_review.md
@@ -1,0 +1,68 @@
+---
+kind: pr-review
+status: review-complete-pending-ci
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-21
+---
+
+# PR #5778 검토 - 검토 PDF 증적의 독립 워크플로 fast-pass
+
+## 접수 메타데이터
+
+| 항목 | 검토 기록 |
+| --- | --- |
+| PR / 작성자 | [#5778](https://github.com/edwardkim/rhwp/pull/5778) / `jangster77` self-review |
+| 관련 issue | [#5777](https://github.com/edwardkim/rhwp/issues/5777) |
+| base / code candidate | `devel` / `dbc91c0b823d6065ddb4bb081725777d280a6965` |
+| source branch | `fix/ci-review-reference-fast-pass` |
+| 변경 규모 | workflow 2개, Python 계약 test 3개, fast-pass 절차 문서 1개 |
+| 라우팅 | `collaborator_self_merge` + `intake_and_review` + `local_validation` |
+| PR 생성 확인 | Open, non-draft, `MERGEABLE`; reviewer 미지정 |
+
+## 원인과 변경 범위
+
+[#5772](https://github.com/edwardkim/rhwp/pull/5772)의 최초 증적 trailing commit은 `mydocs/`와
+루트 `pdf/` 아래의 **새 PDF**만 추가했다. 중앙 Build & Test는 이를 review-only로 판정했지만,
+`Proptest roundtrip`과 `Adapter inter-diff`는 각각 `mydocs/` 밖의 코드 변경으로 분류해 full worker를
+실행했다.
+
+또한 그 PR의 후속 `mydocs/` trailing commit은 fork PR run의 `pull_requests` 배열이 비어 있어 이전
+성공 run을 찾지 못했다. 두 워크플로는 full worker를 실행해 성공했으나, 문서 증적 tail에 필요한
+fast-pass가 적용되지 않았다.
+
+이 PR은 두 독립 워크플로의 review-only 정책을 중앙 CI와 동일하게 맞춘다.
+
+- `mydocs/**` 전체와 새 `samples/**`의 `.hwp`, `.hwpx`, `.pdf`, `.png`만 허용한다.
+- 새 `pdf/**`, `pdf-2020/**`, `pdf-large/**` PDF도 허용하되, 기존 reference PDF 수정은 계속 full
+  검증으로 보낸다.
+- trailing candidate run은 `pull_requests` 배열에 의존하지 않고 `pull_request` event, head SHA,
+  head branch, head repository ID 및 PR 생성 시각으로 확인한다.
+- 검토 전용 PR 자체는 두 worker를 skip하고, 허용되지 않은 path 또는 다른 fork의 run은 이전 결과를
+  재사용하지 않는다.
+
+변경은 GitHub Actions 경로 필터와 그 계약 테스트에만 한정한다. Rust, renderer, fixture, PDF 생성물 및
+기존 CI 결과 해석을 바꾸지 않으므로 시각 검토와 전체 Rust 회귀는 적용 대상이 아니다.
+
+## 로컬 검증
+
+- `node scripts/rust-test-suite-manifest.mjs --prepare`: `cargo fmt`가 참조하는 ignored 파생 suite만 준비.
+  생성물은 수정 diff에 남지 않았다.
+- `cargo fmt --all`, `cargo fmt --all -- --check`, `git diff --check`: 통과.
+- 아래 workflow contract test: **37 passed, exit 0, 1.104초**.
+
+```text
+python3 -m unittest \
+  scripts/tests/test_review_only_fast_pass_workflows.py \
+  scripts/tests/test_proptest_roundtrip_workflow.py \
+  scripts/tests/test_adapter_diff_workflow.py \
+  scripts/tests/test_workflow_contract_wiring.py
+```
+
+새 테스트는 허용된 추가 PDF, `pull_requests`가 없는 동일 fork trailing 후보 재사용, 기존 PDF 수정 및
+다른 fork 후보의 full 검증 fallback을 실제 workflow JavaScript를 mock GitHub API로 실행해 확인한다.
+
+## 최종 권고
+
+**수용 권고, 최신 PR head의 workflow CI 대기.** 경로 허용은 review 증적의 추가에만 제한되고 기존 기준
+파일 수정, code 변경, 다른 fork run 재사용을 여전히 차단한다. CI가 성공하면 이 문서와 오늘할일을 포함한
+최신 head의 mergeability를 다시 확인한 뒤 작업지시자 승인에 따라 merge 및 #5777 후속 처리를 진행한다.

--- a/scripts/tests/test_adapter_diff_workflow.py
+++ b/scripts/tests/test_adapter_diff_workflow.py
@@ -6,6 +6,7 @@ ci.yml 배선을 강제한다(#4080). 배선을 잊으면 그 테스트가 실�
 
 from __future__ import annotations
 
+import subprocess
 import unittest
 from pathlib import Path
 
@@ -36,14 +37,21 @@ class AdapterDiffWorkflowTests(unittest.TestCase):
         self.assertIn("pull_request:", self.wf)
         self.assertIn("branches: [main, devel]", self.wf)
 
-    def test_mydocs_only_or_trusted_trailing_tail_skips_adapter_job_but_keeps_a_stable_check(self) -> None:
+    def test_review_only_or_trusted_trailing_tail_skips_adapter_job_but_keeps_a_stable_check(self) -> None:
         self.assertIn("adapter-impact:", self.wf)
         self.assertIn("name: adapter inter-diff preflight", self.wf)
         self.assertIn("uses: actions/github-script", self.wf)
+        self.assertIn("function isAllowedReviewPath(file)", self.wf)
+        self.assertIn("file.status !== 'added'", self.wf)
+        self.assertIn("const pdfPrefixes = ['pdf/', 'pdf-2020/', 'pdf-large/'];", self.wf)
+        self.assertIn("filename.endsWith('.pdf')", self.wf)
         self.assertIn("github.rest.pulls.listCommits", self.wf)
         self.assertIn("github.rest.repos.getCommit", self.wf)
         self.assertIn("workflow_id: 'adapter-diff.yml'", self.wf)
         self.assertIn("github.rest.actions.listWorkflowRuns", self.wf)
+        self.assertIn("run.head_branch === pr.head.ref", self.wf)
+        self.assertIn("run.head_repository?.id === pr.head.repo?.id", self.wf)
+        self.assertNotIn("run.pull_requests", self.wf)
         self.assertIn("core.setOutput('adapter_required', required ? 'true' : 'false')", self.wf)
         self.assertIn("skip-trusted-mydocs-tail:", self.wf)
         self.assertIn("review-tail-candidate-run-unavailable", self.wf)
@@ -53,12 +61,30 @@ class AdapterDiffWorkflowTests(unittest.TestCase):
         )
         self.assertNotIn("paths-ignore:", self.wf)
 
+    def test_review_only_preflight_script_parses(self) -> None:
+        script = self.wf.split("script: |\n", maxsplit=1)[1].split(
+            "\n\n  adapter-diff:", maxsplit=1
+        )[0]
+        script = "\n".join(
+            line.removeprefix("            ") for line in script.splitlines()
+        )
+        completed = subprocess.run(
+            ["node", "--check"],
+            input=f"(async () => {{\n{script}\n}})();\n",
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
     def test_is_cheap(self) -> None:
-        self.assertNotIn("--features native-skia", self.wf)
-        self.assertNotIn("samples/", self.wf)
-        self.assertNotIn("cargo-fuzz", self.wf)
-        self.assertIn("timeout-minutes: 25", self.wf)
-        self.assertIn("tools/adapter_diff/harness.py --ci --strict", self.wf)
+        worker = self.wf.split("  adapter-diff:\n", maxsplit=1)[1]
+        self.assertNotIn("--features native-skia", worker)
+        self.assertNotIn("samples/", worker)
+        self.assertNotIn("cargo-fuzz", worker)
+        self.assertIn("timeout-minutes: 25", worker)
+        self.assertIn("tools/adapter_diff/harness.py --ci --strict", worker)
 
     def test_uses_debug_cargo_test_not_release_archive(self) -> None:
         self.assertIn("run-adapter-diff.mjs --cargo-test", self.wf)

--- a/scripts/tests/test_proptest_roundtrip_workflow.py
+++ b/scripts/tests/test_proptest_roundtrip_workflow.py
@@ -6,6 +6,7 @@ ci.yml 배선을 강제한다(#4080). 배선을 잊으면 그 테스트가 실�
 
 from __future__ import annotations
 
+import subprocess
 import unittest
 from pathlib import Path
 
@@ -32,21 +33,44 @@ class ProptestRoundtripWorkflowTests(unittest.TestCase):
         self.assertIn("pull_request:", self.wf)
         self.assertIn("branches: [main, devel]", self.wf)
 
-    def test_mydocs_only_or_trusted_trailing_tail_skips_worker_without_hiding_check(self) -> None:
+    def test_review_only_or_trusted_trailing_tail_skips_worker_without_hiding_check(self) -> None:
         self.assertIn("name: Proptest preflight", self.wf)
         self.assertIn("pr.base.ref !== 'devel'", self.wf)
-        self.assertIn("file.filename.startsWith('mydocs/')", self.wf)
-        self.assertIn("file.previous_filename.startsWith('mydocs/')", self.wf)
+        self.assertIn("function isAllowedReviewPath(file)", self.wf)
+        self.assertIn("filename.startsWith('mydocs/')", self.wf)
+        self.assertIn("file.status !== 'added'", self.wf)
+        self.assertIn("const pdfPrefixes = ['pdf/', 'pdf-2020/', 'pdf-large/'];", self.wf)
+        self.assertIn("filename.endsWith('.pdf')", self.wf)
         self.assertIn("github.rest.pulls.listCommits", self.wf)
         self.assertIn("github.rest.repos.getCommit", self.wf)
         self.assertIn("workflow_id: 'proptest-roundtrip.yml'", self.wf)
         self.assertIn("github.rest.actions.listWorkflowRuns", self.wf)
+        self.assertIn("run.head_branch === pr.head.ref", self.wf)
+        self.assertIn("run.head_repository?.id === pr.head.repo?.id", self.wf)
+        self.assertNotIn("run.pull_requests", self.wf)
         self.assertIn("trusted-mydocs-tail:", self.wf)
         self.assertIn("review-tail-candidate-run-unavailable", self.wf)
         self.assertIn("name: prop roundtrip", self.wf)
         self.assertIn("needs: preflight", self.wf)
         self.assertIn("needs.preflight.outputs.fast_pass != 'true'", self.wf)
         self.assertNotRegex(self.wf, r"(?m)^\\s{2,4}paths-ignore:")
+
+    def test_review_only_preflight_script_parses(self) -> None:
+        script = self.wf.split("script: |\n", maxsplit=1)[1].split(
+            "\n\n      - name: Finalize fast pass", maxsplit=1
+        )[0]
+        script = "\n".join(
+            line.removeprefix("            ") for line in script.splitlines()
+        )
+        completed = subprocess.run(
+            ["node", "--check"],
+            input=f"(async () => {{\n{script}\n}})();\n",
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
 
     def test_is_not_a_long_fuzz(self) -> None:
         self.assertNotIn("cargo-fuzz", self.wf)

--- a/scripts/tests/test_review_only_fast_pass_workflows.py
+++ b/scripts/tests/test_review_only_fast_pass_workflows.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 
@@ -12,6 +14,22 @@ WORKFLOWS = {
     "ci": ROOT / ".github/workflows/ci.yml",
     "codeql": ROOT / ".github/workflows/codeql.yml",
     "render-diff": ROOT / ".github/workflows/render-diff.yml",
+}
+WORKER_PREFLIGHTS = {
+    "proptest": (
+        ROOT / ".github/workflows/proptest-roundtrip.yml",
+        "\n\n      - name: Finalize fast pass",
+        "fast_pass",
+        "true",
+        "false",
+    ),
+    "adapter": (
+        ROOT / ".github/workflows/adapter-diff.yml",
+        "\n\n  adapter-diff:",
+        "adapter_required",
+        "false",
+        "true",
+    ),
 }
 RESOLUTION_CHECK = ROOT / "scripts/verify_review_only_merge_resolution.py"
 
@@ -163,6 +181,195 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
         )
         self.assertNotEqual(wrong_base.returncode, 0)
         self.assertIn("current-base-merge-resolution-invalid-merge", wrong_base.stderr)
+
+    def test_worker_preflights_skip_added_review_pdf(self) -> None:
+        files = [
+            {"filename": "mydocs/pr/archives/pr_5772_review.md", "status": "added"},
+            {"filename": "pdf/pr_5772_reference.pdf", "status": "added"},
+        ]
+        for name, (_, _, output_name, skip_value, _) in WORKER_PREFLIGHTS.items():
+            with self.subTest(workflow=name):
+                output = self._run_worker_preflight(name, files=files)
+                self.assertEqual(output[output_name], skip_value)
+
+    def test_worker_preflights_reuse_matching_fork_candidate_after_pdf_and_mydocs_tail(
+        self,
+    ) -> None:
+        code_candidate = "c" * 40
+        evidence_commit = "e" * 40
+        review_commit = "r" * 40
+        files = [
+            {"filename": "src/renderer/layout.rs", "status": "modified"},
+            {"filename": "pdf/pr_5772_reference.pdf", "status": "added"},
+            {"filename": "mydocs/orders/20260820.md", "status": "modified"},
+        ]
+        commits = [
+            {
+                "sha": code_candidate,
+                "parents": [{"sha": "b" * 40}],
+                "files": [{"filename": "src/renderer/layout.rs", "status": "modified"}],
+            },
+            {
+                "sha": evidence_commit,
+                "parents": [{"sha": code_candidate}],
+                "files": [{"filename": "pdf/pr_5772_reference.pdf", "status": "added"}],
+            },
+            {
+                "sha": review_commit,
+                "parents": [{"sha": evidence_commit}],
+                "files": [{"filename": "mydocs/orders/20260820.md", "status": "modified"}],
+            },
+        ]
+        runs = [
+            {
+                "event": "pull_request",
+                "head_sha": code_candidate,
+                "head_branch": "fix/bughunt-batch-r3",
+                "head_repository": {"id": 7},
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": "2026-08-20T12:00:00Z",
+            }
+        ]
+        for name, (_, _, output_name, skip_value, _) in WORKER_PREFLIGHTS.items():
+            with self.subTest(workflow=name):
+                output = self._run_worker_preflight(
+                    name, files=files, commits=commits, runs=runs
+                )
+                self.assertEqual(output[output_name], skip_value)
+
+    def test_worker_preflights_reject_modified_pdf_and_wrong_fork_candidate(self) -> None:
+        code_candidate = "c" * 40
+        modified_pdf = "m" * 40
+        modified_pdf_commits = [
+            {
+                "sha": code_candidate,
+                "parents": [{"sha": "b" * 40}],
+                "files": [{"filename": "src/renderer/layout.rs", "status": "modified"}],
+            },
+            {
+                "sha": modified_pdf,
+                "parents": [{"sha": code_candidate}],
+                "files": [{"filename": "pdf/existing_reference.pdf", "status": "modified"}],
+            },
+        ]
+        trailing_review = "r" * 40
+        trusted_tail = [
+            modified_pdf_commits[0],
+            {
+                "sha": trailing_review,
+                "parents": [{"sha": code_candidate}],
+                "files": [{"filename": "mydocs/orders/20260820.md", "status": "modified"}],
+            },
+        ]
+        wrong_fork_run = {
+            "event": "pull_request",
+            "head_sha": code_candidate,
+            "head_branch": "fix/bughunt-batch-r3",
+            "head_repository": {"id": 999},
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-20T12:00:00Z",
+        }
+        for name, (_, _, output_name, _, full_value) in WORKER_PREFLIGHTS.items():
+            with self.subTest(workflow=name, case="modified-pdf"):
+                output = self._run_worker_preflight(
+                    name,
+                    files=[
+                        {"filename": "src/renderer/layout.rs", "status": "modified"},
+                        {"filename": "pdf/existing_reference.pdf", "status": "modified"},
+                    ],
+                    commits=modified_pdf_commits,
+                )
+                self.assertEqual(output[output_name], full_value)
+            with self.subTest(workflow=name, case="wrong-fork"):
+                output = self._run_worker_preflight(
+                    name,
+                    files=[
+                        {"filename": "src/renderer/layout.rs", "status": "modified"},
+                        {"filename": "mydocs/orders/20260820.md", "status": "modified"},
+                    ],
+                    commits=trusted_tail,
+                    runs=[wrong_fork_run],
+                )
+                self.assertEqual(output[output_name], full_value)
+
+    def _run_worker_preflight(
+        self,
+        name: str,
+        *,
+        files: list[dict[str, object]],
+        commits: list[dict[str, object]] | None = None,
+        runs: list[dict[str, object]] | None = None,
+    ) -> dict[str, str]:
+        workflow_path, end_marker, _, _, _ = WORKER_PREFLIGHTS[name]
+        workflow = workflow_path.read_text(encoding="utf-8")
+        script = workflow.split("script: |\n", maxsplit=1)[1].split(end_marker, maxsplit=1)[0]
+        script = "\n".join(
+            line.removeprefix("            ") for line in script.splitlines()
+        )
+        fixture = {
+            "files": files,
+            "commits": commits or [],
+            "runs": runs or [],
+        }
+        harness = textwrap.dedent(
+            """
+            const fixture = %(fixture)s;
+            const outputs = {};
+            const listFiles = Symbol('pulls.listFiles');
+            const listCommits = Symbol('pulls.listCommits');
+            const listWorkflowRuns = Symbol('actions.listWorkflowRuns');
+            const commits = new Map(fixture.commits.map((commit) => [commit.sha, commit]));
+            const github = {
+              rest: {
+                pulls: { listFiles, listCommits },
+                repos: {
+                  getCommit: async ({ ref }) => ({ data: { files: commits.get(ref).files } }),
+                },
+                actions: { listWorkflowRuns },
+              },
+              paginate: async (endpoint) => {
+                if (endpoint === listFiles) return fixture.files;
+                if (endpoint === listCommits) return fixture.commits;
+                if (endpoint === listWorkflowRuns) return fixture.runs;
+                throw new Error('unexpected paginate endpoint');
+              },
+            };
+            const context = {
+              eventName: 'pull_request',
+              repo: { owner: 'edwardkim', repo: 'rhwp' },
+              payload: {
+                pull_request: {
+                  number: 5772,
+                  created_at: '2026-08-20T00:00:00Z',
+                  base: { ref: 'devel' },
+                  head: { ref: 'fix/bughunt-batch-r3', repo: { id: 7 } },
+                },
+              },
+            };
+            const core = {
+              setOutput: (key, value) => { outputs[key] = String(value); },
+              info: () => {},
+            };
+            (async () => {
+            %(script)s
+            })().then(
+              () => process.stdout.write(JSON.stringify(outputs)),
+              (error) => { process.stderr.write(String(error.stack || error)); process.exitCode = 1; },
+            );
+            """
+        ) % {"fixture": json.dumps(fixture), "script": textwrap.indent(script, "  ")}
+        completed = subprocess.run(
+            ["node"],
+            input=harness,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        return json.loads(completed.stdout)
 
     def _run_resolution_check(
         self,


### PR DESCRIPTION
## 목적

Closes #5777

PR #5772의 trailing 검토 증적에서 루트 `pdf/` PDF와 `mydocs/`만 추가했는데도
`Proptest roundtrip`과 `Adapter inter-diff`가 전체 경로로 실행된 사례를 재현하고 수정합니다.

## 변경

- 두 독립 워크플로가 중앙 CI와 같은 review-only 경로 정책을 사용하도록 맞췄습니다.
- 추가 PDF 증적은 `pdf/`, `pdf-2020/`, `pdf-large/` 및 `samples/`의 허용 확장자에 한정합니다.
- fork PR의 trailing commit 후보는 비어 있을 수 있는 `run.pull_requests` 대신 event, head SHA,
  branch, repository ID와 PR 생성 시각으로 식별합니다.
- 허용 경로, fork 후보 재사용, 기존 PDF 수정 및 다른 fork 후보 거부를 런타임 계약 테스트로 고정했습니다.

## 검증

```text
python3 -m unittest \
  scripts/tests/test_review_only_fast_pass_workflows.py \
  scripts/tests/test_proptest_roundtrip_workflow.py \
  scripts/tests/test_adapter_diff_workflow.py \
  scripts/tests/test_workflow_contract_wiring.py

Ran 37 tests in 1.104s
OK
```

`cargo fmt --all` 및 `cargo fmt --all -- --check`도 통과했습니다. Rust 소스 변경은 없어
전체 Rust 회귀는 실행하지 않았습니다.
