### PR TITLE
fix(studio): PgUp·PgDn·Home·End 를 포커스·편집 모드와 무관하게 동작시킨다 (#5803)

### DIFF
--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -45,6 +45,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `gen-screenshot.mjs` | 유틸 | active | README 용 렌더 스크린샷 생성기 | basic/KTX.hwp | 수동 |  |
 | `global-shortcut.test.mjs` | 상시 | active | 시작 시 빈 문서 + 전역 단축키 | — | 수동 |  |
 | `grid-mode-click-coord.test.mjs` | 진단 | hold | 보류 ① 그리드 좌표 결함 — 정량 e2e 측정 | exam_kor.hwp | 수동 | legacy-name · 보류① 이슈 종속 |
+| `home-end-key.test.mjs` | 상시 | active | Home/End 줄 처음·끝, Ctrl+Home/End 문서 처음·끝 — 포커스 밖·머리말·각주 모드 포함 | biz_plan.hwp, footnote-01.hwp | npm e2e:home-end-key |  |
 | `helpers.mjs` | 유틸 | active | E2E 테스트 헬퍼 — Puppeteer + Chrome CDP | — | 수동 |  |
 | `hml-equation-embed.test.mjs` | 상시 | active | PR #2219 HML equation canvas edit/undo/export/reload | — | 수동 |  |
 | `hml-open.check.mjs` | 상시 | active | Standalone HML browser regression. | — | 수동 | legacy-name |
@@ -79,6 +80,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `navigation-shortcuts.test.mjs` | 상시 | active | 플랫폼별 navigation shortcut | — | 수동 |  |
 | `page-border-toggle.test.mjs` | 상시 | active | 쪽 테두리/배경 미리보기 버튼 토글 | — | 수동 |  |
 | `page-break.test.mjs` | 상시 | active | biz_plan.hwp 강제 쪽 나누기 / "5. 사업추진조직" 문단 앞에 쪽 나누기 삽입 후 페이지 재배치 확인 | biz_plan.hwp | 수동 |  |
+| `page-key-scroll.test.mjs` | 상시 | active | PgUp/PgDn 쪽 단위 스크롤 — 건너뜀 없음·쪽 머리 착지·캐럿 추종·포커스 밖 동작 | biz_plan.hwp | npm e2e:page-key-scroll |  |
 | `page-setup-orientation-icon.test.mjs` | 상시 | active | 편집 용지 대화창의 용지 방향 아이콘 식별성 | — | 수동 |  |
 | `pdf-render-diff-report.mjs` | 상시 | active | Report-only visual diff between browser Canvas output and SVG-deri | — | npm+CI | legacy-name |
 | `plugin-lifecycle.test.mjs` | 상시 | active | 플러그인 호스트 — allowlist·트랜잭션 1스냅샷·롤백·unload 회수 | — | npm e2e:plugin-lifecycle |  |

--- a/rhwp-studio/e2e/home-end-key.test.mjs
+++ b/rhwp-studio/e2e/home-end-key.test.mjs
@@ -1,0 +1,208 @@
+/**
+ * E2E 테스트 — Home/End 가 줄 처음·끝으로, Ctrl+Home/End 가 문서 처음·끝으로 간다
+ *
+ * 검증 항목:
+ * 1. 편집기 포커스에서 Home/End 가 줄 처음·끝으로 이동한다 (회귀 없음)
+ * 2. Shift+Home/End 는 선택을 만든다
+ * 3. 툴바 버튼·서식 콤보로 포커스가 나가도 같은 동작이다
+ *    (종전에는 편집기 textarea 가 키를 못 받아 네 키 모두 무동작이었다)
+ * 4. Ctrl+Home 은 화면을 문서 맨 위에 붙인다
+ *    (종전에는 캐럿만 보이면 멈춰 첫 쪽 위 여백이 잘린 채 122px 내려가 있었다)
+ * 5. Ctrl+End 는 문서 끝으로 가고 캐럿이 화면 안에 남는다
+ * 6. 머리말/꼬리말 편집 모드의 Home/End 는 그 모드 안에서 동작한다
+ *    (종전에는 모드 분기가 키를 삼켜 무동작이었다)
+ * 7. 각주 편집 모드도 같다
+ */
+
+import { runTest, loadHwpFile, assert } from './helpers.mjs';
+
+process.env.VITE_URL = process.env.VITE_URL || 'http://localhost:7700';
+
+const readState = () => {
+  const container = document.getElementById('scroll-container');
+  const handler = window.__inputHandler;
+  const position = handler.cursor.getPosition();
+  const rect = handler.cursor.getRect();
+  const zoom = handler.viewportManager.getZoom();
+  const virtualScroll = handler.virtualScroll;
+  let caretVisible = null;
+  if (rect) {
+    const caretTop = virtualScroll.getPageOffset(rect.pageIndex) + rect.y * zoom - container.scrollTop;
+    caretVisible = caretTop >= -1 && caretTop + rect.height * zoom <= container.clientHeight + 1;
+  }
+  return {
+    top: Math.round(container.scrollTop),
+    maxScroll: Math.round(container.scrollHeight - container.clientHeight),
+    para: position.paragraphIndex,
+    charOffset: position.charOffset,
+    caretX: rect ? Math.round(rect.x) : null,
+    caretVisible,
+    hasSelection: handler.cursor.hasSelection(),
+  };
+};
+
+runTest('Home/End 줄·문서 이동', async ({ page }) => {
+  await loadHwpFile(page, 'biz_plan.hwp');
+  // 첫 실행 스킨 안내가 떠 있으면 모달이 키 전파를 막는다 — 정상 경로로 닫는다.
+  await page.evaluate(() => document.querySelector('.modal-overlay .dialog-btn-primary')?.click());
+  await page.evaluate(() => new Promise(r => setTimeout(r, 300)));
+
+  const state = () => page.evaluate(readState);
+  const press = async (key, modifiers = []) => {
+    for (const modifier of modifiers) await page.keyboard.down(modifier);
+    await page.keyboard.press(key);
+    for (const modifier of [...modifiers].reverse()) await page.keyboard.up(modifier);
+    await page.evaluate(() => new Promise(r => setTimeout(r, 300)));
+    return state();
+  };
+
+  // 글자가 충분히 있는 문단을 찾는다 — 빈 문단에서는 Home/End 가 제자리라 판정이 안 선다.
+  const target = await page.evaluate(() => {
+    const cursor = window.__inputHandler.cursor;
+    for (let para = 0; para < 60; para++) {
+      try {
+        cursor.moveTo({ sectionIndex: 0, paragraphIndex: para, charOffset: 0 });
+        const start = cursor.getRect();
+        cursor.moveToLineEnd();
+        const end = cursor.getRect();
+        if (start && end && end.x - start.x > 40) {
+          return { para, lineStartX: Math.round(start.x), lineEndX: Math.round(end.x) };
+        }
+      } catch { /* 다음 문단 */ }
+    }
+    return null;
+  });
+  assert(target !== null, '전제: 글자가 있는 문단을 찾음');
+
+  /** 대상 문단의 줄 중간에 캐럿을 놓고 화면을 맨 위로 되돌린다. */
+  const seat = async () => {
+    await page.evaluate((paragraphIndex) => {
+      window.__inputHandler.viewportManager.setScrollTop(0);
+      window.__inputHandler.cursor.clearSelection();
+      window.__inputHandler.cursor.moveTo({ sectionIndex: 0, paragraphIndex, charOffset: 1 });
+      window.__inputHandler.focus();
+    }, target.para);
+    await page.evaluate(() => new Promise(r => setTimeout(r, 200)));
+    return state();
+  };
+
+  // ── TC1: 편집기 포커스 — 줄 처음·끝 ──────────────────────
+  await seat();
+  const end1 = await press('End');
+  assert(end1.caretX >= target.lineEndX - 1,
+    `TC1: End 가 줄 끝으로 (x=${end1.caretX}, 줄 끝 ${target.lineEndX})`);
+  const home1 = await press('Home');
+  assert(home1.caretX <= target.lineStartX + 1 && home1.charOffset === 0,
+    `TC1: Home 이 줄 처음으로 (x=${home1.caretX}, offset=${home1.charOffset})`);
+
+  // ── TC2: Shift 조합은 선택을 만든다 ───────────────────────
+  await seat();
+  const shiftEnd = await press('End', ['Shift']);
+  assert(shiftEnd.hasSelection, 'TC2: Shift+End 가 선택을 만든다');
+  await seat();
+  const shiftHome = await press('Home', ['Shift']);
+  assert(shiftHome.hasSelection, 'TC2: Shift+Home 이 선택을 만든다');
+
+  // ── TC3: 편집기 밖(툴바 버튼·서식 콤보) 포커스 ────────────
+  await seat();
+  await page.evaluate(() => document.querySelector('.tb-btn[data-cmd]')?.focus());
+  const toolbarEnd = await press('End');
+  assert(toolbarEnd.caretX === end1.caretX,
+    `TC3: 툴바 포커스에서도 End 가 줄 끝으로 (x=${toolbarEnd.caretX}, 기준 ${end1.caretX})`);
+  const toolbarHome = await press('Home');
+  assert(toolbarHome.charOffset === 0,
+    `TC3: 툴바 포커스에서도 Home 이 줄 처음으로 (offset=${toolbarHome.charOffset})`);
+
+  await seat();
+  await page.evaluate(() => document.querySelector('select')?.focus());
+  const comboEnd = await press('End');
+  assert(comboEnd.caretX === end1.caretX,
+    `TC3: 서식 콤보 포커스에서도 End 가 줄 끝으로 (x=${comboEnd.caretX}, 기준 ${end1.caretX})`);
+
+  // ── TC4/TC5: Ctrl+End / Ctrl+Home ─────────────────────────
+  await seat();
+  const ctrlEnd = await press('End', ['Control']);
+  assert(ctrlEnd.para > target.para,
+    `TC5: Ctrl+End 가 문서 끝으로 (문단 ${target.para} → ${ctrlEnd.para})`);
+  assert(ctrlEnd.caretVisible, `TC5: Ctrl+End 뒤 캐럿이 화면 안 (top=${ctrlEnd.top})`);
+
+  const ctrlHome = await press('Home', ['Control']);
+  assert(ctrlHome.para === 0 && ctrlHome.charOffset === 0,
+    `TC4: Ctrl+Home 이 문서 처음으로 (문단 ${ctrlHome.para}:${ctrlHome.charOffset})`);
+  assert(ctrlHome.top === 0,
+    `TC4: Ctrl+Home 이 화면을 문서 맨 위에 붙임 (top=${ctrlHome.top})`);
+
+  // 편집기 밖 포커스에서도 같다
+  await seat();
+  await page.evaluate(() => document.querySelector('.tb-btn[data-cmd]')?.focus());
+  const toolbarCtrlEnd = await press('End', ['Control']);
+  assert(toolbarCtrlEnd.para === ctrlEnd.para,
+    `TC3: 툴바 포커스에서도 Ctrl+End 동작 (문단 ${toolbarCtrlEnd.para}, 기준 ${ctrlEnd.para})`);
+  const toolbarCtrlHome = await press('Home', ['Control']);
+  assert(toolbarCtrlHome.top === 0 && toolbarCtrlHome.para === 0,
+    `TC3: 툴바 포커스에서도 Ctrl+Home 동작 (top=${toolbarCtrlHome.top}, 문단 ${toolbarCtrlHome.para})`);
+
+  // ── TC6: 머리말 편집 모드 ─────────────────────────────────
+  const headerState = () => page.evaluate(() => ({
+    inHeaderFooter: window.__inputHandler.cursor.isInHeaderFooter(),
+    charOffset: window.__inputHandler.cursor.hfCharOffset,
+  }));
+  const enteredHeader = await page.evaluate(() => {
+    const handler = window.__inputHandler;
+    handler.cursor.enterHeaderFooterMode(true, 0, 0);
+    handler.cursor.setHfCursorPosition(0, 0);
+    handler.focus();
+    return handler.cursor.isInHeaderFooter();
+  });
+  assert(enteredHeader, 'TC6: 머리말 편집 모드 진입');
+  await page.evaluate(() => new Promise(r => setTimeout(r, 200)));
+
+  // 번들 샘플의 머리말은 모두 비어 있어 Home/End 가 제자리다 — 글자를 먼저 넣는다.
+  await page.keyboard.type('HEADER', { delay: 30 });
+  await page.evaluate(() => new Promise(r => setTimeout(r, 300)));
+  const headerTyped = await headerState();
+  assert(headerTyped.charOffset > 0,
+    `TC6: 머리말에 글자 입력 (offset=${headerTyped.charOffset})`);
+
+  await press('Home');
+  const headerAfterHome = await headerState();
+  assert(headerAfterHome.inHeaderFooter, 'TC6: Home 뒤에도 머리말 편집 문맥 유지');
+  assert(headerAfterHome.charOffset === 0,
+    `TC6: Home 이 머리말 줄 처음으로 (offset=${headerAfterHome.charOffset})`);
+
+  await press('End');
+  const headerAfterEnd = await headerState();
+  assert(headerAfterEnd.charOffset === headerTyped.charOffset,
+    `TC6: End 가 머리말 줄 끝으로 (offset=${headerAfterEnd.charOffset}, 기준 ${headerTyped.charOffset})`);
+  await page.evaluate(() => window.__inputHandler.cursor.exitHeaderFooterMode?.());
+
+  // ── TC7: 각주 편집 모드 ───────────────────────────────────
+  await loadHwpFile(page, 'footnote-01.hwp');
+  const footnoteState = () => page.evaluate(() => ({
+    inFootnote: window.__inputHandler.cursor.isInFootnote(),
+    charOffset: window.__inputHandler.cursor.fnCharOffset,
+  }));
+  const enteredFootnote = await page.evaluate(() => {
+    const handler = window.__inputHandler;
+    handler.cursor.enterFootnoteMode(0, 3, 0, 0, 0);
+    handler.eventBus.emit('footnoteModeChanged', true);
+    handler.cursor.setFnCursorPosition(0, 0);
+    handler.active = true;
+    handler.focus();
+    handler.updateCaret();
+    return handler.cursor.isInFootnote();
+  });
+  assert(enteredFootnote, 'TC7: 각주 편집 모드 진입');
+  await page.evaluate(() => new Promise(r => setTimeout(r, 300)));
+
+  await press('End');
+  const footnoteAfterEnd = await footnoteState();
+  assert(footnoteAfterEnd.inFootnote, 'TC7: End 뒤에도 각주 편집 문맥 유지');
+  assert(footnoteAfterEnd.charOffset > 0,
+    `TC7: End 가 각주 줄 끝으로 (offset=${footnoteAfterEnd.charOffset})`);
+
+  await press('Home');
+  const footnoteAfterHome = await footnoteState();
+  assert(footnoteAfterHome.charOffset === 0,
+    `TC7: Home 이 각주 줄 처음으로 (offset=${footnoteAfterHome.charOffset})`);
+});

--- a/rhwp-studio/e2e/page-key-scroll.test.mjs
+++ b/rhwp-studio/e2e/page-key-scroll.test.mjs
@@ -1,0 +1,179 @@
+/**
+ * E2E 테스트 — PgUp/PgDn 이 화면을 쪽 단위로 스크롤하고 캐럿을 데려간다
+ *
+ * 검증 항목:
+ * 1. 편집기 포커스에서 PgDn/PgUp 이 쪽 단위로 움직이고, 한 걸음이 화면을 넘지 않는다
+ *    (종전에는 다음 쪽 머리로 뛰어 확대 상태에서 쪽 중간을 통째로 건너뛰었다)
+ * 2. 계속 누르면 모든 쪽 머리에 정확히 착지한다
+ * 3. 캐럿이 화면을 따라온다 — 이동 후 방향키를 눌러도 원래 쪽으로 되튀지 않는다
+ *    (종전에는 화면만 옮겨 다음 입력 한 번에 이동이 취소된 것처럼 보였다)
+ * 4. 툴바 버튼·서식 콤보로 포커스가 나가도 같은 동작이다
+ *    (종전에는 편집기 textarea 가 키를 못 받아 무동작이었다)
+ * 5. 머리말 편집 같은 하위 모드에서도 키를 삼키지 않되, 캐럿은 그 모드에 남는다
+ * 6. Shift+PgDn 은 선택을 확장한다
+ * 7. 문서 끝/처음에서는 남은 부분까지 붙이고 멈춘다
+ */
+
+import { runTest, loadHwpFile, assert } from './helpers.mjs';
+
+process.env.VITE_URL = process.env.VITE_URL || 'http://localhost:7700';
+
+const SAMPLE = 'biz_plan.hwp';
+
+const readState = () => {
+  const container = document.getElementById('scroll-container');
+  const handler = window.__inputHandler;
+  const position = handler?.cursor?.getPosition?.();
+  const rect = handler?.cursor?.getRect?.();
+  return {
+    top: Math.round(container.scrollTop),
+    viewportHeight: container.clientHeight,
+    maxScroll: Math.round(container.scrollHeight - container.clientHeight),
+    position: position ? JSON.stringify(position) : null,
+    caretPageIndex: rect ? rect.pageIndex : null,
+    hasSelection: handler?.cursor?.hasSelection?.() ?? false,
+  };
+};
+
+/** 각 쪽 머리가 시작되는 스크롤 위치(= 그 쪽의 위 여백부터 보이는 자리). */
+const readPageTops = () => {
+  const vs = window.__canvasView.virtualScroll;
+  const tops = [];
+  for (let page = 0; page < vs.pageCount; page += vs.pagesPerRow) {
+    tops.push(Math.round(vs.getPageOffset(page) - vs.gap));
+  }
+  return tops;
+};
+
+runTest('PgUp/PgDn 쪽 단위 스크롤', async ({ page }) => {
+  await loadHwpFile(page, SAMPLE);
+  // 첫 실행 스킨 안내가 떠 있으면 모달이 키 전파를 막는다 — 정상 경로로 닫는다.
+  await page.evaluate(() => document.querySelector('.modal-overlay .dialog-btn-primary')?.click());
+  await page.evaluate(() => new Promise(r => setTimeout(r, 300)));
+
+  const state = () => page.evaluate(readState);
+  const press = async (key, options = {}) => {
+    const before = await state();
+    if (options.shift) await page.keyboard.down('Shift');
+    await page.keyboard.press(key);
+    if (options.shift) await page.keyboard.up('Shift');
+    await page.evaluate(() => new Promise(r => setTimeout(r, 250)));
+    return { before, after: await state() };
+  };
+  // 앱이 쓰는 경로로 되돌린다 — DOM scrollTop 에 직접 대입하면 ViewportManager 의 캐시가
+  // scroll 이벤트가 돌 때까지 옛 값으로 남아, 다음 키가 옛 위치를 기준으로 계산된다.
+  const resetToTop = async () => {
+    await page.evaluate(() => {
+      window.__inputHandler.viewportManager.setScrollTop(0);
+      window.__inputHandler.cursor.moveToDocumentStart();
+      window.__inputHandler.focus();
+    });
+    await page.evaluate(() => new Promise(r => setTimeout(r, 150)));
+  };
+
+  const pageTops = await page.evaluate(readPageTops);
+  assert(pageTops.length > 1, `전제: 여러 쪽 문서 (${pageTops.length}쪽)`);
+
+  // ── TC1: 편집기 포커스 — 아래로 움직이되 화면을 건너뛰지 않는다 ──
+  await resetToTop();
+  const down1 = await press('PageDown');
+  assert(down1.after.top > down1.before.top,
+    `TC1: PgDn 이 아래로 이동 (${down1.before.top} → ${down1.after.top})`);
+  assert(down1.after.top - down1.before.top <= down1.before.viewportHeight,
+    `TC1: 한 걸음이 화면(${down1.before.viewportHeight})을 넘지 않음 (${down1.after.top - down1.before.top})`);
+
+  const up1 = await press('PageUp');
+  assert(up1.after.top < up1.before.top,
+    `TC1: PgUp 이 위로 이동 (${up1.before.top} → ${up1.after.top})`);
+
+  // ── TC2: 계속 누르면 모든 쪽 머리에 착지 ──────────────────
+  await resetToTop();
+  const visited = new Set([0]);
+  let steps = 0;
+  for (let previous = -1; previous !== (await state()).top && steps < 60; steps++) {
+    previous = (await state()).top;
+    const moved = await press('PageDown');
+    assert(moved.after.top - moved.before.top <= moved.before.viewportHeight,
+      `TC2: ${steps + 1}번째 걸음이 화면을 넘지 않음 (${moved.after.top - moved.before.top})`);
+    visited.add(moved.after.top);
+  }
+  const missed = pageTops.filter(top => !visited.has(top));
+  assert(missed.length === 0,
+    `TC2: 모든 쪽 머리에 착지 (놓친 위치: ${missed.join(', ') || '없음'})`);
+
+  // ── TC3: 캐럿이 화면을 따라온다 ───────────────────────────
+  await resetToTop();
+  const caretStart = await state();
+  const caretMoved = await press('PageDown');
+  assert(caretMoved.after.position !== caretStart.position,
+    `TC3: PgDn 이 캐럿도 옮김 (${caretStart.position} → ${caretMoved.after.position})`);
+
+  // 캐럿이 화면 밖이면 다음 입력 한 번에 화면이 되튄다 — 그게 종전 증상이었다.
+  const afterArrow = await press('ArrowRight');
+  assert(afterArrow.after.top === afterArrow.before.top,
+    `TC3: 방향키를 눌러도 화면이 되튀지 않음 (${afterArrow.before.top} → ${afterArrow.after.top})`);
+
+  const caretBack = await press('PageUp');
+  assert(caretBack.after.position !== afterArrow.after.position,
+    `TC3: PgUp 도 캐럿을 옮김 (${caretBack.after.position})`);
+
+  // ── TC4: 편집기 밖(툴바 버튼·서식 콤보) 포커스 ────────────
+  await resetToTop();
+  const focusBaseline = await press('PageDown');
+  await resetToTop();
+  await page.evaluate(() => document.querySelector('.tb-btn[data-cmd]')?.focus());
+  const toolbarDown = await press('PageDown');
+  assert(toolbarDown.after.top === focusBaseline.after.top,
+    `TC4: 툴바 포커스에서도 같은 자리로 이동 (${toolbarDown.after.top}, 기준 ${focusBaseline.after.top})`);
+  assert(toolbarDown.after.position === focusBaseline.after.position,
+    `TC4: 툴바 포커스에서도 캐럿이 따라옴 (${toolbarDown.after.position})`);
+
+  await resetToTop();
+  await page.evaluate(() => document.querySelector('select')?.focus());
+  const comboDown = await press('PageDown');
+  assert(comboDown.after.top === focusBaseline.after.top,
+    `TC4: 서식 콤보 포커스에서도 같은 자리로 이동 (${comboDown.after.top})`);
+
+  // ── TC5: 머리말 편집 모드 — 화면만 옮기고 문맥은 유지 ─────
+  await resetToTop();
+  const inHeaderFooter = await page.evaluate(() => {
+    window.__inputHandler.cursor.enterHeaderFooterMode(true, 0, 0);
+    return window.__inputHandler.cursor.isInHeaderFooter();
+  });
+  assert(inHeaderFooter, 'TC5: 머리말 편집 모드 진입');
+  const headerDown = await press('PageDown');
+  assert(headerDown.after.top === focusBaseline.after.top,
+    `TC5: 머리말 편집 모드에서도 화면이 이동 (${headerDown.after.top}, 기준 ${focusBaseline.after.top})`);
+  const stillInHeaderFooter = await page.evaluate(
+    () => window.__inputHandler.cursor.isInHeaderFooter(),
+  );
+  assert(stillInHeaderFooter, 'TC5: 머리말 편집 문맥은 그대로 유지');
+  await page.evaluate(() => window.__inputHandler.cursor.exitHeaderFooterMode?.());
+
+  // ── TC6: Shift+PgDn 은 선택을 확장한다 ────────────────────
+  await resetToTop();
+  const shiftDown = await press('PageDown', { shift: true });
+  assert(shiftDown.after.hasSelection,
+    'TC6: Shift+PgDn 이 선택을 만든다');
+  assert(shiftDown.after.top > shiftDown.before.top,
+    `TC6: Shift+PgDn 도 화면을 옮긴다 (${shiftDown.before.top} → ${shiftDown.after.top})`);
+
+  // ── TC7: 문서 끝/처음 경계 ────────────────────────────────
+  await resetToTop();
+  let previous = -1;
+  for (let i = 0; i < 60 && previous !== (await state()).top; i++) {
+    previous = (await state()).top;
+    await press('PageDown');
+  }
+  const atEnd = await state();
+  assert(atEnd.top === atEnd.maxScroll,
+    `TC7: 마지막 쪽 아래 끝까지 도달 (${atEnd.top}, 최대 ${atEnd.maxScroll})`);
+
+  previous = -1;
+  for (let i = 0; i < 60 && previous !== (await state()).top; i++) {
+    previous = (await state()).top;
+    await press('PageUp');
+  }
+  const atStart = await state();
+  assert(atStart.top === 0, `TC7: 문서 맨 위까지 복귀 (${atStart.top})`);
+});

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -31,6 +31,8 @@
     "e2e:loading-busy-cursor": "node e2e/loading-busy-cursor.test.mjs --mode=headless",
     "e2e:hwp-password-open": "node e2e/hwp-password-open.test.mjs --mode=headless",
     "e2e:clipboard-priority": "node e2e/task-871-clipboard-priority.test.mjs",
+    "e2e:page-key-scroll": "node e2e/page-key-scroll.test.mjs --mode=headless",
+    "e2e:home-end-key": "node e2e/home-end-key.test.mjs --mode=headless",
     "e2e:drag-autoscroll": "node e2e/drag-selection-autoscroll.test.mjs",
     "e2e:renderer-contract": "node e2e/renderer-contract.test.mjs",
     "e2e:issue-4430-content-loss": "node e2e/content-loss-save-issue4430.test.mjs --mode=headless",

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -1856,6 +1856,30 @@ export class CursorState {
     this.updateRect();
   }
 
+  /**
+   * 머리말/꼬리말 내 현재 문단의 처음(-1)/끝(1) 으로 — Home/End.
+   *
+   * 이 모드의 문단은 한 줄로 조판되므로 문단 경계가 곧 줄 경계다. 본문의
+   * `moveToLineStart/End` 는 본문 좌표계를 쓰므로 여기에 쓸 수 없다.
+   */
+  moveToParagraphEdgeInHf(edge: -1 | 1): void {
+    if (this._headerFooterMode === 'none') return;
+    if (edge < 0) {
+      this._hfCharOffset = 0;
+    } else {
+      const isHeader = this._headerFooterMode === 'header';
+      try {
+        const info = JSON.parse(this.wasm.getHeaderFooterParaInfo(
+          this._hfSectionIdx, isHeader, this._hfApplyTo, this._hfParaIdx,
+        ));
+        this._hfCharOffset = info.charCount as number;
+      } catch {
+        return; // WASM 호출 실패 — 커서를 옮기지 않는다
+      }
+    }
+    this.updateRect();
+  }
+
   /** 머리말/꼬리말 내 수평 이동 */
   moveHorizontalInHf(delta: number): void {
     if (this._headerFooterMode === 'none') return;
@@ -1950,6 +1974,24 @@ export class CursorState {
   setFnCursorPosition(fnParaIdx: number, charOffset: number): void {
     this._fnInnerParaIdx = fnParaIdx;
     this._fnCharOffset = charOffset;
+    this.updateRect();
+  }
+
+  /** 각주 내 현재 문단의 처음(-1)/끝(1) 으로 — Home/End. `moveToParagraphEdgeInHf` 참고. */
+  moveToParagraphEdgeInFn(edge: -1 | 1): void {
+    if (!this._footnoteMode) return;
+    if (edge < 0) {
+      this._fnCharOffset = 0;
+    } else {
+      try {
+        const info = this.wasm.getFootnoteInfo(
+          this._fnSectionIdx, this._fnParaIdx, this._fnControlIdx,
+        );
+        this._fnCharOffset = (info.texts[this._fnInnerParaIdx] ?? '').length;
+      } catch {
+        return; // WASM 호출 실패 — 커서를 옮기지 않는다
+      }
+    }
     this.updateRect();
   }
 

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -11,9 +11,10 @@ import {
   type NavigationAction,
   type NavigationKeyInput,
 } from './navigation-keymap';
-import type { DocumentPosition, CellBbox, CellPathLike } from '@/core/types';
+import type { DocumentPosition, CursorRect, CellBbox, CellPathLike } from '@/core/types';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import { tableObjectClipboardTarget } from './table-object-clipboard-target';
+import { scrollByPageStep, type PageScrollDirection } from '@/view/page-scroll';
 
 const RHWP_CLIPBOARD_MARKER_RE = /<!--\s*rhwp-studio-clipboard:([A-Za-z0-9._:-]+)\s*-->/;
 const PAGINATION_BOUNDARY_KEYS = new Set([
@@ -412,20 +413,137 @@ const chordMapG: Record<string, string> = {
 };
 
 /**
+ * PgUp/PgDn 처리 — 화면을 쪽 단위로 옮기고, 캐럿을 **화면상 같은 자리**에 남긴다.
+ *
+ * 한글은 PgUp/PgDn 이 캐럿도 함께 옮긴다. 화면만 옮기면 다음 방향키·타이핑 한 번에
+ * 원래 쪽으로 되튀어, 사용자 눈에는 이동이 취소된 것처럼 보인다.
+ *
+ * 캐럿이 없거나(문서 미배치) 캐럿 소유자가 본문이 아닌 하위 모드(머리말/꼬리말·각주·
+ * 개체/셀 선택·서식 모드)일 때는 화면만 옮긴다 — 그 모드들의 캐럿은 본문 좌표계로
+ * hit-test 할 수 없고, 옮기면 편집 문맥이 바뀌어 버린다.
+ *
+ * @returns 실제로 스크롤이 일어났으면 true.
+ */
+export function scrollByPageKey(
+  this: any,
+  direction: PageScrollDirection,
+  extendSelection: boolean,
+): boolean {
+  const beforeRect: CursorRect | null = caretRectForPageScroll.call(this);
+  const result = scrollByPageStep(this.virtualScroll, this.viewportManager, direction);
+  if (!result.moved) return false;
+  if (beforeRect) moveCaretWithPageScroll.call(this, beforeRect, result.delta, extendSelection);
+  return true;
+}
+
+/**
+ * Ctrl+Home/Ctrl+End 뒤 화면을 문서 처음/끝에 붙인다.
+ *
+ * `updateCaret` 의 caret-into-view 는 캐럿이 보이기만 하면 멈추므로, 문서 처음으로
+ * 갔는데도 첫 쪽 위 여백이 잘린 채(실측 122px 내려간 채) 남는다. 사용자가 Ctrl+Home 에
+ * 기대하는 것은 "문서 맨 위" 지 "첫 줄이 어딘가 보이는 화면" 이 아니다.
+ *
+ * 단, 끝 화면에 캐럿이 들어올 때만 붙인다 — 확대해서 첫 줄이 한 화면 아래에 있는
+ * 경우까지 맨 위로 붙이면 방금 옮긴 캐럿을 화면 밖으로 밀어낸다.
+ */
+function snapViewToDocumentEdge(this: any, edge: -1 | 1): void {
+  const rect: CursorRect | null = this.cursor.getRect?.() ?? null;
+  if (!rect) return;
+
+  const zoom = this.viewportManager.getZoom();
+  const viewportHeight = this.viewportManager.getViewportSize().height;
+  const limit = Math.max(0, this.virtualScroll.getTotalHeight() - viewportHeight);
+  const caretTop = this.virtualScroll.getPageOffset(rect.pageIndex) + rect.y * zoom;
+
+  if (edge < 0) {
+    if (caretTop + rect.height * zoom <= viewportHeight) this.viewportManager.setScrollTop(0);
+  } else if (caretTop >= limit) {
+    this.viewportManager.setScrollTop(limit);
+  }
+}
+
+/** 화면과 함께 옮겨도 되는 캐럿이면 그 rect 를, 아니면 null 을 준다. */
+function caretRectForPageScroll(this: any): CursorRect | null {
+  const cursor = this.cursor;
+  if (this.isFormMode?.()) return null;
+  if (cursor.isInHeaderFooter?.() || cursor.isInFootnote?.()) return null;
+  if (cursor.isInPictureObjectSelection?.() || cursor.isInTableObjectSelection?.()) return null;
+  if (cursor.isInBlockSelectionMode?.() || cursor.isInCellSelectionMode?.()) return null;
+  return cursor.getRect?.() ?? null;
+}
+
+/**
+ * 스크롤 뒤, 스크롤 전 캐럿이 있던 **화면 위치**에 해당하는 문서 위치로 캐럿을 옮긴다.
+ * 내용이 `delta` 만큼 위로 흘렀으니, 같은 화면 자리는 문서 좌표로 `delta` 만큼 아래다.
+ */
+function moveCaretWithPageScroll(
+  this: any,
+  beforeRect: CursorRect,
+  delta: number,
+  extendSelection: boolean,
+): void {
+  const hit = hitTestAfterPageScroll.call(this, beforeRect, delta);
+  // hit 이 없으면(여백·빈 쪽에 떨어짐) 캐럿을 그대로 둔다 — 화면 이동만으로도
+  // 읽기는 되고, 엉뚱한 위치로 옮기는 것보다 낫다.
+  if (!hit) return;
+
+  if (extendSelection) {
+    this.cursor.setAnchor();
+  } else {
+    this.cursor.clearSelection();
+  }
+  this.cursor.moveToHit(hit);
+  this.cursor.resetPreferredX();
+  // 캐럿은 이미 화면 안(스크롤 전과 같은 자리)이라 다시 스크롤할 이유가 없다.
+  // updateCaret() 을 쓰면 caret-into-view 가 방금 맞춘 화면을 흔든다.
+  this.updateCaretNoScroll();
+  if (extendSelection) this.updateSelection();
+}
+
+/** 스크롤 전 캐럿 rect + 스크롤 변화량 → 스크롤 후 같은 화면 자리의 문서 위치. */
+function hitTestAfterPageScroll(
+  this: any,
+  beforeRect: CursorRect,
+  delta: number,
+): DocumentPosition | null {
+  const scrollContent = this.container.querySelector('#scroll-content');
+  if (!scrollContent) return null;
+
+  const zoom = this.viewportManager.getZoom();
+  const pageLeft = this.virtualScroll.getPageLeftResolved(
+    beforeRect.pageIndex,
+    scrollContent.clientWidth,
+  );
+  const contentX = pageLeft + beforeRect.x * zoom;
+  // 캐럿 세로 중앙을 기준점으로 삼는다 — 줄 경계에 딱 걸려 이웃 줄로 새지 않게.
+  const contentY = this.virtualScroll.getPageOffset(beforeRect.pageIndex)
+    + (beforeRect.y + beforeRect.height / 2) * zoom;
+
+  // scroll-content 의 화면 좌표는 이미 스크롤이 반영된 값이라, 문서 좌표에 그대로 더하면
+  // 스크롤 후의 화면 좌표가 된다.
+  const contentRect = scrollContent.getBoundingClientRect();
+  return this.hitTestFromClientPoint(
+    contentRect.left + contentX,
+    contentRect.top + contentY + delta,
+  );
+}
+
+/**
  * 키보드 이벤트 처리 순서:
  *
 
  * 1. 코드 단축키 2번째 키 (Ctrl+K → ? / Ctrl+M → ?)
  * 2. 특수 모드 탈출 (연결선/다각형/이미지/글상자 배치 모드 → Escape)
  * 3. IME 조합 중 네비게이션 키 보류
- * 4. 편집 모드별 키 처리 (머리말꼬리말 / 각주)
- * 5. F5 셀 선택 모드
- * 6. 셀 선택 모드 키 처리
- * 7. 그림/표 객체 선택 모드 키 처리
- * 8. 플랫폼별 navigation shortcut 처리
- * 9. Ctrl/Meta 조합 → handleCtrlKey() → shortcut-map.ts 단축키 테이블 경유
- * 10. Alt 조합 → shortcut-map.ts 단축키 테이블 경유
- * 11. 본문 키 처리 (Esc, Backspace, Enter, Arrow 등)
+ * 4. PgUp/PgDn 화면 이동 — 아래 편집 모드 분기(5~8)가 삼키기 전에 먼저 소비한다
+ * 5. 편집 모드별 키 처리 (머리말꼬리말 / 각주)
+ * 6. F5 셀 선택 모드
+ * 7. 셀 선택 모드 키 처리
+ * 8. 그림/표 객체 선택 모드 키 처리
+ * 9. 플랫폼별 navigation shortcut 처리
+ * 10. Ctrl/Meta 조합 → handleCtrlKey() → shortcut-map.ts 단축키 테이블 경유
+ * 11. Alt 조합 → shortcut-map.ts 단축키 테이블 경유
+ * 12. 본문 키 처리 (Esc, Backspace, Enter, Arrow 등)
  *
  * 새 단축키 추가 시: shortcut-map.ts의 defaultShortcuts 테이블에 등록
  */
@@ -590,6 +708,15 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
     }
   }
 
+  // ─── 4. PgUp/PgDn 화면 이동 ───────────────────────────────
+  // 편집 위치가 아니라 화면을 옮기는 키다. 아래 모드별 분기(머리말/꼬리말·각주·개체
+  // 선택·셀 선택 등)가 키를 삼켜 무동작이 되지 않도록 여기서 먼저 처리한다.
+  if ((e.key === 'PageUp' || e.key === 'PageDown') && !e.ctrlKey && !e.metaKey && !e.altKey) {
+    e.preventDefault();
+    scrollByPageKey.call(this, e.key === 'PageUp' ? -1 : 1, e.shiftKey);
+    return;
+  }
+
   // ─── 머리말/꼬리말 편집 모드 키보드 처리 ──────────────────
   if (this.cursor.isInHeaderFooter()) {
     if (dispatchSubmodeGlobalShortcut.call(this, e)) return;
@@ -621,6 +748,16 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       e.preventDefault();
       const delta = e.key === 'ArrowLeft' ? -1 : 1;
       this.cursor.moveHorizontalInHf(delta);
+      this.updateCaret();
+      return;
+    }
+
+    // Home/End → 머리말/꼬리말 내 줄 처음·끝. 이 분기가 없으면 키가 여기서 삼켜져
+    // 아래 본문 navigation 경로에 닿지 못하고 무동작이 된다.
+    // Ctrl 조합(문서 처음/끝)은 본문 명령이라 이 모드에서 가로채지 않는다.
+    if ((e.key === 'Home' || e.key === 'End') && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      e.preventDefault();
+      this.cursor.moveToParagraphEdgeInHf(e.key === 'Home' ? -1 : 1);
       this.updateCaret();
       return;
     }
@@ -692,6 +829,14 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       e.preventDefault();
       const delta = e.key === 'ArrowLeft' ? -1 : 1;
       this.cursor.moveHorizontalInFn(delta);
+      this.updateCaret();
+      return;
+    }
+
+    // Home/End → 각주 내 줄 처음·끝. 머리말/꼬리말과 같은 이유로 여기서 처리한다.
+    if ((e.key === 'Home' || e.key === 'End') && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      e.preventDefault();
+      this.cursor.moveToParagraphEdgeInFn(e.key === 'Home' ? -1 : 1);
       this.updateCaret();
       return;
     }
@@ -1204,27 +1349,6 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       if (e.shiftKey) this.updateSelection();
       break;
     }
-    case 'PageUp':
-    case 'PageDown': {
-      e.preventDefault();
-      const vpSize = this.viewportManager.getViewportSize();
-      const scrollY = this.viewportManager.getScrollY();
-      const vpCenter = scrollY + vpSize.height / 2;
-      // [#2560] 그리드 모드에서는 한 행의 쪽들이 같은 offset 을 갖는다. 행의
-      // 마지막 쪽에서 ±1 하면 같은 행에 머물러 스크롤이 움직이지 않으므로
-      // (PageUp 이 무동작), 행의 첫 쪽 기준으로 행 단위(±열수)로 이동한다.
-      // 단일 컬럼에서는 pagesPerRow=1 이라 종전 동작과 동일하다.
-      const currentPage = this.virtualScroll.getRowFirstPageAtY(vpCenter);
-      const step = this.virtualScroll.pagesPerRow;
-      const targetPage = e.key === 'PageUp'
-        ? Math.max(0, currentPage - step)
-        : Math.min(this.virtualScroll.pageCount - 1, currentPage + step);
-      if (targetPage !== currentPage) {
-        const targetOffset = this.virtualScroll.getPageOffset(targetPage);
-        this.viewportManager.setScrollTop(targetOffset - this.virtualScroll.gap);
-      }
-      break;
-    }
     case 'Home': {
       e.preventDefault();
       if (e.shiftKey) {
@@ -1383,6 +1507,7 @@ export function handleCtrlKey(this: any, e: KeyboardEvent): void {
         this.cursor.moveToDocumentStart();
       }
       this.updateCaret();
+      snapViewToDocumentEdge.call(this, -1);
       break;
     }
     case 'end': {
@@ -1395,6 +1520,7 @@ export function handleCtrlKey(this: any, e: KeyboardEvent): void {
         this.cursor.moveToDocumentEnd();
       }
       this.updateCaret();
+      snapViewToDocumentEdge.call(this, 1);
       break;
     }
     case 'arrowleft': {

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -1853,6 +1853,18 @@ export class InputHandler {
     _keyboard.onKeyDown.call(this, e);
   }
 
+  /**
+   * PgUp/PgDn·Home/End 를 포커스 주인과 무관하게 편집기 경로로 처리한다.
+   *
+   * 편집기 textarea 가 포커스를 잃으면(툴바 버튼·서식 콤보) keydown 이 오지 않아 이
+   * 키들이 통째로 무동작이 된다. 전역 폴백(main.ts)이 그때 keydown 을 그대로 넘기는
+   * 진입점이다 — 분기 로직을 복제하지 않고 같은 경로를 태워 동작을 하나로 유지한다.
+   */
+  handleDocumentNavigationKey(e: KeyboardEvent): void {
+    if (!this.active) return;
+    _keyboard.onKeyDown.call(this, e);
+  }
+
   /** Ctrl/Meta 단축키 처리 */
   private handleCtrlKey(e: KeyboardEvent): void {
     _keyboard.handleCtrlKey.call(this, e);

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -755,6 +755,9 @@ function setupModalFocusRestore(): void {
   });
 }
 
+/** 포커스 주인과 무관하게 문서를 움직여야 하는 키 — 편집기 경로로 넘긴다. */
+const DOCUMENT_NAVIGATION_KEYS = new Set(['PageUp', 'PageDown', 'Home', 'End']);
+
 /**
  * 전역 단축키 핸들러 — InputHandler.active 여부와 무관하게 동작해야 하는 단축키.
  * 예: 문서 미로드 상태에서도 Alt+N(새 문서), Ctrl+O(열기) 등.
@@ -764,6 +767,28 @@ function setupGlobalShortcuts(): void {
     // input/textarea 등 편집 가능 요소 내부에서는 무시
     const target = e.target as HTMLElement;
     if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) return;
+
+    // PgUp/PgDn·Home/End 는 문서를 보며 움직이는 키다. 툴바 버튼·서식 콤보를 한 번
+    // 누르면 포커스가 편집기 textarea 를 떠나 InputHandler 가 키를 받지 못하고, 스크롤
+    // 컨테이너도 포커스 대상이 아니라 브라우저 기본 동작조차 없어 통째로 무동작이 된다.
+    // 편집기가 활성이면 keydown 을 그대로 편집기 경로에 넘겨, 포커스가 어디에 있든 같은
+    // 분기·같은 결과(캐럿 이동 + 화면 이동)를 준다 — 여기에 로직을 복제하지 않는다.
+    // (textarea/input 이 target 이면 위에서 이미 return 하므로 이중 실행되지 않고,
+    //  모달이 떠 있으면 Dialog 의 capture 핸들러가 먼저 전파를 끊는다.)
+    // select 등 이 키를 자체 소비하는 위젯보다 문서 이동을 우선한다 — studio 에서
+    // chrome 위젯은 스쳐 가는 대상이고 사용자가 보고 있는 것은 문서다.
+    if (DOCUMENT_NAVIGATION_KEYS.has(e.key) && !e.altKey) {
+      if (inputHandler?.isActive()) {
+        inputHandler.handleDocumentNavigationKey(e);
+        return;
+      }
+      if (e.key === 'PageUp' || e.key === 'PageDown') {
+        // 문서는 떠 있지만 편집기가 활성이 아닌 보기 상태 — 화면만 옮긴다.
+        e.preventDefault();
+        canvasView?.scrollByPage(e.key === 'PageUp' ? -1 : 1);
+        return;
+      }
+    }
     // textarea가 아닌 곳에 포커스가 빠진 활성 편집기는 자체 keydown을 받지 못한다.
     // 이때 undo/redo만 dispatcher로 보완한다. textarea가 target이면 위에서 이미 return하므로
     // InputHandler와 이중 실행되지 않으며, 다른 단축키의 기존 전역 소유 범위도 넓히지 않는다.

--- a/rhwp-studio/src/view/canvas-view.ts
+++ b/rhwp-studio/src/view/canvas-view.ts
@@ -6,6 +6,7 @@ import { CanvasPool } from './canvas-pool';
 import { PageRenderer, type PageRenderContext, type PageRenderResult } from './page-renderer';
 import { ViewportManager } from './viewport-manager';
 import { CoordinateSystem } from './coordinate-system';
+import { scrollByPageStep, type PageScrollDirection } from './page-scroll';
 import type { CanvasKitRenderDiagnostics } from './canvaskit-renderer';
 import type { FontDecisionTraceRecordV1 } from '@/core/font-decision-trace';
 import { clampRenderScale, type RenderBackend } from './render-backend';
@@ -160,6 +161,16 @@ export class CanvasView {
     await Promise.resolve();
 
     console.log(`[CanvasView] ${this.pages.length}/${pageCount}페이지 로드, 총 높이: ${this.virtualScroll.getTotalHeight()}px`);
+  }
+
+  /**
+   * PgUp/PgDn — 화면을 쪽 단위로 옮긴다. 문서는 떠 있지만 편집기가 활성이 아닐 때
+   * (InputHandler 가 키를 소유하지 않는 상태) 전역 폴백이 쓰는 진입점이다.
+   * 편집기가 활성이면 캐럿까지 함께 옮기는 `InputHandler.scrollByPageKey` 가 처리한다.
+   */
+  scrollByPage(direction: PageScrollDirection): boolean {
+    if (this.disposed) return false;
+    return scrollByPageStep(this.virtualScroll, this.viewportManager, direction).moved;
   }
 
   /** WASM 문서 교체 직후 호출하여 이전 문서의 renderer와 canvas를 동기적으로 분리한다. */

--- a/rhwp-studio/src/view/page-scroll.ts
+++ b/rhwp-studio/src/view/page-scroll.ts
@@ -1,0 +1,99 @@
+import type { VirtualScroll } from './virtual-scroll';
+import type { ViewportManager } from './viewport-manager';
+
+/** -1 = PgUp(위로), 1 = PgDn(아래로) */
+export type PageScrollDirection = -1 | 1;
+
+export interface PageScrollResult {
+  /** 실제로 스크롤이 일어났으면 true */
+  moved: boolean;
+  /** 스크롤 변화량(px, 아래로 이동이 +). `moved` 가 false 면 0 */
+  delta: number;
+}
+
+const NO_MOVE: PageScrollResult = { moved: false, delta: 0 };
+
+/** 부동소수 오차로 "같은 자리에 또 스크롤" 이 나지 않게 하는 하한. */
+const EPSILON = 0.5;
+
+/**
+ * 행 `pageIdx` 의 위쪽 여백이 시작되는 문서 Y — 화면을 여기에 맞추면 그 쪽의 위
+ * 여백부터 보인다. 그리드 모드에서는 한 행의 쪽들이 같은 offset 을 가지므로 행 값이다.
+ */
+function rowTop(virtualScroll: VirtualScroll, pageIdx: number): number {
+  return virtualScroll.getPageOffset(pageIdx) - virtualScroll.gap;
+}
+
+/** 스크롤 가능한 최대 위치. 이 아래로는 문서가 없다. */
+function maxScrollTop(virtualScroll: VirtualScroll, viewportHeight: number): number {
+  return Math.max(0, virtualScroll.getTotalHeight() - viewportHeight);
+}
+
+/** `scrollY` 바로 아래의 행 경계. 더 없으면 문서 끝. */
+function nextRowBoundary(
+  virtualScroll: VirtualScroll,
+  scrollY: number,
+  step: number,
+  limit: number,
+): number {
+  for (let page = 0; page < virtualScroll.pageCount; page += step) {
+    const top = rowTop(virtualScroll, page);
+    if (top > scrollY + EPSILON) return top;
+  }
+  return limit;
+}
+
+/** `scrollY` 바로 위의 행 경계. 더 없으면 문서 처음. */
+function prevRowBoundary(
+  virtualScroll: VirtualScroll,
+  scrollY: number,
+  step: number,
+): number {
+  const lastRowStart = Math.floor((virtualScroll.pageCount - 1) / step) * step;
+  for (let page = lastRowStart; page >= 0; page -= step) {
+    const top = rowTop(virtualScroll, page);
+    if (top < scrollY - EPSILON) return top;
+  }
+  return 0;
+}
+
+/**
+ * PgUp/PgDn — 화면을 쪽 단위로 옮긴다.
+ *
+ * 목표는 **쪽 경계에 정확히 붙되 지나친 내용이 없게** 하는 것이다. 한 번에 가는 거리는
+ * `min(다음 쪽 경계, 화면 하나)` 다.
+ *
+ * - 쪽이 화면 안에 들어오면(쪽 맞춤·그리드) 경계가 화면보다 가까우니 한 번에 다음 쪽으로
+ *   넘어간다 — 종전과 같은 쪽 단위 이동이다.
+ * - 쪽이 화면보다 크면(100% 이상 확대) 종전에는 다음 쪽 머리로 뛰어 그 사이를 한 번도
+ *   보여주지 않고 건너뛰었다. 이제 화면 하나씩 밟아 내려가되 **착지점은 항상 쪽 경계**라,
+ *   몇 번을 눌러도 쪽 머리 정렬이 어긋나지 않는다.
+ *
+ * 그리드 모드에서는 한 행의 쪽들이 같은 offset 을 가지므로 행 단위(`pagesPerRow`)로 센다.
+ */
+export function scrollByPageStep(
+  virtualScroll: VirtualScroll,
+  viewportManager: ViewportManager,
+  direction: PageScrollDirection,
+): PageScrollResult {
+  if (virtualScroll.pageCount <= 0) return NO_MOVE;
+
+  const scrollY = viewportManager.getScrollY();
+  const viewportHeight = viewportManager.getViewportSize().height;
+  const limit = maxScrollTop(virtualScroll, viewportHeight);
+  const step = Math.max(1, virtualScroll.pagesPerRow);
+
+  const target = direction > 0
+    ? Math.min(nextRowBoundary(virtualScroll, scrollY, step, limit), scrollY + viewportHeight)
+    : Math.max(prevRowBoundary(virtualScroll, scrollY, step), scrollY - viewportHeight);
+
+  const clamped = Math.max(0, Math.min(target, limit));
+  if (Math.abs(clamped - scrollY) < EPSILON) return NO_MOVE;
+
+  viewportManager.setScrollTop(clamped);
+  // 브라우저가 자체 clamp 를 할 수 있으니 실제 반영된 값으로 delta 를 낸다 —
+  // 캐럿을 같은 화면 위치에 붙여 두려면 이 값이 정확해야 한다.
+  const delta = viewportManager.getScrollY() - scrollY;
+  if (Math.abs(delta) < EPSILON) return NO_MOVE;
+  return { moved: true, delta };
+}

--- a/rhwp-studio/tests/page-scroll-step.test.ts
+++ b/rhwp-studio/tests/page-scroll-step.test.ts
@@ -1,0 +1,191 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { VirtualScroll } from '../src/view/virtual-scroll.ts';
+import { scrollByPageStep } from '../src/view/page-scroll.ts';
+import type { ViewportManager } from '../src/view/viewport-manager.ts';
+
+// PgUp/PgDn 은 화면을 쪽 단위로 옮긴다. 이 테스트가 그 계약을 DOM 없이 고정한다.
+//
+// 종전에는 이 계산이 input-handler-keyboard.ts 의 switch case 안에만 있어서,
+//   - 머리말/각주·개체 선택 같은 모드별 조기 반환이 키를 삼키면 무동작이었고
+//   - 편집기 textarea 밖(툴바 버튼·서식 콤보)으로 포커스가 나가면 아무도 처리하지 않았다.
+// 계산을 이 순수 모듈로 옮겨 편집기 경로와 전역 폴백이 같은 규칙을 쓰게 했다.
+//
+// 그리고 "다음 쪽 머리로 뛴다" 는 단순 규칙은 쪽이 화면보다 클 때(100% 이상 확대)
+// 그 사이를 한 번도 보여주지 않고 건너뛰었다. 지금 규칙은 `min(다음 쪽 경계, 화면 하나)`
+// 이라, 착지점은 여전히 쪽 경계지만 지나친 내용이 남지 않는다.
+
+const VIEWPORT_HEIGHT = 700;
+const PAGE_HEIGHT = 1000;
+const GAP = 10;
+
+function pages(n: number, width = 800, height = PAGE_HEIGHT) {
+  return Array.from({ length: n }, () => ({ width, height })) as never;
+}
+
+/** setScrollTop/getScrollY 만 쓰는 ViewportManager 대역. */
+function fakeViewport(height = VIEWPORT_HEIGHT) {
+  let scrollY = 0;
+  return {
+    getScrollY: () => scrollY,
+    getViewportSize: () => ({ width: 1000, height }),
+    setScrollTop: (y: number) => { scrollY = y; },
+  } as unknown as ViewportManager & { getScrollY(): number };
+}
+
+/** 단일 컬럼(zoom 1.0). 쪽 높이 1000 > 뷰포트 700 이라 쪽이 화면보다 크다. */
+function singleColumn(pageCount: number) {
+  const vs = new VirtualScroll(GAP);
+  vs.setPageDimensions(pages(pageCount), 1.0, 1200);
+  assert.equal(vs.isGridMode(), false, '전제: 단일 컬럼이어야 함');
+  return vs;
+}
+
+/** 쪽이 화면 안에 들어오는 배치(쪽 맞춤에 해당). */
+function pageFitsViewport(pageCount: number) {
+  const vs = new VirtualScroll(GAP);
+  vs.setPageDimensions(pages(pageCount, 800, 600), 1.0, 1200);
+  assert.equal(vs.isGridMode(), false, '전제: 단일 컬럼이어야 함');
+  return vs;
+}
+
+/** 행 위쪽 여백이 시작되는 문서 Y — 화면을 여기 맞추면 그 쪽 머리부터 보인다. */
+const rowTop = (vs: VirtualScroll, page: number) => vs.getPageOffset(page) - GAP;
+
+test('쪽이 화면 안에 들어오면 한 번에 다음 쪽 머리로 간다', () => {
+  const vs = pageFitsViewport(5);
+  const vm = fakeViewport();
+
+  assert.equal(scrollByPageStep(vs, vm, 1).moved, true);
+  assert.equal(vm.getScrollY(), rowTop(vs, 1));
+
+  assert.equal(scrollByPageStep(vs, vm, 1).moved, true);
+  assert.equal(vm.getScrollY(), rowTop(vs, 2));
+
+  assert.equal(scrollByPageStep(vs, vm, -1).moved, true);
+  assert.equal(vm.getScrollY(), rowTop(vs, 1));
+});
+
+test('쪽이 화면보다 크면 화면 하나씩 밟되 쪽 머리에 정확히 착지한다', () => {
+  const vs = singleColumn(5);
+  const vm = fakeViewport();
+
+  // 1) 첫 걸음은 화면 하나 — 다음 쪽 머리(1010)까지 한 번에 뛰면 그 사이 310px 을
+  //    한 번도 보여주지 않고 건너뛴다.
+  assert.equal(scrollByPageStep(vs, vm, 1).moved, true);
+  assert.equal(vm.getScrollY(), VIEWPORT_HEIGHT);
+
+  // 2) 두 번째 걸음은 화면 하나(1400)가 아니라 쪽 경계(1010)에서 멈춘다.
+  assert.equal(scrollByPageStep(vs, vm, 1).moved, true);
+  assert.equal(vm.getScrollY(), rowTop(vs, 1), '쪽 머리 정렬이 어긋나지 않는다');
+
+  assert.equal(scrollByPageStep(vs, vm, 1).moved, true);
+  assert.equal(vm.getScrollY(), rowTop(vs, 1) + VIEWPORT_HEIGHT);
+
+  assert.equal(scrollByPageStep(vs, vm, 1).moved, true);
+  assert.equal(vm.getScrollY(), rowTop(vs, 2), '다음 쪽 머리에도 정확히 착지한다');
+});
+
+test('PgDn 은 어떤 배치에서도 한 화면보다 많이 건너뛰지 않는다', () => {
+  for (const vs of [singleColumn(6), pageFitsViewport(6)]) {
+    const vm = fakeViewport();
+    let previous = vm.getScrollY();
+    for (let i = 0; i < 30; i++) {
+      if (!scrollByPageStep(vs, vm, 1).moved) break;
+      const advanced = vm.getScrollY() - previous;
+      assert.ok(advanced > 0, '아래로 움직여야 한다');
+      assert.ok(
+        advanced <= VIEWPORT_HEIGHT + 0.5,
+        `한 걸음이 화면(${VIEWPORT_HEIGHT})을 넘으면 그만큼이 안 보인 채 지나간다: ${advanced}`,
+      );
+      previous = vm.getScrollY();
+    }
+  }
+});
+
+test('PgDn 을 계속 누르면 모든 쪽 머리를 하나도 빠짐없이 지난다', () => {
+  const vs = singleColumn(4);
+  const vm = fakeViewport();
+  const visited = new Set<number>([vm.getScrollY()]);
+  for (let i = 0; i < 30 && scrollByPageStep(vs, vm, 1).moved; i++) {
+    visited.add(vm.getScrollY());
+  }
+  for (let page = 0; page < vs.pageCount; page++) {
+    assert.ok(visited.has(rowTop(vs, page)), `${page + 1}쪽 머리에 착지한 적이 있어야 한다`);
+  }
+});
+
+test('PgUp 도 한 화면 이내로 올라가며 모든 쪽 머리를 지난다', () => {
+  // PgDn 이 쪽 경계에 붙고 PgUp 도 쪽 경계에 붙으므로, 올라가는 경로가 내려온 경로와
+  // 같은 좌표를 밟지는 않는다(쪽 머리에서 한 화면 위는 내려올 때의 직전 위치가 아니다).
+  // 보장하는 것은 방향과 무관한 두 성질이다 — 건너뛰지 않고, 쪽 머리에 정확히 선다.
+  const vs = singleColumn(4);
+  const vm = fakeViewport();
+  while (scrollByPageStep(vs, vm, 1).moved) { /* 문서 끝까지 */ }
+
+  const visited = new Set<number>([vm.getScrollY()]);
+  let previous = vm.getScrollY();
+  for (let i = 0; i < 30 && scrollByPageStep(vs, vm, -1).moved; i++) {
+    const climbed = previous - vm.getScrollY();
+    assert.ok(climbed > 0, '위로 움직여야 한다');
+    assert.ok(
+      climbed <= VIEWPORT_HEIGHT + 0.5,
+      `한 걸음이 화면(${VIEWPORT_HEIGHT})을 넘으면 그만큼이 안 보인 채 지나간다: ${climbed}`,
+    );
+    visited.add(vm.getScrollY());
+    previous = vm.getScrollY();
+  }
+
+  assert.equal(vm.getScrollY(), 0, '문서 맨 위까지 되돌아온다');
+  for (let page = 0; page < vs.pageCount; page++) {
+    assert.ok(visited.has(rowTop(vs, page)), `${page + 1}쪽 머리에 착지한 적이 있어야 한다`);
+  }
+});
+
+test('문서 끝에서는 마지막 쪽 아래까지 붙이고 멈춘다', () => {
+  const vs = singleColumn(3);
+  const vm = fakeViewport();
+  const bottom = vs.getTotalHeight() - VIEWPORT_HEIGHT;
+  for (let i = 0; i < 30 && scrollByPageStep(vs, vm, 1).moved; i++) { /* 끝까지 */ }
+  assert.equal(vm.getScrollY(), bottom, '마지막 쪽의 안 보인 아래쪽까지 보여준다');
+  assert.deepEqual(scrollByPageStep(vs, vm, 1), { moved: false, delta: 0 });
+});
+
+test('문서 처음에서는 맨 위까지만 간다', () => {
+  const vs = singleColumn(3);
+  const vm = fakeViewport();
+  scrollByPageStep(vs, vm, 1);
+  assert.equal(scrollByPageStep(vs, vm, -1).moved, true);
+  assert.equal(vm.getScrollY(), 0, '첫 쪽 위쪽 여백까지 되돌아온다');
+  assert.deepEqual(scrollByPageStep(vs, vm, -1), { moved: false, delta: 0 });
+});
+
+test('그리드 모드는 쪽이 아니라 행 단위로 움직인다 (#2560)', () => {
+  const vs = new VirtualScroll(GAP);
+  vs.setPageDimensions(pages(12), 0.4, 1000);
+  assert.ok(vs.isGridMode() && vs.pagesPerRow > 1, '전제: 다중 열 그리드');
+  const vm = fakeViewport();
+
+  assert.equal(scrollByPageStep(vs, vm, 1).moved, true);
+  assert.equal(vm.getScrollY(), rowTop(vs, vs.pagesPerRow));
+});
+
+test('delta 는 실제 스크롤 변화량이다 — 캐럿을 같은 화면 자리에 붙이는 근거', () => {
+  const vs = singleColumn(5);
+  const vm = fakeViewport();
+  const before = vm.getScrollY();
+  const result = scrollByPageStep(vs, vm, 1);
+  assert.equal(result.delta, vm.getScrollY() - before);
+
+  const beforeUp = vm.getScrollY();
+  const up = scrollByPageStep(vs, vm, -1);
+  assert.equal(up.delta, vm.getScrollY() - beforeUp);
+  assert.ok(up.delta < 0, 'PgUp 의 delta 는 음수다');
+});
+
+test('문서가 없으면 아무 것도 하지 않는다', () => {
+  const vs = new VirtualScroll(GAP);
+  const vm = fakeViewport();
+  assert.deepEqual(scrollByPageStep(vs, vm, 1), { moved: false, delta: 0 });
+  assert.equal(vm.getScrollY(), 0);
+});


### PR DESCRIPTION
closes #5803

studio 에서 화면·커서를 옮기는 키 4종(PgUp·PgDn·Home·End)이 상황에 따라 통째로 무동작이거나,
동작하더라도 화면이 내용을 건너뛰던 문제를 고칩니다.

## 무엇이 문제였나

헤드리스 Chrome + `biz_plan.hwp`(6쪽, 뷰포트 705px)로 실측한 결과입니다.

| # | 결함 | 실측 |
|---|---|---|
| 1 | 편집기 밖 포커스에서 네 키 모두 무동작 | 툴바 버튼 포커스 후 PageDown·End·Ctrl+End 전부 `scrollTop 0 → 0`, 커서 이동 없음 |
| 2 | 머리말/꼬리말·각주 편집 모드가 키를 삼킴 | 같은 상태에서 네 키 모두 무동작 |
| 3 | 쪽이 화면보다 크면 PgUp/PgDn 이 중간을 건너뜀 | 100% 줌에서 매 쪽 428px(38%), 200% 줌에서 1550px(69%)이 한 번도 표시되지 않음 |
| 4 | PgUp/PgDn 이 캐럿을 두고 감 | 이동 뒤 방향키 한 번에 caret-into-view 가 원래 쪽으로 화면을 되돌림 |
| 5 | Ctrl+Home 이 문서 맨 위에 붙지 않음 | `scrollTop=122` — 첫 쪽 위 여백이 잘린 채로 멈춤 |

1번의 뿌리는 `keydown` 리스너가 편집기 hidden textarea 에만 붙어 있다는 점입니다
(`input-handler.ts` 의 `this.textarea.addEventListener('keydown', ...)`). 툴바 버튼이나 서식
콤보를 한 번 누르면 InputHandler 가 키를 받지 못하고, 스크롤 컨테이너도 포커스 대상이 아니라
브라우저 기본 스크롤조차 일어나지 않습니다.

## 어떻게 고쳤나

**포커스 독립 (#1)** — 전역 keydown 핸들러가 네 키에 한해 `keydown` 을 편집기 경로에 그대로
넘깁니다(`InputHandler.handleDocumentNavigationKey`). 키별 로직을 `main.ts` 에 복제하지 않고 같은
분기를 태워, 포커스가 어디에 있든 동작이 하나로 유지됩니다. `select` 처럼 이 키를 자체 소비하는
위젯보다 문서 이동을 우선했습니다 — studio 에서 chrome 위젯은 스쳐 가는 대상이고 사용자가 보고
있는 것은 문서라는 판단이며, 코드에 근거를 남겼습니다.

**하위 모드 (#2)** — PgUp/PgDn 은 모드별 분기보다 앞에서 소비합니다. Home/End 는 본문으로
빼돌리지 않고 머리말/꼬리말·각주 분기가 **그 모드 안에서** 줄 처음·끝으로 처리합니다
(`cursor.moveToParagraphEdgeInHf/InFn`). 이 모드의 문단은 한 줄로 조판되므로 문단 경계가 곧 줄
경계입니다. Ctrl 조합(문서 처음/끝)은 본문 명령이라 가로채지 않습니다.

**건너뜀 제거 (#3)** — 한 걸음을 `min(다음 쪽 경계, 화면 하나)` 로 바꿨습니다. 착지점은 여전히
쪽 경계라 쪽 머리 정렬이 어긋나지 않고, 안 보인 채 지나가는 구간이 없습니다.

| 줌 | PgDn 연속 걸음(px) | 착지 |
|---|---|---|
| 100% | 705, 428, 705, 427, 705, 428 | 1133·2265·3398 = 각 쪽 머리에 정확히 |
| 200% | 705, 705, 705, **140**, 705, 705 | 140 은 2쪽 머리(2255)에 붙이는 보정 |
| 50%(3열 그리드) | 448 → 끝 | 행 단위 유지 |

**캐럿 추종 (#4)** — 스크롤 전 캐럿의 화면 좌표를 스크롤 뒤 그대로 hit-test 해 같은 자리에
남깁니다. Shift 조합은 선택을 확장합니다. 본문이 아닌 하위 모드(머리말/꼬리말·각주·개체/셀
선택·서식 모드)에서는 화면만 옮깁니다 — 그 캐럿들은 본문 좌표계로 hit-test 할 수 없고, 옮기면
편집 문맥이 바뀝니다.

**문서 끝 착지 (#5)** — 끝 화면에 캐럿이 들어올 때만 문서 처음·끝에 화면을 붙입니다. 아니면
방금 옮긴 캐럿을 화면 밖으로 밀어냅니다. 결과: Ctrl+Home → `top=0`, Ctrl+End → `top=6100`(=maxScroll),
캐럿 화면 안 유지.

## 설계상 절충 (리뷰 포인트)

PgDn 으로 내려간 좌표와 PgUp 으로 올라오는 좌표가 정확히 일치하지 않습니다. 양방향 모두 쪽
경계에 붙이면 왕복 대칭이 성립하지 않기 때문입니다. 대신 **어느 방향이든 한 화면을 넘게
건너뛰지 않고, 모든 쪽 머리를 지난다**는 두 성질을 단위 테스트로 고정했습니다.

개체 선택·셀 선택 모드의 Home/End 는 손대지 않았습니다 — 한글에서도 의미가 없어 무동작이 맞다고
보았습니다.

## 검증

```bash
(cd rhwp-studio && npx tsc --noEmit)                    # 통과
npm --prefix rhwp-studio test                            # 1058 pass / 0 fail / 1 skip
npm --prefix rhwp-studio run build                       # 통과
npm --prefix rhwp-studio run e2e:page-key-scroll         # 30/30
npm --prefix rhwp-studio run e2e:home-end-key            # 23/23
git diff --check                                         # 통과
```

E2E 두 개를 새로 추가하고 `rhwp-studio/e2e/MANIFEST.md` 와 package script 에 등록했습니다.

- `e2e/page-key-scroll.test.mjs` (30 판정) — TC1 한 걸음 상한 / TC2 모든 쪽 머리 착지 /
  TC3 캐럿 추종·되튐 없음 / TC4 툴바·콤보 포커스 / TC5 머리말 모드 / TC6 Shift 선택 / TC7 경계
- `e2e/home-end-key.test.mjs` (23 판정) — TC1 줄 처음·끝 / TC2 Shift 선택 / TC3 툴바·콤보 포커스 /
  TC4 Ctrl+Home 맨 위 / TC5 Ctrl+End 캐럿 가시 / TC6 머리말 모드 / TC7 각주 모드

단위 테스트 `rhwp-studio/tests/page-scroll-step.test.ts` 10 케이스가 DOM 없이 스텝 계약을
고정합니다(건너뜀 상한·쪽 머리 전수 착지·그리드 행 단위·문서 경계·delta 정확도).

사용한 공개 sample: `rhwp-studio/public/samples/biz_plan.hwp`, `footnote-01.hwp`.
Rust 코드 변경이 없어 Rust 게이트는 해당 없습니다.

**성능 영향**: 영향 없음으로 판단합니다. 키 입력 시점에만 도는 계산이고, 쪽 경계 탐색은 쪽 수에
선형인 단순 루프입니다.

## 남은 사항 (이 PR 범위 밖)

`python3 scripts/check_e2e_manifest.py` 는 이 PR 뒤에도 3건을 보고합니다 —
`loading-busy-cursor.test.mjs`, `status-page-number.test.mjs`, `toolbox-visibility.test.mjs` 의
MANIFEST 미등재입니다. `devel`(`fb434269e`)에서도 같아 기존 상태이며, 무관한 변경을 이 PR 에
섞지 않으려고 그대로 두었습니다.

로컬 e2e 에서 확인한 기존 실패 3건도 이 변경과 무관합니다(같은 `devel` 커밋에서 stash 로 재현):
`form-edit-escape-cancel`, `cell-enter-pagination-issue4031`, `issue-4026-footnote-global-shortcuts`.
