### PR TITLE
수정: studio 에서 flow 그림이 있는 쪽의 쪽 배경색이 사라지던 결함 (#5780)

### DIFF
--- a/mydocs/working/studio_page_background_5780.md
+++ b/mydocs/working/studio_page_background_5780.md
@@ -1,0 +1,90 @@
+---
+kind: working
+status: active
+issue: 5780
+---
+
+# studio 에서 flow 그림이 있는 쪽의 쪽 배경색이 사라지는 결함 (#5780)
+
+작업 브랜치: `fix/5780-studio-page-background`
+대상: `rhwp-studio/src/view/page-renderer.ts` · `rhwp-studio/tests/render-backend.test.ts`
+
+## 한 줄
+
+DOM 그림 갈래에도 Background plane 을 그린 canvas 를 그림 layer 아래에 깐다 — 그 갈래에는
+쪽 배경을 실을 평면이 하나도 없었다.
+
+## 이슈가 요구한 것
+
+`prism_downloads/서울특별시 성북구/3070000-202200004_…자원순환집행계획.hwp` 는 구역 배경이
+`#1c3d62` 다. `export-svg` 는 남색을 칠하는데 studio 는 흰 종이만 낸다. 1쪽은 표지 글자가
+흰색이라 **완전히 빈 흰 쪽**으로 보인다.
+
+원인은 flow-static 분리의 두 갈래 중 하나에 배경 자리가 없는 것이다.
+
+| 갈래 | 아래 평면 | Background plane |
+|---|---|---|
+| `flowImages.length > 0` | **DIV** (`background: var(--doc-paper)` 하드코딩) | **없음** |
+| else | `flow-static` **canvas** | `FlowStatic` 필터가 그린다 |
+
+위 본문 canvas 는 `flow-dynamic` 으로 그리는데
+`LayerFilter::FlowDynamic => replay_plane == Flow && !is_flow_static` 라 Background plane 이
+통째로 빠지고 `transparent_page_background = true` 다.
+
+수정 전 실측(headless studio, `origin/devel`):
+
+```
+layer tree   1·2·3쪽 모두 "type":"pageBackground" "backgroundColor":"#1c3d62"   ← WASM 정상
+요약         1쪽 flowImageCount=1  2쪽 =2  3쪽 =0
+canvas 픽셀  1쪽 본문 canvas(z=1) [0,0,0,0]        ← 투명, 아래에 배경 평면 없음
+             2쪽 본문 canvas(z=1) [0,0,0,0]
+             3쪽 canvas(z=0)      [28,61,98,255]  ← 분리를 안 해서 정상
+```
+
+`flowImageCount > 0` 인 쪽만 배경을 잃는다.
+
+## 고친 방법
+
+1. DOM 그림 갈래에서 `createOrReuseFilteredCanvasLayer(…, 'background', …)` 로 배경 canvas 를
+   만들어 그림 DIV **아래**에 깐다. 둘 다 `z-index: 0` 이고 DOM 순서로 DIV 가 위에 온다 —
+   뒤따르는 `behind`(1)/`front`(2·3) layer 의 z 계약을 건드리지 않는다.
+2. 그림 DIV 의 `background` 하드코딩(`var(--doc-paper)`)을 없앤다. 그게 남아 있으면 아래
+   배경 canvas 를 가린다. 배경이 없는 쪽의 흰 종이도 `BackgroundOnly` 렌더가 그린다
+   (`should_render_page_background()` → `begin_page` 가 종이를 칠한다).
+3. `!layers.hasBehind` 가지의 `removeOverlayLayer(…, 'background')` 를 `usesDomFlowImages` 일 때
+   건너뛴다 — `hasFront` 인 쪽이 이 가지를 타는데, 지우면 그 쪽만 다시 배경을 잃는다.
+
+## 만지지 않은 경로
+
+- `LayerFilter` 술어(`web_canvas.rs`) — 평면 정의는 그대로 두고, 없던 평면을 studio 가 깔게
+  했다.
+- `flow-static` canvas 갈래 — 이미 Background plane 을 싣고 있어 무변경.
+- 어느 쪽에 배경을 칠할지(구역 첫 쪽 한정)는 #5717 · PR #5745 의 몫이다. 이 변경은 **배경을
+  잃지 않게** 할 뿐이다.
+
+## 시험 명령
+
+```bash
+cd rhwp-studio && npx tsc --noEmit                # exit 0
+cd rhwp-studio && node --test tests/*.test.ts     # 1002 passed / 1 skipped / 0 failed
+cargo fmt --all -- --check                        # exit 0 (Rust 무변경)
+cargo clippy --all-targets -- -D warnings         # exit 0 (Rust 무변경)
+```
+
+신규 계약: `rhwp-studio/tests/render-backend.test.ts` —
+`[#5780] DOM flow-image pages still get a Background plane layer under the images`
+(배경 layer 생성 · 제거 가드 · DIV 종이색 하드코딩 부재 4개 앵커).
+
+## 수정 후 실측 (headless studio, 같은 문서)
+
+```
+page 1  background-0 canvas z=0  px=[28,61,98,255]   flow-images-0 DIV 투명   본문 canvas z=1 투명
+page 2  background-1 canvas z=0  px=[28,61,98,255]   flow-images-1 DIV 투명   front-1 canvas z=2
+page 3  (main) canvas z=0        px=[28,61,98,255]   ← 종전 경로 그대로
+```
+
+1쪽이 남색 배경 + 흰 글자로 `export-svg` 와 같아진다.
+
+## PR 메모
+
+`gh pr create --base devel --body-file` · `closes #5780`

--- a/rhwp-studio/src/view/page-renderer.ts
+++ b/rhwp-studio/src/view/page-renderer.ts
@@ -402,8 +402,25 @@ export class PageRenderer {
     const left = canvas.style.left;
     const transform = canvas.style.transform;
 
+    // [#5780] DOM 그림 갈래는 flow-static canvas 대신 DIV 를 깐다. 위 canvas 는
+    // 'flow-dynamic' 이라 Background plane 이 빠지므로, 이 갈래에서는 쪽 배경(색·그라데이션·
+    // 배경 이미지)을 실을 평면이 하나도 없다. 그래서 배경 canvas 를 DIV 아래에 함께 깐다.
+    const usesDomFlowImages = reuseStaticFlow && flowImages.length > 0;
+
     if (reuseStaticFlow) {
-      if (flowImages.length > 0) {
+      if (usesDomFlowImages) {
+        const background = this.createOrReuseFilteredCanvasLayer(
+          pageIdx,
+          canvas,
+          renderScale,
+          'background',
+          layers,
+          allowReuse,
+        );
+        this.applyPageLayerBox(background, top, left, transform, cssWidth, cssHeight);
+        background.style.zIndex = '0';
+        parent.insertBefore(background, canvas);
+
         const flowImageLayer = this.createOrReuseFlowImageLayer(
           pageIdx,
           canvas,
@@ -413,6 +430,8 @@ export class PageRenderer {
           flowImages,
         );
         this.applyPageLayerBox(flowImageLayer, top, left, transform, cssWidth, cssHeight);
+        // 배경 canvas 와 같은 z-index 를 쓰고 DOM 순서로 위에 온다 — 뒤따르는
+        // behind/front layer 의 z 계약(1·2·3)을 건드리지 않는다.
         flowImageLayer.style.zIndex = '0';
         parent.insertBefore(flowImageLayer, canvas);
       } else {
@@ -463,7 +482,9 @@ export class PageRenderer {
       background.style.zIndex = '0';
       parent.insertBefore(background, canvas);
     } else {
-      this.removeOverlayLayer(parent, pageIdx, 'background');
+      // [#5780] DOM 그림 갈래가 방금 깐 배경 layer 는 지우지 않는다 — 지우면 그 쪽만
+      // 쪽 배경을 잃는다(hasFront 인 쪽에서 이 가지를 탄다).
+      if (!usesDomFlowImages) this.removeOverlayLayer(parent, pageIdx, 'background');
       this.removeOverlayLayer(parent, pageIdx, 'behind');
       canvas.style.background = reuseStaticFlow ? 'transparent' : '';
       canvas.style.zIndex = layers.hasFront || reuseStaticFlow ? '1' : '';
@@ -524,7 +545,10 @@ export class PageRenderer {
     layer.dataset.rhwpFlowImagePage = String(pageIdx);
     layer.dataset.rhwpStaticOverlayKey = key;
     layer.style.pointerEvents = 'none';
-    layer.style.background = 'var(--doc-paper)';
+    // [#5780] 종이색을 여기서 칠하지 않는다. 이 layer 바로 아래에 Background plane 을 그린
+    // canvas 가 깔리므로(`applyOverlays`), 여기서 칠하면 쪽 배경색·그라데이션·배경 이미지를
+    // 가린다. 배경이 없는 쪽의 흰 종이도 그 canvas 가 그린다.
+    layer.style.background = 'transparent';
 
     for (const image of images) {
       const visibleBbox = visibleFlowImageBbox(image);

--- a/rhwp-studio/tests/render-backend.test.ts
+++ b/rhwp-studio/tests/render-backend.test.ts
@@ -318,6 +318,24 @@ test('PageRenderer uses filtered canvas layers for background, behind, and front
   assert.match(source, /collectLayerPlaneSummary\(root,\s*summary,\s*null\)/);
 });
 
+test('[#5780] DOM flow-image pages still get a Background plane layer under the images', () => {
+  const source = readFileSync(new URL('../src/view/page-renderer.ts', import.meta.url), 'utf8');
+  // DOM 그림 갈래는 flow-static canvas 를 쓰지 않으므로, 배경 layer 를 스스로 깔아야 한다.
+  // 'flow-dynamic' 본문 canvas 는 Background plane 을 그리지 않는다.
+  assert.match(source, /const usesDomFlowImages = reuseStaticFlow && flowImages\.length > 0;/);
+  assert.match(
+    source,
+    /if \(usesDomFlowImages\) \{[\s\S]{0,400}?createOrReuseFilteredCanvasLayer\([\s\S]{0,120}?'background'/,
+  );
+  // hasFront 인 쪽은 !hasBehind 가지를 타는데, 거기서 방금 깐 배경 layer 를 지우면 안 된다.
+  assert.match(
+    source,
+    /if \(!usesDomFlowImages\) this\.removeOverlayLayer\(parent, pageIdx, 'background'\);/,
+  );
+  // 그림 layer 가 종이색을 칠하면 그 아래 배경 canvas 를 가린다.
+  assert.doesNotMatch(source, /layer\.style\.background = 'var\(--doc-paper\)';/);
+});
+
 test('CanvasKit and comparison canvas bitmap extents preserve fractional page edges', () => {
   const pageRenderer = readFileSync(new URL('../src/view/page-renderer.ts', import.meta.url), 'utf8');
   const compareResult = readFileSync(new URL('../src/ui/compare-result-window.ts', import.meta.url), 'utf8');


### PR DESCRIPTION
## 변경 요약

rhwp-studio 에서 **flow 그림이 있는 쪽의 쪽 배경색이 통째로 사라지던** 결함을 고칩니다.

flow-static 분리는 두 갈래인데, 배경을 실을 수 있는 건 한쪽뿐이었습니다.

| 갈래 | 아래 평면 | Background plane |
|---|---|---|
| `flowImages.length > 0` | **DIV** (`background: var(--doc-paper)` 하드코딩) | **없음** |
| else | `flow-static` **canvas** | `FlowStatic` 필터가 그린다 |

위 본문 canvas 는 `flow-dynamic` 으로 그리는데
`LayerFilter::FlowDynamic => replay_plane == Flow && !is_flow_static` 라 Background plane 이
통째로 빠지고 `transparent_page_background = true` 입니다. 그래서 DOM 갈래에서는 쪽 배경
(색·그라데이션·배경 이미지)을 실을 평면이 하나도 없었습니다.

재현: `prism_downloads/서울특별시 성북구/3070000-202200004_D0150004-1-001_■[성북구
자원순환집행계획].hwp` — 구역 배경 `#1c3d62`.

- `export-svg` 1쪽: `<rect x="0" y="0" width="793.71" height="1122.48" fill="#1c3d62"/>`
- studio 1쪽: **완전히 빈 흰 쪽** (표지 글자가 흰색이라 흰 배경 위에서 같이 사라짐)

## 실측 — 판별자가 정확히 갈린다

수정 전 (headless studio, `origin/devel`):

```
layer tree   1·2·3쪽 모두 "type":"pageBackground" "backgroundColor":"#1c3d62"   ← WASM 정상
요약         1쪽 flowImageCount=1   2쪽 =2   3쪽 =0
canvas 픽셀  1쪽 본문 canvas(z=1) [0,0,0,0]        ← 투명, 아래에 배경 평면 없음
             2쪽 본문 canvas(z=1) [0,0,0,0]
             3쪽 canvas(z=0)      [28,61,98,255]  ← 분리를 안 해서 정상
```

`flowImageCount > 0` 인 쪽만 배경을 잃습니다.

## 고친 방법

1. DOM 그림 갈래에서 `createOrReuseFilteredCanvasLayer(…, 'background', …)` 로 배경 canvas 를
   만들어 그림 DIV **아래**에 깝니다. 둘 다 `z-index: 0` 이고 DOM 순서로 DIV 가 위에 오므로,
   뒤따르는 `behind`(1)/`front`(2·3) layer 의 z 계약을 건드리지 않습니다.
2. 그림 DIV 의 `background` 하드코딩(`var(--doc-paper)`)을 없앱니다 — 남아 있으면 아래 배경
   canvas 를 가립니다. 배경이 없는 쪽의 흰 종이도 `BackgroundOnly` 렌더가 그립니다
   (`should_render_page_background()` → `begin_page` 가 종이를 칠함).
3. `!layers.hasBehind` 가지의 `removeOverlayLayer(…, 'background')` 를 `usesDomFlowImages` 일 때
   건너뜁니다 — `hasFront` 인 쪽이 이 가지를 타는데, 지우면 그 쪽만 다시 배경을 잃습니다.

`LayerFilter` 술어(`web_canvas.rs`)는 손대지 않았습니다. 평면 정의는 그대로 두고, **없던
평면을 studio 가 깔게** 했습니다. Rust 변경 없이 studio 쪽만 바뀝니다.

## 수정 후 실측 (headless studio, 같은 문서)

```
page 1  background-0 canvas z=0  px=[28,61,98,255]   flow-images-0 DIV 투명   본문 canvas z=1 투명
page 2  background-1 canvas z=0  px=[28,61,98,255]   flow-images-1 DIV 투명   front-1 canvas z=2
page 3  (main) canvas z=0        px=[28,61,98,255]   ← 종전 경로 그대로
```

1쪽이 남색 배경 + 흰 글자로 `export-svg` 와 같아집니다. 분리를 안 하는 3쪽은 종전 경로를
그대로 탑니다.

## 범위 밖

**어느 쪽에** 배경을 칠할지(구역 첫 쪽 한정, 구역 flags bit 8·9)는 #5717 · PR #5745 의 몫입니다.
이 PR 은 **배경을 잃지 않게** 할 뿐이고, 두 변경은 서로 독립입니다 — #5745 가 들어가도 이
결함이 남으면 studio 의 첫 쪽 배경은 여전히 안 나옵니다.

## 관련 이슈

closes #5780

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (exit 0, Diff 0건 — Rust 무변경)
- [x] 새 integration test 없음 — studio 계약 테스트 1건을 기존 파일에 추가
- [x] `src/**` 의 `#[cfg(test)]` 변경 없음 — 해당 없음
- [x] `cargo clippy --all-targets -- -D warnings` 통과 (exit 0 — Rust 무변경)
- [x] `npx tsc --noEmit` 통과 (exit 0)
- [x] `node --test rhwp-studio/tests/*.test.ts` — 1002 passed / 1 skipped / 0 failed
- [x] 웹(WASM) 렌더링 확인 — studio dev 서버에서 1·2·3쪽 canvas 픽셀·스크린샷 실측
- [x] rhwp-studio 렌더 변경 — 계약 테스트 4개 앵커 추가
- [ ] 관련 샘플 파일로 SVG 내보내기 — SVG 는 원래 정상이고 이 PR 이 건드리지 않습니다
      (오히려 SVG 가 정답지였습니다)
- [ ] 작업 증빙 캡슐 — 문서를 편집·생성하지 않는 렌더 경로 수정이라 해당 없음

신규 계약 테스트
`[#5780] DOM flow-image pages still get a Background plane layer under the images`
— 배경 layer 생성 · `usesDomFlowImages` 제거 가드 · DIV 종이색 하드코딩 부재까지 4개 앵커.

## 성능 영향 및 측정 결과

- DOM 그림 갈래인 쪽마다 `BackgroundOnly` canvas layer 하나가 더 생깁니다. 이미 `hasBehind`
  인 쪽에서 쓰던 것과 같은 layer 이고 같은 재사용 키(`buildStaticOverlayKey`) 경로를 탑니다.
- 그림이 없는 쪽·분리를 안 하는 쪽은 종전과 동일합니다.
