### PR TITLE
fix(ci): review-only green 후보 실행을 재사용

### DIFF
--- a/.github/workflows/adapter-diff.yml
+++ b/.github/workflows/adapter-diff.yml
@@ -97,7 +97,9 @@ jobs:
               pull_number: pr.number,
               per_page: 100,
             });
-            let tailStart = commits.length;
+            const reviewOnlyCandidates = [];
+            let codeCandidateSha = '';
+            let newerTailCommit = null;
             for (let index = commits.length - 1; index >= 0; index -= 1) {
               const commit = commits[index];
               const detail = await github.rest.repos.getCommit({
@@ -106,23 +108,33 @@ jobs:
                 ref: commit.sha,
               });
               const commitFiles = detail.data.files || [];
-              if (commitFiles.length === 0 || commitFiles.length >= 300
-                || !commitFiles.every((file) => isAllowedReviewPath(file))) {
+              if (commitFiles.length === 0 || commitFiles.length >= 300) {
+                setResult(true, `unusable-file-list:${commit.sha}`);
+                return;
+              }
+              if (!commitFiles.every((file) => isAllowedReviewPath(file))) {
+                codeCandidateSha = commit.sha;
                 break;
               }
-              tailStart = index;
+              const parents = commit.parents || [];
+              if (parents.length !== 1
+                || (newerTailCommit && newerTailCommit.parents[0].sha !== commit.sha)) {
+                setResult(true, 'full-code-or-non-mydocs-change');
+                return;
+              }
+              reviewOnlyCandidates.push(commit.sha);
+              if (reviewOnlyCandidates.length > 20) {
+                setResult(true, 'review-tail-too-long');
+                return;
+              }
+              newerTailCommit = commit;
             }
-
-            const tail = commits.slice(tailStart);
-            const candidate = commits[tailStart - 1];
-            const linearTail = tail.length > 0 && tail.length <= 20 && candidate && tail.every((commit, index) => {
-              const expectedParent = index === 0 ? candidate.sha : tail[index - 1].sha;
-              return (commit.parents || []).length === 1 && commit.parents[0].sha === expectedParent;
-            });
-            if (!linearTail) {
+            if (reviewOnlyCandidates.length === 0 || !codeCandidateSha
+              || newerTailCommit.parents[0].sha !== codeCandidateSha) {
               setResult(true, 'full-code-or-non-mydocs-change');
               return;
             }
+            reviewOnlyCandidates.push(codeCandidateSha);
 
             const candidateRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
               owner: context.repo.owner,
@@ -131,26 +143,33 @@ jobs:
               event: 'pull_request',
               per_page: 100,
             });
-            const latestCandidateRun = candidateRuns
-              .filter((run) => (
-                run.event === 'pull_request'
-                && run.head_sha === candidate.sha
-                && run.head_branch === pr.head.ref
-                && run.head_repository?.id === pr.head.repo?.id
-              ))
-              .sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at))[0];
-            const runCreatedAt = Date.parse(latestCandidateRun?.created_at || '');
-            const pullCreatedAt = Date.parse(pr.created_at || '');
-            if (!latestCandidateRun || latestCandidateRun.status !== 'completed'
-              || latestCandidateRun.conclusion !== 'success'
-              || !Number.isFinite(runCreatedAt)
-              || !Number.isFinite(pullCreatedAt)
-              || runCreatedAt < pullCreatedAt) {
-              setResult(true, 'review-tail-candidate-run-unavailable');
+            for (const candidateSha of reviewOnlyCandidates) {
+              const latestCandidateRun = candidateRuns
+                .filter((run) => (
+                  run.event === 'pull_request'
+                  && run.head_sha === candidateSha
+                  && run.head_branch === pr.head.ref
+                  && run.head_repository?.id === pr.head.repo?.id
+                ))
+                .sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at))[0];
+              if (!latestCandidateRun || latestCandidateRun.status !== 'completed') {
+                core.info(`candidate not reusable yet: ${candidateSha}`);
+                continue;
+              }
+              const runCreatedAt = Date.parse(latestCandidateRun.created_at || '');
+              const pullCreatedAt = Date.parse(pr.created_at || '');
+              if (latestCandidateRun.conclusion !== 'success'
+                || !Number.isFinite(runCreatedAt)
+                || !Number.isFinite(pullCreatedAt)
+                || runCreatedAt < pullCreatedAt) {
+                setResult(true, 'review-tail-candidate-run-unavailable');
+                return;
+              }
+              setResult(false, `skip-trusted-mydocs-tail:${candidateSha}`);
               return;
             }
 
-            setResult(false, `skip-trusted-mydocs-tail:${candidate.sha}`);
+            setResult(true, 'review-tail-candidate-run-unavailable');
 
   adapter-diff:
     name: adapter inter-diff

--- a/.github/workflows/proptest-roundtrip.yml
+++ b/.github/workflows/proptest-roundtrip.yml
@@ -104,7 +104,9 @@ jobs:
               pull_number: pr.number,
               per_page: 100,
             });
-            let tailStart = commits.length;
+            const reviewOnlyCandidates = [];
+            let codeCandidateSha = '';
+            let newerTailCommit = null;
             for (let index = commits.length - 1; index >= 0; index -= 1) {
               const commit = commits[index];
               const detail = await github.rest.repos.getCommit({
@@ -113,23 +115,33 @@ jobs:
                 ref: commit.sha,
               });
               const commitFiles = detail.data.files || [];
-              if (commitFiles.length === 0 || commitFiles.length >= 300
-                || !commitFiles.every((file) => isAllowedReviewPath(file))) {
+              if (commitFiles.length === 0 || commitFiles.length >= 300) {
+                setResult(false, `unusable-file-list:${commit.sha}`);
+                return;
+              }
+              if (!commitFiles.every((file) => isAllowedReviewPath(file))) {
+                codeCandidateSha = commit.sha;
                 break;
               }
-              tailStart = index;
+              const parents = commit.parents || [];
+              if (parents.length !== 1
+                || (newerTailCommit && newerTailCommit.parents[0].sha !== commit.sha)) {
+                setResult(false, 'code-or-non-mydocs-change');
+                return;
+              }
+              reviewOnlyCandidates.push(commit.sha);
+              if (reviewOnlyCandidates.length > 20) {
+                setResult(false, 'review-tail-too-long');
+                return;
+              }
+              newerTailCommit = commit;
             }
-
-            const tail = commits.slice(tailStart);
-            const candidate = commits[tailStart - 1];
-            const linearTail = tail.length > 0 && tail.length <= 20 && candidate && tail.every((commit, index) => {
-              const expectedParent = index === 0 ? candidate.sha : tail[index - 1].sha;
-              return (commit.parents || []).length === 1 && commit.parents[0].sha === expectedParent;
-            });
-            if (!linearTail) {
+            if (reviewOnlyCandidates.length === 0 || !codeCandidateSha
+              || newerTailCommit.parents[0].sha !== codeCandidateSha) {
               setResult(false, 'code-or-non-mydocs-change');
               return;
             }
+            reviewOnlyCandidates.push(codeCandidateSha);
 
             const candidateRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
               owner: context.repo.owner,
@@ -138,26 +150,33 @@ jobs:
               event: 'pull_request',
               per_page: 100,
             });
-            const latestCandidateRun = candidateRuns
-              .filter((run) => (
-                run.event === 'pull_request'
-                && run.head_sha === candidate.sha
-                && run.head_branch === pr.head.ref
-                && run.head_repository?.id === pr.head.repo?.id
-              ))
-              .sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at))[0];
-            const runCreatedAt = Date.parse(latestCandidateRun?.created_at || '');
-            const pullCreatedAt = Date.parse(pr.created_at || '');
-            if (!latestCandidateRun || latestCandidateRun.status !== 'completed'
-              || latestCandidateRun.conclusion !== 'success'
-              || !Number.isFinite(runCreatedAt)
-              || !Number.isFinite(pullCreatedAt)
-              || runCreatedAt < pullCreatedAt) {
-              setResult(false, 'review-tail-candidate-run-unavailable');
+            for (const candidateSha of reviewOnlyCandidates) {
+              const latestCandidateRun = candidateRuns
+                .filter((run) => (
+                  run.event === 'pull_request'
+                  && run.head_sha === candidateSha
+                  && run.head_branch === pr.head.ref
+                  && run.head_repository?.id === pr.head.repo?.id
+                ))
+                .sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at))[0];
+              if (!latestCandidateRun || latestCandidateRun.status !== 'completed') {
+                core.info(`candidate not reusable yet: ${candidateSha}`);
+                continue;
+              }
+              const runCreatedAt = Date.parse(latestCandidateRun.created_at || '');
+              const pullCreatedAt = Date.parse(pr.created_at || '');
+              if (latestCandidateRun.conclusion !== 'success'
+                || !Number.isFinite(runCreatedAt)
+                || !Number.isFinite(pullCreatedAt)
+                || runCreatedAt < pullCreatedAt) {
+                setResult(false, 'review-tail-candidate-run-unavailable');
+                return;
+              }
+              setResult(true, `trusted-mydocs-tail:${candidateSha}`);
               return;
             }
 
-            setResult(true, `trusted-mydocs-tail:${candidate.sha}`);
+            setResult(false, 'review-tail-candidate-run-unavailable');
 
       - name: Finalize fast pass
         id: finalize

--- a/mydocs/orders/20260821.md
+++ b/mydocs/orders/20260821.md
@@ -6,6 +6,18 @@ date: 2026-08-21
 
 # 2026-08-21 오늘할 일
 
+## Review-only 후보 실행 재사용
+
+- [#5834](https://github.com/edwardkim/rhwp/issues/5834)의 #5832 재현을 수정했다. `af9ea69`처럼 review 문서와
+  신규 PDF 증적을 담았지만 Full CI가 성공한 head도 Adapter inter-diff·Proptest roundtrip의 후보로 다시
+  시도한다. 현재 head의 진행 중 run이나 없는 run은 더 이전 후보를 확인하고, 완료 실패·identity 불일치는
+  fail-closed로 worker를 실행한다.
+- [#5835](https://github.com/edwardkim/rhwp/pull/5835)의 code candidate `7ed4296`에서 workflow contract
+  171건, Python compile, `cargo fmt --all -- --check`, `git diff --check`를 완료했다. Rust·renderer 변경은
+  없으므로 전체 Cargo 회귀는 적용 대상이 아니다.
+- workflow 변경 PR이므로 review·오늘할일 trailing commit도 fast-pass로 취급하지 않는다. 최신 head의 Full CI,
+  CodeQL, Adapter inter-diff, Proptest roundtrip과 mergeability를 확인한 뒤 작업지시자 승인으로 merge한다.
+
 ## CI 통과 외부 PR 통합 검토
 
 - 최신 `upstream/devel@fb434269e` 위 `review/green-ci-20260821`에서 CI 성공·non-draft·mergeable 조건을

--- a/mydocs/pr/archives/pr_5835_review.md
+++ b/mydocs/pr/archives/pr_5835_review.md
@@ -1,0 +1,51 @@
+---
+kind: pr-review
+status: review-complete-pending-merge
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-21
+---
+
+# PR #5835 검토 - review-only green 후보 실행 재사용
+
+## 접수 메타데이터
+
+| 항목 | 검토 기록 |
+| --- | --- |
+| PR / 작성자 | [#5835](https://github.com/edwardkim/rhwp/pull/5835) / `jangster77` self-review |
+| 관련 issue | [#5834](https://github.com/edwardkim/rhwp/issues/5834) |
+| base / code candidate | `devel` / `7ed4296b581374477637a82c12d739bff99c93ef` |
+| source branch | `fix/5834-review-tail-candidate` |
+| 변경 규모 | 3 files, +210 / -58 |
+| 라우팅 | `collaborator_self_merge` + `intake_and_review` + `local_validation` |
+| GitHub 상태 | 작성 시점 Open, non-draft, `MERGEABLE`; workflow 변경 CI 실행 중이며 merge 전 최신 head 재확인 필요 |
+
+## 변경 범위와 판정
+
+[PR #5832](https://github.com/edwardkim/rhwp/pull/5832)에서는 Full CI가 성공한 `af9ea69`가 review 문서와
+신규 PDF 증적을 함께 담았다는 이유만으로 trailing tail에 소비됐다. 그 결과 Adapter inter-diff와
+Proptest roundtrip은 실제 green head 대신 이전 `47251a1`의 run을 찾았고,
+`review-tail-candidate-run-unavailable`으로 worker를 다시 실행했다.
+
+두 worker preflight를 CI·CodeQL·Render Diff와 같은 후보 탐색 방식으로 맞췄다. 최신 review-only commit부터
+차례로 같은 PR branch, source repository, PR 생성 이후 실행 조건을 확인한다. 현재 head의 run이 진행 중이거나
+없으면 더 이전 후보를 계속 확인하고, 완료 실패·identity 불일치는 즉시 fail-closed로 worker를 실행한다.
+후보 tail은 single-parent 20개 이하와 parent chain을 계속 요구한다.
+
+renderer, HWP/HWPX fixture, Rust source, 기준 PDF는 바꾸지 않았다. 시각 검증은 적용 대상이 아니다.
+
+## 로컬 검증
+
+- `python3 -m unittest discover -s scripts/tests -p 'test_*workflow*.py'`: **171 passed**.
+- `cargo fmt --all -- --check`: 통과.
+- `git diff --check`: 통과.
+- Python compile: `test_review_only_fast_pass_workflows.py`, `test_proptest_roundtrip_workflow.py`,
+  `test_adapter_diff_workflow.py` 통과.
+
+추가 계약은 #5832와 동일한 graph를 고정한다. green review-only head 뒤의 오늘할일 commit은 worker를 skip하며,
+그 green 후보가 실패한 경우에는 더 오래된 성공 run으로 우회하지 않고 worker를 실행한다. 기존 PDF/mydocs
+허용 경로, fork repository identity, modified PDF 거부도 함께 통과했다.
+
+## 최종 권고
+
+**수용 권고, 최신 GitHub Actions 승인 대기.** CI workflow를 바꾸므로 이 PR의 trailing review·오늘할일 commit도
+fast-pass 대상이 아니며, 최신 head의 Full CI·CodeQL·필요 check 성공과 작업지시자 승인을 확인한 뒤 merge한다.

--- a/scripts/tests/test_review_only_fast_pass_workflows.py
+++ b/scripts/tests/test_review_only_fast_pass_workflows.py
@@ -238,6 +238,120 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
                 )
                 self.assertEqual(output[output_name], skip_value)
 
+    def test_worker_preflights_reuse_a_green_review_only_candidate_head(
+        self,
+    ) -> None:
+        code_candidate = "c" * 40
+        green_review_head = "g" * 40
+        trailing_review = "r" * 40
+        files = [
+            {"filename": "src/renderer/layout.rs", "status": "modified"},
+            {"filename": "mydocs/pr/archives/pr_5832_review.md", "status": "added"},
+            {"filename": "pdf/pr_5832_reference.pdf", "status": "added"},
+            {"filename": "mydocs/orders/20260821.md", "status": "modified"},
+        ]
+        commits = [
+            {
+                "sha": code_candidate,
+                "parents": [{"sha": "b" * 40}],
+                "files": [{"filename": "src/renderer/layout.rs", "status": "modified"}],
+            },
+            {
+                "sha": green_review_head,
+                "parents": [{"sha": code_candidate}],
+                "files": [
+                    {"filename": "mydocs/pr/archives/pr_5832_review.md", "status": "added"},
+                    {"filename": "pdf/pr_5832_reference.pdf", "status": "added"},
+                ],
+            },
+            {
+                "sha": trailing_review,
+                "parents": [{"sha": green_review_head}],
+                "files": [{"filename": "mydocs/orders/20260821.md", "status": "modified"}],
+            },
+        ]
+        runs = [
+            {
+                "event": "pull_request",
+                "head_sha": trailing_review,
+                "head_branch": "fix/bughunt-batch-r3",
+                "head_repository": {"id": 7},
+                "status": "in_progress",
+                "conclusion": None,
+                "created_at": "2026-08-20T12:01:00Z",
+            },
+            {
+                "event": "pull_request",
+                "head_sha": green_review_head,
+                "head_branch": "fix/bughunt-batch-r3",
+                "head_repository": {"id": 7},
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": "2026-08-20T12:00:00Z",
+            },
+        ]
+        for name, (_, _, output_name, skip_value, _) in WORKER_PREFLIGHTS.items():
+            with self.subTest(workflow=name):
+                output = self._run_worker_preflight(
+                    name, files=files, commits=commits, runs=runs
+                )
+                self.assertEqual(output[output_name], skip_value)
+
+    def test_worker_preflights_do_not_bypass_a_failed_newer_candidate(
+        self,
+    ) -> None:
+        code_candidate = "c" * 40
+        failed_review_head = "f" * 40
+        trailing_review = "r" * 40
+        files = [
+            {"filename": "src/renderer/layout.rs", "status": "modified"},
+            {"filename": "mydocs/pr/archives/pr_5834_review.md", "status": "added"},
+            {"filename": "mydocs/orders/20260821.md", "status": "modified"},
+        ]
+        commits = [
+            {
+                "sha": code_candidate,
+                "parents": [{"sha": "b" * 40}],
+                "files": [{"filename": "src/renderer/layout.rs", "status": "modified"}],
+            },
+            {
+                "sha": failed_review_head,
+                "parents": [{"sha": code_candidate}],
+                "files": [{"filename": "mydocs/pr/archives/pr_5834_review.md", "status": "added"}],
+            },
+            {
+                "sha": trailing_review,
+                "parents": [{"sha": failed_review_head}],
+                "files": [{"filename": "mydocs/orders/20260821.md", "status": "modified"}],
+            },
+        ]
+        runs = [
+            {
+                "event": "pull_request",
+                "head_sha": failed_review_head,
+                "head_branch": "fix/bughunt-batch-r3",
+                "head_repository": {"id": 7},
+                "status": "completed",
+                "conclusion": "failure",
+                "created_at": "2026-08-20T12:00:00Z",
+            },
+            {
+                "event": "pull_request",
+                "head_sha": code_candidate,
+                "head_branch": "fix/bughunt-batch-r3",
+                "head_repository": {"id": 7},
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": "2026-08-20T11:59:00Z",
+            },
+        ]
+        for name, (_, _, output_name, _, full_value) in WORKER_PREFLIGHTS.items():
+            with self.subTest(workflow=name):
+                output = self._run_worker_preflight(
+                    name, files=files, commits=commits, runs=runs
+                )
+                self.assertEqual(output[output_name], full_value)
+
     def test_worker_preflights_reject_modified_pdf_and_wrong_fork_candidate(self) -> None:
         code_candidate = "c" * 40
         modified_pdf = "m" * 40


### PR DESCRIPTION
## 관련 이슈

- Closes #5834

## 원인

Adapter inter-diff와 Proptest roundtrip preflight가 허용된 review-only commit을 모두 tail로 소비해, 그중 Full CI가 성공한 head도 후보에서 제외했습니다. [PR #5832](https://github.com/edwardkim/rhwp/pull/5832)는 이 때문에 `review-tail-candidate-run-unavailable`으로 두 worker를 다시 실행했습니다.

## 변경

- review-only tail commit을 최신순 후보 목록으로 만들고, 현재 PR branch·repository·PR 생성 이후 실행 조건을 만족한 최신 성공 run을 순차적으로 재사용합니다.
- 현재 head의 진행 중 run과 없는 run은 더 이전 후보를 계속 탐색합니다. 가장 최근 완료 후보가 실패하거나 identity가 불일치하면 기존처럼 fail-closed로 worker를 실행합니다.
- #5832와 같은 graph, failed 후보 우회 금지, 기존 PDF/mydocs·fork identity 경로를 workflow contract test로 고정했습니다.

## 로컬 검증

- `python3 -m unittest discover -s scripts/tests -p "test_*workflow*.py"` — 171 passed
- `cargo fmt --all -- --check`
- `git diff --check`

## CI 기대

이 PR은 workflow를 변경하므로 trusted controller가 현재 head를 독립적으로 증명하기 전까지 Full CI가 정상입니다. 이후 review-only trailing commit은 새 preflight가 green review head를 재사용하는지 확인합니다.