### PR TITLE
fix(hwpx): 표 셀 안 구역 나누기를 secPr 로 내보낸다 — 한글이 폐기하던 45쪽·57,525자 복원 (#5873)

### DIFF
--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -695,7 +695,7 @@ pub(crate) fn render_hp_p_open(p: &Paragraph, id: u32, style_id_ref: u8) -> Stri
 
 /// 문단 첫 run 의 charPrIDRef. IR의 `char_shapes[0].char_shape_id` 사용.
 /// 비어있으면 0 (기본 글자모양) 반환.
-fn first_run_char_shape_id(p: &Paragraph) -> u32 {
+pub(super) fn first_run_char_shape_id(p: &Paragraph) -> u32 {
     p.char_shapes.first().map(|r| r.char_shape_id).unwrap_or(0)
 }
 
@@ -711,7 +711,10 @@ fn first_run_char_shape_id(p: &Paragraph) -> u32 {
 /// 커스터마이즈 앵커(pagePr·visibility·scalars·footNotePr·pageBorderFill)가 모두 secPr
 /// 내부라 첫 구역과 같은 함수를 재사용한다. 바탕쪽(masterPage)은 이 경로에서 미지원
 /// (`masterPageCnt="0"` 유지) — 후속 구역의 바탕쪽은 드물다.
-fn build_secpr_run(sd: &SectionDef, first_cs: u32) -> String {
+///
+/// [#5873] 표 셀(subList) 안 문단도 같은 보완이 필요하다 —
+/// `table.rs::write_sub_list_paragraphs` 가 이 함수를 재사용한다.
+pub(super) fn build_secpr_run(sd: &SectionDef, first_cs: u32) -> String {
     let start = EMPTY_SECTION_XML
         .find("<hp:secPr ")
         .expect("템플릿에 secPr 열기 태그가 있어야 함");

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -34,7 +34,9 @@ use crate::model::shape::{
 use crate::model::table::{Cell, Table, TablePageBreak, VerticalAlign};
 
 use super::context::SerializeContext;
-use super::section::{render_hp_p_open, render_paragraph_parts};
+use super::section::{
+    build_secpr_run, first_run_char_shape_id, render_hp_p_open, render_paragraph_parts,
+};
 use super::shape::numbering_type_str;
 use super::utils::{empty_tag, end_tag, start_tag, start_tag_attrs};
 use super::SerializeError;
@@ -348,6 +350,17 @@ fn write_sub_list<W: Write>(
 /// 본문과 동일한 공유 직렬화 경로(render_paragraph_parts)로 컨트롤 슬롯(표 재귀
 /// 포함) 방출 + run 분할 + lineseg IR 보존/fallback (#1379 2단계).
 /// sub_list_depth: subList 경로 한정 colPr 인라인 방출 스코프 (#1379 3단계).
+///
+/// [#5873] 셀 안 문단이 구역 나누기(`SectionDef`)를 들고 있으면 `hp:secPr` 도 낸다.
+/// `render_runs` 는 `SectionDef` 슬롯을 hidden 처리해 XML 을 내지 않고, 본문 최상위
+/// 문단만 #4056 이 `write_section` 루프에서 보완해 왔다. subList 에는 그 보완이 없어
+/// 셀 안 구역이 통째로 사라졌다 — 뒤따르는 `hp:colPr` 만 남는다.
+///
+/// 코퍼스 HWP5 6,491문서 전수(레코드 단위): BodyText 스트림 수보다 `secd` 가 많은 문서
+/// 3건이고 그 **17개 전부 표 셀 안(level 3)** 이다. 그중 06874 는 `secd` 15개를 잃어
+/// 한글이 `부록 4-④` 문단부터 문서 끝까지 폐기했다(204→159쪽, −57,525자).
+/// 한글 2022 오라클 주입 검정: 그 자리 **한 곳에만** `secPr` 를 되살리면 쪽수·글자수가
+/// 원본과 정확히 같아지고 컨트롤 인구조사(`atno:6`·`fn:6`·`tbl:113`·`gso:41`)도 일치한다.
 fn write_sub_list_paragraphs<W: Write>(
     w: &mut Writer<W>,
     paragraphs: &[crate::model::paragraph::Paragraph],
@@ -364,6 +377,14 @@ fn write_sub_list_paragraphs<W: Write>(
         vert_cursor = advance;
         let pid = ctx.next_para_id();
         let mut p_xml = render_hp_p_open(para, pid, sid);
+        // [#5873] 셀 안 구역 나누기 — #4056 의 본문 경로와 같은 보완.
+        if let Some(crate::model::control::Control::SectionDef(sd)) = para
+            .controls
+            .iter()
+            .find(|c| matches!(c, crate::model::control::Control::SectionDef(_)))
+        {
+            p_xml.push_str(&build_secpr_run(sd, first_run_char_shape_id(para)));
+        }
         p_xml.push_str(&runs);
         p_xml.push_str(&linesegs);
         p_xml.push_str("</hp:p>");

--- a/tests/cases/issue_5873_cell_sec_pr.rs
+++ b/tests/cases/issue_5873_cell_sec_pr.rs
@@ -1,0 +1,161 @@
+//! [Issue #5873] 표 셀 안 구역 나누기(`secd`)를 HWPX 저장에서 통째로 버린다.
+//!
+//! `render_runs` 는 `SectionDef` 슬롯을 hidden 처리해 XML 을 내지 않는다. 본문 최상위
+//! 문단은 #4056 이 `write_section` 루프에서 `build_secpr_run` 으로 보완해 왔지만
+//! subList(셀) 경로에는 그 보완이 없어, 셀 안 구역이 `hp:secPr` 없이 뒤따르는
+//! `hp:colPr` 만 남았다.
+//!
+//! 실물 피해: 코퍼스 HWP5 6,491문서를 레코드 단위로 전수해 보면 BodyText 스트림 수보다
+//! `secd` 가 많은 문서가 3건이고 그 17개가 전부 표 셀 안(level 3)이다. 그중 06874 는
+//! 셀 안 `secd` 15개를 잃어 한글이 `부록 4-④` 문단부터 문서 끝까지 폐기했다
+//! (204→159쪽, −57,525자). 한글 2022 오라클 주입 검정에서 그 자리 **한 곳에만**
+//! `secPr` 를 되살리면 쪽수·글자수가 원본과 정확히 같아졌다.
+//!
+//! 계약: 셀 문단이 `Control::SectionDef` 를 들고 있으면 그 셀의 `hp:subList` 안에
+//! `hp:secPr` 가 나와야 한다. 본문 최상위 구역(#4056)은 종전대로 유지된다.
+
+use std::io::Read;
+
+use rhwp::model::control::Control;
+use rhwp::model::document::{Document, Section, SectionDef};
+use rhwp::model::page::PageDef;
+use rhwp::model::paragraph::Paragraph;
+use rhwp::model::style::{CharShape, ParaShape};
+use rhwp::model::table::{Cell, Table};
+
+fn secdef() -> SectionDef {
+    SectionDef {
+        page_def: PageDef {
+            width: 59528,
+            height: 84188,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn text_para(text: &str) -> Paragraph {
+    Paragraph {
+        text: text.to_string(),
+        char_count: text.chars().count() as u32,
+        ..Default::default()
+    }
+}
+
+/// 표 한 개, 둘째 셀의 첫 문단이 구역 나누기를 든 최소 문서.
+fn cell_sec_pr_document() -> Document {
+    let head = Cell {
+        col: 0,
+        row: 0,
+        col_span: 1,
+        row_span: 1,
+        width: 20000,
+        paragraphs: vec![text_para("검토 의견")],
+        ..Default::default()
+    };
+
+    let mut body_para = text_para("체계적으로 잘 정돈되어 있습니다.");
+    body_para
+        .controls
+        .insert(0, Control::SectionDef(Box::new(secdef())));
+    let body = Cell {
+        col: 0,
+        row: 1,
+        col_span: 1,
+        row_span: 1,
+        width: 20000,
+        paragraphs: vec![body_para],
+        ..Default::default()
+    };
+
+    let table = Table {
+        col_count: 1,
+        row_count: 2,
+        cells: vec![head, body],
+        ..Default::default()
+    };
+
+    let mut owner = text_para("부록");
+    owner.controls.push(Control::Table(Box::new(table)));
+
+    let mut section = Section::default();
+    section.section_def = secdef();
+    section.paragraphs.push(text_para("본문 첫 문단"));
+    section.paragraphs.push(owner);
+
+    let mut doc = Document::default();
+    // 직렬화기가 참조 무결성을 검사한다 — 문단/글자 모양 0번을 등록한다.
+    doc.doc_info.para_shapes = vec![ParaShape::default()];
+    doc.doc_info.char_shapes = vec![CharShape::default()];
+    doc.doc_properties.section_count = 1;
+    doc.sections.push(section);
+    doc
+}
+
+/// 저장된 HWPX 의 `Contents/section*.xml` 을 모두 이어 붙인다.
+fn section_xml(doc: &Document) -> String {
+    let bytes = rhwp::serializer::hwpx::serialize_hwpx(doc).expect("serialize hwpx");
+    let mut zin = zip::ZipArchive::new(std::io::Cursor::new(bytes)).expect("zip 열기");
+    let mut out = String::new();
+    for i in 0..zin.len() {
+        let mut f = zin.by_index(i).expect("zip 항목");
+        let name = f.name().to_string();
+        if name.starts_with("Contents/section") && name.ends_with(".xml") {
+            let mut s = String::new();
+            f.read_to_string(&mut s).expect("section xml 읽기");
+            out.push_str(&s);
+        }
+    }
+    out
+}
+
+/// 셀 안 구역 나누기가 `hp:subList` 안의 `hp:secPr` 로 나와야 한다.
+#[test]
+fn cell_section_def_is_emitted_as_sec_pr() {
+    let xml = section_xml(&cell_sec_pr_document());
+
+    // 구역 정의는 두 개다 — 구역 첫 문단(템플릿)과 셀 안 하나.
+    assert_eq!(
+        xml.matches("<hp:secPr ").count(),
+        2,
+        "셀 안 SectionDef 가 secPr 로 나오지 않았다 (#5873 회귀)\n{xml}"
+    );
+
+    // 그 두 번째 secPr 은 subList 안에 있어야 한다.
+    let second = xml
+        .match_indices("<hp:secPr ")
+        .nth(1)
+        .map(|(i, _)| i)
+        .expect("두 번째 secPr");
+    let before = &xml[..second];
+    let depth = before.matches("<hp:subList").count() - before.matches("</hp:subList>").count();
+    assert!(
+        depth > 0,
+        "셀 안 secPr 이 subList 밖으로 나갔다 (depth={depth}) — 셀 구역이 본문 구역이 된다"
+    );
+}
+
+/// 셀에 구역 나누기가 없으면 종전대로 구역 정의는 하나뿐이다.
+#[test]
+fn plain_cell_keeps_a_single_sec_pr() {
+    let mut doc = cell_sec_pr_document();
+    for section in doc.sections.iter_mut() {
+        for para in section.paragraphs.iter_mut() {
+            for ctrl in para.controls.iter_mut() {
+                if let Control::Table(t) = ctrl {
+                    for cell in t.cells.iter_mut() {
+                        for p in cell.paragraphs.iter_mut() {
+                            p.controls.retain(|c| !matches!(c, Control::SectionDef(_)));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let xml = section_xml(&doc);
+    assert_eq!(
+        xml.matches("<hp:secPr ").count(),
+        1,
+        "구역 나누기가 없는 셀에서 secPr 이 늘었다"
+    );
+}


### PR DESCRIPTION
load/save 서베이(s36) 잔존 경로 중 **가장 큰 미귀속 손실**이었던 `06874.h2x`(−45쪽·−57,525자)를
닫는다. 원인은 **표 셀 안 구역 나누기(`secd`)를 HWPX 저장에서 통째로 버리는 것**이었다.

Closes #5873

## 무엇이 잘못됐나

`render_runs` 는 `SectionDef` 슬롯을 hidden 처리해 XML 을 내지 않는다. 본문 최상위 문단은
#4056 이 `write_section` 루프에서 `build_secpr_run` 으로 보완해 왔지만 **subList(셀) 경로에는
그 보완이 없다**. 그래서 셀 안 구역은 `hp:secPr` 없이 뒤따르는 `hp:colPr` 만 남는다.

```xml
<hp:p id="2905" …><hp:run charPrIDRef="146">
  <hp:ctrl><hp:colPr id="" type="NEWSPAPER" layout="LEFT" colCount="1" sameSz="1" sameGap="0"/></hp:ctrl>
  <hp:t>체계적으로 잘 정돈되어 있어 …</hp:t>
</hp:run>
```

한글은 그 지점부터 문서 끝까지 본문을 폐기한다. `06874` 는 `부록 4-④` 문단부터 590줄이
사라진다(`4-①`·`②`·`③` 까지는 살아 있다). **`h2h` 는 OK** — 저장 축만 깨진다.

## 원인 확정 — 한글 2022 오라클 돌연변이 검정

산출본에서 출발해 되돌리는 역방향으로 쟀다(같은 큐에 정상 대조군 동반, 11쪽 유지).

| 변형 | 쪽수 | 글자수 | 읽는 법 |
|---|---|---|---|
| 원본 `.hwp` | 204 | 229,768 | 기준 |
| 산출본(재압축, 무변경) | 159 | 172,243 | 재현 |
| 고아 `colPr` **전부 제거** | **52** | 47,925 | 더 나빠짐 → `colPr` 은 원인이 아니다 |
| 그 자리 `colPr` 만 제거 | 159 | 172,243 | 무변화 |
| 고아 `colPr` 앞마다 `secPr` 주입 | **204** | **229,768** | 완전 복원 |
| **한 곳에만** `secPr` 주입 | **204** | **229,768** | 완전 복원 |

`secPr` **하나**가 45쪽을 가른다.

## 범위 — 코퍼스 HWP5 6,491문서 중 3문서

CFB 원본 전수를 레코드 단위로 걸어 "BodyText 스트림 수보다 `secd` 가 많은 문서"를 셌다.

```
docs with more secd than BodyText streams: 3   (total extra secd: 17)
  06874  streams=2  secd=17  nested=15
  03385  streams=1  secd=2   nested=1
  07718  streams=1  secd=2   nested=1
```

**17개 전부 표(`tbl `) 셀 안(level 3)** 이다 — 머리말·각주·글상자에는 없다. 그래서 수정은
`write_sub_list_paragraphs` 한 곳으로 충분하다.

## 수정 후 실측 (한글 2022, 12.0.0.535)

| 키 | 쪽수 | 글자수 | 본문 SHA-256 | `secd` |
|---|---|---|---|---|
| 06874 원본 | 204 | 229,768 | `21f0997f…` | 17 |
| 06874 수정 전 산출 | 159 | 172,243 | `e5f17378…` | 2 |
| **06874 수정 후 산출** | **204** | **229,768** | **`21f0997f…`** | **17** |
| 03385 원본 → 수정 후 | 30 → 30 | 51,337 → 51,337 | `9de216f8…` 동일 | 2 → 2 |
| 07718 원본 → 수정 후 | 1 → 1 | 1,175 → 1,175 | `04e3c8c1…` 동일 | 2 → 2 |

06874 산출의 한글 추출 본문이 원본과 **해시까지 같아지고**, 컨트롤 인구조사도
`%hlk:2,atno:6,cold:39,fn:6,gso:41,head:7,nwno:1,pghd:4,pgnp:5,secd:17,tbl:113` 로 원본과
완전히 일치한다. 이미 OK 였던 두 문서는 쪽수·본문 해시가 그대로이고 `secd` 만 원본 값으로 맞는다.

## 수정 전 실패 증명

새 통합 시험 `cell_section_def_is_emitted_as_sec_pr` 은 셀 문단이 `Control::SectionDef` 를
들었을 때 `<hp:secPr ` 이 **2개**(구역 첫 문단 템플릿 + 셀 안 하나)이고 두 번째가 `hp:subList`
안에 있어야 한다고 단언한다. 수정 전 방출은 템플릿 하나뿐이라(`count == 1`) 실패한다 —
위 오라클 표의 "수정 전 산출 `secd:2`"(= 두 section 파일의 템플릿 secPr 둘)와 같은 사실이다.

## 실행한 검증

```
cargo fmt --all -- --check                                                 # OK
node scripts/rust-unit-test-tiers.mjs --check                              # 4225 tests / 299 modules
cargo clippy --locked --all-targets --target-dir <별도> -- -D warnings      # OK
cargo nextest run --locked --cargo-profile release-test --target-dir <별도> \
  --tests --test-threads 4 --no-fail-fast                                  # 8046 passed, 0 failed (843.6s)
```

`tests/cases/issue_5873_cell_sec_pr.rs` 는 suite 자동 배정 전이라 임시 `[[test]]` target 으로
전체 실행에 함께 태워 통과를 확인하고(`PASS … tmp_check_5873` 2건) `Cargo.toml` 은 원복했다
(PR 에 포함하지 않음).

환경: Windows 11, devel `0f9ceeb19` 기준 워크트리. 코퍼스는 비공개 로컬 자료라 파일은 첨부하지
않고 문서 번호(s36 코퍼스 인덱스)와 집계만 적었다.
