### PR TITLE
fix(#5769): after 스냅샷을 undo 시점에 잡아 undo 깊이를 49 → 98 로 늘린다

### DIFF
--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -2101,10 +2101,16 @@ export class SetFormValueCommand implements EditCommand {
  * Document 스냅샷을 이용한 Undo/Redo 명령.
  *
  * 역연산 구현이 복잡한 작업(붙여넣기, 객체 삭제 등)에 사용한다.
- * - 최초 실행: before 스냅샷 저장 → 작업 수행 → after 스냅샷 저장
- * - Undo: before 스냅샷으로 복원
- * - Redo: after 스냅샷으로 복원
- * - Discard: 양쪽 스냅샷 메모리 해제
+ * - 최초 실행: before 스냅샷 저장 → 작업 수행 (**after 는 저장하지 않는다**)
+ * - Undo: after 스냅샷 저장 → before 스냅샷으로 복원
+ * - Redo: after 스냅샷으로 복원 → 그 스냅샷 즉시 반환
+ * - Discard: 살아있는 스냅샷 메모리 해제
+ *
+ * **[Task #5769] after 는 undo 시점에 잡는다.** 이 명령이 undo 스택 top 이라는 것은
+ * 히스토리 불변식상 "현재 문서 == 이 명령 실행 직후 상태" 를 뜻하므로, 그때 찍어도 값이
+ * 같다. 그래서 undo 스택 엔트리는 스냅샷 id 를 **1개**만 점유한다(redo 스택 엔트리는 2개).
+ * 예산 98 기준 최악 undo 깊이가 49 → 98 로 배가된다. 복원 의미는 종전과 같은 문서 전체
+ * 치환이라 문서 충실도는 달라지지 않는다.
  */
 export class SnapshotCommand implements EditCommand {
   readonly type: string;
@@ -2113,6 +2119,16 @@ export class SnapshotCommand implements EditCommand {
   private beforeId: number | null = null;
   private afterId: number | null = null;
   private noOp = false;
+  /**
+   * 최초 실행이 끝났는가. redo 판별에 쓴다.
+   *
+   * 종전에는 `afterId !== null` 이 곧 "이미 실행됨" 이었지만, after 를 undo 시점에 잡게
+   * 되면서 그 등가가 깨졌다 — 실행 직후에도 `afterId` 는 `null` 이다. 플래그 없이 두면
+   * redo 가 최초 실행으로 오인돼 `beforeId` 를 덮어쓰고 앞의 스냅샷을 누수한다.
+   */
+  private executed = false;
+  /** undo 시점 after 저장에 실패해 redo 를 제공할 수 없는 상태인가. */
+  private redoUnavailable = false;
 
   /**
    * @param operationType 작업 종류 (예: 'pasteInternal', 'deleteControl')
@@ -2130,18 +2146,29 @@ export class SnapshotCommand implements EditCommand {
   }
 
   execute(wasm: WasmBridge): DocumentPosition {
-    if (this.afterId !== null) {
-      // Redo: after 스냅샷으로 복원
+    if (this.executed) {
+      // Redo: undo 시점에 잡아 둔 after 로 복원하고 **그 스냅샷을 즉시 반환한다** —
+      // 복원 뒤 이 명령은 undo 스택으로 돌아가고, 그러면 after 는 다시 "현재 문서" 와
+      // 같아져 들고 있을 이유가 없다. 이 반환이 없으면 undo↔redo 왕복마다 엔트리가
+      // 2슬롯으로 남아 지연 저장의 이득이 사라진다.
+      if (this.redoUnavailable || this.afterId === null) {
+        // undo 시점 after 저장이 실패한 명령이다. 조용히 성공한 척하면 문서가 그대로인
+        // 채 redo 스택만 움직여 이후 undo 가 어긋난다 — 히스토리의 실패시-드롭
+        // 하이브리드(#2328)가 이 엔트리를 걷어내도록 던진다.
+        throw new Error(`${this.type} redo 불가 — undo 시점 after 스냅샷 저장 실패`);
+      }
       wasm.restoreSnapshot(this.afterId);
+      wasm.discardSnapshot(this.afterId);
+      this.afterId = null;
       return { ...this.cursorAfter };
     }
 
-    // 최초 실행: before 저장 → 작업 수행 → after 저장
+    // 최초 실행: before 저장 → 작업 수행 (after 는 undo 시점에 잡는다)
+    this.executed = true;
     this.beforeId = wasm.saveSnapshot();
-    // [Task #2328] operation 또는 after-save 중 어느 것이 throw 하든 커맨드가
-    // 히스토리에 등록되지 못해 discard 주체가 사라진다 → 스냅샷 영구 누수(orphan
-    // → WASM 무통보 축출 재발). after-save(대용량 문서 클론 시 메모리 압박 등)까지
-    // try 범위에 포함해 before/after 를 대칭적으로 해제한다.
+    // [Task #2328] operation 이 throw 하면 커맨드가 히스토리에 등록되지 못해 discard
+    // 주체가 사라진다 → 스냅샷 영구 누수(orphan → WASM 무통보 축출 재발). 아래 catch 가
+    // before 를 대칭적으로 해제한다.
     try {
       if (this.operation) {
         const result = this.operation(wasm);
@@ -2155,11 +2182,10 @@ export class SnapshotCommand implements EditCommand {
         }
         this.cursorAfter = result;
       }
-      this.afterId = wasm.saveSnapshot();
     } catch (operationError) {
       // [#3350] 최초 execute 가 실패하면 명령 전체를 원자적으로 되돌린다. 이 커맨드는
       // history 에 push 되기 전이므로 before 스냅샷을 가진 SnapshotCommand만 rollback을
-      // 수행할 수 있다. after-save 실패도 execute 실패이므로 같은 계약을 따른다.
+      // 수행할 수 있다.
       try {
         if (this.beforeId !== null) {
           wasm.restoreSnapshot(this.beforeId);
@@ -2187,6 +2213,17 @@ export class SnapshotCommand implements EditCommand {
   }
 
   undo(wasm: WasmBridge): DocumentPosition {
+    // [Task #5769] after 를 여기서 잡는다. 이 명령이 undo 스택 top 이라는 것은
+    // "현재 문서 == 이 명령 실행 직후 상태" 라는 뜻이므로 실행 시점에 찍은 것과 값이 같다.
+    if (this.afterId === null && !this.redoUnavailable) {
+      try {
+        this.afterId = wasm.saveSnapshot();
+      } catch {
+        // 저장 실패로 **되돌리기 자체를 막지 않는다.** undo 는 수행하고 redo 만 포기한다 —
+        // 여기서 던지면 사용자의 Ctrl+Z 가 아무 일도 못 하고 히스토리 엔트리까지 잃는다.
+        this.redoUnavailable = true;
+      }
+    }
     if (this.beforeId !== null) {
       wasm.restoreSnapshot(this.beforeId);
     }

--- a/rhwp-studio/src/engine/history.ts
+++ b/rhwp-studio/src/engine/history.ts
@@ -52,14 +52,33 @@ export class CommandHistory {
    * 연속 축출한다. front 축출은 contiguous 하므로 bounded-history 시멘틱을
    * 지키며(오래된 것부터 사라짐), 스냅샷 커맨드를 discard 해 WASM id 를 즉시
    * 반환한다. 텍스트 커맨드가 front 에 있으면 함께 밀려나지만(0 id) 오래된
-   * 순서라 정합적이다. redo 스택은 새 명령 실행 시 항상 비워지므로 여기서만
-   * front 를 다룬다.
+   * 순서라 정합적이다.
    */
   private enforceSnapshotBudget(wasm: WasmBridge): void {
     while (this.liveSnapshotIds() > SNAPSHOT_ID_BUDGET && this.undoStack.length > 1) {
       const evicted = this.undoStack.shift();
       evicted?.discard?.(wasm);
     }
+  }
+
+  /**
+   * [Task #5769] undo 직후의 예산 강제.
+   *
+   * after 지연 저장(#5769) 이후 **undo 가 스냅샷 id 를 늘리는 연산이 됐다** — undo 스택
+   * 엔트리(1개)가 redo 스택 엔트리(2개)로 바뀌므로 매 undo 마다 +1 이다. execute 에서만
+   * 예산을 강제하던 종전 배선을 그대로 두면, 예산을 채운 상태에서 연속 undo 할 때 store 가
+   * WASM 상한을 넘어 **무통보 축출**이 발동한다 — #2328 이 근절한 그 회귀다.
+   *
+   * 축출 대상은 **redo 스택 bottom**(가장 먼 미래)이다. undo 중인 사용자가 지키려는 것은
+   * 과거이지 미래가 아니고, redo 는 top 부터 순서대로 소비되므로 bottom 을 걷어내도 남은
+   * redo 열은 top 기준으로 연속이다. redo 로 부족하면 종전 규칙대로 undo front 를 민다.
+   */
+  private enforceSnapshotBudgetAfterUndo(wasm: WasmBridge): void {
+    while (this.liveSnapshotIds() > SNAPSHOT_ID_BUDGET && this.redoStack.length > 1) {
+      const evicted = this.redoStack.shift();
+      evicted?.discard?.(wasm);
+    }
+    this.enforceSnapshotBudget(wasm);
   }
 
   private captureExecutionEffects(command: EditCommand): void {
@@ -133,7 +152,10 @@ export class CommandHistory {
   ): DocumentPosition | null {
     this.lastExecutionEffects = NO_TEXT_MUTATION_EFFECTS;
     const command = this.undoStack[this.undoStack.length - 1];
-    if (!command || command.type !== expectedType || command.snapshotResourceCount?.() !== 2) {
+    // [Task #5769] 최초 실행 직후의 스냅샷 명령은 before 하나만 들고 있다(after 는 undo
+    // 시점에 잡는다). 종전 상수 2 를 그대로 두면 이 경로가 영영 매칭되지 않아 rollback 이
+    // 조용히 죽는다.
+    if (!command || command.type !== expectedType || command.snapshotResourceCount?.() !== 1) {
       return null;
     }
     const cursorAfter = command.undo(wasm);
@@ -164,6 +186,11 @@ export class CommandHistory {
     }
     this.undoStack.pop();
     this.redoStack.push(command);
+    // [Task #5769] undo 가 스냅샷 id 를 늘리므로(엔트리 1 → 2) 여기서도 예산을 강제한다.
+    // 스택 이동 이후에 불러야 방금 늘어난 +1 이 계산에 포함된다.
+    if ((command.snapshotResourceCount?.() ?? 0) > 0) {
+      this.enforceSnapshotBudgetAfterUndo(wasm);
+    }
     return cursorAfter;
   }
 

--- a/rhwp-studio/tests/command-history-snapshot.test.ts
+++ b/rhwp-studio/tests/command-history-snapshot.test.ts
@@ -71,19 +71,45 @@ test('[결함2] redo 도 execute-우선 + 실패시-드롭 하이브리드다', 
   assert.match(catchBody, /throw/, 'catch 에서 rethrow');
 });
 
-test('[결함3] execute 는 operation·after-save 어느 throw 에도 스냅샷을 누수하지 않는다', () => {
+test('[결함3] execute 는 operation throw 에 스냅샷을 누수하지 않는다', () => {
   const block = methodBlock(command, 'execute(wasm: WasmBridge): DocumentPosition {');
   assert.match(block, /this\.beforeId = wasm\.saveSnapshot\(\);/, 'before 저장이 있어야 함');
-  // try 는 operation 과 after-save 를 모두 감싸야 한다 — after-save(대용량 클론
-  // 메모리 압박 등) throw 도 before 누수 → orphan 이므로 대칭 보호 필수.
-  assert.match(block, /try\s*\{[\s\S]*this\.operation\(wasm\)[\s\S]*this\.afterId = wasm\.saveSnapshot\(\)[\s\S]*\}\s*catch[\s\S]*throw/,
-    'operation 과 after-save 를 함께 try 로 감싸야 함(after-save 가 try 밖이면 누수)');
-  // catch 는 before/after 를 해제해야 한다(discard() 는 둘 다 null-safe 처리).
+  // [Task #5769] after 저장은 undo 로 옮겼다. execute 에 남은 유일한 throw 원천은
+  // operation 이고, 그것이 try 안에 있어야 before 누수(orphan)를 막는다.
+  assert.match(block, /try\s*\{[\s\S]*this\.operation\(wasm\)[\s\S]*\}\s*catch[\s\S]*throw/,
+    'operation 을 try 로 감싸야 함');
   assert.match(block, /catch[\s\S]*this\.discard\(wasm\)[\s\S]*throw/,
-    'catch 에서 discard(wasm)로 before/after 대칭 해제 후 rethrow 해야 함');
-  // after-save 가 try 밖(구 구조)이면 실패해야 한다 — catch 다음에 saveSnapshot 금지.
-  assert.ok(!/\}\s*catch[\s\S]*?throw;\s*\}\s*this\.afterId = wasm\.saveSnapshot/.test(block),
-    'after-save 가 catch 밖(try 이후)에 남아있음 — 누수 경로');
+    'catch 에서 discard(wasm)로 해제 후 rethrow 해야 함');
+  // execute 안에 after 저장이 남아 있으면 지연 저장이 무력화된다(엔트리가 다시 2슬롯).
+  assert.doesNotMatch(block, /this\.afterId = wasm\.saveSnapshot\(\)/,
+    '[#5769] execute 는 after 를 저장하지 않는다 — undo 시점에 잡는다');
+});
+
+test('[#5769] after 는 undo 에서 잡고, 저장 실패가 되돌리기를 막지 않는다', () => {
+  const block = methodBlock(command, 'undo(wasm: WasmBridge): DocumentPosition {');
+  const idxSave = block.indexOf('this.afterId = wasm.saveSnapshot()');
+  const idxRestore = block.indexOf('wasm.restoreSnapshot(this.beforeId)');
+  assert.ok(idxSave !== -1, 'undo 가 after 를 잡아야 redo 가 가능하다');
+  assert.ok(idxRestore !== -1 && idxSave < idxRestore,
+    'after 저장이 before 복원보다 먼저여야 한다 — 복원 뒤면 before 상태를 after 로 찍는다');
+  assert.match(block, /catch\s*\{[\s\S]*this\.redoUnavailable = true;/,
+    '저장 실패는 redo 만 포기하고 undo 는 계속해야 한다');
+  const catchEnd = block.indexOf('redoUnavailable = true');
+  assert.ok(block.indexOf('wasm.restoreSnapshot(this.beforeId)') > catchEnd,
+    '저장 실패 뒤에도 복원에 도달해야 한다(던지면 Ctrl+Z 가 먹통이 된다)');
+});
+
+test('[#5769] redo 는 after 로 복원한 뒤 그 스냅샷을 즉시 반환한다', () => {
+  const block = methodBlock(command, 'execute(wasm: WasmBridge): DocumentPosition {');
+  const redoArm = block.slice(0, block.indexOf('this.executed = true'));
+  assert.match(redoArm, /if \(this\.executed\)/,
+    'redo 판별은 executed 플래그여야 한다 — afterId 로는 실행 직후와 구분되지 않는다');
+  const idxRestore = redoArm.indexOf('wasm.restoreSnapshot(this.afterId)');
+  const idxDiscard = redoArm.indexOf('wasm.discardSnapshot(this.afterId)');
+  assert.ok(idxRestore !== -1 && idxDiscard !== -1 && idxRestore < idxDiscard,
+    '복원 후 반환해야 undo 스택으로 돌아간 엔트리가 1슬롯을 유지한다');
+  assert.match(redoArm, /throw new Error/,
+    'after 가 없으면 성공한 척하지 말고 던져야 한다(히스토리가 드롭한다)');
 });
 
 test('[#3350] 최초 execute 실패는 before 스냅샷 복원 후 ID를 해제한다', () => {
@@ -119,10 +145,12 @@ test('[#3350] 최초 execute 실패는 before 스냅샷 복원 후 ID를 해제�
     'rollback 실패 경로도 스냅샷 ID 를 해제해야 함');
 });
 
-test('[결함1] 스냅샷 예산은 WASM 상한에서 순간 +2 여유를 뺀 값이다', () => {
-  // 새 SnapshotCommand.execute 는 before/after 2개를 예산 강제 이전에 저장하므로,
-  // 예산 == MAX 면 그 순간 store 가 MAX 초과 → WASM 무통보 축출 → orphan.
-  // 예산 = MAX - 2 여야 순간 +2 가 MAX 를 넘지 않는다(인터리브 회귀 근절).
+test('[결함1] 스냅샷 예산은 WASM 상한에서 순간 여유를 뺀 값이다', () => {
+  // 예산 == MAX 면 예산 강제 이전의 순간 저장이 store 를 MAX 초과로 밀어 WASM 무통보
+  // 축출 → orphan 이 된다. 예산 = MAX - 2 여야 그 순간이 MAX 를 넘지 않는다.
+  // [Task #5769] after 지연 저장 이후 execute 의 순간 저장은 before 하나(+1)이고 undo 의
+  // 순간 저장도 +1 이라 여유 2 는 그대로 충분하다 — 상수는 Rust MAX_SNAPSHOTS 와
+  // 양방향 결합이므로 여유가 남는다고 좁히지 않는다.
   assert.match(history, /const WASM_MAX_SNAPSHOTS = 100;/,
     'WASM MAX_SNAPSHOTS(document.rs) 미러 상수가 있어야 함');
   assert.match(history, /const SNAPSHOT_ID_BUDGET = WASM_MAX_SNAPSHOTS - 2;/,
@@ -143,7 +171,26 @@ test('[결함1] 스냅샷 예산은 WASM 상한에서 순간 +2 여유를 뺀 �
   const idxPush = exec.indexOf('this.undoStack.push(command)');
   const idxEnforce = exec.indexOf('this.enforceSnapshotBudget(wasm)');
   assert.ok(idxPush !== -1 && idxEnforce !== -1 && idxPush < idxEnforce,
-    'execute 가 push 이후에 enforceSnapshotBudget 를 호출해야 함(전이면 +2 미반영)');
+    'execute 가 push 이후에 enforceSnapshotBudget 를 호출해야 함(전이면 미반영)');
+});
+
+test('[#5769] undo 도 스냅샷 id 를 늘리므로 undo 경로에서 예산을 강제한다', () => {
+  // after 지연 저장 이후 undo 는 엔트리를 1슬롯 → 2슬롯으로 바꾼다. execute 에서만
+  // 강제하면 예산을 채운 뒤 연속 undo 할 때 store 가 MAX 를 넘어 #2328 무통보 축출이
+  // 되살아난다.
+  const undoBlock = methodBlock(history, 'undo(wasm: WasmBridge): DocumentPosition | null {');
+  assert.match(undoBlock, /this\.enforceSnapshotBudgetAfterUndo\(wasm\)/,
+    'undo 도 예산을 강제해야 한다');
+  const idxPush = undoBlock.indexOf('this.redoStack.push(command)');
+  const idxEnforce = undoBlock.indexOf('enforceSnapshotBudgetAfterUndo');
+  assert.ok(idxPush !== -1 && idxEnforce !== -1 && idxPush < idxEnforce,
+    '스택 이동 이후에 강제해야 방금 늘어난 +1 이 반영된다');
+
+  // 축출은 redo 스택 bottom 부터 — undo 중인 사용자가 지키려는 것은 과거다.
+  const block = methodBlock(history, 'enforceSnapshotBudgetAfterUndo(wasm: WasmBridge): void {');
+  assert.match(block, /this\.redoStack\.shift\(\)/, 'redo bottom(가장 먼 미래)부터 축출');
+  assert.match(block, /this\.redoStack\.length\s*>\s*1/, '최소 1개 보존 가드');
+  assert.match(block, /this\.enforceSnapshotBudget\(wasm\)/, 'redo 로 부족하면 종전 규칙');
 });
 
 test('SnapshotCommand 는 점유 스냅샷 id 수를 보고한다(예산 계산용)', () => {
@@ -157,7 +204,8 @@ test('document-agent 미commit rollback은 exact 최신 snapshot만 폐기하고
     'rollbackUncommittedSnapshot(',
   );
   assert.match(block, /command\.type !== expectedType/, '다른 최신 명령을 되돌리면 안 됨');
-  assert.match(block, /snapshotResourceCount\?\.\(\) !== 2/, '완성된 before\/after snapshot만 대상');
+  assert.match(block, /snapshotResourceCount\?\.\(\) !== 1/,
+    '[#5769] 최초 실행 직후는 before 하나만 점유 — 상수 2 를 두면 이 경로가 죽는다');
   const undoAt = block.indexOf('command.undo(wasm)');
   const popAt = block.indexOf('this.undoStack.pop()');
   const discardAt = block.indexOf('command.discard?.(wasm)');

--- a/rhwp-studio/tests/issue-5769-deferred-after-snapshot.test.ts
+++ b/rhwp-studio/tests/issue-5769-deferred-after-snapshot.test.ts
@@ -1,0 +1,120 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'vite';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [#5769] after 스냅샷 지연 저장 — undo 스택 엔트리를 2슬롯에서 1슬롯으로 줄인다.
+//
+// 히스토리 불변식상 undo 스택 top 의 after 상태는 "지금 문서" 와 같다. 그래서 after 는
+// 실행 시점이 아니라 undo 시점에 찍어도 값이 같고, 그 사이에는 들고 있을 이유가 없다.
+// 예산 98 기준 최악 undo 깊이가 49 → 98 로 배가된다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+/** 스냅샷 id 발급·해제를 세는 최소 wasm 대역. */
+function fakeWasm() {
+  let next = 1;
+  const live = new Set<number>();
+  const log: string[] = [];
+  return {
+    live,
+    log,
+    saveSnapshot() {
+      const id = next++;
+      live.add(id);
+      log.push(`save:${id}`);
+      return id;
+    },
+    restoreSnapshot(id: number) {
+      assert.ok(live.has(id), `해제된 스냅샷 ${id} 복원 시도 — orphan`);
+      log.push(`restore:${id}`);
+    },
+    discardSnapshot(id: number) {
+      assert.ok(live.has(id), `이미 해제된 스냅샷 ${id} 재해제`);
+      live.delete(id);
+      log.push(`discard:${id}`);
+    },
+  };
+}
+
+const pos = (o: number) => ({ sectionIndex: 0, paragraphIndex: 0, charOffset: o });
+
+async function load() {
+  const vite = await createServer({
+    root: rootDir, appType: 'custom', logLevel: 'silent', server: { middlewareMode: true },
+  });
+  const mod = await vite.ssrLoadModule('/src/engine/command.ts');
+  return { vite, SnapshotCommand: mod.SnapshotCommand };
+}
+
+test('[#5769] 실행 직후 엔트리는 1슬롯, undo 하면 2슬롯, redo 하면 다시 1슬롯', async () => {
+  const { vite, SnapshotCommand } = await load();
+  try {
+    const w = fakeWasm();
+    const cmd: any = new SnapshotCommand('paste', pos(0), pos(5), () => pos(5));
+
+    cmd.execute(w);
+    assert.equal(cmd.snapshotResourceCount(), 1, '실행 직후는 before 하나뿐');
+    assert.equal(w.live.size, 1);
+
+    cmd.undo(w);
+    assert.equal(cmd.snapshotResourceCount(), 2, 'undo 가 after 를 잡는다(redo 대비)');
+
+    cmd.execute(w);
+    assert.equal(cmd.snapshotResourceCount(), 1, 'redo 뒤 after 는 반환한다');
+    assert.equal(w.live.size, 1, '살아있는 스냅샷도 하나로 돌아온다');
+
+    // 왕복을 반복해도 슬롯이 늘지 않는다(누수 없음).
+    for (let i = 0; i < 5; i++) { cmd.undo(w); cmd.execute(w); }
+    assert.equal(cmd.snapshotResourceCount(), 1, '왕복 반복에도 1슬롯 유지');
+    assert.equal(w.live.size, 1, '왕복 반복에도 누수 없음');
+  } finally { await vite.close(); }
+});
+
+test('[#5769] after 는 before 복원 **전에** 찍는다', async () => {
+  const { vite, SnapshotCommand } = await load();
+  try {
+    const w = fakeWasm();
+    const cmd: any = new SnapshotCommand('paste', pos(0), pos(5), () => pos(5));
+    cmd.execute(w);
+    const beforeId = 1;
+    w.log.length = 0;
+    cmd.undo(w);
+    const idxSave = w.log.findIndex((e) => e.startsWith('save:'));
+    const idxRestore = w.log.indexOf(`restore:${beforeId}`);
+    assert.ok(idxSave !== -1 && idxRestore !== -1 && idxSave < idxRestore,
+      'before 를 먼저 복원하면 after 로 before 상태가 찍힌다');
+  } finally { await vite.close(); }
+});
+
+test('[#5769] after 저장이 실패해도 undo 는 수행되고 redo 만 포기한다', async () => {
+  const { vite, SnapshotCommand } = await load();
+  try {
+    const w = fakeWasm();
+    const cmd: any = new SnapshotCommand('paste', pos(0), pos(5), () => pos(5));
+    cmd.execute(w);
+
+    const realSave = w.saveSnapshot.bind(w);
+    w.saveSnapshot = () => { throw new Error('OOM'); };
+    const at = cmd.undo(w);
+    assert.deepEqual(at, pos(0), '저장 실패와 무관하게 되돌리기는 수행된다');
+    assert.equal(cmd.snapshotResourceCount(), 1, 'after 는 없다');
+
+    w.saveSnapshot = realSave;
+    assert.throws(() => cmd.execute(w), /redo 불가/,
+      'redo 는 성공한 척하지 말고 던져야 한다 — 히스토리가 엔트리를 드롭한다');
+  } finally { await vite.close(); }
+});
+
+test('[#5769] 무변경 연산은 종전대로 아무 스냅샷도 남기지 않는다', async () => {
+  const { vite, SnapshotCommand } = await load();
+  try {
+    const w = fakeWasm();
+    const cmd: any = new SnapshotCommand('noop', pos(0), pos(0), () => null);
+    cmd.execute(w);
+    assert.equal(cmd.isNoOp(), true, '#2370 무변경 신호 유지');
+    assert.equal(w.live.size, 0, '무변경이면 before 도 즉시 해제');
+    assert.equal(cmd.snapshotResourceCount(), 0);
+  } finally { await vite.close(); }
+});


### PR DESCRIPTION
관련 이슈: #5769

## 문제

**실효 undo 깊이가 49 입니다.** 스냅샷 커맨드가 최초 실행에서 before/after 두 개를 즉시
저장해, undo 스택 엔트리 하나가 예산 98 중 2슬롯을 먹습니다. 한컴은 256 입니다.

## 원인

`SnapshotCommand.execute` 가 최초 실행에서 `beforeId` 와 `afterId` 를 **둘 다** 저장합니다.
그런데 그 `after` 는 그 명령이 undo 스택에 앉아 있는 동안 **아무도 읽지 않습니다** — redo 는
그 명령이 redo 스택으로 옮겨간 뒤에야 가능하기 때문입니다.

그리고 히스토리 불변식상 **undo 스택 top 의 after 상태는 곧 "지금 문서"** 입니다. 스택
`[C1, C2, C3]` 에서 C2 를 undo 하려면 C3 가 먼저 정확히 역실행돼 있어야 하고, 그 결과가 곧
after(C2) 입니다. 즉 after 는 **undo 하는 순간에 찍어도 값이 같습니다.**

## 변경

after 를 undo 시점으로 미룹니다. undo 스택 엔트리는 1슬롯, redo 스택 엔트리는 2슬롯이 됩니다.

- **최초 실행**은 before 만 저장합니다.
- **undo** 가 after 를 잡고 before 로 복원합니다. 저장이 `saveSnapshot` 실패로 안 되면
  **되돌리기는 그대로 수행하고 redo 만 포기합니다** — 여기서 던지면 사용자의 Ctrl+Z 가 아무
  일도 못 하고 히스토리 엔트리까지 잃습니다. 그 엔트리의 redo 는 던져서 히스토리의
  실패시-드롭 하이브리드(#2328)가 걷어내게 합니다.
- **redo** 는 after 로 복원한 뒤 **그 스냅샷을 즉시 반환합니다.** 복원 후 엔트리는 undo
  스택으로 돌아가고 after 는 다시 현재 문서와 같아지므로 들고 있을 이유가 없습니다.
  반환하지 않으면 undo↔redo 왕복마다 2슬롯으로 남아 이득이 사라집니다.
- redo 판별을 `executed` 플래그로 바꿉니다. `afterId !== null` 은 더 이상 "이미 실행됨" 과
  등가가 아닙니다 — 그대로 두면 redo 가 최초 실행으로 오인돼 `beforeId` 를 덮어쓰고
  앞의 스냅샷을 누수합니다.

### undo 경로에도 예산을 강제합니다

지연 저장으로 **undo 가 스냅샷 id 를 늘리는 연산이 됐습니다**(엔트리 1 → 2). `execute` 에서만
강제하던 종전 배선을 그대로 두면, 예산을 채운 뒤 연속 undo 할 때 store 가 WASM 상한을 넘어
**무통보 축출**이 발동합니다 — #2328 이 근절한 그 회귀입니다.

축출 대상은 **redo 스택 bottom**(가장 먼 미래)입니다. undo 중인 사용자가 지키려는 것은
과거이지 미래가 아니고, redo 는 top 부터 순서대로 소비되므로 bottom 을 걷어내도 남은 redo 열은
top 기준으로 연속입니다. redo 로 부족하면 종전 규칙대로 undo front 를 밉니다.

### 함께 맞춘 계약

`rollbackUncommittedSnapshot` 의 `snapshotResourceCount() !== 2` 게이트를 `!== 1` 로
바꿉니다. 최초 실행 직후는 before 하나만 점유하므로, 상수 2 를 두면 이 경로가 영영 매칭되지
않아 **조용히 죽습니다**(document-agent strict render gate 복구 경로).

**예산 상수(98)는 건드리지 않았습니다.** Rust `MAX_SNAPSHOTS` 와 양방향 결합이고, 순간 저장이
+2 에서 +1 로 줄어 여유는 오히려 늘었습니다.

## 검증

devel `bba0ba2d2` 기준.

- **수정 전/후 대조(브라우저 실측, 같은 스크립트)** — 스냅샷 300회 실행 후:

  | | undo 깊이 | 슬롯 | 연속 undo 60회 |
  |---|---|---|---|
  | devel 소스 | **49** | 98 | 49회 성공 |
  | 이 브랜치 | **98** | 98 | **60회 성공, 오류 없음, 이후 슬롯 97 ≤ 98** |

  연속 undo 가 예산을 무너뜨리지 않는 것까지 확인했습니다(#2328 회귀 검사).
- `tests/issue-5769-deferred-after-snapshot.test.ts` (4개) — 실행 직후 1슬롯 / undo 후 2슬롯 /
  redo 후 다시 1슬롯, **왕복 반복에도 누수 없음**, after 가 before 복원 **전**에 찍히는지,
  저장 실패 시 undo 는 수행되고 redo 만 포기하는지, #2370 무변경 경로 유지.
- `tests/command-history-snapshot.test.ts` — 계약이 바뀐 가드를 갱신했습니다(execute 안의
  after-save 요구 → undo 로 이동, rollback 게이트 2 → 1). 잠그는 불변식은 그대로이고
  **새 불변식 3개**를 더했습니다(undo 경로 예산 강제, redo bottom 축출, executed 플래그).
  10/10 통과.
- `npm --prefix rhwp-studio run test` — **1040 tests, 0 fail**(skipped 1 은 기존).
- `tsc --noEmit` 0 · `tsconfig.ci-unit.json` 0 · `npm run build` 0.
- Rust 를 건드리지 않으므로 `cargo` 게이트는 영향 없습니다.

## 범위 외

- **256 은 이 PR 로 닿지 않습니다.** 98 이 이 변경의 천장입니다. 다음은 이슈 ②
  (`DeleteSelectionCommand` 를 참 역연산으로) — 빈도 1등이고, `delete_range_native` 가 제거분을
  반환하지 않는 것이 선결 과제입니다.
- **예산 상수 상향** — 스냅샷 구성 실측에서 97~99% 가 `sections` 로 나와 배제했습니다(#5769
  본문 표). 라운드트립 생바이트를 전부 공유해도 1% 남짓입니다.
- **redo 깊이가 상황에 따라 달라지는 것은 새 동작입니다.** 엔트리 총합은 `U + 2R ≤ 98` 이라
  항상 종전(`U + R ≤ 49`) 이상이지만, 예산이 꽉 찬 상태에서 깊게 undo 하면 가장 먼 redo 부터
  사라집니다.
