### PR TITLE
fix(git): 스킬 마크다운 체크아웃 개행을 LF 로 고정한다 (#5795)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,11 @@ fuzz/corpus/** -text -diff
 # trailing-whitespace 오류로 취급하지 않는다.
 output/poc/**/*.tsv -whitespace
 
+# [#5795] 스킬 마크다운은 계약이 바이트로 검사된다 (frontmatter 를 개행까지 포함해 본다).
+# 체크아웃 개행이 플랫폼마다 갈리면 같은 커밋이 Windows 에서만 빨개진다.
+.claude/skills/**/*.md text eol=lf
+.agents/skills/**/*.md text eol=lf
+
 # Agent skill fixture TSV/CSV는 끝 빈 열 또는 CRLF 입력 자체가 계약이다.
 .claude/skills/rhwp-fde/fixtures/tsv/*.tsv -whitespace
 .claude/skills/rhwp-table-exchange/fixtures/csv/table0_control_lf.csv -whitespace

--- a/mydocs/report/task_m100_5795_report.md
+++ b/mydocs/report/task_m100_5795_report.md
@@ -1,0 +1,64 @@
+# task_m100_5795 처리결과 — 스킬 마크다운 체크아웃 개행 고정
+
+- 이슈: [#5795](https://github.com/edwardkim/rhwp/issues/5795)
+- 기준: `fb434269e` (devel)
+
+## 1. 증상 (실측)
+
+Windows 기본 설정(Git for Windows `core.autocrlf=true`)으로 `devel` 을 클린 체크아웃하면
+스킬 계약 **14본**이 손대지 않은 상태에서 실패한다.
+
+```
+agent_knowledge_map_skill_contract::skill_frontmatter_names_knowledge_map ... FAILED
+agent_fde_skill_contract::skill_frontmatter_names_fde                     ... FAILED
+agent_fidelity_compare_skill_contract::skill_frontmatter_names_...        ... FAILED
+agent_bug_hunter_skill_contract::skill_frontmatter_names_bug_hunter       ... FAILED
+    panicked: frontmatter 필요
+```
+
+## 2. 원인
+
+계약이 `SKILL.md` 첫 바이트를 개행까지 포함해 본다 — `assert!(text.starts_with("---\n"))`.
+인덱스 바이트는 LF 라 Ubuntu CI 는 초록인데, Windows 체크아웃은 작업 트리에 CRLF 로 풀어
+`---\r\n` 이 된다.
+
+- `.claude/skills/*/SKILL.md` **27개 전부** 작업 트리 CRLF (인덱스는 전부 LF)
+- 같은 판정을 쓰는 계약 14본 — 그중 1본은 `.agents/skills/bug-hunter/SKILL.md` 를 읽는다
+- `.gitattributes` 에 스킬 마크다운 개행 지정이 없었다
+
+## 3. 변경
+
+`.gitattributes` 두 줄. 선례는 같은 파일의 `tests/golden_svg/**/*.svg text eol=lf` (#1786).
+
+```
+.claude/skills/**/*.md text eol=lf
+.agents/skills/**/*.md text eol=lf
+```
+
+인덱스 바이트가 이미 LF 이므로 **저장소 내용은 바뀌지 않는다.** 바뀌는 것은 체크아웃뿐이라
+Linux/macOS·CI 는 영향이 없다. `*.md` 로 좁혔다 — 같은 트리의 TSV/CSV 픽스처는
+"CRLF 입력 자체가 계약"이라 건드리면 안 된다(같은 파일의 기존 주석).
+
+## 4. 검증 (같은 PC, 같은 체크아웃)
+
+작업 트리를 새 속성으로 다시 풀고(`git checkout`) 계약 14본을 전부 돌렸다.
+
+| 스위트 | 계약 | 전 | 후 |
+| --- | --- | --- | --- |
+| 005·007·015·016·019·021·026·028·029·030·031·032 | 각 1본 | FAILED | ok |
+| 020 | 2본 (fde·fidelity_compare) | FAILED | ok |
+| **합계** | **14본** | 14 FAILED | **14 ok** |
+
+- `.claude/skills/*/SKILL.md` CRLF **27/27 → 0/27**
+- `python tools/skill_router/gate_new_skill.py` — OK (27 skills × 3 scans)
+- `cargo test --test regression_suite_011` — 122 passed (skills·cli_json 계약)
+- `cargo test --test regression_suite_020` 전체 — 121 passed
+
+## 5. 이미 체크아웃한 사람이 할 일
+
+속성은 다음 체크아웃부터 적용된다. 지금 작업 트리를 맞추려면:
+
+```bash
+git ls-files .claude/skills .agents/skills | grep '\.md$' | xargs rm -f
+git checkout -- .claude/skills .agents/skills
+```


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님).
> 작업 브랜치는 최신 `upstream/devel`(`fb434269e`)에서 만들었습니다.

## 변경 요약

Windows 기본 설정(Git for Windows `core.autocrlf=true`)으로 `devel` 을 **클린 체크아웃**하면,
아무것도 고치지 않은 상태에서 스킬 계약 **14본이 실패**합니다.

```
agent_knowledge_map_skill_contract::skill_frontmatter_names_knowledge_map ... FAILED
agent_fde_skill_contract::skill_frontmatter_names_fde                     ... FAILED
agent_fidelity_compare_skill_contract::skill_frontmatter_names_...        ... FAILED
agent_bug_hunter_skill_contract::skill_frontmatter_names_bug_hunter       ... FAILED
    panicked: frontmatter 필요
```

계약이 첫 바이트를 **개행까지 포함해** 봅니다 — `assert!(text.starts_with("---\n"))`.
인덱스 바이트는 LF 라 Ubuntu CI 는 초록인데, Windows 체크아웃은 작업 트리에 CRLF 로 풀어
`---\r\n` 이 됩니다. `.claude/skills/*/SKILL.md` **27개 전부** 해당합니다.

`.gitattributes` 두 줄로 체크아웃 개행을 못박습니다. 같은 파일에 이미 같은 이유의 선례가
있습니다 — `tests/golden_svg/**/*.svg text eol=lf` (#1786).

```
.claude/skills/**/*.md text eol=lf
.agents/skills/**/*.md text eol=lf
```

- 인덱스 바이트가 이미 LF 이므로 **저장소 내용은 바뀌지 않습니다.** 바뀌는 것은 체크아웃뿐이고
  Linux/macOS·CI 동작은 그대로입니다.
- `*.md` 로만 좁혔습니다 — 같은 트리의 TSV/CSV 픽스처는 "CRLF 입력 자체가 계약"이라
  (`.gitattributes` 의 기존 주석) 건드리면 안 됩니다.
- `.agents/skills` 도 넣은 이유: 계약 14본 중 `agent_bug_hunter_skill_contract` 하나가
  `.agents/skills/bug-hunter/SKILL.md` 를 읽습니다.

## 관련 이슈

closes #5795

## 테스트 (같은 PC·같은 체크아웃, 속성 적용 후 작업 트리 재체크아웃)

| 스위트 | 계약 | 전 | 후 |
| --- | --- | --- | --- |
| 005·007·015·016·019·021·026·028·029·030·031·032 | 각 1본 | FAILED | **ok** |
| 020 | 2본 (fde·fidelity_compare) | FAILED | **ok** |
| 합계 | **14본** | 14 FAILED | **14 ok** |

- [x] `.claude/skills/*/SKILL.md` CRLF **27/27 → 0/27**
- [x] `python tools/skill_router/gate_new_skill.py` — OK (27 skills × 3 scans, catalog=27, probes=81)
- [x] `cargo test --test regression_suite_011` — 122 passed (skills·cli_json 계약)
- [x] `cargo test --test regression_suite_020` 전체 — 121 passed
- [x] `git ls-files --eol` 로 `.claude/skills`·`.agents` 인덱스가 이미 전부 LF 임을 확인
      (md 아닌 CRLF/바이너리 픽스처는 규칙 밖)

### 이미 체크아웃한 사람이 작업 트리를 맞추는 법

```bash
git ls-files .claude/skills .agents/skills | grep '\.md$' | xargs rm -f
git checkout -- .claude/skills .agents/skills
```

## 문서

- 처리결과: `mydocs/report/task_m100_5795_report.md`
