### PR TITLE
fix(hwpx): 컨테이너·OLE의 groupLevel을 IR 보존 값으로 되쓴다 (#5716)

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -7013,6 +7013,9 @@ fn parse_hp_ole_element(
     // 원문 id=0을 instance_id로 다시 써서 라운드트립을 깨뜨린다.
     let mut id_attr: Option<u32> = None;
     let mut saw_instid = false;
+    // [#5716] hp:ole 자신의 groupLevel — shape_attr 는 자식 파싱 단계에서 만들어지므로
+    // 지역에 받아 두었다가 채운다.
+    let mut group_level: u16 = 0;
 
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
@@ -7072,6 +7075,9 @@ fn parse_hp_ole_element(
             // [#2931] 개체 잠금(lock) — 종전 미파싱으로 직렬화 시 항상 "0"으로
             // 되돌아가 OLE 개체의 잠금 상태가 유실됐다.
             b"lock" => common.locked = attr_str(&attr) == "1",
+            // [#5716] groupLevel — 종전 미파싱으로 그룹 멤버 OLE 의 중첩 레벨이
+            // 왕복 시 0 으로 유실됐다(직렬화기 하드코딩도 같은 이슈에서 제거).
+            b"groupLevel" => group_level = attr_str(&attr).parse().unwrap_or(0),
             _ => {}
         }
     }
@@ -7083,7 +7089,10 @@ fn parse_hp_ole_element(
     }
 
     let mut extent: Option<(i32, i32)> = None;
-    let mut shape_attr = ShapeComponentAttr::default();
+    let mut shape_attr = ShapeComponentAttr {
+        group_level,
+        ..Default::default()
+    };
     let mut caption: Option<crate::model::shape::Caption> = None;
     let mut line_shape: Option<crate::model::style::ShapeBorderLine> = None;
     parse_common_shape_children(

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -285,6 +285,10 @@ pub fn write_container_open<W: Write>(
     let z_order = common.z_order.to_string();
     let tw = text_wrap_str(common.text_wrap);
     let tf = text_flow_str(common.text_flow);
+    // [#5716] groupLevel 은 IR(shape_attr.group_level)을 보존한다. 종전 "0" 하드코딩은
+    // 다른 그룹의 멤버인 컨테이너의 중첩 레벨이 저장 시 전부 0 으로 유실됐다
+    // (리프 도형 경로는 #2746 에서 이미 보존 — 컨테이너 자신만 누락).
+    let group_level = sa.group_level.to_string();
 
     start_tag_attrs(
         w,
@@ -299,7 +303,7 @@ pub fn write_container_open<W: Write>(
             ("lock", bool01(common.locked)),
             ("dropcapstyle", "None"),
             ("href", ""),
-            ("groupLevel", "0"),
+            ("groupLevel", &group_level),
             ("instid", &id_str),
         ],
     )?;
@@ -373,6 +377,9 @@ pub(crate) fn write_ole<W: Write>(
     };
     // [#2931] 개체 잠금(lock) — IR(common.locked)을 보존(종전 "0" 하드코딩 제거).
     let lock = if c.locked { "1" } else { "0" };
+    // [#5716] groupLevel — 컨테이너와 동형. IR(drawing.shape_attr.group_level)을
+    // 보존한다(종전 "0" 하드코딩은 그룹 내 OLE 의 중첩 레벨을 저장 시 유실).
+    let group_level = ole.drawing.shape_attr.group_level.to_string();
 
     start_tag_attrs(
         w,
@@ -387,7 +394,7 @@ pub(crate) fn write_ole<W: Write>(
             ("lock", bool01(c.locked)),
             ("dropcapstyle", "None"),
             ("href", ""),
-            ("groupLevel", "0"),
+            ("groupLevel", &group_level),
             ("instid", &instid_str),
             ("objectType", "UNKNOWN"),
             ("binaryItemIDRef", &bidref),

--- a/tests/cases/issue_5716_group_level_roundtrip.rs
+++ b/tests/cases/issue_5716_group_level_roundtrip.rs
@@ -1,0 +1,116 @@
+//! Issue #5716: 중첩 그룹 컨테이너·그룹 멤버 OLE 의 `groupLevel` 이 HWPX 저장
+//! 왕복에서 보존되어야 한다.
+//!
+//! Regression shape (samples/task1771/nested_group_vectors.hwpx, 컨테이너 223개·
+//! 중첩 깊이 8):
+//! - 수정 전: `write_container_open`/`write_ole` 이 groupLevel 을 "0" 으로
+//!   하드코딩 → 컨테이너 groupLevel 분포(0~7)가 저장 시 전건 0 으로 붕괴
+//!   (리프 도형 경로는 #2746 에서 이미 보존). hp:ole 은 파서 arm 도 없어
+//!   HWPX 출신 그룹 멤버 OLE 는 파싱 단계에서부터 유실.
+//! - 수정 후: 컨테이너·OLE 모두 IR(shape_attr.group_level) 보존 값을 되쓴다.
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::model::control::Control;
+use rhwp::model::document::Document;
+use rhwp::model::shape::ShapeObject;
+use rhwp::parser::hwpx::parse_hwpx;
+use rhwp::serializer::hwpx::serialize_hwpx;
+
+const SAMPLE: &str = "samples/task1771/nested_group_vectors.hwpx";
+
+/// 도형 트리를 돌며 (컨테이너 여부, group_level) 를 평탄화 수집한다.
+fn collect_levels(shape: &ShapeObject, out: &mut Vec<(bool, u16)>) {
+    let is_group = matches!(shape, ShapeObject::Group(_));
+    out.push((is_group, shape.shape_attr().group_level));
+    if let ShapeObject::Group(g) = shape {
+        for child in &g.children {
+            collect_levels(child, out);
+        }
+    }
+}
+
+fn doc_levels(doc: &Document) -> Vec<(bool, u16)> {
+    let mut out = Vec::new();
+    for section in &doc.sections {
+        for para in &section.paragraphs {
+            for c in &para.controls {
+                if let Control::Shape(s) = c {
+                    collect_levels(s, &mut out);
+                }
+            }
+        }
+    }
+    out
+}
+
+fn load_sample() -> Document {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", SAMPLE, e));
+    parse_hwpx(&bytes).expect("parse hwpx")
+}
+
+#[test]
+fn issue_5716_container_group_level_survives_hwpx_roundtrip() {
+    let doc = load_sample();
+    let original = doc_levels(&doc);
+    let containers_nonzero = original
+        .iter()
+        .filter(|(is_group, lv)| *is_group && *lv > 0)
+        .count();
+    assert!(
+        containers_nonzero > 100,
+        "재현 전제: 중첩 컨테이너(groupLevel>0)가 다수여야 한다: {containers_nonzero}"
+    );
+
+    let out = serialize_hwpx(&doc).expect("serialize hwpx");
+    let reparsed = parse_hwpx(&out).expect("reparse hwpx");
+    let roundtripped = doc_levels(&reparsed);
+
+    assert_eq!(
+        roundtripped, original,
+        "컨테이너·리프의 groupLevel 분포가 왕복에서 그대로 보존되어야 한다"
+    );
+}
+
+#[test]
+fn issue_5716_ole_group_level_survives_hwpx_roundtrip() {
+    // 샘플의 hp:ole 은 최상위(groupLevel=0)뿐이라, 그룹 멤버 OLE 의 하드코딩·
+    // 파서 arm 부재는 IR 에 비영 값을 실어 왕복시켜 검출한다.
+    let mut doc = load_sample();
+    let mut seeded = 0usize;
+    for section in &mut doc.sections {
+        for para in &mut section.paragraphs {
+            for c in &mut para.controls {
+                if let Control::Shape(s) = c {
+                    if let ShapeObject::Ole(ole) = s.as_mut() {
+                        ole.drawing.shape_attr.group_level = 2;
+                        seeded += 1;
+                    }
+                }
+            }
+        }
+    }
+    assert!(seeded > 0, "재현 전제: 샘플에 hp:ole 이 있어야 한다");
+
+    let out = serialize_hwpx(&doc).expect("serialize hwpx");
+    let reparsed = parse_hwpx(&out).expect("reparse hwpx");
+    let mut preserved = 0usize;
+    for section in &reparsed.sections {
+        for para in &section.paragraphs {
+            for c in &para.controls {
+                if let Control::Shape(s) = c {
+                    if let ShapeObject::Ole(ole) = s.as_ref() {
+                        assert_eq!(
+                            ole.drawing.shape_attr.group_level, 2,
+                            "hp:ole groupLevel 이 왕복에서 보존되어야 한다"
+                        );
+                        preserved += 1;
+                    }
+                }
+            }
+        }
+    }
+    assert_eq!(preserved, seeded, "OLE 개수 보존");
+}


### PR DESCRIPTION
> PR base: `devel` / 작업 브랜치는 최신 `upstream/devel`(fb434269) 기준입니다.

## 변경 요약

HWPX 저장 시 `hp:container`(중첩 그룹 컨테이너)와 `hp:ole`의 `groupLevel` 속성이 `"0"`으로 하드코딩되어 파싱된 IR 값(`shape_attr.group_level`)이 유실되는 문제를 수정합니다.

- **serializer**: `write_container_open`·`write_ole`(src/serializer/hwpx/shape.rs)이 리프 도형 경로(#2746의 hp:pic과 동형)와 같이 IR 보존 값을 방출합니다.
- **parser**: `parse_hp_ole_element`(src/parser/hwpx/section.rs)에 `groupLevel` 속성 arm을 추가합니다 — 종전에는 arm이 없어 HWPX 출신 OLE는 파싱 단계에서부터 0으로 유실됐습니다.
- **회귀 테스트**: `tests/cases/issue_5716_group_level_roundtrip.rs` — 커밋된 샘플 `samples/task1771/nested_group_vectors.hwpx`(컨테이너 223개·중첩 깊이 8, 그중 217개가 groupLevel>0)의 parse→serialize→reparse 왕복에서 전 도형의 groupLevel 분포 보존을 고정합니다. 샘플의 hp:ole은 최상위(level 0)뿐이라 OLE 테스트는 IR에 비영 값을 주입해 왕복시키는 합성 방식입니다.

## 관련 이슈

closes #5716

### 범위 밖 인접 간극 (미해결로 남음)

`parse_container_body`의 자식 dispatch(src/parser/hwpx/section.rs:4662-4702)에 `b"ole"` arm이 없어, HWPX 원산 문서의 **그룹 멤버 hp:ole은 groupLevel 이전에 요소째 IR에서 드롭**됩니다. 따라서 이번 파서 arm은 run 레벨·차트 fallback 경로에서만 도달하고, 직렬화기 수정의 실효는 HWP5 원산 중첩 OLE의 HWPX 저장에 있습니다. 이 요소 드롭은 별개 결함이라 본 PR 범위에 넣지 않았습니다 — 필요하면 후속 이슈로 분리하겠습니다.

## 테스트

이 환경에 Rust 툴체인을 상주시킬 수 없어, **본 커밋을 fork devel에 반영해 동일 CI 전체를 사전 실행**했습니다: [fork CI run (success)](https://github.com/JamesPsh/rhwp/actions/runs/32440135239) — Lint(fmt/clippy/WASM)·빌더 3·테스트 워커 4 전부 success, 신규 테스트는 `regression_suite_025`에 자동 배정되어 실행됐습니다. [Proptest roundtrip](https://github.com/JamesPsh/rhwp/actions/runs/32440135154)·Adapter inter-diff·python-binding도 success.

- [x] **`cargo fmt --all -- --check` 통과** — fork CI Lint Format check success + 로컬에서 핀 버전(rustfmt 1.93.1) 단독 바이너리로 변경 3파일 `--check` 통과
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가 — `tests/generated/`·`tests/suites/manifest.json`·Cargo generated target 미포함
- [x] `src/**`의 `#[cfg(test)]` 변경 없음 (`node scripts/rust-unit-test-tiers.mjs --check` 통과: 4225 유지)
- [x] `cargo test` 통과 — fork CI Build & Test 4워커 success (위 링크)
- [x] `cargo clippy -- -D warnings` 통과 — fork CI Lint job success
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음 (렌더링 무관, 저장 속성 보존만 변경)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음 (동일 사유; CI WASM check는 success)
- [ ] rhwp-studio 편집·UI 변경 없음
- [ ] 작업 증빙 — 문서 편집 작업 아님 (재현·판정 근거는 #5716의 census와 본 PR 회귀 테스트)

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 (속성 1개를 리터럴 대신 IR 값 문자열로 방출, 파서 arm 1개 추가)
- 재현·측정: 미측정 (성능 경로 아님)
