### PR TITLE
fix(hwpx→hwp): 책갈피 이름을 HWP5 CTRL_DATA 로 되살린다 — 정답지와 바이트 동일 (#5838)

### DIFF
--- a/mydocs/report/task_m100_5838_report.md
+++ b/mydocs/report/task_m100_5838_report.md
@@ -1,0 +1,76 @@
+# task_m100_5838 처리결과 — HWPX 책갈피 이름을 HWP5 `CTRL_DATA` 로 되살린다
+
+- 이슈: [#5838](https://github.com/edwardkim/rhwp/issues/5838)
+- 기준: `0697bc559` (devel)
+- 관련: [#5249](https://github.com/edwardkim/rhwp/issues/5249)(같은 조사 축) · [#4396](https://github.com/edwardkim/rhwp/issues/4396)(경계)
+
+## 1. 결함
+
+HWPX 는 책갈피를 `<hp:fieldBegin type="BOOKMARK" name="_top">` 으로 싣는다. rhwp 는 `%bmk`
+컨트롤까지 정확히 방출하면서 **이름을 담는 `HWPTAG_CTRL_DATA` 를 만들지 않았다.**
+이름 없는 책갈피는 상호참조·하이퍼링크가 가리킬 대상이 되지 못한다.
+
+원인은 방출 조건 한 줄이다 — 이름 `CTRL_DATA` 를 `FieldType::ClickHere`(누름틀)에만 붙였다.
+HWPX 파서는 이미 `Field::ctrl_data_name` 을 채워 두고 있었다.
+
+## 2. 근거 — 정답지 바이트
+
+`samples/hwpx/aift.hwpx` ↔ 같은 문서의 한컴 저작본 `samples/aift.hwp`:
+
+| | `%bmk` | 그 아래 `CTRL_DATA` |
+|---|---:|---|
+| 정답지 | 1 | `1b02 01000000 0040 0100 0400 5f00 7400 6f00 7000` (ParameterSet 0x021b · item 0x4000 String `"_top"`) |
+| 종전 변환 | 1 | **없음** |
+| 수정 후 변환 | 1 | **정답지와 바이트 동일** |
+
+컨트롤 구성은 양쪽 다 134개·13종으로 같다. 사라지던 것은 이름뿐이었다.
+
+## 3. item ID 를 발명하지 않았다 (#4396 과의 경계)
+
+- 누름틀 경로가 **이미 쓰는 바이트 모양**과 같다(`samples/form-01.hwp` 역공학, 코드 주석에 기록).
+- 스펙 §4.2.10.11 은 책갈피에 대해 "책갈피 이름 밖에 없다"고 못박는다.
+- #4396 이 되돌린 것은 MEMO·수식의 `ResultFormat` 처럼 **스펙에 item ID 가 없는** named param
+  들이다. 이 건은 스펙과 정답지가 둘 다 있는 유일한 item ID 를 쓴다 — 반대 경우다.
+
+## 4. 변경
+
+`src/serializer/control.rs` — 이름 `CTRL_DATA` 방출 조건에 `FieldType::Bookmark` 추가.
+`ctrl_data_record.is_none()` 가드는 그대로라 **HWP5 원본에서 파싱한 raw 는 손대지 않는다.**
+
+`tests/cases/issue_5838_bookmark_ctrl_data.rs` (신규) — 변환 산출에서 `%bmk` 아래 `CTRL_DATA`
+를 뜯어 정답지와 바이트 비교하고, ParameterSet 머리(0x021b)·item id(0x4000)·이름 문자열까지 판정.
+
+## 5. 검증
+
+### red → green
+
+방출 조건에서 `Bookmark` 만 빼고 돌렸다.
+
+```
+test issue_5838_bookmark_ctrl_data::bookmark_name_survives_hwpx_to_hwp_and_matches_the_oracle ... FAILED
+    변환본에서 책갈피 이름 레코드가 사라졌다 (#5838): 0건
+```
+
+되돌리면 통과.
+
+### 실행한 것
+
+| 명령 | 결과 |
+|---|---|
+| `cargo test --lib -p rhwp` | **3,893 passed** / 13 ignored |
+| `cargo test --test regression_suite_020` (신규 계약 포함) | 115 passed / 2 ignored |
+| `cargo test --test regression_suite_001` (`hwpx_to_hwp_adapter`) | 74 passed / 15 ignored |
+| `cargo test --test regression_suite_028` (`convert_verify_corpus_ratchet`) | 126 passed / 2 ignored |
+| `rustfmt --edition 2021` (변경 파일; `control.rs` 는 스텁 디렉터리 사본으로 검사) | 차이 없음 |
+| `cargo clippy --all-targets -- -D warnings` | exit 0 |
+| `node scripts/rust-unit-test-tiers.mjs --check --base-ref origin/devel` | 4,225 tests (기준선 유지) |
+
+## 6. 조사에서 나온 "결함 아님" 기록
+
+같은 대조에서 걸렸지만 고칠 수 없거나 고칠 필요가 없는 것들이다.
+
+- `aift` 의 나머지 `CTRL_DATA` 10건 — 표 이름(`_표2.2`) 7건과 표 layout ParameterSet(0x0242)
+  3건. **원본 HWPX 에 그 값이 없다.**
+- `tbl`·`gso`·`eqed` 의 46 vs 48 바이트 — **버전 차이**. 48 은 5.1.1.0 저작본에서만 나오고
+  rhwp 는 5.1.0.0 으로 저장하므로 46 이 그 버전의 정답이다(#5249 의 규칙과 같은 축).
+- `PARA_RANGE_TAG` 소실(`온새미로` 104 → 0) — 원본 HWPX 에 범위 태그 요소 자체가 없다.

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -162,7 +162,21 @@ pub fn serialize_control(
             //   12..   UTF-16 LE 필드 이름 (예: "myMsg01")
             //
             // ctrl_data_name (HWPX `<hp:fieldBegin name="...">`) 우선, 비어있으면 생성 안 함.
-            if matches!(f.field_type, FieldType::ClickHere) && ctrl_data_record.is_none() {
+            //
+            // [#5838] 책갈피도 같은 자리를 쓴다. HWPX `<hp:fieldBegin type="BOOKMARK"
+            // name="_top">` 은 rhwp 에서 `Field{field_type: Bookmark}` 가 되어 이 경로로
+            // 오는데, 종전에는 ClickHere 만 CTRL_DATA 를 냈으므로 **책갈피 이름이 저장에서
+            // 통째로 사라졌다**(이름 없는 책갈피는 상호참조·하이퍼링크의 대상이 못 된다).
+            //
+            // 정답지 `samples/aift.hwp`(한컴 저작)는 같은 문서의 `%bmk` 컨트롤 아래에
+            // `ParameterSet ps_id=0x021b · item id=0x4000(String) = "_top"` 을 싣는다 —
+            // 위 ClickHere 구조와 **같은 바이트 모양**이다. 스펙(§4.2.10.11)도 책갈피는
+            // "책갈피 이름 밖에 없다"고 못박으므로 item ID 를 새로 발명할 필요가 없다
+            // (#4396 이 되돌린 것은 MEMO·수식의 이름 없는 named param 들이고, 이 건은
+            // 그 반대 — 스펙과 정답지가 둘 다 있는 유일한 item ID 다).
+            if matches!(f.field_type, FieldType::ClickHere | FieldType::Bookmark)
+                && ctrl_data_record.is_none()
+            {
                 if let Some(name) = &f.ctrl_data_name {
                     if !name.is_empty() {
                         let name_utf16: Vec<u16> = name.encode_utf16().collect();

--- a/tests/cases/issue_5838_bookmark_ctrl_data.rs
+++ b/tests/cases/issue_5838_bookmark_ctrl_data.rs
@@ -1,0 +1,152 @@
+//! [#5838] HWPX 책갈피의 이름이 HWP5 저장에서 사라진다.
+//!
+//! HWPX 는 책갈피를 `<hp:fieldBegin type="BOOKMARK" name="_top">` 으로 싣고, rhwp 는 그것을
+//! `Field{field_type: Bookmark}` 로 읽어 `%bmk` 컨트롤까지 정확히 방출한다. 그런데 이름을
+//! 담는 `HWPTAG_CTRL_DATA` 는 `ClickHere`(누름틀)에만 붙었으므로 **이름 없는 책갈피**가
+//! 저장됐다 — 상호참조·하이퍼링크가 가리킬 대상이 없어진다.
+//!
+//! 정답지는 같은 문서의 한컴 저작본이다. `samples/aift.hwp` 의 `%bmk` 아래에는
+//! `ParameterSet ps_id=0x021b · item id=0x4000(String) = "_top"` 이 있고, 이는 누름틀
+//! 경로가 이미 쓰던 바이트 모양과 같다(스펙 §4.2.10.11 "책갈피는 이름 밖에 없다").
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+const HWPTAG_CTRL_HEADER: u16 = 0x010 + 55;
+const HWPTAG_CTRL_DATA: u16 = 0x010 + 71;
+/// ctrl_id 는 big-endian 으로 조립해 u32 LE 로 실린다.
+const CTRL_BOOKMARK: u32 =
+    ((b'%' as u32) << 24) | ((b'b' as u32) << 16) | ((b'm' as u32) << 8) | b'k' as u32;
+
+fn records(buf: &[u8]) -> Vec<(u16, u16, Vec<u8>)> {
+    let mut out = Vec::new();
+    let mut off = 0usize;
+    while off + 4 <= buf.len() {
+        let header = u32::from_le_bytes([buf[off], buf[off + 1], buf[off + 2], buf[off + 3]]);
+        off += 4;
+        let tag = (header & 0x3FF) as u16;
+        let level = ((header >> 10) & 0x3FF) as u16;
+        let mut size = ((header >> 20) & 0xFFF) as usize;
+        if size == 0xFFF {
+            if off + 4 > buf.len() {
+                break;
+            }
+            size =
+                u32::from_le_bytes([buf[off], buf[off + 1], buf[off + 2], buf[off + 3]]) as usize;
+            off += 4;
+        }
+        let end = (off + size).min(buf.len());
+        out.push((tag, level, buf[off..end].to_vec()));
+        off = end;
+    }
+    out
+}
+
+/// 저장된 HWP5 에서 `%bmk` 컨트롤 바로 아래의 `CTRL_DATA` 페이로드를 모은다.
+fn bookmark_ctrl_data(hwp: &[u8]) -> Vec<Vec<u8>> {
+    let mut cfb = cfb::CompoundFile::open(std::io::Cursor::new(hwp.to_vec())).expect("CFB 열기");
+    let compressed = {
+        let mut stream = cfb.open_stream("/FileHeader").expect("FileHeader");
+        let mut buf = Vec::new();
+        std::io::Read::read_to_end(&mut stream, &mut buf).expect("FileHeader 읽기");
+        u32::from_le_bytes([buf[36], buf[37], buf[38], buf[39]]) & 1 == 1
+    };
+    let section_paths: Vec<std::path::PathBuf> = cfb
+        .walk()
+        .filter(|entry| {
+            let path = entry.path().to_string_lossy().into_owned();
+            entry.is_stream() && path.contains("BodyText") && path.contains("Section")
+        })
+        .map(|entry| entry.path().to_path_buf())
+        .collect();
+
+    let mut out = Vec::new();
+    for section_path in section_paths {
+        let mut stream = cfb.open_stream(&section_path).expect("Section 스트림");
+        let mut raw = Vec::new();
+        std::io::Read::read_to_end(&mut stream, &mut raw).expect("Section 읽기");
+        let body = if compressed {
+            let mut decoded = Vec::new();
+            let mut decoder = flate2::read::DeflateDecoder::new(&raw[..]);
+            std::io::Read::read_to_end(&mut decoder, &mut decoded).expect("Section 압축 해제");
+            decoded
+        } else {
+            raw
+        };
+        // level → 그 level 에서 마지막으로 본 컨트롤 이름.
+        let mut open: std::collections::BTreeMap<u16, u32> = std::collections::BTreeMap::new();
+        for (tag, level, data) in records(&body) {
+            if tag == HWPTAG_CTRL_HEADER && data.len() >= 4 {
+                open.insert(
+                    level,
+                    u32::from_le_bytes([data[0], data[1], data[2], data[3]]),
+                );
+            } else if tag == HWPTAG_CTRL_DATA
+                && level > 0
+                && open.get(&(level - 1)) == Some(&CTRL_BOOKMARK)
+            {
+                out.push(data);
+            }
+        }
+    }
+    out
+}
+
+fn convert_hwpx_to_hwp_bytes(sample: &str) -> Vec<u8> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(sample);
+    let data = std::fs::read(&path).unwrap_or_else(|e| panic!("read {sample}: {e}"));
+    let mut doc = rhwp::parse_document(&data).unwrap_or_else(|e| panic!("parse {sample}: {e:?}"));
+    rhwp::document_core::converters::hwpx_to_hwp::convert_hwpx_to_hwp_ir(&mut doc);
+    rhwp::serializer::serialize_document(&doc).unwrap_or_else(|e| panic!("serialize: {e:?}"))
+}
+
+/// 변환본의 책갈피 이름 레코드가 한컴 정답지와 **바이트 동일**해야 한다.
+#[test]
+fn bookmark_name_survives_hwpx_to_hwp_and_matches_the_oracle() {
+    let converted = convert_hwpx_to_hwp_bytes("samples/hwpx/aift.hwpx");
+    let ours = bookmark_ctrl_data(&converted);
+
+    let oracle_bytes =
+        std::fs::read(Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/aift.hwp"))
+            .expect("정답지 읽기");
+    let oracle = bookmark_ctrl_data(&oracle_bytes);
+
+    assert_eq!(
+        oracle.len(),
+        1,
+        "정답지에는 이름 붙은 책갈피가 하나 있어야 한다"
+    );
+    assert_eq!(
+        ours.len(),
+        oracle.len(),
+        "변환본에서 책갈피 이름 레코드가 사라졌다 (#5838): {}건",
+        ours.len()
+    );
+    assert_eq!(
+        ours[0], oracle[0],
+        "책갈피 CTRL_DATA 가 정답지와 다르다\n  변환: {:02x?}\n  정답: {:02x?}",
+        ours[0], oracle[0]
+    );
+
+    // 실린 값이 실제로 이름인지까지 본다 — ParameterSet 0x021b · item 0x4000(String).
+    let payload = &ours[0];
+    assert_eq!(
+        u16::from_le_bytes([payload[0], payload[1]]),
+        0x021b,
+        "ParameterSet 머리(0x021b)가 아니다"
+    );
+    assert_eq!(
+        u16::from_le_bytes([payload[6], payload[7]]),
+        0x4000,
+        "item id 가 0x4000(필드 이름)이 아니다"
+    );
+    let chars = u16::from_le_bytes([payload[10], payload[11]]) as usize;
+    let name: String = char::decode_utf16(
+        payload[12..12 + chars * 2]
+            .chunks_exact(2)
+            .map(|pair| u16::from_le_bytes([pair[0], pair[1]])),
+    )
+    .map(|ch| ch.unwrap_or('\u{fffd}'))
+    .collect();
+    assert_eq!(name, "_top", "책갈피 이름이 원본과 다르다");
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님).
> 작업 브랜치는 최신 `upstream/devel`(`0697bc559`)에서 만들었습니다.

## 변경 요약

HWPX 는 책갈피를 `<hp:fieldBegin type="BOOKMARK" name="_top">` 으로 싣고, rhwp 는 그것을
`%bmk` 컨트롤까지 정확히 방출합니다. 그런데 **이름을 담는 `CTRL_DATA` 는 누름틀(ClickHere)에만**
붙어 있어서, 저장된 책갈피에 이름이 없었습니다. 이름 없는 책갈피는 상호참조·하이퍼링크가
가리킬 대상이 되지 못합니다.

같은 문서의 한컴 저작본과 대조한 결과입니다.

| | `%bmk` | 그 아래 `CTRL_DATA` |
|---|---:|---|
| 정답지 `samples/aift.hwp` | 1 | `1b02 01000000 0040 0100 0400 5f00 7400 6f00 7000` (ParameterSet `0x021b` · item `0x4000` String `"_top"`) |
| 종전 변환 | 1 | **없음** |
| 수정 후 | 1 | **정답지와 바이트 동일** |

컨트롤 구성은 양쪽 다 134개·13종으로 같습니다. 사라지던 것은 이름뿐이었습니다.

## item ID 를 새로 정하지 않았습니다 (#4396 과의 경계)

- 누름틀 경로가 **이미 쓰는 바이트 모양**과 같습니다 (`samples/form-01.hwp` 역공학,
  `serializer/control.rs` 주석에 구조가 그대로 적혀 있습니다).
- 스펙 §4.2.10.11 은 책갈피에 대해 "책갈피 이름 밖에 없다"고 못박습니다.
- [#4396](https://github.com/edwardkim/rhwp/issues/4396) 이 되돌린 것은 MEMO·수식의
  `ResultFormat` 처럼 **스펙에 item ID 가 없는** named param 들입니다. 이 건은 스펙과 정답지가
  둘 다 있는 유일한 item ID 를 씁니다 — 반대 경우입니다.

바뀌는 것은 방출 조건 한 줄이고, `ctrl_data_record.is_none()` 가드는 그대로라 **HWP5 원본에서
파싱한 raw `CTRL_DATA` 는 손대지 않습니다.**

## 어떻게 찾았나

같은 문서의 HWPX/HWP 쌍 30건을 변환해 레코드 태그별 개수·크기 프로파일을 대조했습니다
([#5249](https://github.com/edwardkim/rhwp/issues/5249) 에서 `secd` 하나에 썼던 방법을 전 태그로 넓힌 것). 동시대(5.1.x) 21쌍만 판정에 썼고,
`aift` 가 `CTRL_DATA` 11 → 0 으로 가장 크게 벌어져 `rhwp hwp5-ctrl-data-trace` 로 11건을
디코드해 이 건을 분리했습니다.

같은 조사에서 나온 **결함이 아닌** 것들도 처리결과 문서에 남겼습니다(다음 사람이 다시 파지 않도록).

- `aift` 나머지 10건은 표 이름(`_표2.2`)·표 layout ParameterSet(0x0242) — **원본 HWPX 에 값이 없습니다.**
- `tbl`·`gso`·`eqed` 46 vs 48 바이트 — **버전 차이**입니다(48 은 5.1.1.0 저작본 전용, rhwp 는 5.1.0.0 저장).
- `PARA_RANGE_TAG` 소실(`온새미로` 104 → 0) — 원본 HWPX 에 범위 태그 요소 자체가 없습니다.

## 관련 이슈

closes #5838

## 테스트

- [x] **정답지 바이트 대조**: 변환본 `%bmk` 아래 `CTRL_DATA` 가 한컴 저작본과 완전히 같은 바이트
- [x] **red→green**: 방출 조건에서 `Bookmark` 만 빼면
      `변환본에서 책갈피 이름 레코드가 사라졌다 (#5838): 0건` 으로 실패, 되돌리면 통과
- [x] `cargo test --lib -p rhwp` — **3,893 passed** / 13 ignored
- [x] `cargo test --test regression_suite_020` (신규 계약 포함) — 115 passed / 2 ignored
- [x] `cargo test --test regression_suite_001` (`hwpx_to_hwp_adapter`) — 74 passed / 15 ignored
- [x] `cargo test --test regression_suite_028` (`convert_verify_corpus_ratchet`) — 126 passed / 2 ignored
- [x] `rustfmt --edition 2021` 변경 파일 — 차이 없음
      (`control.rs` 는 `mod tests;` 가 있어 스텁 디렉터리 사본으로 검사했습니다. 이 환경은
      `cargo fmt --all` 이 Windows 명령행 한계로 `os error 206` 입니다)
- [x] `cargo clippy --all-targets -- -D warnings` — exit 0
- [x] `node scripts/rust-unit-test-tiers.mjs --check --base-ref origin/devel` — 4,225 tests
      (src 유닛 테스트 기준선 유지 — 새 계약은 `tests/` 에 두었습니다)

## 문서

- 처리결과: `mydocs/report/task_m100_5838_report.md`
