### PR TITLE
fix: emit strict MS-CFB container metadata

### DIFF
--- a/src/serializer/mini_cfb.rs
+++ b/src/serializer/mini_cfb.rs
@@ -38,6 +38,7 @@ struct DirEntry {
     left: u32,
     right: u32,
     child: u32,
+    color: u8,
     start_sector: u32,
     is_mini: bool,
     /// 디렉터리 엔트리 +80, 16바이트. OLE 개체는 이 값으로 서버를 식별한다 (#4097).
@@ -59,6 +60,7 @@ impl DirEntry {
             left: NOSTREAM,
             right: NOSTREAM,
             child: NOSTREAM,
+            color: 1,
             // Storage(1)는 start_sector=0 (MS-CFB 스펙: "SHOULD be set to all zeroes")
             // Root(5), Stream(2)은 ENDOFCHAIN → 나중에 실제 값으로 교체
             start_sector: if obj_type == 1 { 0 } else { ENDOFCHAIN },
@@ -468,12 +470,45 @@ fn build_tree(entries: &mut Vec<DirEntry>, idx: usize) {
     let root = build_balanced_tree(entries, &sorted);
     entries[idx].child = root;
 
+    // Midpoint BST의 leaf 깊이는 최대 깊이 또는 그보다 1 작다. 최하단 노드만
+    // red, 나머지를 black으로 두면 모든 NIL 경로의 black-height가 같아지고
+    // red-red 인접도 생기지 않는다. 각 자식 트리의 root는 항상 black이다.
+    let max_depth = tree_max_depth(entries, root, 0);
+    color_deepest_nodes(entries, root, 0, max_depth);
+
     // 하위 스토리지에 대해 재귀
     for &child_idx in &children {
         if entries[child_idx].obj_type == 1 {
             build_tree(entries, child_idx);
         }
     }
+}
+
+fn tree_max_depth(entries: &[DirEntry], idx: u32, depth: usize) -> usize {
+    if idx == NOSTREAM {
+        return depth.saturating_sub(1);
+    }
+    let entry = &entries[idx as usize];
+    tree_max_depth(entries, entry.left, depth + 1).max(tree_max_depth(
+        entries,
+        entry.right,
+        depth + 1,
+    ))
+}
+
+fn color_deepest_nodes(entries: &mut [DirEntry], idx: u32, depth: usize, max_depth: usize) {
+    if idx == NOSTREAM {
+        return;
+    }
+    let left = entries[idx as usize].left;
+    let right = entries[idx as usize].right;
+    entries[idx as usize].color = if depth > 0 && depth == max_depth {
+        0 // red
+    } else {
+        1 // black
+    };
+    color_deepest_nodes(entries, left, depth + 1, max_depth);
+    color_deepest_nodes(entries, right, depth + 1, max_depth);
 }
 
 /// 정렬된 인덱스 배열로 균형 이진 트리를 구축한다.
@@ -590,8 +625,8 @@ fn write_dir_entry(output: &mut [u8], offset: usize, entry: &DirEntry) {
     // Object type
     buf[66] = entry.obj_type;
 
-    // Color flag: 1 = black (유효한 red-black 트리)
-    buf[67] = 1;
+    // Color flag: 0 = red, 1 = black
+    buf[67] = entry.color;
 
     // Left sibling
     buf[68..72].copy_from_slice(&entry.left.to_le_bytes());

--- a/src/serializer/mini_cfb.rs
+++ b/src/serializer/mini_cfb.rs
@@ -282,7 +282,16 @@ pub fn build_cfb_with_root_clsid(
         difat_count,
     );
 
-    // 디렉토리 엔트리 작성
+    // 디렉토리 엔트리 작성. 마지막 디렉토리 섹터의 빈 슬롯은 object type 0인
+    // unallocated entry이면서 sibling/child ID가 모두 NOSTREAM이어야 한다.
+    for i in entries.len()..dir_sectors * ENTRIES_PER_DIR_SECTOR {
+        let sector_idx = i / ENTRIES_PER_DIR_SECTOR;
+        let entry_in_sector = i % ENTRIES_PER_DIR_SECTOR;
+        let offset = 512 + sector_idx * SECTOR_SIZE + entry_in_sector * DIR_ENTRY_SIZE;
+        output[offset + 68..offset + 72].copy_from_slice(&NOSTREAM.to_le_bytes());
+        output[offset + 72..offset + 76].copy_from_slice(&NOSTREAM.to_le_bytes());
+        output[offset + 76..offset + 80].copy_from_slice(&NOSTREAM.to_le_bytes());
+    }
     for (i, entry) in entries.iter().enumerate() {
         let sector_idx = i / ENTRIES_PER_DIR_SECTOR;
         let entry_in_sector = i % ENTRIES_PER_DIR_SECTOR;
@@ -305,8 +314,17 @@ pub fn build_cfb_with_root_clsid(
             .copy_from_slice(&entries[0].data);
     }
 
-    // 미니 FAT 작성
+    // 미니 FAT 작성. 할당되지 않은 슬롯은 FREESECT여야 한다. 출력 버퍼의
+    // 기본값 0은 관대한 파서에서는 통과하지만 strict CFB 검증에서는 실제
+    // sector 0을 가리키는 값으로 해석된다.
     if mini_fat_start != ENDOFCHAIN {
+        for sector_idx in 0..mini_fat_sector_count as usize {
+            let sector_base = 512 + (mini_fat_start as usize + sector_idx) * SECTOR_SIZE;
+            for entry_idx in 0..FAT_ENTRIES_PER_SECTOR {
+                let offset = sector_base + entry_idx * 4;
+                output[offset..offset + 4].copy_from_slice(&FREESECT.to_le_bytes());
+            }
+        }
         for (i, &mf) in mini_fat.iter().enumerate() {
             let sector_idx = i / FAT_ENTRIES_PER_SECTOR;
             let entry_in_sector = i % FAT_ENTRIES_PER_SECTOR;
@@ -316,7 +334,15 @@ pub fn build_cfb_with_root_clsid(
         }
     }
 
-    // FAT 작성
+    // FAT 작성. 마지막 FAT 섹터의 total_sectors 뒤 미사용 슬롯도 FREESECT로
+    // 초기화해야 한다.
+    for sector_idx in 0..fat_count as usize {
+        let sector_base = 512 + (fat_start as usize + sector_idx) * SECTOR_SIZE;
+        for entry_idx in 0..FAT_ENTRIES_PER_SECTOR {
+            let offset = sector_base + entry_idx * 4;
+            output[offset..offset + 4].copy_from_slice(&FREESECT.to_le_bytes());
+        }
+    }
     for (i, &fat_entry) in fat.iter().enumerate() {
         let fat_sector_idx = i / FAT_ENTRIES_PER_SECTOR;
         let entry_in_sector = i % FAT_ENTRIES_PER_SECTOR;

--- a/tests/cases/mini_cfb_strict_contract.rs
+++ b/tests/cases/mini_cfb_strict_contract.rs
@@ -1,0 +1,74 @@
+//! `mini_cfb` strict MS-CFB container contracts.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::serializer::mini_cfb;
+
+const SECTOR_SIZE: usize = 512;
+const MINI_SECTOR_SIZE: usize = 64;
+const DIR_ENTRY_SIZE: usize = 128;
+const DIR_ENTRIES_PER_SECTOR: usize = SECTOR_SIZE / DIR_ENTRY_SIZE;
+const FAT_ENTRIES_PER_SECTOR: usize = SECTOR_SIZE / 4;
+const FREESECT: u32 = 0xFFFF_FFFF;
+const NOSTREAM: u32 = 0xFFFF_FFFF;
+
+fn read_u32_at(bytes: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap())
+}
+
+#[test]
+fn unused_container_slots_use_required_sentinels() {
+    let owned = [
+        ("/SmallA", vec![0x11; 100]),
+        ("/SmallB", vec![0x22; 200]),
+        ("/SmallC", vec![0x33; 300]),
+        ("/Large", vec![0x44; 5_000]),
+    ];
+    let streams: Vec<_> = owned
+        .iter()
+        .map(|(path, data)| (*path, data.as_slice()))
+        .collect();
+    let entry_count = 1 + streams.len(); // Root Entry + four top-level streams
+    let bytes = mini_cfb::build_cfb(&streams).unwrap();
+
+    let total_sectors = (bytes.len() - SECTOR_SIZE) / SECTOR_SIZE;
+    let fat_count = read_u32_at(&bytes, 44) as usize;
+    assert_eq!(fat_count, 1, "fixture must use exactly one FAT sector");
+    let fat_sector = read_u32_at(&bytes, 76) as usize;
+    let fat_base = SECTOR_SIZE + fat_sector * SECTOR_SIZE;
+    for index in total_sectors..FAT_ENTRIES_PER_SECTOR {
+        assert_eq!(
+            read_u32_at(&bytes, fat_base + index * 4),
+            FREESECT,
+            "unused FAT entry {index}"
+        );
+    }
+
+    let mini_fat_start = read_u32_at(&bytes, 60) as usize;
+    let mini_fat_count = read_u32_at(&bytes, 64) as usize;
+    assert_eq!(
+        mini_fat_count, 1,
+        "fixture must use exactly one MiniFAT sector"
+    );
+    let first_dir_sector = read_u32_at(&bytes, 48) as usize;
+    let root_offset = SECTOR_SIZE + first_dir_sector * SECTOR_SIZE;
+    let used_mini_entries = read_u32_at(&bytes, root_offset + 120) as usize / MINI_SECTOR_SIZE;
+    let mini_fat_base = SECTOR_SIZE + mini_fat_start * SECTOR_SIZE;
+    for index in used_mini_entries..FAT_ENTRIES_PER_SECTOR {
+        assert_eq!(
+            read_u32_at(&bytes, mini_fat_base + index * 4),
+            FREESECT,
+            "unused MiniFAT entry {index}"
+        );
+    }
+
+    let dir_capacity = entry_count.div_ceil(DIR_ENTRIES_PER_SECTOR) * DIR_ENTRIES_PER_SECTOR;
+    for index in entry_count..dir_capacity {
+        let offset = SECTOR_SIZE
+            + (first_dir_sector + index / DIR_ENTRIES_PER_SECTOR) * SECTOR_SIZE
+            + (index % DIR_ENTRIES_PER_SECTOR) * DIR_ENTRY_SIZE;
+        assert_eq!(bytes[offset + 66], 0, "unused directory object type");
+        assert_eq!(read_u32_at(&bytes, offset + 68), NOSTREAM);
+        assert_eq!(read_u32_at(&bytes, offset + 72), NOSTREAM);
+        assert_eq!(read_u32_at(&bytes, offset + 76), NOSTREAM);
+    }
+}

--- a/tests/cases/mini_cfb_strict_contract.rs
+++ b/tests/cases/mini_cfb_strict_contract.rs
@@ -15,6 +15,52 @@ fn read_u32_at(bytes: &[u8], offset: usize) -> u32 {
     u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap())
 }
 
+fn directory_entry_offset(bytes: &[u8], index: usize) -> usize {
+    let first_dir_sector = read_u32_at(bytes, 48) as usize;
+    SECTOR_SIZE
+        + (first_dir_sector + index / DIR_ENTRIES_PER_SECTOR) * SECTOR_SIZE
+        + (index % DIR_ENTRIES_PER_SECTOR) * DIR_ENTRY_SIZE
+}
+
+fn assert_valid_red_black_subtree(
+    bytes: &[u8],
+    index: u32,
+    entry_count: usize,
+    parent_is_red: bool,
+    visited: &mut [bool],
+) -> usize {
+    if index == NOSTREAM {
+        return 1; // NIL leaves are black.
+    }
+
+    let index = index as usize;
+    assert!(index < entry_count, "directory index out of range: {index}");
+    assert!(
+        !visited[index],
+        "directory tree contains a cycle at {index}"
+    );
+    visited[index] = true;
+
+    let offset = directory_entry_offset(bytes, index);
+    let color = bytes[offset + 67];
+    assert!(color <= 1, "invalid directory color {color} at {index}");
+    let is_red = color == 0;
+    assert!(
+        !(parent_is_red && is_red),
+        "adjacent red directory nodes at {index}"
+    );
+
+    let left = read_u32_at(bytes, offset + 68);
+    let right = read_u32_at(bytes, offset + 72);
+    let left_height = assert_valid_red_black_subtree(bytes, left, entry_count, is_red, visited);
+    let right_height = assert_valid_red_black_subtree(bytes, right, entry_count, is_red, visited);
+    assert_eq!(
+        left_height, right_height,
+        "directory black-height mismatch at {index}"
+    );
+    left_height + usize::from(!is_red)
+}
+
 #[test]
 fn unused_container_slots_use_required_sentinels() {
     let owned = [
@@ -70,5 +116,38 @@ fn unused_container_slots_use_required_sentinels() {
         assert_eq!(read_u32_at(&bytes, offset + 68), NOSTREAM);
         assert_eq!(read_u32_at(&bytes, offset + 72), NOSTREAM);
         assert_eq!(read_u32_at(&bytes, offset + 76), NOSTREAM);
+    }
+}
+
+#[test]
+fn directory_tree_obeys_red_black_invariants() {
+    for stream_count in 1..=128usize {
+        let owned: Vec<_> = (0..stream_count)
+            .map(|index| (format!("/Stream{index:04}"), Vec::<u8>::new()))
+            .collect();
+        let streams: Vec<_> = owned
+            .iter()
+            .map(|(path, data)| (path.as_str(), data.as_slice()))
+            .collect();
+        let bytes = mini_cfb::build_cfb(&streams).unwrap();
+        let entry_count = 1 + stream_count;
+
+        let root_offset = directory_entry_offset(&bytes, 0);
+        let tree_root = read_u32_at(&bytes, root_offset + 76);
+        assert_ne!(tree_root, NOSTREAM);
+        let tree_root_offset = directory_entry_offset(&bytes, tree_root as usize);
+        assert_eq!(
+            bytes[tree_root_offset + 67],
+            1,
+            "directory tree root must be black for {stream_count} streams"
+        );
+
+        let mut visited = vec![false; entry_count];
+        visited[0] = true; // Root Entry owns the child tree but is not in it.
+        assert_valid_red_black_subtree(&bytes, tree_root, entry_count, false, &mut visited);
+        assert!(
+            visited.iter().all(|seen| *seen),
+            "directory tree omitted an entry for {stream_count} streams"
+        );
     }
 }


### PR DESCRIPTION
## 변경 요약

MiniCFB 출력이 strict MS-CFB 검증을 만족하도록 두 결함을 독립 커밋으로 수정한다.

1. 미사용 FAT/MiniFAT 및 디렉터리 슬롯을 `FREESECT`/`NOSTREAM`으로 초기화한다.
2. 균형 디렉터리 BST에 유효한 red-black color를 부여한다.

시험은 실제 문서를 사용하지 않고 메모리에서 생성한 합성 CFB 바이트만 디코딩한다.

## 관련 이슈

closes #5892
closes #5893

## 수정 전 실패 증명

- 미사용 FAT entry 16: `0`, 기대 `0xFFFFFFFF`
- 디렉터리 tree: node 2에서 black-height 불일치

## 테스트

- [x] `cargo fmt --all -- --check` 통과
- [x] 새 integration 원본은 `tests/cases/mini_cfb_strict_contract.rs`에만 있으며 파생 harness/manifest는 미포함
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `cargo nextest run --locked --cargo-profile release-test --target-dir target/pr-review-current --tests --no-fail-fast` — `8161/8161` 통과, 39 skip
- [x] `CARGO_TARGET_DIR=target/current-upstream-clippy cargo clippy --locked --all-targets -- -D warnings` 통과
- [x] 관련 샘플 SVG 내보내기: 해당 없음 — CFB 컨테이너 직렬화 변경
- [x] 웹(WASM) 렌더링: 해당 없음 — 렌더러/UI 변경 없음
- [x] Studio e2e: 해당 없음 — UI 변경 없음
- [ ] 작업 증빙 capsule: 미첨부 — 결정적 합성 회귀시험과 전체 시험 결과를 본문에 기록
- [x] capability 카탈로그: 해당 없음 — agent/skill 변경 없음

추가 집중 검증:

- `mini_cfb_strict_contract`: 2/2 통과
- 기존 `serializer::mini_cfb` unit tests: 13/13 통과
- stream 1..=128에 대해 root color, red-red, black-height, cycle/누락을 검사

## 성능 영향 및 측정 결과

- 예상 영향: 유의미한 영향 없음. 디렉터리 구성 시 기존 O(n) 순회에서 color를 함께 계산한다.
- 출력 크기: 변경 없음. 기존 고정 슬롯의 초기값과 color byte만 바로잡는다.
- 재현·측정: 별도 벤치마크 미실시. 전체 회귀시험 통과.

## 에이전트 보조

Codex를 사용해 기존 다운스트림 수정과 현재 `devel`의 MiniCFB 구현을 대조하고, 두 불변식을
각각 수정 전 실패하는 합성 시험으로 분리했다.

## 스크린샷

해당 없음. 컨테이너 구조를 바이트 수준 결정적 시험으로 검증한다.
