### PR TITLE
test(#3315): Track 4 프로브에 표본 수 인자와 출처 표지를 더한다

### DIFF
--- a/rhwp-studio/e2e/probe-image-repaint-issue3315.mjs
+++ b/rhwp-studio/e2e/probe-image-repaint-issue3315.mjs
@@ -28,9 +28,16 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '../..');
 const JPEG_PATH = path.join(REPO_ROOT, 'samples/images/tiger01.jpg');
-const KEYS = 20;
-const REFRESHES = 20;
-const WARMUP = 5;
+const num = (name, def) => {
+  const hit = process.argv.find((a) => a.startsWith(`--${name}=`));
+  const v = hit ? Number(hit.split('=')[1]) : NaN;
+  return Number.isFinite(v) && v > 0 ? Math.floor(v) : def;
+};
+// sub-ms 구간에서는 표본이 적으면 타이머 해상도가 배율을 지배한다. 기본값으로도 판정이
+// 서지만, 경계에 걸리면 `--keys=200` 처럼 올려 다시 잰다.
+const KEYS = num('keys', 20);
+const REFRESHES = num('refreshes', 20);
+const WARMUP = num('warmup', 5);
 
 function arg(name, def) {
   const hit = process.argv.find((a) => a.startsWith(`--${name}=`));
@@ -170,6 +177,29 @@ async function measurePictureMove(page, info, n, warmup) {
 
 const fmt = (m) => `${m.mean.toFixed(2)} ms (median ${m.median.toFixed(2)}, max ${m.max.toFixed(2)})`;
 
+/**
+ * 무엇을 쟀는지 산출물에 남긴다.
+ *
+ * 이 프로브는 dev 서버가 서빙하는 번들을 잰다. 그 번들이 측정 대상 트리가 아니면 수치는
+ * 조용히 무의미해진다 — 실제로 그렇게 잘못 잰 적이 있다(#3315 Track 4 초회 측정: 서버가 다른
+ * 워크트리를 서빙해 Track 1~3 이전 상태를 쟀다). 트랙별 API 의 실재를 함께 적어 나중에
+ * 산출물만 보고도 판별할 수 있게 한다.
+ */
+async function captureProvenance(page) {
+  return page.evaluate(() => {
+    const w = window.__wasm;
+    const present = (n) => typeof w[n] === 'function';
+    return {
+      origin: location.origin,
+      trackApis: {
+        getPageFlowImageOps: present('getPageFlowImageOps'),
+        getPageSourceImageKeys: present('getPageSourceImageKeys'),
+        getSourceImageBytes: present('getSourceImageBytes'),
+      },
+    };
+  });
+}
+
 async function main() {
   if (!existsSync(JPEG_PATH)) throw new Error(`픽스처 없음: ${JPEG_PATH}`);
   const jpeg = readFileSync(JPEG_PATH);
@@ -180,6 +210,19 @@ async function main() {
   const out = { fixtureBytes: jpeg.length, keys: KEYS, refreshes: REFRESHES };
   try {
     await loadApp(page);
+
+    out.provenance = await captureProvenance(page);
+    const missingApis = Object.entries(out.provenance.trackApis)
+      .filter(([, ok]) => !ok).map(([n]) => n);
+    console.log(`[served] ${out.provenance.origin}`);
+    if (missingApis.length > 0) {
+      out.provenanceWarning = `Track 3 API 부재: ${missingApis.join(', ')}`;
+      console.log(`  !! ${out.provenanceWarning}`);
+      console.log('     서빙되는 트리가 측정 대상이 맞는지 확인하십시오 — 이 상태의 수치는');
+      console.log('     Track 1~3 이전을 잰 것일 수 있습니다.');
+    } else {
+      console.log('  Track 3 API 확인됨');
+    }
 
     console.log('\n=== A. 그림 없음 (베이스라인) ===');
     await createNewDocument(page);


### PR DESCRIPTION
관련 이슈: #3315 (Track 4)

## 문제

이 프로브(#5695)로 낸 **첫 Track 4 수치가 무효였습니다.** "타이핑 ×392 · 드래그 3fps · FAIL" 로
보고했는데, 실제 devel 은 **×1.62 · 4,348 fps · PASS** 입니다. 잘못된 근거로 이슈(#5694)까지
열었다가 닫았습니다.

원인 둘 다 **프로브가 막을 수 있는 것**이었습니다.

**① 서빙 트리를 확인하지 않았습니다.** dev 서버가 측정 대상이 아닌 다른 워크트리를 서빙하고
있었습니다(devel 보다 6,248 커밋 뒤, Track 3 의 좁은 질의가 아예 없는 상태). 프로브는 그 트리를
성실히 쟀고, 산출물만 봐서는 무엇을 쟀는지 알 수 없었습니다.

**② 표본이 적으면 sub-ms 구간에서 타이머 해상도가 배율을 지배합니다.** 같은 devel 을 표본 20
으로 재면 ×2.42(FAIL), 300 으로 재면 ×1.62(PASS) 로 판정이 갈립니다. Track 1~3 덕분에 절대값이
1 ms 아래로 내려오면서 기본 표본 20 이 부족해졌습니다.

## 원인

프로브가 **"무엇을 쟀는지" 를 산출물에 남기지 않았고**, 표본 수가 상수로 박혀 있었습니다.
`arg()` 헬퍼는 이미 있었지만 쓰이지 않았습니다.

## 변경

**출처 표지** — origin 과 트랙별 API 실재를 `provenance` 로 산출 JSON 에 남기고, 하나라도 없으면
경고를 찍습니다. Track 3 API(`getPageFlowImageOps`·`getPageSourceImageKeys`·
`getSourceImageBytes`)의 부재는 곧 "Track 1~3 이전 트리를 쟀다" 는 신호입니다.

```
[served] http://localhost:7701
  Track 3 API 확인됨
```

부재 시에는 `provenanceWarning` 이 JSON 에 남고 콘솔에 경고가 찍힙니다. 실행을 막지는 않습니다 —
의도적으로 옛 트리를 재는 비교 측정도 있을 수 있어, 판단은 사람이 합니다.

**표본 수 인자** — `--keys` · `--refreshes` · `--warmup`. 기본값은 종전과 같아 기존 호출은
그대로 동작합니다. 이미 있던 인자 파서를 씁니다.

## 검증

devel `bba0ba2d2` 기준.

- `--keys=300 --refreshes=300 --warmup=50` 재측정:

  | 항목 | 그림 없음 | JPEG 4.55MB 1장 | 배율 | 기준 |
  |---|---|---|---|---|
  | 타이핑 | 0.51 ms/키 | 0.82 ms/키 | ×1.62 | ×2 **PASS** |
  | `document-changed` | 0.00 ms | 0.00 ms | ×1.17 | ×2 **PASS** |
  | 개체 이동 1틱 | — | 0.23 ms (4,348 fps) | — | — |

  브리지 내역에서 `getPageLayerTree` 가 사라진 것도 확인했습니다 — Track 3 이 의도대로 동작합니다.
- 출처 표지가 `Track 3 API 확인됨` 을 찍는 것을 확인했습니다.
- e2e 매니페스트 게이트 `python3 scripts/check_e2e_manifest.py` — 파일 104개 / 행 104개, 이상 없음.
- 소스를 건드리지 않으므로 studio 단위 테스트·빌드·`cargo` 게이트에 영향이 없습니다.

정정 전문은 [#3315 코멘트](https://github.com/edwardkim/rhwp/issues/3315#issuecomment-5364589777)
이고, 무효 근거로 열었던 #5694 는 닫았습니다.

## 범위 외

- **서빙 트리 불일치 시 실행 중단** — 경고까지만 합니다. 옛 트리를 의도적으로 재는 비교 측정을
  막고 싶지 않습니다.
- **CI 편입** — 시간 수치는 머신 편차가 커 게이트로 쓰지 않습니다(종전 판단 유지).
