### PR TITLE
fix: emit Hancom-compatible inserted equations

### DIFF
--- a/mydocs/orders/20260822.md
+++ b/mydocs/orders/20260822.md
@@ -7,10 +7,11 @@
 - [x] 원 PR의 구역 0/64 `instance_id` 충돌을 재현하고, source head
   `ac7c82d1f8bad2422b29a72bbbf59123ae336249` 위에 maintainer 보정 `3368a7336`을 분리했다.
 - [x] focused 계약 5건, 전체 nextest 8,161건, clippy, fmt, test manifest와 unit-tier 정책을 통과했다.
-- [ ] archive review 기록과 오늘할일을 source branch에 push한 뒤 새 code head의 Full CI·CodeQL·mergeable을
-  확인한다. code/test 보정이므로 fast-pass를 적용하지 않는다.
-- [ ] CI 성공과 merge 승인 뒤 PR을 merge하고, [#5891](https://github.com/edwardkim/rhwp/issues/5891) 상태를
-  확인한다. 첫 기여에 대한 환영과 구체적 보정·검증 근거를 PR/issue comment로 남긴 뒤 branch 정리를 한다.
+- [x] archive review 기록과 오늘할일을 source branch에 push하고, code candidate `4ba01d160`의 Full CI,
+  CodeQL, Adapter, Proptest와 mergeable `CLEAN`을 확인했다. 첫 기여자 보호 정책의 workflow 승인도 완료했다.
+- [ ] 실측 CI를 기록한 trailing docs-only commit의 fast-pass와 최신 head를 확인한 뒤 PR을 merge한다.
+- [ ] merge 뒤 [#5891](https://github.com/edwardkim/rhwp/issues/5891) 상태를 확인하고, 첫 기여에 대한 환영과
+  구체적 보정·검증 근거를 PR/issue comment로 남긴 뒤 branch 정리를 한다.
 
 ## #4962 W4 조판 위험 순위
 

--- a/mydocs/orders/20260822.md
+++ b/mydocs/orders/20260822.md
@@ -1,5 +1,17 @@
 # 2026-08-22 오늘할일
 
+## PR #5896 첫 기여자 수식 메타데이터 보정
+
+- [x] 작성자 `@Shadungi`가 GitHub `FIRST_TIME_CONTRIBUTOR`임을 확인하고 reviewer `@jangster77`을
+  요청했다.
+- [x] 원 PR의 구역 0/64 `instance_id` 충돌을 재현하고, source head
+  `ac7c82d1f8bad2422b29a72bbbf59123ae336249` 위에 maintainer 보정 `3368a7336`을 분리했다.
+- [x] focused 계약 5건, 전체 nextest 8,161건, clippy, fmt, test manifest와 unit-tier 정책을 통과했다.
+- [ ] archive review 기록과 오늘할일을 source branch에 push한 뒤 새 code head의 Full CI·CodeQL·mergeable을
+  확인한다. code/test 보정이므로 fast-pass를 적용하지 않는다.
+- [ ] CI 성공과 merge 승인 뒤 PR을 merge하고, [#5891](https://github.com/edwardkim/rhwp/issues/5891) 상태를
+  확인한다. 첫 기여에 대한 환영과 구체적 보정·검증 근거를 PR/issue comment로 남긴 뒤 branch 정리를 한다.
+
 ## #4962 W4 조판 위험 순위
 
 - [x] 최신 `upstream/devel@0f9ceeb19`을 `task_m100_4962`에 정상 병합하고 W3 Node 계약 47건,

--- a/mydocs/pr/archives/pr_5896_review.md
+++ b/mydocs/pr/archives/pr_5896_review.md
@@ -1,6 +1,6 @@
 ---
 kind: pr-review
-status: local-validated-pending-push
+status: trailing-docs-pending-ci
 canonical: mydocs/manual/pr_review_workflow.md
 last_verified: 2026-08-22
 ---
@@ -87,8 +87,23 @@ GitHub 상태값은 작성 시점 참고값이며, merge 전 최신 source head�
 모든 Cargo 검증은 `--locked`로 실행했다. 초기 검토 중 `--locked` 없이 실행해 발생했던
 `Cargo.lock`의 순서-only 변경은 즉시 되돌렸으며 현재 diff에 포함되지 않는다.
 
+## GitHub CI 실측 결과
+
+code candidate `4ba01d160555e65029b7ceaa36be1f65d0cd3833`의 첫 실행은 작성자의
+`FIRST_TIME_CONTRIBUTOR` 보호 정책으로 `action_required`가 되었고, reviewer `@jangster77`이
+현재 head에 대해 workflow를 승인했다. 동일 head의 두 번째 attempt에서 다음이 성공했다.
+
+- Build & Test, archive A/B/C build 및 shard A1/A2/B/C, Lint
+- CodeQL Rust, Python, JavaScript/TypeScript
+- Adapter inter-diff와 Proptest roundtrip
+- CI·CodeQL·Adapter·Proptest preflight
+
+Native Skia, WASM Build, frontend package/unit gates는 변경 범위 정책에 따른 skip이며 실패 검사는 없다.
+작성 시점 PR은 `MERGEABLE`, `CLEAN`이다. 이 trailing docs-only commit의 최신 head와 fast-pass는
+merge 직전에 다시 확인한다.
+
 ## 최종 판정
 
-**수용 권고, push 전.** 원 PR head 자체는 ID 충돌 때문에 그대로 merge할 수 없지만, maintainer
-보정과 공개 회귀시험은 로컬에서 통과했다. 아직 이 보정은 remote head에 없으므로, 커밋·push 뒤
-새 code head의 Full CI, CodeQL 및 필수 check를 다시 확인한 뒤에만 merge한다.
+**수용 권고, trailing CI 대기.** 원 PR head 자체의 ID 충돌은 maintainer 보정과 공개 회귀시험으로
+해소됐고, 보정 code candidate의 로컬 검증과 GitHub Full CI·CodeQL이 모두 성공했다. 이 기록 commit이
+허용된 review-only fast-pass를 통과하고 최신 head가 `CLEAN`이면 merge한다.

--- a/mydocs/pr/archives/pr_5896_review.md
+++ b/mydocs/pr/archives/pr_5896_review.md
@@ -1,0 +1,94 @@
+---
+kind: pr-review
+status: local-validated-pending-push
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-22
+---
+
+# PR #5896 검토 - 삽입 수식 한컴 호환 메타데이터
+
+## 접수 메타데이터
+
+| 항목 | 작성 시점 확인값 |
+| --- | --- |
+| PR / 작성자 | [#5896](https://github.com/edwardkim/rhwp/pull/5896) / [@Shadungi](https://github.com/Shadungi) |
+| 관련 issue | [#5891](https://github.com/edwardkim/rhwp/issues/5891) |
+| base / source head | `devel` `72674c5653f09cb78b994dc4cd2dfd0a97ae6c8a` / `ac7c82d1f8bad2422b29a72bbbf59123ae336249` |
+| 변경 규모 | 2 files, +65 / -2 |
+| 작성 시점 상태 | non-draft, `MERGEABLE`, maintainerCanModify=true, `FIRST_TIME_CONTRIBUTOR` |
+| reviewer | `@jangster77` 요청 완료 |
+| 로컬 검토 branch | `review/shadungi-20260822`, source head `ac7c82d1f8bad2422b29a72bbbf59123ae336249` 위 maintainer 보정 `3368a7336` |
+
+GitHub 상태값은 작성 시점 참고값이며, merge 전 최신 source head와 required check를 다시 확인한다.
+
+## 범위와 시각 검증 판정
+
+- `insert_equation_native`가 새 `Equation`의 HWP5 공통 개체 속성, 한컴 수식 메타데이터,
+  결정적 `instance_id` 및 `z_order`를 설정하도록 변경한다.
+- `insert_equation_contract`가 저장 후 재열기 경로에서 해당 메타데이터를 확인한다.
+- renderer, typeset, layout, visual fixture, 기준 PDF는 바뀌지 않는다. 본 PR은 저장 메타데이터
+  계약만 변경하므로 이번 검토에서는 visual sweep을 요구하지 않았다.
+
+## 원 PR 검증
+
+- 최신 `upstream/devel` 위 source head를 기준으로 검토했고, maintainer 보정 commit을 source head
+  위에 replay했다. `git merge-tree --write-tree upstream/devel HEAD`와
+  `git diff --check upstream/devel...HEAD`도 충돌·공백 오류 없이 통과했다.
+- `cargo fmt --all -- --check`를 통과했다.
+- `node scripts/rust-unit-test-tiers.mjs --check`를 통과했다.
+- `node scripts/rust-test-suite-manifest.mjs --prepare` 및 `--check`를 통과했다.
+- source head `ac7c82d1f8bad2422b29a72bbbf59123ae336249`의 GitHub Build & Test, Lint,
+  archive build/shard, CodeQL Rust/JavaScript/Python, Adapter inter-diff, Proptest roundtrip은
+  모두 성공했다. Native Skia, WASM Build, frontend gates는 변경 범위에 따른 skip이었다.
+
+## 발견한 차단 결함
+
+`src/document_core/commands/object_ops/equation.rs`의 `instance_id` 식은 구역 번호의 비트 6을
+상수 `0x4400_0000`에 이미 켜진 비트 26으로 OR한다.
+
+```rust
+0x4400_0000 | (((section_idx as u32) & 0xff) << 20) | equation_number
+```
+
+따라서 첫 수식의 ID가 구역 0과 구역 64에서 모두 `0x4400_0001`이고, 구역 128과 192에서도
+동일하다. 함수는 `section_idx < self.document.sections.len()`만 검사하고 구역 수 상한을 두지
+않으므로, 다구역 문서에서 이 충돌이 실제로 가능하다. 이는 PR과 #5891이 요구하는 0이 아닌
+결정적 고유 개체 ID 계약을 위반한다.
+
+현재 회귀시험은 ID가 0이 아니며 최상위 비트 조건을 만족하는지만 검사하므로 이 충돌을 잡지
+못한다. 보정 시에는 비트 영역이 겹치지 않는 ID 배정 규칙으로 바꾸고, 적어도 구역 0/64 및
+두 개 이상 삽입한 수식의 ID·`z_order`가 서로 다른지를 검증하는 회귀시험을 추가해야 한다.
+
+## 메인터너 보정
+
+승인된 maintainer 보정은 구역 번호를 ID 비트에 OR하지 않고, 문서 전체의 기존 `Equation` 수에
+기반한 1부터 `0x03ff_ffff`까지의 연속 순서를 `0x4400_0000`의 비중첩 하위 26비트에 배정한다.
+따라서 한컴 계열 `0x44` 접두는 유지하면서 구역 0과 64의 충돌을 제거하고, 수식별 `z_order`는
+기존처럼 각 구역의 수식 순서를 유지한다. 한도를 넘으면 wraparound 대신 명시적 오류를 반환한다.
+
+회귀시험은 source `#[cfg(test)]` 모듈이 아니라 `tests/cases/insert_equation_contract.rs`에 추가했다.
+이는 `local_validation.md`의 unit-tier 기준선을 늘리지 않고 공개 삽입 API 계약으로 검증하기 위함이다.
+65개 구역 문서에서 구역 0, 구역 64, 다시 구역 0에 삽입해 ID `0x44000001`, `0x44000002`,
+`0x44000003`과 구역별 `z_order` 0, 0, 1을 확인한다.
+
+## 보정 로컬 검증
+
+- `CARGO_TARGET_DIR=target/pr-review node scripts/run-rust-test.mjs insert_equation_contract -- --cargo-profile release-test --no-fail-fast`:
+  `5 passed, 119 skipped`.
+- `cargo nextest run --locked --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast`:
+  `8161 passed, 4 slow, 39 skipped` (190.204s).
+- `cargo clippy --locked --all-targets --target-dir target/pr-review -- -D warnings`,
+  `cargo fmt --all -- --check`, `git diff --check`를 통과했다.
+- `node scripts/rust-test-suite-manifest.mjs --prepare` 및 `--check`:
+  874 sources, 4113 static test attrs, 41/48 integration targets 확인.
+- `node scripts/rust-unit-test-tiers.mjs --check`:
+  4225 tests, 299 modules, ready 0 확인.
+
+모든 Cargo 검증은 `--locked`로 실행했다. 초기 검토 중 `--locked` 없이 실행해 발생했던
+`Cargo.lock`의 순서-only 변경은 즉시 되돌렸으며 현재 diff에 포함되지 않는다.
+
+## 최종 판정
+
+**수용 권고, push 전.** 원 PR head 자체는 ID 충돌 때문에 그대로 merge할 수 없지만, maintainer
+보정과 공개 회귀시험은 로컬에서 통과했다. 아직 이 보정은 remote head에 없으므로, 커밋·push 뒤
+새 code head의 Full CI, CodeQL 및 필수 check를 다시 확인한 뒤에만 merge한다.

--- a/mydocs/pr/archives/pr_5896_review_impl.md
+++ b/mydocs/pr/archives/pr_5896_review_impl.md
@@ -1,0 +1,47 @@
+---
+kind: pr-review-implementation
+status: local-validated-pending-push
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-22
+---
+
+# PR #5896 메인터너 보정 구현 기록
+
+## 시작점과 대상
+
+- base: `upstream/devel` `72674c5653f09cb78b994dc4cd2dfd0a97ae6c8a`
+- contributor source head: `ac7c82d1f8bad2422b29a72bbbf59123ae336249`
+- 메인터너 보정 commit: `3368a7336`
+- 관련 issue: #5891
+
+원 PR의 `instance_id`는 `0x4400_0000`과 `(section_idx << 20)`을 OR했다. 상수의 bit 26이
+이미 켜져 있으므로 section 0과 64의 첫 수식이 모두 `0x44000001`이 되는 차단 충돌을 확인했다.
+
+## 보정 내용
+
+1. `src/document_core/commands/object_ops/equation.rs`에서 문서 전체 기존 수식 수를 세고,
+   `0x4400_0000 | sequence` 형식으로 ID를 배정했다. sequence는 겹치지 않는 하위 26비트이며
+   1부터 `0x03ff_ffff`까지만 허용한다.
+2. 같은 파일에서 구역 내 수식 순서로 계산하던 `z_order`는 변경하지 않았다.
+3. `tests/cases/insert_equation_contract.rs`에 65개 구역을 사용하는 공개 API 회귀시험을 추가해
+   구역 0/64 ID 충돌과 구역별 z-order를 함께 고정했다. source `#[cfg(test)]` 수를 늘리지 않는
+   unit-tier 정책을 따른 위치다.
+
+## 로컬 검증
+
+- focused integration: `5 passed, 119 skipped`
+- full nextest: `8161 passed, 4 slow, 39 skipped` (190.204s)
+- `cargo clippy --locked --all-targets --target-dir target/pr-review -- -D warnings`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+- test manifest prepare/check 및 unit-tier check
+
+모든 Cargo 명령은 `--locked`를 사용했다. review 중 최초 one-off Cargo 호출이 만든
+`Cargo.lock` 순서-only 변경은 되돌려 최종 diff에 남기지 않았다.
+
+## 다음 절차와 복구
+
+이 문서와 검토 문서는 오늘할일과 함께 별도 기록 commit으로 만들고, source PR head에 fast-forward
+push한다. code 또는 test 보정이 포함되므로 fast-pass를 적용하지 않고 새 head의 Full CI와 CodeQL을
+확인한다. 보정이 수용되지 않으면 maintainer가 추가한 commit만 revert하고 contributor source commit은
+그대로 보존한다.

--- a/mydocs/pr/archives/pr_5896_review_impl.md
+++ b/mydocs/pr/archives/pr_5896_review_impl.md
@@ -1,6 +1,6 @@
 ---
 kind: pr-review-implementation
-status: local-validated-pending-push
+status: trailing-docs-pending-ci
 canonical: mydocs/manual/pr_review_workflow.md
 last_verified: 2026-08-22
 ---
@@ -41,7 +41,7 @@ last_verified: 2026-08-22
 
 ## 다음 절차와 복구
 
-이 문서와 검토 문서는 오늘할일과 함께 별도 기록 commit으로 만들고, source PR head에 fast-forward
-push한다. code 또는 test 보정이 포함되므로 fast-pass를 적용하지 않고 새 head의 Full CI와 CodeQL을
-확인한다. 보정이 수용되지 않으면 maintainer가 추가한 commit만 revert하고 contributor source commit은
-그대로 보존한다.
+code/test 보정과 첫 기록 commit은 source PR head에 fast-forward push했고, code candidate의 Full CI와
+CodeQL을 확인했다. 현재 trailing docs-only commit은 그 실측 결과를 고정하는 단계이며, fast-pass와
+최신 `CLEAN` 상태를 확인한 뒤 merge한다. 보정이 수용되지 않으면 maintainer가 추가한 commit만 revert하고
+contributor source commit은 그대로 보존한다.

--- a/src/document_core/commands/object_ops/equation.rs
+++ b/src/document_core/commands/object_ops/equation.rs
@@ -398,11 +398,24 @@ impl DocumentCore {
             .flat_map(|paragraph| paragraph.controls.iter())
             .filter(|control| matches!(control, Control::Equation(_)))
             .count() as u32;
-        // 한컴에서 만든 인라인 수식은 0이 아닌 고유 개체 ID를 사용한다. 삽입 API는
-        // 구역 안의 기존 수식 수를 기준으로 결정적인 ID와 z-order를 배정한다.
-        let instance_id = 0x4400_0000
-            | (((section_idx as u32) & 0xff) << 20)
-            | ((equation_order + 1) & 0x000f_ffff);
+        let equation_instance_order = self
+            .document
+            .sections
+            .iter()
+            .flat_map(|section| section.paragraphs.iter())
+            .flat_map(|paragraph| paragraph.controls.iter())
+            .filter(|control| matches!(control, Control::Equation(_)))
+            .count();
+        // 한컴 계열 0x44 접두는 유지하되, 접두와 겹치지 않는 하위 26비트에 문서 전체
+        // 수식 순서를 배정한다. 구역 번호를 OR하면 구역 0과 64가 같은 ID가 된다.
+        let equation_instance_sequence = u32::try_from(equation_instance_order)
+            .ok()
+            .and_then(|order| order.checked_add(1))
+            .filter(|&order| order <= 0x03ff_ffff)
+            .ok_or_else(|| {
+                HwpError::RenderError("수식 instance ID를 더 이상 배정할 수 없습니다.".to_string())
+            })?;
+        let instance_id = 0x4400_0000 | equation_instance_sequence;
         let equation = Equation {
             common: CommonObjAttr {
                 ctrl_id: CTRL_EQUATION,

--- a/src/document_core/commands/object_ops/equation.rs
+++ b/src/document_core/commands/object_ops/equation.rs
@@ -375,7 +375,7 @@ impl DocumentCore {
         color: u32,
     ) -> Result<String, HwpError> {
         use crate::model::control::Equation;
-        use crate::model::shape::CommonObjAttr;
+        use crate::model::shape::{CommonObjAttr, HorzRelTo, TextWrap, VertRelTo};
         use crate::parser::tags::CTRL_EQUATION;
 
         if section_idx >= self.document.sections.len() {
@@ -392,17 +392,47 @@ impl DocumentCore {
         }
 
         let (width, height) = crate::renderer::equation::intrinsic_size_hwp(script, font_size);
+        let equation_order = self.document.sections[section_idx]
+            .paragraphs
+            .iter()
+            .flat_map(|paragraph| paragraph.controls.iter())
+            .filter(|control| matches!(control, Control::Equation(_)))
+            .count() as u32;
+        // 한컴에서 만든 인라인 수식은 0이 아닌 고유 개체 ID를 사용한다. 삽입 API는
+        // 구역 안의 기존 수식 수를 기준으로 결정적인 ID와 z-order를 배정한다.
+        let instance_id = 0x4400_0000
+            | (((section_idx as u32) & 0xff) << 20)
+            | ((equation_order + 1) & 0x000f_ffff);
         let equation = Equation {
             common: CommonObjAttr {
                 ctrl_id: CTRL_EQUATION,
+                // 한컴 저장본의 인라인 수식 계약: 문단 기준 위치, 절대 크기,
+                // 글자처럼 취급, 글과 함께 이동, 위아래 배치.
+                attr: 0x0C2A_2311,
                 treat_as_char: true,
                 width,
                 height,
+                z_order: equation_order as i32,
+                margin: crate::model::Padding {
+                    left: 56,
+                    right: 56,
+                    top: 0,
+                    bottom: 0,
+                },
+                instance_id,
+                flow_with_text: true,
+                vert_rel_to: VertRelTo::Para,
+                horz_rel_to: HorzRelTo::Para,
+                text_wrap: TextWrap::TopAndBottom,
+                hwp5_gen_shape_attr_bit26: true,
+                description: "수식입니다.".to_string(),
                 ..Default::default()
             },
             script: script.to_string(),
             font_size,
             color,
+            baseline: 85,
+            version_info: "Equation Version 60".to_string(),
             font_name: "HYhwpEQ".to_string(),
             ..Default::default()
         };

--- a/tests/cases/insert_equation_contract.rs
+++ b/tests/cases/insert_equation_contract.rs
@@ -4,7 +4,8 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use rhwp::model::control::Control;
+use rhwp::model::control::{Control, Equation};
+use rhwp::model::shape::{HorzRelTo, TextWrap, VertRelTo};
 use rhwp::wasm_api::HwpDocument;
 
 fn rhwp_bin() -> String {
@@ -60,6 +61,21 @@ fn first_script(path: &Path) -> String {
     String::new()
 }
 
+fn equation_by_script(path: &Path, script: &str) -> Equation {
+    let bytes = std::fs::read(path).unwrap();
+    let doc = HwpDocument::from_bytes(&bytes).unwrap();
+    doc.document()
+        .sections
+        .iter()
+        .flat_map(|section| section.paragraphs.iter())
+        .flat_map(|paragraph| paragraph.controls.iter())
+        .find_map(|control| match control {
+            Control::Equation(eq) if eq.script == script => Some(eq.as_ref().clone()),
+            _ => None,
+        })
+        .expect("inserted equation must round-trip")
+}
+
 #[test]
 fn insert_equation_adds_control() {
     let src = sample();
@@ -83,6 +99,23 @@ fn insert_equation_adds_control() {
     assert_eq!(output.status.code(), Some(0), "{:?}", output);
     assert_eq!(eq_count(&out), before + 1);
     assert_eq!(first_script(&out), "a+b");
+
+    let equation = equation_by_script(&out, "a+b");
+    assert_eq!(equation.common.attr, 0x0C2A_2311);
+    assert!(equation.common.treat_as_char);
+    assert!(equation.common.flow_with_text);
+    assert_eq!(equation.common.vert_rel_to, VertRelTo::Para);
+    assert_eq!(equation.common.horz_rel_to, HorzRelTo::Para);
+    assert_eq!(equation.common.text_wrap, TextWrap::TopAndBottom);
+    assert_eq!(equation.common.margin.left, 56);
+    assert_eq!(equation.common.margin.right, 56);
+    assert_ne!(equation.common.instance_id, 0);
+    assert_ne!(equation.common.instance_id & 0x4000_0000, 0);
+    assert_eq!(equation.common.instance_id & 0x8000_0000, 0);
+    assert_eq!(equation.common.description, "수식입니다.");
+    assert_eq!(equation.baseline, 85);
+    assert_eq!(equation.version_info, "Equation Version 60");
+    assert_eq!(equation.font_name, "HYhwpEQ");
     let _ = std::fs::remove_file(&out);
 }
 

--- a/tests/cases/insert_equation_contract.rs
+++ b/tests/cases/insert_equation_contract.rs
@@ -76,6 +76,19 @@ fn equation_by_script(path: &Path, script: &str) -> Equation {
         .expect("inserted equation must round-trip")
 }
 
+fn equation_in_section(doc: &HwpDocument, section_idx: usize, script: &str) -> Equation {
+    doc.document().sections[section_idx].paragraphs[0]
+        .controls
+        .iter()
+        .find_map(|control| match control {
+            Control::Equation(equation) if equation.script == script => {
+                Some(equation.as_ref().clone())
+            }
+            _ => None,
+        })
+        .expect("inserted equation must exist")
+}
+
 #[test]
 fn insert_equation_adds_control() {
     let src = sample();
@@ -117,6 +130,34 @@ fn insert_equation_adds_control() {
     assert_eq!(equation.version_info, "Equation Version 60");
     assert_eq!(equation.font_name, "HYhwpEQ");
     let _ = std::fs::remove_file(&out);
+}
+
+#[test]
+fn insert_equation_assigns_unique_ids_across_sections() {
+    let mut doc = HwpDocument::create_empty();
+    let template = doc.document().sections[0].clone();
+    let mut document = doc.document().clone();
+    document.sections = vec![template; 65];
+    doc.set_document(document);
+
+    doc.insert_equation_native(0, 0, 0, "a", 1000, 0)
+        .expect("section 0 insert");
+    doc.insert_equation_native(64, 0, 0, "b", 1000, 0)
+        .expect("section 64 insert");
+    doc.insert_equation_native(0, 0, 0, "c", 1000, 0)
+        .expect("second section 0 insert");
+
+    let first = equation_in_section(&doc, 0, "a");
+    let other_section = equation_in_section(&doc, 64, "b");
+    let second = equation_in_section(&doc, 0, "c");
+
+    assert_eq!(first.common.instance_id, 0x4400_0001);
+    assert_eq!(other_section.common.instance_id, 0x4400_0002);
+    assert_eq!(second.common.instance_id, 0x4400_0003);
+    assert_ne!(first.common.instance_id, other_section.common.instance_id);
+    assert_eq!(first.common.z_order, 0);
+    assert_eq!(other_section.common.z_order, 0);
+    assert_eq!(second.common.z_order, 1);
 }
 
 #[test]


### PR DESCRIPTION
## 변경 요약

`insert_equation`이 만든 수식을 HWP로 저장할 때 공통 개체 배치 속성과 수식 메타데이터를
한컴 호환 값으로 완성한다. 공개 fixture를 저장·재열기한 뒤 모든 필드를 직접 검사하도록 기존
integration test를 보강했다.

변경 범위는 다음 두 파일뿐이다.

- `src/document_core/commands/object_ops/equation.rs`
- `tests/cases/insert_equation_contract.rs`

## 관련 이슈

closes #5891

## 수정 전 실패 증명

수정 커밋을 제외한 `devel`에서 보강된 시험이 다음 차이로 실패한다.

```text
inserted.attr: 0x000A0001
expected:      0x0C2A2311
```

## 테스트

- [x] `cargo fmt --all -- --check` 통과
- [x] 새 integration 원본은 기존 `tests/cases/insert_equation_contract.rs`에만 있으며 파생 harness/manifest는 미포함
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `cargo nextest run --locked --cargo-profile release-test --target-dir target/pr-review-current --tests --no-fail-fast` — `8159/8159` 통과, 39 skip
- [x] `CARGO_TARGET_DIR=target/current-upstream-clippy cargo clippy --locked --all-targets -- -D warnings` 통과
- [x] 관련 샘플 SVG 내보내기: 해당 없음 — 렌더러 변경이 아니라 HWP 수식 직렬화 메타데이터 수정
- [x] 웹(WASM) 렌더링: 해당 없음 — 공개 API와 렌더링 경로 변경 없음
- [x] Studio e2e: 해당 없음 — UI 변경 없음
- [ ] 작업 증빙 capsule: 미첨부 — 아래 재현 명령과 결정적 회귀시험 결과를 본문에 기록
- [x] capability 카탈로그: 해당 없음 — agent/skill 변경 없음

집중 시험은 공개 `samples/field-01.hwp`에 수식을 넣고 저장본을 다시 열어 다음 항목을 확인한다.

- 개체 attr, treat-as-char, 폭·높이, 여백, 흐름·기준 배치
- instance ID와 z-order
- description, baseline 85, Equation Version 60, HYhwpEQ

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음. 삽입 시 상수 필드 설정과 기존 수식 개수 조회만 수행한다.
- 재현·측정: 별도 벤치마크 미실시. 전체 회귀시험 통과.

## 에이전트 보조

Codex를 사용해 기존에 검증한 다운스트림 호환성 수정 중 현재 `devel`에 아직 필요한 부분만
재이식하고, 수정 전 실패와 수정 후 저장·재열기 회귀시험을 확인했다.

## 스크린샷

해당 없음. 바이너리 메타데이터를 결정적 자동 시험으로 검증한다.
