### PR TITLE
chore(docker): 쓰이지 않는 683MB 를 빌드 컨텍스트에서 뺀다

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,9 @@ mydocs/
 .git/
 *.wasm
 samples/
+# samples/ 와 같은 이유. Dockerfile 에는 COPY·ADD 가 없고 소스는 compose 의
+# 볼륨 마운트(`.:/app`)로 들어오므로, 빌드 컨텍스트로 보낸 것은 쓰이지 않는다.
+# 이 둘만 683MB 다 (pdf 711MB · tools/llm_verifier 559MB, 실측 739MB → 56MB).
+pdf/
+tools/
 rhwp-studio/node_modules/


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님).
> 작업 브랜치는 `devel`(`2afa53a5`)에서 만들었습니다.

두 번째로 기여하게 되어 기쁩니다. 첫 PR(#5758) 때 제가 잘못 짚은 것을 두 분이
차분히 짚어 주신 덕에 많이 배웠습니다. 이번에는 그때 배운 대로, 제보 전에
README 의 명령을 글자 그대로 돌려 전후를 재고 왔습니다.

## 변경 요약

`.dockerignore` 에 `pdf/` 와 `tools/` 두 줄을 더합니다.

빌드마다 **683MB 가 도커 데몬으로 전송되는데 한 바이트도 쓰이지 않습니다.**

## 왜 쓰이지 않나

`Dockerfile` 31줄에 **`COPY` 도 `ADD` 도 없습니다.** 전부 툴체인 설치와 사용자
생성이고, 소스는 `docker-compose.yml` 의 볼륨 마운트로 들어옵니다.

```yaml
volumes:
  - .:/app
```

빌드 컨텍스트로 보낸 것은 이미지에 들어가지 않으므로, 전송한 만큼이 그대로
버려집니다.

## 실측

같은 기기·같은 클론에서 `README` 의 명령 그대로 돌렸습니다.

```bash
cp .env.docker.example .env.docker
docker compose --env-file .env.docker build wasm
```

| | 전송량 |
| --- | --- |
| 전 | `Sending build context to Docker daemon  739MB` |
| 후 | `Sending build context to Docker daemon  56.25MB` |

**683MB · 92% 감소**입니다.

크기 내역 (`devel` 체크아웃 기준):

| 폴더 | 크기 | 내용 |
| --- | --- | --- |
| `pdf/` | 711MB | 309개 |
| `tools/` | 578MB | 559MB 가 `tools/llm_verifier/.../corpus` 의 TSV 17샤드 |

## 잃는 것이 없는지 확인했습니다

`.dockerignore` 는 **빌드 컨텍스트에만** 적용되고 볼륨 마운트는 건드리지
않습니다. 막은 뒤 컨테이너 안에서 확인했습니다.

```
$ docker compose run --rm --entrypoint sh dev -c 'ls /app/pdf | wc -l; ...'
pdf/   309 개
tools/ 119 개
corpus 17 개
```

그대로 있습니다.

## 빌드도 통과합니다

문서가 시키는 전체 명령(빌드 + 실행)까지 돌렸습니다.

```bash
docker compose --env-file .env.docker run --rm wasm
```

```
[INFO]: :-) Done in 3m 35s
[INFO]: :-) Your wasm pkg is ready to publish at /app/pkg.
```

`pkg/` 에 `rhwp.d.ts`(164KB) 등 산출물이 정상적으로 생성됐습니다.

## 선례

`samples/`(459MB) 가 이미 같은 이유로 들어가 있습니다. 그 옆에 두고, 주석에
근거를 남겼습니다.

`mydocs/` 처럼 **빌드에 필요한 것은 건드리지 않았습니다** — 거기에는 이미
`!mydocs/manual` 예외가 달려 있습니다(#4354).

---

## 끝으로 — 고맙습니다

문서를 텍스트·Markdown 으로 뽑는 **kayatext** 와, HWP·엑셀·워드를 PDF 로 바꾸고
합치는 **KayaPDF**(아직 미공개)를 만들고 있습니다. 둘 다 **HWP 를 읽는 일은
전적으로 rhwp 에 기대고 있습니다.**

맥에는 한컴 자동화 API 가 없어서 대안이 없습니다. rhwp 가 없었으면 이 도구들은
「엑셀만 되는 변환기」로 끝났을 겁니다. 공개해 주셔서 고맙습니다.

받기만 하는 관계가 되지 않으려고 돌려드릴 것을 따로 정리해 두고 하나씩 내고
있습니다. 앞으로도 쓰다가 걸리는 것이 있으면 재서 가져오겠습니다.
