### PR TITLE
fix: preserve HWP paragraph stream coordinates

### DIFF
--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -1329,6 +1329,14 @@ impl Paragraph {
         let new_control_mask =
             Self::compute_control_mask_for(&new_text, &new_controls, &new_field_ranges);
 
+        // PARA_HEADER instanceId는 문단별 식별자다. Enter로 만든 문단이 원문 tail을
+        // 그대로 복제하면 동일한 비영 ID가 반복된다. 새 문단의 ID만 초기화하고 뒤의
+        // 변경 추적 suffix는 보존한다. 병합 undo는 `apply_meta`가 원래 tail을 복원한다.
+        let mut new_raw_header_extra = self.raw_header_extra.clone();
+        if new_raw_header_extra.len() >= 10 {
+            new_raw_header_extra[6..10].fill(0);
+        }
+
         Paragraph {
             text: new_text,
             char_offsets: new_char_offsets,
@@ -1351,7 +1359,7 @@ impl Paragraph {
             controls: new_controls,
             ctrl_data_records: new_ctrl_data_records,
             char_count_msb: false,
-            raw_header_extra: self.raw_header_extra.clone(),
+            raw_header_extra: new_raw_header_extra,
             has_para_text: new_has_para_text,
             tab_extended: Vec::new(),
             title_marks: new_title_marks,

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -653,6 +653,18 @@ impl Paragraph {
         }
     }
 
+    /// `PARA_TEXT`에서 한 문자가 차지하는 UTF-16 code unit 수를 반환한다.
+    ///
+    /// 탭은 Rust 문자열에서는 한 문자지만 HWP5에서는 7개 확장 데이터 unit이 뒤따르는
+    /// 8-unit 확장 문자다. 문단 좌표와 `char_count`는 이 스트림 폭을 사용해야 한다.
+    fn char_stream_len(c: char) -> u32 {
+        if c == '\t' {
+            CTRL_CHAR_CODE_UNITS
+        } else {
+            Self::char_utf16_len(c)
+        }
+    }
+
     /// char_offset 위치에 텍스트를 삽입한다.
     /// 인라인 컨트롤(각주/미주/수식/새 번호 등, 8 code unit)을 char_offset 위치에 삽입할 때
     /// 문단 메타데이터를 일괄 시프트한다.
@@ -681,7 +693,7 @@ impl Paragraph {
                 .text
                 .chars()
                 .nth(last_idx)
-                .map(|c| if (c as u32) > 0xFFFF { 2 } else { 1 })
+                .map(Self::char_stream_len)
                 .unwrap_or(1);
             self.char_offsets[last_idx] + last_w
         };
@@ -805,7 +817,7 @@ impl Paragraph {
             // 텍스트 끝 이후 (인라인 컨트롤 뒤): 마지막 문자의 UTF-16 위치 + 폭 + 후행 갭
             let last_idx = self.char_offsets.len() - 1;
             let last_char_end =
-                self.char_offsets[last_idx] + Self::char_utf16_len(text_chars[last_idx]);
+                self.char_offsets[last_idx] + Self::char_stream_len(text_chars[last_idx]);
             // 후행 컨트롤 수 = char_offset - text_len
             let trailing_ctrl_count = (char_offset - text_len) as u32;
             last_char_end + trailing_ctrl_count * 8
@@ -814,7 +826,7 @@ impl Paragraph {
                 0
             } else if !self.char_offsets.is_empty() {
                 let prev_idx = effective_char_offset - 1;
-                self.char_offsets[prev_idx] + Self::char_utf16_len(text_chars[prev_idx])
+                self.char_offsets[prev_idx] + Self::char_stream_len(text_chars[prev_idx])
             } else {
                 0
             }
@@ -822,7 +834,7 @@ impl Paragraph {
             self.char_offsets[effective_char_offset]
         } else if !self.char_offsets.is_empty() {
             let last_idx = self.char_offsets.len() - 1;
-            self.char_offsets[last_idx] + Self::char_utf16_len(text_chars[last_idx])
+            self.char_offsets[last_idx] + Self::char_stream_len(text_chars[last_idx])
         } else {
             // 텍스트가 비어있을 때: 기존 컨트롤 뒤에 삽입 (각 컨트롤 = 8 code units)
             (self.controls.len() as u32) * 8
@@ -831,7 +843,7 @@ impl Paragraph {
 
         // 새 텍스트의 UTF-16 총 길이
         let new_chars: Vec<char> = new_text.chars().collect();
-        let utf16_delta: u32 = new_chars.iter().map(|c| Self::char_utf16_len(*c)).sum();
+        let utf16_delta: u32 = new_chars.iter().map(|c| Self::char_stream_len(*c)).sum();
 
         // 1. 텍스트 삽입
         self.text.insert_str(byte_offset, new_text);
@@ -846,7 +858,7 @@ impl Paragraph {
         let mut pos = utf16_insert_pos;
         for c in &new_chars {
             new_offsets.push(pos);
-            pos += Self::char_utf16_len(*c);
+            pos += Self::char_stream_len(*c);
         }
         // char_offset 위치에 새 오프셋 삽입
         let mut updated_offsets = Vec::with_capacity(self.char_offsets.len() + new_offsets.len());
@@ -896,7 +908,7 @@ impl Paragraph {
         }
 
         // 6. char_count 갱신
-        self.char_count += new_chars.len() as u32;
+        self.char_count += utf16_delta;
 
         effective_char_offset
     }
@@ -937,7 +949,7 @@ impl Paragraph {
         };
         let utf16_delta: u32 = text_chars[char_offset..del_end]
             .iter()
-            .map(|c| Self::char_utf16_len(*c))
+            .map(|c| Self::char_stream_len(*c))
             .sum();
         let utf16_end = utf16_start + utf16_delta;
 
@@ -1027,7 +1039,7 @@ impl Paragraph {
             .retain(|fr| fr.start_char_idx <= fr.end_char_idx);
 
         // 6. char_count 갱신
-        self.char_count -= actual_count as u32;
+        self.char_count -= utf16_delta;
 
         actual_count
     }
@@ -1077,9 +1089,12 @@ impl Paragraph {
             self.char_offsets[split_pos]
         } else if !self.char_offsets.is_empty() {
             let last = self.char_offsets.len() - 1;
-            self.char_offsets[last] + Self::char_utf16_len(text_chars[last])
+            self.char_offsets[last] + Self::char_stream_len(text_chars[last])
         } else {
-            split_pos as u32
+            text_chars[..split_pos]
+                .iter()
+                .map(|character| Self::char_stream_len(*character))
+                .sum()
         };
 
         // === 새 문단 구성 ===
@@ -1298,10 +1313,11 @@ impl Paragraph {
 
         // 6. char_count 갱신
         //    원본 문단에 남은 controls는 각각 8 code unit을 차지하므로 반영 필요
-        let new_text_char_count = new_text.chars().count() as u32;
+        let kept_text_code_units: u32 = self.text.chars().map(Self::char_stream_len).sum();
+        let new_text_code_units: u32 = new_text.chars().map(Self::char_stream_len).sum();
         let ctrl_code_units: u32 = self.controls.len() as u32 * 8;
-        self.char_count = split_pos as u32 + ctrl_code_units + 1; // +1 for paragraph end marker
-        let new_char_count = new_text_char_count + new_controls.len() as u32 * 8 + 1;
+        self.char_count = kept_text_code_units + ctrl_code_units + 1; // +1 for paragraph end marker
+        let new_char_count = new_text_code_units + new_controls.len() as u32 * 8 + 1;
 
         // 7. has_para_text: 빈 문단(텍스트 없고 컨트롤 없음)이면 PARA_TEXT 불필요
         //    HWP 프로그램은 cc=1(빈 문단)에 PARA_TEXT가 있으면 파일 손상으로 판단
@@ -1371,7 +1387,7 @@ impl Paragraph {
         let utf16_end: u32 = if !self.char_offsets.is_empty() {
             let last = self.char_offsets.len() - 1;
             let text_chars: Vec<char> = self.text.chars().collect();
-            self.char_offsets[last] + Self::char_utf16_len(text_chars[last])
+            self.char_offsets[last] + Self::char_stream_len(text_chars[last])
         } else {
             0
         } + trailing_ctrl_units;
@@ -1483,7 +1499,7 @@ impl Paragraph {
         // 6. char_count 갱신: 텍스트 + 컨트롤(각 8 code unit) + 문단끝(1)
         //    split_at의 ctrl_code_units 계산과 정합. HWPX 직렬화가 char_count에서
         //    컨트롤 수를 역산하므로 컨트롤 유닛 포함 필수.
-        self.char_count = (self_text_len + other.text.chars().count()) as u32
+        self.char_count = self.text.chars().map(Self::char_stream_len).sum::<u32>()
             + self.controls.len() as u32 * 8
             + 1;
 

--- a/tests/cases/paragraph_stream_coordinates_contract.rs
+++ b/tests/cases/paragraph_stream_coordinates_contract.rs
@@ -32,3 +32,24 @@ fn insert_split_merge_preserves_hwp_stream_widths() {
     assert_eq!(paragraph.char_offsets, vec![0, 1]);
     assert_eq!(paragraph.char_count, 3);
 }
+
+#[test]
+fn split_clears_new_paragraph_instance_id_and_preserves_suffix() {
+    let mut paragraph = Paragraph {
+        text: "AB".to_string(),
+        char_count: 3,
+        char_offsets: vec![0, 1],
+        // counts(6) + instanceId(4) + change-tracking suffix(2)
+        raw_header_extra: vec![1, 2, 3, 4, 5, 6, 0xD2, 0x94, 0x09, 0xBA, 7, 8],
+        ..Paragraph::new_empty()
+    };
+
+    let tail = paragraph.split_at(1);
+
+    assert_eq!(
+        &paragraph.raw_header_extra[6..10],
+        &[0xD2, 0x94, 0x09, 0xBA]
+    );
+    assert_eq!(&tail.raw_header_extra[6..10], &[0, 0, 0, 0]);
+    assert_eq!(&tail.raw_header_extra[10..12], &[7, 8]);
+}

--- a/tests/cases/paragraph_stream_coordinates_contract.rs
+++ b/tests/cases/paragraph_stream_coordinates_contract.rs
@@ -1,0 +1,34 @@
+//! HWP5 `PARA_TEXT` 좌표 계약.
+//!
+//! 공개 스펙의 확장 문자는 8 UTF-16 code unit 슬롯을 차지한다. 탭은 Rust 문자열에서
+//! 한 문자지만 HWP5 스트림에서는 확장 문자이므로, 문자 오프셋과 `char_count` 계산에
+//! 슬롯 전체 폭이 반영되어야 한다.
+
+use rhwp::model::paragraph::Paragraph;
+
+#[test]
+fn insert_split_merge_preserves_hwp_stream_widths() {
+    let mut paragraph = Paragraph::new_empty();
+    paragraph.insert_text_at(0, "A🙂\tB");
+
+    assert_eq!(paragraph.char_offsets, vec![0, 1, 3, 11]);
+    assert_eq!(paragraph.char_count, 13);
+
+    let tail = paragraph.split_at(3);
+    assert_eq!(paragraph.text, "A🙂\t");
+    assert_eq!(paragraph.char_offsets, vec![0, 1, 3]);
+    assert_eq!(paragraph.char_count, 12);
+    assert_eq!(tail.text, "B");
+    assert_eq!(tail.char_offsets, vec![0]);
+    assert_eq!(tail.char_count, 2);
+
+    paragraph.merge_from(&tail);
+    assert_eq!(paragraph.text, "A🙂\tB");
+    assert_eq!(paragraph.char_offsets, vec![0, 1, 3, 11]);
+    assert_eq!(paragraph.char_count, 13);
+
+    paragraph.delete_text_at(1, 2);
+    assert_eq!(paragraph.text, "AB");
+    assert_eq!(paragraph.char_offsets, vec![0, 1]);
+    assert_eq!(paragraph.char_count, 3);
+}


### PR DESCRIPTION
## 변경 요약

문단 편집·직렬화 좌표에 관한 두 결함을 독립 커밋으로 수정한다.

1. 탭을 HWP5의 8-unit 확장 문자로 계산하고 astral UTF-16 폭과 함께 삽입·삭제·분할·병합 전 경로에서
   일관되게 사용한다.
2. 문단 분할 시 새 문단의 PARA_HEADER instance ID만 초기화하고 뒤의 변경 추적 suffix는 보존한다.

시험은 `A🙂\tB`와 합성 header bytes만 사용하며 실제 문서 fixture를 추가하지 않는다.

## 관련 이슈

closes #5894
closes #5895

## 수정 전 실패 증명

- `A🙂\tB`의 `B` offset: 실제 4, 기대 11
- 분할된 새 문단 instance ID: 실제 `D2 94 09 BA`, 기대 `00 00 00 00`

## 테스트

- [x] `cargo fmt --all -- --check` 통과
- [x] 새 integration 원본은 `tests/cases/paragraph_stream_coordinates_contract.rs`에만 있으며 파생 harness/manifest는 미포함
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `cargo nextest run --locked --cargo-profile release-test --target-dir target/pr-review-current --tests --no-fail-fast` — `8161/8161` 통과, 39 skip
- [x] `CARGO_TARGET_DIR=target/current-upstream-clippy cargo clippy --locked --all-targets -- -D warnings` 통과
- [x] 관련 샘플 SVG 내보내기: 해당 없음 — 문단 내부 스트림 좌표와 식별자 수정
- [x] 웹(WASM) 렌더링: 해당 없음 — UI/렌더러 변경 없음
- [x] Studio e2e: 해당 없음 — UI 변경 없음
- [ ] 작업 증빙 capsule: 미첨부 — 결정적 합성 회귀시험과 전체 시험 결과를 본문에 기록
- [x] capability 카탈로그: 해당 없음 — agent/skill 변경 없음

추가 집중 검증:

- `paragraph_stream_coordinates_contract`: 2/2 통과
- 기존 `model::paragraph` unit tests: 60/60 통과
- 삽입 → 분할 → 병합 → 삭제 후 offset과 `char_count`를 모두 검증

## 성능 영향 및 측정 결과

- 예상 영향: 유의미한 영향 없음. 기존 문단 순회에서 문자별 stream width를 계산하며 점근 복잡도는 같다.
- 재현·측정: 별도 벤치마크 미실시. 전체 회귀시험 통과.

## 에이전트 보조

Codex를 사용해 기존 다운스트림 수정에서 현재 `devel`에도 남아 있는 좌표·ID 결함만 분리해
재이식하고, 각 결함에 수정 전 실패하는 합성 integration test를 추가했다.

## 스크린샷

해당 없음. 문단 내부 좌표와 header 식별자를 결정적 자동 시험으로 검증한다.
