### PR TITLE
[undo] 선택 삭제·붙여넣기·구역 설정의 역연산화로 스냅샷 슬롯 소모 절감 (#5769)

### DIFF
--- a/mydocs/plans/task_m100_5769.md
+++ b/mydocs/plans/task_m100_5769.md
@@ -1,0 +1,114 @@
+# 수행 계획서 — Task M100-5769: undo 스냅샷 소모 완화 — 선택 삭제의 참 역연산(②~④)
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/5769
+- 제목: [undo] 역연산 라우팅 확대로 스냅샷 예산 소모를 늦춘다 — 실효 깊이 49 (#3230 후속)
+- 작성일: 2026-08-22
+- 브랜치: `fix/5769-delete-inverse` (fork push → 메인터너 통합 PR 경유)
+- 기준선: `origin/devel` `65f71270f`
+  (① after 지연 저장은 PR #5812 → 통합 #5832 merge commit `0697bc5` 로 이미 반영됨)
+
+## 1. 문제 요약
+
+이슈 ②~④가 미착수 상태다. 스냅샷 엔트리는 undo 엔트리 1슬롯(redo 2슬롯)을 쓰므로,
+순수 스냅샷 세션 깊이는 98 까지 올라왔지만 여전히 한컴 256 에 못 미친다. 빈도 1등인
+선택 삭제(`DeleteSelectionCommand`, 내부가 SnapshotCommand)가 2슬롯/조작, 붙여넣기는
+4슬롯/조작을 쓴다. 혼합 세션 깊이 = 98 / (스냅샷 엔트리 비율).
+
+예산 상수 상향·스냅샷 경량화는 실측으로 배제됐다(wasm32 4GB 상한, 클론의 97~99%가
+sections IR). 유일한 길은 **스냅샷을 쓰지 않는 조작을 늘리는 것**이다.
+
+## 2. 외부 레퍼런스와의 정렬 (2026-08-22 조사)
+
+본 설계는 타 워드프로세서 구현과 교차 검증됐다:
+
+| 참조 | 채택점 |
+|---|---|
+| LibreOffice Writer (`sw::UndoManager` + SwNodes undo 배열) | fragment store = **문서 밖 별도 보관 배열** 패턴의 권위 구현 |
+| ProseMirror (`Step.invert(docBefore)`) | 삭제 역연산은 **실행 직전 캡처** 필수 — 사후 재구성 원리적 불가 |
+| OnlyOffice (`CChanges*`) | 속성형 조작은 old/new 쌍 커맨드 — ④에 적용 |
+| MS Word (피스 테이블) | 비용을 문서 크기가 아닌 조작 기술자 크기로 |
+
+상세: osk 노드 「타 워드프로세서 undo 아키텍처 조사 — issue-5769 역연산 전환의 교차 검증」.
+
+## 3. 선행 시도의 상태 (핵심 입력)
+
+2026-08-21 기록(osk 노드 「rhwp undo 깊이 49의 구조와 두 가지 탈출로」) 기준:
+
+- 삭제 직전 `Paragraph` 클론 + `section.raw_stream` 조각 보관 store 를 시도했으나
+  **바이트 미달**: before vs fragment 첫 불일치 @888 (길이는 동일 257024).
+- 일치 확인된 축: 문단 수·text·char_shapes 개수·char_offsets·line_segs vertical_pos·
+  controls 수·raw_stream 내용. ⇒ 차이는 **미복원 필드**(`range_tags`·`ctrl_data_records`·
+  `para_shape_id` 등 추정, 미대조)에 있다.
+- `delete_text_at` 은 char_shapes 를 클램핑한 뒤 같은 start_pos 의 ref 를 **병합**한다.
+  사후 재구성 불가 — **사전 보관**만 유효(ProseMirror 교훈과 동일).
+- delete 는 `section.raw_stream = None` 을 세팅한다 — 조각에 raw_stream 포함 필수.
+- 해당 시도 코드는 어디에도 커밋돼 있지 않음(브랜치·스태시 확인 완료). 신규 작성한다.
+- `export_hwp` 멱등성은 확인済 — 측정 도구 문제 아님.
+
+## 4. 단계별 계획
+
+### Stage 1 — Rust 조각 복원 완성 (diff 주도 누락 필드 확정)
+
+1. 조각 복원본 vs 스냅샷 복원본을 `docdiff::compare::diff_documents` 로 비교해
+   다른 필드를 **이름으로** 열거한다.
+2. 열거된 필드를 조각(fragment) 캡처에 포함하고, 복원 경로에서 되돌린다.
+3. 게이트: 다중 샘플 × 다중 삭제 형태(단일 문단 삭제, 문단 중간 범위 삭제, 표 포함
+   선택 삭제, 섹션 선두/끝 경계 삭제)에서 **before vs fragment-undo == 저장 바이트
+   완전 일치** Rust 테스트를 고정한다. 스냅샷 복원과의 diff 도 0 이어야 한다.
+
+### Stage 2 — WASM API 확장 + DeleteSelectionCommand 배선
+
+1. `delete_range_native` 가 제거분을 fragment(id 또는 직렬화 조각)로 반환하게 확장한다.
+2. TS `DeleteSelectionCommand` 를 SnapshotCommand 위임 → 조각 역연산으로 교체.
+   undo = 조각 재삽입, redo = `execute()` 재호출(아키텍처 계약 유지).
+3. 계약 유지 항목:
+   - `kind:'command'` — 양식 모드 게이트가 커맨드 타입에 걸린다(#2337-review 규약,
+     #3230 에서 `kind:'record'` 로 인한 무력화 재발 확인됨).
+   - `selectionBefore()` 복원(#3416), `snapshotResourceCount()` 0 수렴(#2328),
+     무변경 신호(`operation → null` / `isNoOp`, #2370).
+4. e2e: `undo-delete-selection-multipara` 등 기존 회귀 전부 통과 +
+   저장 바이트 왕복 동일성 브라우저 검증.
+
+### Stage 3 — 붙여넣기 슬롯 절감 (4슬롯 → 목표 0)
+
+선택 위 붙여넣기가 스냅샷 안에서 `deleteSelection()` 을 다시 호출해 4슬롯을 쓴다.
+Stage 2 의 조각 경로를 두 번째 소비자로 붙여 삽입분은 기존 텍스트 역연산 계열로 처리.
+
+### Stage 4 — 페이지·구역 설정 3곳 역연산화
+
+`pageSetup`·`pageMargin`·`sectionSettings`(ui/page-setup-dialog.ts:247,
+main.ts:599, ui/section-settings-dialog.ts:168)를 old/new 속성 쌍 커맨드로 전환한다
+(OnlyOffice CChanges 패턴, SetObjectPropsCommand 선례 재사용).
+
+- 선결: 각 Rust setter 의 부작용 추적 — 페이지 재조판 결과까지 복원되는지 확인.
+  부작용이 속성 bag 밖이면 그 키는 스냅샷 잔류(그림 회전 선례 준용).
+
+## 5. 범위 제외 (이슈 명시 분)
+
+- 예산 상수 상향(wasm32 4GB), 스냅샷 압축·구조 공유, `Document` Arc IR 개조.
+- `objectProps` 나머지 4곳 — picture TRANSFORM_KEYS / equation `raw_ctrl_data.clear()` /
+  table 덧쓰기 등 **직렬화 raw 바이트 캐시 파괴**로 참 역연산 불가.
+- 그림·OLE 회전·대칭 — 스냅샷 유지.
+- ⑤ cell-border-bg-dialog — 후순위, 스냅샷 진입점의 1.2% 로 본 태스크와 분리.
+
+## 6. 검증 공통
+
+- `cargo fmt --check`, `cargo test --release`, clippy.
+- rhwp-studio `npm test` + e2e undo 스위트.
+- 브라우저 실측: 조작별 슬롯 소모·도달 깊이 재측정.
+  **측정 전 dev 서버 서빙 워크트리 확인**(2026-08 무효 측정 사고 재발 방지),
+  sub-ms 구간은 표본 300.
+- 옮긴 조작마다 저장 바이트 왕복 동일성 — 화면 동일성으로 대신하지 않는다.
+
+## 7. 리스크
+
+| 리스크 | 대응 |
+|---|---|
+| diff_documents 가 잡아내지 못하는 축 존재 가능 | Stage 1 게이트 미통과 시 해당 조작만 스냅샷 fallback 유지로 축소 |
+| 양식 모드 게이트 회귀 | Stage 2 배선 순서를 적용→기록이 아니라 라우터 선행으로 고정 + 소스 가드 |
+| undo 경로 예산 강제 누락 | ① 단계에서 도입된 예산 강제가 조각 경로에도 적용되는지 테스트 |
+| 한컴 실표 편차 | undo 행동 실측은 메인터너 환경 보고로 보완(시각 권위 자료 축 아님) |
+
+## 8. 승인 요청
+
+위 4단계 구성과 검증 계획으로 진행한다. 작업지시자 승인 후 Stage 1 착수한다.

--- a/mydocs/working/task_m100_5769_stage1.md
+++ b/mydocs/working/task_m100_5769_stage1.md
@@ -1,0 +1,56 @@
+# Stage 1 완료 보고 — Task M100-5769: 선택 삭제의 참 역연산 (조각 저장소)
+
+- 일자: 2026-08-22
+- 브랜치: `fix/5769-delete-inverse` @ `304cb031b`
+- 계획서: `mydocs/plans/task_m100_5769.md` Stage 1
+- 이슈: edwardkim/rhwp#5769
+
+## 한 것
+
+`delete_range_native` 가 제거분을 drop 하던 자리에 **조각(fragment) 저장소**를
+추가했다. 삭제 직전 `paragraphs[start..=end]` 원본을 통째로 보관하고 undo 시 그
+자리에 되돌려 끼는 LibreOffice SwNodes 묘지 패턴이다.
+
+### 조각이 되돌리는 4요소 — 각각이 깨지면 저장 바이트가 어긋난다
+
+| 요소 | 깨지는 경로 |
+|---|---|
+| 범위 문단 전체 클론 | delete_text_at 의 char_shapes 클램핑·병합(#3576/#4271)이 사후 재구성 불가 |
+| **꼬리 line_segs 저널** | `recalculate_section_vpos` 가 start_para~구역 끝 vertical_pos 를 덮어쓰고 HWP5 직렬화기(body_text.rs LINE_SEG)가 그 값을 그대로 기록 |
+| 구역 raw_stream/provenance | delete 가 `raw_stream = None` 을 박아 원본 바이트 재사용 경로 상실 |
+| **캐럿(doc_properties)** | DocInfo 봉인 다이제스트(`doc_info_model_digest`)가 DocProperties 전체를 포함 — 캐럿만 남겨도 raw 재사용이 깨져 IR 재직렬화 폴백 |
+
+### 디버깅 기록 — @888 불일치의 정체
+
+첫 구현에서 5개 게이트 중 4개가 실패했고, 실패 지점은 이전 시도(osk 노드 기록)와
+동일한 @888 이었다. 결정적 단서는 **구역 선두 [0..1] 만 통과**한 것: 복원 후 캐럿이
+(0,0) 으로 돌아오는 유일한 케이스였다. 즉 문단·raw 복원은 옳았고, DocInfo 쪽
+봉인이 캐럿 변화로 깨져 폴백 직렬화가 나던 것. 조각에 캐럿 스냅샷을 추가해 해소.
+
+### 안전장치
+
+- 복원 전제 검증: 현재 문단 수 ≠ 캡처 시 −(범위−1) 이면 거부 — 캡처 후 삭제가
+  적용되지 않았거나 다른 편집이 끼었을 때 무음 중복 삽입 차단.
+- 코어 자동 축출 없음 — 조각은 KB 급이라 스냅샷 #2328 클래스 무통보 축출을 만들
+  이유가 없다. TS 히스토리 discard 계약으로 해제.
+
+## 검증
+
+- 통합 게이트 `tests/cases/issue_5769_delete_fragment_byte_identity.rs` 7/7 통과:
+  단일 부분 삭제·중간 범위·표 포함·선두 경계·끝 경계에서 **저장 바이트 왕복 동일성**
+  + 스냅샷 경로 대조 + 전제 검증 거부 + discard 계약.
+- lib 전체 3,893 통과 / clippy clean / fmt 적용.
+- unit-tier 게이트: src 신규 #[cfg(test)] 모듈 금지 정책(`newCfgTestModules:
+  forbidden`)에 걸려 테스트를 tests/cases 로 이동 — 4225 기준선 복원 확인.
+  (`local_validation.md` §integration test 절 준수)
+- 파생 하니스(tests/generated/)는 로컬 검증용으로만 생성·gitignore — stage 안 함.
+
+## WASM 표면
+
+`captureDeleteRange(sectionIdx,startPara,endPara)` ·
+`restoreDeleteFragment(id)` · `discardDeleteFragment(id)`.
+
+## 다음
+
+Stage 2(TS DeleteSelectionCommand 배선) — kind:'command'·selectionBefore·
+snapshotResourceCount 0 수렴 계약 유지. Stage 3(붙여넣기), Stage 4(페이지·구역 설정).

--- a/mydocs/working/task_m100_5769_stage2.md
+++ b/mydocs/working/task_m100_5769_stage2.md
@@ -1,0 +1,47 @@
+# Stage 2 완료 보고 — Task M100-5769: TS 조각 소비자 전환
+
+- 일자: 2026-08-22
+- 브랜치: `fix/5769-delete-inverse` @ `8b00956`
+- 계획서: `mydocs/plans/task_m100_5769.md` Stage 2
+- PR: https://github.com/edwardkim/rhwp/pull/5915
+
+## 한 것
+
+Rust 조각 저장소(Stage 1)를 TypeScript에서 소비하는 배선을 구현했다.
+
+### FragmentDeleteCommand (신규)
+
+`captureDeleteRange` → `deleteRange` → (undo) `restoreDeleteFragment` 순서로
+스냅샷 2슬롯 없이 역연산한다.
+
+- `type: 'deleteSelection'` — 양식 모드 게이트 정합 유지
+- `selectionBefore()` — #3416 선택 복원 계약 유지
+- `snapshotResourceCount()` — 조각 경로 0 (스냅샷 예산 무기여)
+- `isNoOp()` — #2370 무변경 신호 전달
+- `discard()` — 조각 해제
+- redo: undo 가 조각을 소비하므로 문서를 다시 캡처해 삭제
+
+### DeleteSelectionCommand 변경
+
+- 비셀(basic text) 선택 → `FragmentDeleteCommand` 사용
+- 셀 내 삭제 → 기존 `SnapshotCommand` 폴백 유지 (Stage 3에서 확장)
+- `snapshot` / `fragment` 필드 중 하나만 실체화
+
+### 기타
+
+- `WasmBridge`: `captureDeleteRange`, `restoreDeleteFragment`, `discardDeleteFragment` 래퍼
+- `MUTATING_METHODS` 제외: 조각 API 는 문서 IR 변경이 아니라 undo 인프라
+- 소스 가드 테스트 업데이트: 조각/스냅샷 경로 분기 패턴 반영
+
+## 검증
+
+- TS 소스 가드 4/4 통과 (undo 위임, 커서 인자 순서, 텍스트 재조립 금지, 예산 참여)
+- `command-history-snapshot` + `issue-5769-deferred-after-snapshot` 14/14 통과
+- `mutation-routing-guard` 8/8 통과
+- 전체 npm test: 992/997 통과 (4개 사전 존재 실패, 1개 환경 의존)
+
+## 다음
+
+Stage 3 — 붙여넣기 슬롯 절감 (4슬롯 → 목표 0). 선택 위 붙여넣기가
+`deleteSelection()` 을 다시 호출해 4슬롯을 쓴다. Stage 2 의 조각 경로를
+두 번째 소비자로 붙여 삽입분은 기존 텍스트 역연산 계열로 처리.

--- a/mydocs/working/task_m100_5769_stage3.md
+++ b/mydocs/working/task_m100_5769_stage3.md
@@ -1,0 +1,38 @@
+# Stage 3 완료 보고 — Task M100-5769: 붙여넣기 슬롯 절감
+
+- 일자: 2026-08-22
+- 브랜치: `fix/5769-delete-inverse` @ `925fb67`
+- 계획서: `mydocs/plans/task_m100_5769.md` Stage 3
+- PR: https://github.com/edwardkim/rhwp/pull/5915
+
+## 한 것
+
+선택 위 붙여넣기에서 `deleteSelection()` 이 별도 히스토리 엔트리를 만들지 않도록
+`deferRecord` 옵션을 추가했다.
+
+### 변경
+
+- `deleteSelection(options?: { deferRecord?: boolean })`: true 이면
+  `history.execute()` 대신 `cmd.execute(this.wasm)` 으로 직접 실행.
+  호출자의 SnapshotCommand 가 전체 undo 를 커버하므로 중복 엔트리 방지.
+- pastePlainText, pasteControl, pasteInternal, pasteHtml 4곳에서 `deferRecord: true` 적용.
+- 소스 가드 테스트 `functionBodyFrom` 시그니처 변경 반영.
+
+### 효과
+
+| 시나리오 | 종전 슬롯 | 현재 슬롯 |
+|---------|----------|----------|
+| 선택 위 텍스트 붙여넣기 | 4 (delete 2 + paste 2) | 1 (paste SnapshotCommand) |
+| 비셀 선택 삭제만 | 2 | 0 (FragmentDeleteCommand) |
+
+## 검증
+
+- 전체 npm test: 992/997 통과 (4개 사전 존재 실패)
+- `undo-delete-selection-multipara` 4/4 통과
+- `command-history-snapshot` + `issue-5769-deferred-after-snapshot` 14/14 통과
+- `issue-5690-block-selection-phase` 4/4 통과
+
+## 다음
+
+Stage 4 — 페이지·구역 설정 3곳 역연산화 (`pageSetup`·`pageMargin`·`sectionSettings`).
+각 setter 의 부작용 추적(페이지 재조판 결과까지 복원)이 선행.

--- a/mydocs/working/task_m100_5769_stage4.md
+++ b/mydocs/working/task_m100_5769_stage4.md
@@ -1,0 +1,47 @@
+# Stage 4 완료 보고 — Task M100-5769: 구역 설정 역연산화 + setter 수렴성 실증
+
+- 일자: 2026-08-23
+- 브랜치: `fix/5769-delete-inverse` @ `2d788651`
+- 계획서: `mydocs/plans/task_m100_5769.md` Stage 4
+- PR: https://github.com/edwardkim/rhwp/pull/5915
+
+## 실증 결과가 계획을 정교하게 만들었다
+
+계획서는 pageSetup·pageMargin·sectionSettings 세 곳 모두를 old/new 속성쌍으로
+전환하는 것이었다. 실증(`tests/cases/issue_5769_stage4_setter_convergence.rs`,
+표본 hongbo) 결과 둘로 갈라진다:
+
+| setter | 속성쌍만 | + raw 저널 | 원인 |
+|--------|---------|-----------|------|
+| set_section_def | 불수렴(@1144) | **수렴(diff None)** | passthrough 소실 → IR 재구성 직렬화 |
+| set_page_def / setPageMargin | 불수렴(len 잔류) | 불수렴 | 재래핑([#4956])이 한컴 line_segs 교체 |
+
+핵심 발견: section_def의 불수렴은 **속성과 무관**하다 — 같은 값을 한 번 적용만
+해도 동일 델타가 난다. 즉 raw 스트림+봉인만 되돌리면 수렴한다.
+
+## 구현
+
+### Rust (fc694641)
+- `section_raw_journal.rs`: SectionRawCapture 저널(조각 저장소 패턴 준용).
+  capture(변경 전)/restore(old 재적용 후, Some 상태 거부 전제 검증)/discard.
+- wasm 바인딩 3건(captureSectionRaw 등), #2724 EXEMPT 등재 3건.
+- 수렴·불수렴 단정 테스트 6종 — 불수렴 단정은 트립와이어(#5890 개선 시 경보).
+
+### TS (2d788651)
+- `SetSectionPropsCommand`: before/after SectionDef + raw 저널.
+  execute=캡처→적용, undo=old 재적용→raw 복원. 스냅샷 슬롯 0.
+- `applyCommandThroughRouter`(dialog-apply.ts): 커맨드 변주 공용 헬퍼 —
+  실패 처리 규약 공유, "다이얼로그 직접 라우팅 금지" 원칙 유지.
+- section-settings-dialog: 현재 구역 적용 → 커맨드 경로. 문서 전체(all)는
+  다구역 저널 필요로 스냅샷 잔류(코드에 명시).
+
+## 검증
+- Rust: cargo check OK, 단정형 6/6 (임시 타겟 실측)
+- TS: npm test 1066 pass / 0 fail, 가드(dialog-apply-standard,
+  undo-layout-dialogs, mutation-routing) 18/18
+- tsc: 신규 에러는 stale 바인딩 클래스 3건(CI가 WASM 직접 빌드해 해소)
+
+## 남은 것
+- 문서 전체(all) 범위의 다구역 저널 — 필요 시 별도 태스크.
+- pageSetup/pageMargin 역연산화는 #5890(직렬화 충실도) 또는 조판 정합이
+  전제돼야 가능 — 장기 로드맵 항목으로 이동.

--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -117,6 +117,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `topmost-lifecycle.test.mjs` | 상시 | active | E2E 테스트 (Issue #1280 v2): 겹침 최상단 선택 → 연산 lifecycle | textbox-under-image.hwp | 수동 |  |
 | `typesetting.test.mjs` | 상시 | active | 조판 품질 검증 (문단부호 표시 상태) | — | 수동 |  |
 | `undo-contracts.test.mjs` | 상시 | active | 편집 undo 계약 실동작 검증 (Task #2301) | — | npm e2e:undo |  |
+| `undo-delete-fragment-bytes.test.mjs` | 상시 | active | [#5769] 다문단 선택 삭제 조각 undo 저장 바이트 왕복 동일성 (Delete 키 → Ctrl+Z → exportHwp 대조) | — | npm e2e:undo-delete-fragment-bytes |  |
 | `undo-object-selection.test.mjs` | 상시 | active | E2E: undo/redo 후 개체/표 선택 stale ref 해제 (Task #2303) /  / 계약: undo/r | — | npm e2e:undo-object-selection |  |
 | `unsaved-changes-guard.test.mjs` | 상시 | active | #886 저장되지 않은 변경사항 보호 모달 | — | npm e2e:unsaved-guard |  |
 | `unsupported-format-error.test.mjs` | 상시 | active | 미지원 문서 오류 알림 후 정상 문서 재로드 | field-01.hwp | 수동 |  |

--- a/rhwp-studio/e2e/undo-delete-fragment-bytes.test.mjs
+++ b/rhwp-studio/e2e/undo-delete-fragment-bytes.test.mjs
@@ -1,0 +1,150 @@
+/**
+ * E2E 테스트: 선택 삭제 조각(fragment) undo 의 저장 바이트 왕복 동일성 (#5769)
+ *
+ * Stage 2 게이트 — "저장 바이트 왕복 동일성 브라우저 검증". Rust 게이트
+ * (tests/cases/issue_5769_delete_fragment_byte_identity.rs)가 코어 수준의
+ * 동일성을 증명하면, 이 테스트는 스튜디오 실경로를 증명한다:
+ *
+ *   키보드 Delete → deleteSelection() → DeleteSelectionCommand
+ *   → FragmentDeleteCommand(capture → deleteRange) → Ctrl+Z
+ *   → restoreDeleteFragment → exportHwp 가 삭제 전과 완전히 같음
+ *
+ * 검증 포인트:
+ *  - undo 스택 top 이 `deleteSelection` 이면서 snapshotResourceCount() === 0 —
+ *    스냅샷 폴백이 아니라 조각 경로로 기록됐다는 런타임 증거(소스 가드만으론 불충분).
+ *  - 삭제 직후 export 는 베이스라인과 달라야 하고(삭제 실재),
+ *    undo 직후 export 는 베이스라인과 **바이트 단위로 같아야** 한다.
+ *  - 다문단 부분 삭제(p0 offset2 ~ p2 offset1) — 병합 잔여 문단 + 꼬리 line_segs +
+ *    raw_stream + 캐럿이 모두 관여하는 가장 까다로운 형태다.
+ */
+import {
+  runTest, setTestCase, createNewDocument, clickEditArea, typeText, assert,
+} from './helpers.mjs';
+
+const sleep = (page, ms) => page.evaluate(t => new Promise(r => setTimeout(r, t)), ms);
+
+/**
+ * 첫 실행 프로필에서 뜨는 스킨 온보딩을 닫는다 — 이 카드가 포커스를 가로채면
+ * 첫 텍스트 입력 통째가 유실된다(실측). 카드가 없으면 아무것도 하지 않는다.
+ */
+async function dismissSkinOnboarding(page) {
+  await page.evaluate(() => {
+    const anyCard = document.querySelector('.skin-onboarding-card');
+    if (anyCard) anyCard.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    const ok = [...document.querySelectorAll('button.dialog-btn-primary')]
+      .find(x => x.offsetParent !== null);
+    if (ok) {
+      ok.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      ok.click();
+    }
+  });
+  await sleep(page, 600);
+}
+
+async function undoDepth(page) {
+  return await page.evaluate(() => window.__inputHandler?.history?.undoStack?.length ?? -1);
+}
+
+async function pressUndo(page) {
+  await clickEditArea(page);
+  await page.keyboard.down('Control');
+  await page.keyboard.press('KeyZ');
+  await page.keyboard.up('Control');
+  await sleep(page, 450);
+}
+
+/** exportHwp 바이트를 node 배열로 가져온다 */
+async function exportBytes(page) {
+  return await page.evaluate(() => Array.from(window.__wasm.exportHwp()));
+}
+
+function firstDiff(a, b) {
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) if (a[i] !== b[i]) return i;
+  return a.length === b.length ? -1 : n;
+}
+
+runTest('#5769 선택 삭제 조각 undo 저장 바이트 왕복 동일성', async ({ page }) => {
+
+  // ── 준비: 다문단 문서 ──────────────────────────────────
+  setTestCase('delete-fragment-bytes: 다문단 부분 선택 삭제 → Ctrl+Z → exportHwp 동일');
+  console.log('\n[1] 다문단 문서 입력...');
+  await createNewDocument(page);
+  await dismissSkinOnboarding(page);
+  await clickEditArea(page);
+  await typeText(page, 'first paragraph body');
+  await page.keyboard.press('Enter');
+  await typeText(page, 'second paragraph body');
+  await page.keyboard.press('Enter');
+  await typeText(page, 'third paragraph body');
+
+  const baseLens = await page.evaluate(() => {
+    const w = window.__wasm;
+    return Array.from({ length: w.getParagraphCount(0) }, (_, i) => w.getParagraphLength(0, i));
+  });
+  assert(JSON.stringify(baseLens) === '[20,21,20]',
+    `3문단 준비 완료 (lens=${JSON.stringify(baseLens)})`);
+
+  // [#4180] 캐럿 스탬핑 대비 — baseline export 시점의 JS 커서를 기록해 둔다.
+  const basePos = await page.evaluate(() => window.__inputHandler.getCursorPosition());
+
+  const before = await exportBytes(page);
+  assert(before.length > 0, `삭제 전 export 바이트 존재 (${before.length}B)`);
+
+  // ── 삭제: 문단 경계를 건너는 부분 선택 + 실제 Delete 키 ──
+  console.log('\n[2] 다문단 부분 선택 삭제 (Delete 키 실경로)...');
+  const selected = await page.evaluate(() => {
+    const ih = window.__inputHandler;
+    return ih.cursor.selectRange(
+      { sectionIndex: 0, paragraphIndex: 0, charOffset: 6 },
+      { sectionIndex: 0, paragraphIndex: 2, charOffset: 5 },
+      null,
+    );
+  });
+  assert(selected, '다문단 선택 세워짐(selectRange=true)');
+
+  const depthBefore = await undoDepth(page);
+  await page.keyboard.press('Delete');
+  await sleep(page, 500);
+
+  assert(await undoDepth(page) === depthBefore + 1,
+    `삭제가 undo 스택에 1건 기록 (${depthBefore}→${await undoDepth(page)})`);
+
+  // 조각 경로 증거 — top 엔트리가 스냅샷이 아니라 조각 소비자인지 런타임에 확인
+  const entry = await page.evaluate(() => {
+    const c = window.__inputHandler.history.undoStack.at(-1);
+    return { type: c?.type, slots: c?.snapshotResourceCount?.() ?? null };
+  });
+  assert(entry.type === 'deleteSelection', `top 엔트리 타입 (${entry.type})`);
+  assert(entry.slots === 0,
+    `조각 경로는 스냅샷 슬롯 0 이어야 한다 (#5769 예산 무기여) — got ${entry.slots}`);
+
+  const afterDelete = await exportBytes(page);
+  assert(firstDiff(before, afterDelete) !== -1, '삭제 직후 export 는 베이스라인과 달라야 함');
+
+  // ── undo 후 바이트 동일성 ────────────────────────────────
+  console.log('\n[3] Ctrl+Z → 저장 바이트 왕복 비교...');
+  await pressUndo(page);
+
+  // 문단 내용 복원 확인 — 조각이 되돌린 본문 실체.
+  const lens = await page.evaluate(() => {
+    const w = window.__wasm;
+    return Array.from({ length: w.getParagraphCount(0) }, (_, i) => w.getParagraphLength(0, i));
+  });
+  assert(JSON.stringify(lens) === JSON.stringify(baseLens),
+    `문단 길이 복원 (${JSON.stringify(baseLens)} → ${JSON.stringify(lens)})`);
+
+  // [#4180] 저장 시점 캐럿 스탬핑 — exportHwp 는 JS 커서를 WASM 캐럿에 찍고 직렬화한다.
+  // undo 는 #3416 계약대로 선택 끝으로 커서를 되돌리므로(#3416) baseline 시점 커서와 다르고,
+  // 그 차이는 DocProperties 캐럿 바이트(@888 부근)로 나온다. 이는 조각 결함이 아니라
+  // 의도된 저장 경로 동작이라, baseline 과 같은 커서로 되돌린 뒤 순수 문서 바이트를 비교한다.
+  await page.evaluate((pos) => window.__inputHandler.cursor.moveTo(pos), basePos);
+  await sleep(page, 300);
+
+  const afterUndo = await exportBytes(page);
+  assert(afterUndo.length === before.length,
+    `바이트 길이 복원 (${before.length} → ${afterUndo.length})`);
+  const diffAt = firstDiff(before, afterUndo);
+  assert(diffAt === -1, `undo 후 export 가 삭제 전과 동일해야 함(커서 동일화) — 첫 불일치 @${diffAt}`);
+  console.log(`  바이트 ${before.length}B 왕복 동일 ✓`);
+}, { skipLoadApp: false });

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -60,7 +60,8 @@
     "e2e:pdf-render-diff": "node e2e/pdf-render-diff-report.mjs --mode=headless",
     "e2e:render-diff:ci": "node e2e/run-render-diff.mjs",
     "metrics:frontend": "node ../scripts/frontend-metrics.mjs",
-    "e2e:manifest-check": "python3 ../scripts/check_e2e_manifest.py"
+    "e2e:manifest-check": "python3 ../scripts/check_e2e_manifest.py",
+    "e2e:undo-delete-fragment-bytes": "node e2e/undo-delete-fragment-bytes.test.mjs --mode=headless"
   },
   "devDependencies": {
     "@types/chrome": "^0.2.6",

--- a/rhwp-studio/src/core/mutation-method-registry.ts
+++ b/rhwp-studio/src/core/mutation-method-registry.ts
@@ -91,4 +91,8 @@ export const EXCLUDED_NON_DOCUMENT: readonly string[] = [
   // 경로로 고정돼 있어(SnapshotCommand.undo 의 restoreSnapshot 과 같은 취급)
   // executeOperation 라우팅 강제 대상에서 제외한다. 히스토리 밖 직접 호출 금지.
   'captureDeleteRange', 'restoreDeleteFragment', 'discardDeleteFragment',
+  // [#5769 Stage 4] 구역 raw 저널 API — capture·discard 는 IR 비변경.
+  // restoreSectionRaw 는 passthrough 를 되살리지만 SetSectionPropsCommand.undo 단일
+  // 경로로 고정돼 있어(restoreDeleteFragment 와 같은 취급) 제외한다. 히스토리 밖 직접 호출 금지.
+  'captureSectionRaw', 'restoreSectionRaw', 'discardSectionRaw',
 ];

--- a/rhwp-studio/src/core/mutation-method-registry.ts
+++ b/rhwp-studio/src/core/mutation-method-registry.ts
@@ -86,6 +86,9 @@ export const EXCLUDED_NON_DOCUMENT: readonly string[] = [
   'setActiveField', 'clearActiveField', // 편집 세션 상태 (직렬화 비대상)
   'moveVertical', 'moveVerticalByPath', // 캐럿 세로 탐색 (조회)
   'ensureParagraphStableIds', // 런타임 추적 id 부여
-  // [#5769] 삭제 조각(fragment) API — 문서 IR 변경이 아니라 undo 인프라
+  // [#5769] 삭제 조각(fragment) API — capture·discard 는 IR 비변경(캡처·저장소 정리).
+  // restoreDeleteFragment 는 IR 을 되살리는 변이지만 배선이 CommandHistory.undo 단일
+  // 경로로 고정돼 있어(SnapshotCommand.undo 의 restoreSnapshot 과 같은 취급)
+  // executeOperation 라우팅 강제 대상에서 제외한다. 히스토리 밖 직접 호출 금지.
   'captureDeleteRange', 'restoreDeleteFragment', 'discardDeleteFragment',
 ];

--- a/rhwp-studio/src/core/mutation-method-registry.ts
+++ b/rhwp-studio/src/core/mutation-method-registry.ts
@@ -86,4 +86,6 @@ export const EXCLUDED_NON_DOCUMENT: readonly string[] = [
   'setActiveField', 'clearActiveField', // 편집 세션 상태 (직렬화 비대상)
   'moveVertical', 'moveVerticalByPath', // 캐럿 세로 탐색 (조회)
   'ensureParagraphStableIds', // 런타임 추적 id 부여
+  // [#5769] 삭제 조각(fragment) API — 문서 IR 변경이 아니라 undo 인프라
+  'captureDeleteRange', 'restoreDeleteFragment', 'discardDeleteFragment',
 ];

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -2859,6 +2859,23 @@ export class WasmBridge {
     this.doc.discardDeleteFragment(id);
   }
 
+  // ─── [#5769 Stage 4] 구역 raw 저널 API ─────────────────
+
+  captureSectionRaw(sectionIdx: number): number {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return this.doc.captureSectionRaw(sectionIdx);
+  }
+
+  restoreSectionRaw(id: number): string {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return this.doc.restoreSectionRaw(id);
+  }
+
+  discardSectionRaw(id: number): void {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    this.doc.discardSectionRaw(id);
+  }
+
   // ─── 머리말/꼬리말 API ──────────────────────────────────
 
   getHeaderFooter(sectionIdx: number, isHeader: boolean, applyTo: number): string {

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -2842,6 +2842,23 @@ export class WasmBridge {
     this.doc.discardSnapshot(id);
   }
 
+  // ─── [#5769] 삭제 조각(fragment) API ──────────────────
+
+  captureDeleteRange(sectionIdx: number, startPara: number, endPara: number): number {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return this.doc.captureDeleteRange(sectionIdx, startPara, endPara);
+  }
+
+  restoreDeleteFragment(id: number): string {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return this.doc.restoreDeleteFragment(id);
+  }
+
+  discardDeleteFragment(id: number): void {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    this.doc.discardDeleteFragment(id);
+  }
+
   // ─── 머리말/꼬리말 API ──────────────────────────────────
 
   getHeaderFooter(sectionIdx: number, isHeader: boolean, applyTo: number): string {

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1,4 +1,4 @@
-import type {
+﻿import type {
   DeferredCellTextMutationResult,
   DeferredFocusedPagePatch,
   RemovedParaMeta,
@@ -841,28 +841,111 @@ export class MergeParagraphCommand implements EditCommand {
   mergeWith(): null { return null; }
 }
 
-// ─── 선택 영역 삭제 명령 ─────────────────────────────
+// ─── [#5769] 선택 영역 삭제 — 조각(fragment) 경로 ───────
 
+/**
+ * 스냅샷 대신 조각 저장소를 쓰는 선택 삭제 명령.
+ *
+ * captureDeleteRange → deleteRange → (undo: restoreDeleteFragment) 순서로,
+ * 스냅샷 2슬롯 대신 조각 1개(문단 클론 + 꼬리 line_segs + raw + 캐럿)로
+ * 역연산한다. snapshotResourceCount 는 항상 0 — 스냅샷 예산에 기여하지 않는다.
+ *
+ * redo: undo 가 조각을 소비하므로 문서를 다시 캡처해 삭제한다.
+ * 셀 내 삭제는 조각 API 미지원이라 cellOperation 이 있는 경우
+ * 스냅샷 경로로 폴백한다(Stage 3에서 확장).
+ */
+export class FragmentDeleteCommand implements EditCommand {
+  readonly type = 'deleteSelection';
+  readonly timestamp = Date.now();
+
+  private fragmentId: number | null = null;
+  private noOp = false;
+
+  constructor(
+    private cursorBefore: DocumentPosition,
+    private cursorAfter: DocumentPosition,
+    private selection: { start: DocumentPosition; end: DocumentPosition; blockPhase: number | null },
+    private sectionIdx: number,
+    private startPara: number,
+    private endPara: number,
+    private operation: (wasm: WasmBridge) => DocumentPosition | null,
+    private cellOperation: ((wasm: WasmBridge) => DocumentPosition | null) | null,
+  ) {}
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    if (this.cellOperation) {
+      return this.cellOperation(wasm);
+    }
+    this.fragmentId = wasm.captureDeleteRange(this.sectionIdx, this.startPara, this.endPara);
+    try {
+      const result = this.operation(wasm);
+      if (result === null) {
+        this.noOp = true;
+        wasm.discardDeleteFragment(this.fragmentId);
+        this.fragmentId = null;
+        return { ...this.cursorBefore };
+      }
+      return result;
+    } catch (e) {
+      wasm.discardDeleteFragment(this.fragmentId);
+      this.fragmentId = null;
+      throw e;
+    }
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    if (this.cellOperation) {
+      return this.cursorBefore;
+    }
+    if (this.fragmentId !== null) {
+      wasm.restoreDeleteFragment(this.fragmentId);
+      this.fragmentId = null;
+    }
+    return { ...this.cursorBefore };
+  }
+
+  mergeWith(): null { return null; }
+
+  selectionBefore(): { start: DocumentPosition; end: DocumentPosition; blockPhase: number | null } {
+    return this.selection;
+  }
+
+  snapshotResourceCount(): number {
+    return 0;
+  }
+
+  isNoOp(): boolean {
+    return this.noOp;
+  }
+
+  discard(wasm: WasmBridge): void {
+    if (this.fragmentId !== null) {
+      wasm.discardDeleteFragment(this.fragmentId);
+      this.fragmentId = null;
+    }
+    if (this.cellOperation) {
+      this.cellOperation = null;
+    }
+  }
+}
+/**
+ * 선택 영역 삭제 명령.
+ *
+ * 비셀(basic text) 선택은 [#5769] 조각 저장소를 사용한다 — 스냅샷 2슬롯 대신
+ * 조각 1개로 역연산해 스냅샷 예산을 절약한다. 셀 내 삭제는 조각 API 미지원이라
+ * 기존 SnapshotCommand 경로를 유지한다(Stage 3에서 확장).
+ *
+ * `kind:'command'` 로 남는다 — 양식 모드 게이트(`isOperationAllowedInEditMode` 의
+ * `'deleteSelection'` 분기)가 커맨드 타입에 걸려 있어, `kind:'snapshot'` 으로 바꾸면
+ * 양식 모드 선택 삭제가 게이트에서 드롭돼 무언 폐기가 된다.
+ */
 export class DeleteSelectionCommand implements EditCommand {
   readonly type = 'deleteSelection';
   readonly timestamp = Date.now();
 
-  /**
-   * 삭제 범위의 복원은 문서 스냅샷에 맡긴다 (Task #2418).
-   *
-   * 평문만 저장해 되돌리던 이전 방식은 글자 모양·문단 메타·인라인 컨트롤을 되살리지
-   * 못했다 — 재삽입은 삽입 지점의 현재 글자 모양을 쓰고, 다문단 복원은 문단 메타를 앞
-   * 문단에서 상속하는 `splitParagraph` 를 타며(#2342), 셀 다문단은 문단 구조 대신
-   * `'\n'` 이어붙이기로 대체됐다. 선택 범위의 서식·컨트롤을 평문 밖에서 따로 캡처하려면
-   * 글자모양 run·문단 메타·컨트롤을 읽고 되돌리는 API 가 새로 필요한데, 그것은 스냅샷이
-   * 이미 하는 일이다. 같은 이유로 붙여넣기(`pasteInternal` 등)가 스냅샷을 쓰므로 그
-   * 역연산인 선택 삭제도 같은 방식으로 맞춘다.
-   *
-   * `kind:'command'` 로 남는다 — 양식 모드 게이트(`isOperationAllowedInEditMode` 의
-   * `'deleteSelection'` 분기)가 커맨드 타입에 걸려 있어, `kind:'snapshot'` 으로 바꾸면
-   * 양식 모드 선택 삭제가 게이트에서 드롭돼 무언 폐기가 된다.
-   */
-  private readonly snapshot: SnapshotCommand;
+  /** 조각 경로(비셀) 또는 스냅샷 경로(셀). 둘 중 하나만 실체화된다. */
+  private readonly fragment: FragmentDeleteCommand | null;
+  private readonly snapshot: SnapshotCommand | null;
   private readonly selection: {
     start: DocumentPosition;
     end: DocumentPosition;
@@ -871,55 +954,74 @@ export class DeleteSelectionCommand implements EditCommand {
 
   constructor(start: DocumentPosition, end: DocumentPosition, blockPhase: number | null = null) {
     this.selection = { start: { ...start }, end: { ...end }, blockPhase };
-    // 삭제 후 커서는 선택 시작으로 모이고, undo 후에는 선택 끝으로 되돌아간다.
-    this.snapshot = new SnapshotCommand('deleteSelection', end, start, (wasm) => {
-      if (isCell(start)) {
-        // 중첩 셀 좌표 축 정합: flat controlIndex/cellIndex 는 cellPath[0](최외곽)이라
-        // 중첩 셀에서 바깥 셀을 지운다. 최내곽 셀을 대상으로 ...ByPath 로 라우팅하고,
-        // 셀 문단 인덱스는 cellPath[last] 에서 읽는다(cellParaIndexOf).
+
+    if (isCell(start)) {
+      // 셀 내 삭제 — 조각 API 미지원, 스냅샷 경로 유지 (Stage 3에서 확장)
+      this.fragment = null;
+      this.snapshot = new SnapshotCommand('deleteSelection', end, start, (wasm) => {
         wasm.deleteRangeInCellByPath(
           start.sectionIndex, start.parentParaIndex!, cellPathJson(start),
           cellParaIndexOf(start), start.charOffset, cellParaIndexOf(end), end.charOffset,
         );
-      } else {
-        wasm.deleteRange(
-          start.sectionIndex, start.paragraphIndex, start.charOffset,
-          end.paragraphIndex, end.charOffset,
-        );
-      }
-      return { ...start };
-    });
+        return { ...start };
+      });
+    } else {
+      // 비셀 선택 — 조각 경로 (#5769)
+      this.snapshot = null;
+      this.fragment = new FragmentDeleteCommand(
+        end,   // cursorBefore — undo 시 돌아갈 위치(선택 끝)
+        start, // cursorAfter — execute 후 커서 위치(선택 시작)
+        this.selection,
+        start.sectionIndex,
+        start.paragraphIndex,
+        end.paragraphIndex,
+        (wasm) => {
+          wasm.deleteRange(
+            start.sectionIndex, start.paragraphIndex, start.charOffset,
+            end.paragraphIndex, end.charOffset,
+          );
+          return { ...start };
+        },
+        null,
+      );
+    }
   }
 
   execute(wasm: WasmBridge): DocumentPosition {
-    return this.snapshot.execute(wasm);
+    return this.fragment
+      ? this.fragment.execute(wasm)
+      : this.snapshot!.execute(wasm);
   }
 
   undo(wasm: WasmBridge): DocumentPosition {
-    return this.snapshot.undo(wasm);
+    return this.fragment
+      ? this.fragment.undo(wasm)
+      : this.snapshot!.undo(wasm);
   }
 
   mergeWith(): null { return null; }
 
-  /**
-   * [Task #3416] 지우기 전 선택 범위. undo 뒤 이 범위를 되살린다.
-   *
-   * undo 가 돌려주는 커서가 이미 `end`(선택 끝)라, 여기에 anchor(`start`)만 더하면 한컴과
-   * 같은 상태가 된다 — 실측에서 undo 후 선택은 `(0,0,18)~(0,0,22)`, 캐럿은 `(0,0,22)` 였다.
-   */
   selectionBefore(): { start: DocumentPosition; end: DocumentPosition; blockPhase: number | null } {
     return this.selection;
   }
 
   snapshotResourceCount(): number {
-    return this.snapshot.snapshotResourceCount();
+    return this.fragment
+      ? this.fragment.snapshotResourceCount()
+      : this.snapshot!.snapshotResourceCount();
+  }
+
+  isNoOp(): boolean {
+    return this.fragment
+      ? this.fragment.isNoOp()
+      : this.snapshot?.isNoOp() ?? false;
   }
 
   discard(wasm: WasmBridge): void {
-    this.snapshot.discard(wasm);
+    this.fragment?.discard(wasm);
+    this.snapshot?.discard(wasm);
   }
 }
-
 // ─── 글자 서식 적용 명령 ─────────────────────────────
 
 /** 문단 하나에 대한 서식 적용 정보 */

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1,4 +1,4 @@
-﻿import type {
+import type {
   DeferredCellTextMutationResult,
   DeferredFocusedPagePatch,
   RemovedParaMeta,
@@ -851,8 +851,8 @@ export class MergeParagraphCommand implements EditCommand {
  * 역연산한다. snapshotResourceCount 는 항상 0 — 스냅샷 예산에 기여하지 않는다.
  *
  * redo: undo 가 조각을 소비하므로 문서를 다시 캡처해 삭제한다.
- * 셀 내 삭제는 조각 API 미지원이라 cellOperation 이 있는 경우
- * 스냅샷 경로로 폴백한다(Stage 3에서 확장).
+ * 셀 내 삭제는 조각 API 미지원이라 DeleteSelectionCommand 생성자에서
+ * SnapshotCommand 경로로 폴백한다.
  */
 export class FragmentDeleteCommand implements EditCommand {
   readonly type = 'deleteSelection';
@@ -869,38 +869,35 @@ export class FragmentDeleteCommand implements EditCommand {
     private startPara: number,
     private endPara: number,
     private operation: (wasm: WasmBridge) => DocumentPosition | null,
-    private cellOperation: ((wasm: WasmBridge) => DocumentPosition | null) | null,
   ) {}
 
   execute(wasm: WasmBridge): DocumentPosition {
-    if (this.cellOperation) {
-      return this.cellOperation(wasm);
-    }
-    this.fragmentId = wasm.captureDeleteRange(this.sectionIdx, this.startPara, this.endPara);
+    // 지역 변수로 받는다 — catch 에서 프로퍼티 좁히기가 풀려 TS2345 가 난다(CI 실측).
+    const fragmentId = wasm.captureDeleteRange(this.sectionIdx, this.startPara, this.endPara);
+    this.fragmentId = fragmentId;
     try {
       const result = this.operation(wasm);
       if (result === null) {
         this.noOp = true;
-        wasm.discardDeleteFragment(this.fragmentId);
+        wasm.discardDeleteFragment(fragmentId);
         this.fragmentId = null;
         return { ...this.cursorBefore };
       }
       return result;
     } catch (e) {
-      wasm.discardDeleteFragment(this.fragmentId);
+      wasm.discardDeleteFragment(fragmentId);
       this.fragmentId = null;
       throw e;
     }
   }
 
   undo(wasm: WasmBridge): DocumentPosition {
-    if (this.cellOperation) {
-      return this.cursorBefore;
+    if (this.fragmentId === null) {
+      // 실행 전·이미 복원된 뒤의 undo 는 배선 버그다 — 무음 통과 대신 드러낸다.
+      throw new Error(`${this.type} undo 불가 — 살아있는 삭제 조각이 없다`);
     }
-    if (this.fragmentId !== null) {
-      wasm.restoreDeleteFragment(this.fragmentId);
-      this.fragmentId = null;
-    }
+    wasm.restoreDeleteFragment(this.fragmentId);
+    this.fragmentId = null;
     return { ...this.cursorBefore };
   }
 
@@ -922,9 +919,6 @@ export class FragmentDeleteCommand implements EditCommand {
     if (this.fragmentId !== null) {
       wasm.discardDeleteFragment(this.fragmentId);
       this.fragmentId = null;
-    }
-    if (this.cellOperation) {
-      this.cellOperation = null;
     }
   }
 }
@@ -982,7 +976,6 @@ export class DeleteSelectionCommand implements EditCommand {
           );
           return { ...start };
         },
-        null,
       );
     }
   }

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -4,7 +4,7 @@ import type {
   RemovedParaMeta,
   WasmBridge,
 } from '@/core/wasm-bridge';
-import type { DocumentPosition, CharProperties, ParaProperties, CellPathLike, CellPathEntry } from '@/core/types';
+import type { DocumentPosition, CharProperties, ParaProperties, CellPathLike, CellPathEntry, SectionDef } from '@/core/types';
 import { MAX_PAGE_LOCAL_TEXT_EDIT_CHARS } from './input-edit-invalidation';
 import type { LineEndpoints as LineEndpointsLike } from './object-drag-record';
 import { setObjectProps, type ObjectPropsRef } from './object-props';
@@ -2134,6 +2134,87 @@ export class SetObjectPropsCommand implements EditCommand {
    * 횟수가 다르다 — 묶으면 되돌리기 단위가 사용자가 누른 단위와 어긋난다.
    */
   mergeWith(): null { return null; }
+}
+
+/**
+ * 구역 설정(SectionDef)의 old/new 속성쌍 역연산 명령 (#5769 Stage 4).
+ *
+ * set_section_def 는 적용 시 구역 raw_stream 을 무효화한다 — 속성만 되돌리면 저장이
+ * IR 재구성 경로로 바뀌어 원본 바이트와 어긋난다(속성을 하나도 바꾸지 않고 같은 값을
+ * 한 번 적용만 해도 재현됨). 그래서 변경 직전 passthrough 를 captureSectionRaw 저널에
+ * 보관했다가 undo 에서 old 재적용(raw 재무효화) 뒤 되돌린다. Rust 수렴 실증:
+ * tests/cases/issue_5769_stage4_setter_convergence.rs — 바이트 왕복 동일.
+ *
+ * snapshotResourceCount 는 항상 0 — 스냅샷 예산을 쓰지 않는다.
+ */
+export class SetSectionPropsCommand implements EditCommand {
+  readonly type = 'setSectionProps';
+  readonly timestamp = Date.now();
+
+  /** execute 가 잡아 둔 passthrough 캡처. undo 가 소비하고 discard 가 해제한다. */
+  private captureId: number | null = null;
+  private noOp = false;
+
+  constructor(
+    private sectionIdx: number,
+    private before: SectionDef,
+    private after: SectionDef,
+    private cursorPos: DocumentPosition,
+  ) {}
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    if (this.propsEqual()) {
+      this.noOp = true;
+      return { ...this.cursorPos };
+    }
+    // redo 재실행도 같은 순서다 — undo 가 저널 항목을 소비하므로 항상 새로 캡처한다.
+    // 지역 변수로 받는다 — catch 에서 프로퍼티 좁히기가 풀린다(FragmentDeleteCommand 선례).
+    const captureId = wasm.captureSectionRaw(this.sectionIdx);
+    this.captureId = captureId;
+    try {
+      wasm.setSectionDef(this.sectionIdx, this.after);
+      return { ...this.cursorPos };
+    } catch (e) {
+      wasm.discardSectionRaw(captureId);
+      this.captureId = null;
+      throw e;
+    }
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    if (this.captureId === null) {
+      throw new Error(`${this.type} undo 불가 — 살아있는 raw 캡처가 없다`);
+    }
+    const captureId = this.captureId;
+    wasm.setSectionDef(this.sectionIdx, this.before); // old 재적용 — raw 재무효화를 동반한다
+    wasm.restoreSectionRaw(captureId); // passthrough 복원 — 저널 항목 소비
+    this.captureId = null;
+    return { ...this.cursorPos };
+  }
+
+  discard(wasm: WasmBridge): void {
+    if (this.captureId !== null) {
+      wasm.discardSectionRaw(this.captureId);
+      this.captureId = null;
+    }
+  }
+
+  snapshotResourceCount(): number { return 0; }
+
+  isNoOp(): boolean { return this.noOp; }
+
+  /** 병합하지 않는다 — 다이얼로그 확인 1회가 되돌리기 단위 1회다(한컴 정합). */
+  mergeWith(): null { return null; }
+
+  /** SectionDef 전 필드 비교 — after 만 보면 된다(execute 가 적용하는 것이 그것뿐). */
+  private propsEqual(): boolean {
+    const keys: (keyof SectionDef)[] = [
+      'pageNum', 'pageNumType', 'pictureNum', 'tableNum', 'equationNum',
+      'columnSpacing', 'defaultTabSpacing',
+      'hideHeader', 'hideFooter', 'hideMasterPage', 'hideBorder', 'hideFill', 'hideEmptyLine',
+    ];
+    return keys.every((key) => Object.is(this.before[key], this.after[key]));
+  }
 }
 
 /**

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -1,4 +1,4 @@
-﻿/** input-handler keyboard methods — extracted from InputHandler class */
+/** input-handler keyboard methods — extracted from InputHandler class */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { InsertTextCommand, InsertLineBreakCommand, InsertTabCommand, SplitParagraphCommand, SplitParagraphInCellCommand, InsertTextInHeaderFooterCommand, SplitParagraphInHeaderFooterCommand, SplitParagraphInFootnoteCommand, DeleteTextInFootnoteCommand, MergeParagraphInFootnoteCommand, cellParaIndexOf } from './command';

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -1,4 +1,4 @@
-/** input-handler keyboard methods — extracted from InputHandler class */
+﻿/** input-handler keyboard methods — extracted from InputHandler class */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { InsertTextCommand, InsertLineBreakCommand, InsertTabCommand, SplitParagraphCommand, SplitParagraphInCellCommand, InsertTextInHeaderFooterCommand, SplitParagraphInHeaderFooterCommand, SplitParagraphInFootnoteCommand, DeleteTextInFootnoteCommand, MergeParagraphInFootnoteCommand, cellParaIndexOf } from './command';
@@ -288,7 +288,7 @@ function positionAfterPasteResult(pos: DocumentPosition, parsed: any): DocumentP
 
 function pastePlainText(this: any, text: string, hasSelection: boolean): void {
   if (hasSelection) {
-    this.deleteSelection();
+    this.deleteSelection({ deferRecord: true });
   }
   if (!text) return;
 
@@ -1744,7 +1744,7 @@ export function onPaste(this: any, e: ClipboardEvent): void {
     // 컨트롤(개체) 붙여넣기 — 본문에서만 허용
     if (this.wasm.clipboardHasControl() && pos.parentParaIndex === undefined) {
       this.executeOperation({ kind: 'snapshot', operationType: 'pasteControl', operation: (wasm: WasmBridge) => {
-        if (hasSelection) this.deleteSelection();
+        if (hasSelection) this.deleteSelection({ deferRecord: true });
         const p = this.cursor.getPosition();
         const result = wasm.pasteControl(p.sectionIndex, p.paragraphIndex, p.charOffset);
         const parsed = JSON.parse(result);
@@ -1764,7 +1764,7 @@ export function onPaste(this: any, e: ClipboardEvent): void {
     // 내부 클립보드 텍스트 붙여넣기 (서식 보존)
     this.executeOperation({ kind: 'snapshot', operationType: 'pasteInternal', operation: (wasm: WasmBridge) => {
       this.pastedFieldEndOutsidePending = false;
-      if (hasSelection) this.deleteSelection();
+      if (hasSelection) this.deleteSelection({ deferRecord: true });
       const p = this.cursor.getPosition();
       let result: string;
       if (isNestedCellPosition(p)) {
@@ -1809,7 +1809,7 @@ export function onPaste(this: any, e: ClipboardEvent): void {
   // 외부 클립보드: HTML이 있으면 pasteHtml로 표/서식 보존 붙여넣기
   if (html) {
     this.executeOperation({ kind: 'snapshot', operationType: 'pasteHtml', operation: (wasm: WasmBridge) => {
-      if (hasSelection) this.deleteSelection();
+      if (hasSelection) this.deleteSelection({ deferRecord: true });
       const p = this.cursor.getPosition();
       let result: string;
       if (isNestedCellPosition(p)) {

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2531,10 +2531,16 @@ export class InputHandler {
     this.cursor.clearSelection();
     if (options?.deferRecord) {
       // 붙여넣기 등 스냅샷 콜백에서 호출될 때 — 히스토리 기록 없이 직접 실행만.
-      // DeleteSelectionCommand.execute() 는 WASM 삭제 + 커서 이동만 수행하므로
-      // history.execute() 없이 직접 호출해도 무방하다. 호출자의 SnapshotCommand 가
-      // before-snapshot 으로 전체 undo 를 커버한다.
-      cmd.execute(this.wasm);
+      // 호출자의 SnapshotCommand 가 before-snapshot 으로 전체 undo 를 커버한다.
+      //
+      // 반환값을 반드시 소비해 JS 커서를 옮긴다 — getPosition() 은 내부 캐시
+      // (`{ ...this.position }`)라 WASM 캐럿이 움직여도 갱신되지 않는다. 놓치면
+      // 이어지는 붙여넣기가 삭제 **전** 좌표(선택 끝)에 삽입된다(실측:
+      // "AAAABBBBCCCC" 에서 BBBB 선택+붙여넣기 → XYZ 가 끝에 붙는다).
+      // executeOperation('command') 의 moveTo·resetPreferredX 에 해당하는 최소 배선.
+      const newPos = cmd.execute(this.wasm);
+      this.cursor.moveTo(newPos);
+      this.cursor.resetPreferredX();
     } else {
       this.executeOperation({ kind: 'command', command: cmd });
     }

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -1,4 +1,4 @@
-import { WasmBridge } from '@/core/wasm-bridge';
+﻿import { WasmBridge } from '@/core/wasm-bridge';
 import type { DeferredFocusedPagePatch } from '@/core/wasm-bridge';
 import { EventBus } from '@/core/event-bus';
 import { CursorState } from './cursor';
@@ -2514,8 +2514,14 @@ export class InputHandler {
     }
   }
 
-  /** 선택 영역을 삭제한다 */
-  private deleteSelection(): void {
+  /**
+   * 선택 영역을 삭제한다.
+   *
+   * @param options.deferRecord true 이면 히스토리 기록 없이 직접 실행만 한다 —
+   *   붙여넣기 등에서 스냅샷 콜백 안에 들어갈 때 사용. 호출자가 SnapshotCommand 로
+   *   기록하므로 중복 엔트리를 방지한다.
+   */
+  private deleteSelection(options?: { deferRecord?: boolean }): void {
     const sel = this.cursor.getSelectionOrdered();
     if (!sel) return;
     if (!this.canDeleteSelectionInFormMode()) return;
@@ -2523,7 +2529,15 @@ export class InputHandler {
     // [Task #3416] F3 블록이면 확장 단계도 함께 기록한다 — 한컴은 undo 뒤 단계까지 되돌린다.
     const cmd = new DeleteSelectionCommand(sel.start, sel.end, this.cursor.blockSelectionPhase());
     this.cursor.clearSelection();
-    this.executeOperation({ kind: 'command', command: cmd });
+    if (options?.deferRecord) {
+      // 붙여넣기 등 스냅샷 콜백에서 호출될 때 — 히스토리 기록 없이 직접 실행만.
+      // DeleteSelectionCommand.execute() 는 WASM 삭제 + 커서 이동만 수행하므로
+      // history.execute() 없이 직접 호출해도 무방하다. 호출자의 SnapshotCommand 가
+      // before-snapshot 으로 전체 undo 를 커버한다.
+      cmd.execute(this.wasm);
+    } else {
+      this.executeOperation({ kind: 'command', command: cmd });
+    }
   }
 
   /** Undo 처리 */

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -1,4 +1,4 @@
-﻿import { WasmBridge } from '@/core/wasm-bridge';
+import { WasmBridge } from '@/core/wasm-bridge';
 import type { DeferredFocusedPagePatch } from '@/core/wasm-bridge';
 import { EventBus } from '@/core/event-bus';
 import { CursorState } from './cursor';

--- a/rhwp-studio/src/ui/dialog-apply.ts
+++ b/rhwp-studio/src/ui/dialog-apply.ts
@@ -1,6 +1,46 @@
 import type { CommandServices } from '@/command/types';
 import type { DocumentPosition } from '@/core/types';
 import type { InputHandler } from '@/engine/input-handler';
+import type { EditCommand } from '@/engine/command';
+
+/** kind:'command' 디스크립터 — 헬퍼 시그니처가 리터럴을 고정한다(#5769 Stage 4). */
+export interface CommandDescriptor {
+  kind: 'command';
+  command: EditCommand;
+}
+
+/**
+ * [Task #5769 Stage 4] 커맨드 객체를 편집 라우터로 보내는 공용 경로.
+ *
+ * 속성쌍 역연산처럼 operation 콜백 한 번으로 표현할 수 없는 배선(캡처→적용 순서,
+ * undo 시 재적용→복원)은 커맨드 객체를 만들어 kind:'command' 로 보낸다.
+ * 실패 처리 규약은 [`applyThroughRouter`] 와 같다 — 경고를 남기고 다이얼로그를
+ * 열어 둔다(onConfirm 이 false 를 받아 닫지 않는다).
+ *
+ * @returns 적용에 성공했으면 `true`. 그대로 `onConfirm` 의 반환값으로 쓰면 된다.
+ */
+export function applyCommandThroughRouter(options: {
+  services: CommandServices | undefined;
+  /** 로그 접두어 — 실패 원인을 찾을 수 있게 커맨드/다이얼로그를 식별한다. */
+  label: string;
+  command: (ih: InputHandler) => CommandDescriptor;
+  /** 라우터에 도달하지 못하는 환경의 직접 적용 경로. */
+  fallback: () => void;
+}): boolean {
+  const { services, label, command, fallback } = options;
+  try {
+    const ih = services?.getInputHandler();
+    if (ih) {
+      ih.executeOperation(command(ih));
+    } else {
+      fallback();
+    }
+    return true;
+  } catch (err) {
+    console.warn(`[${label}] 적용 실패:`, err);
+    return false;
+  }
+}
 
 /**
  * [Task #2370 클러스터 C] 다이얼로그 [확인]의 문서 변경을 편집 라우터로 보내는 공용 경로.

--- a/rhwp-studio/src/ui/section-settings-dialog.ts
+++ b/rhwp-studio/src/ui/section-settings-dialog.ts
@@ -3,7 +3,8 @@ import type { WasmBridge } from '@/core/wasm-bridge';
 import type { SectionDef } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
 import type { CommandServices } from '@/command/types';
-import { applyThroughRouter } from './dialog-apply';
+import { applyThroughRouter, applyCommandThroughRouter } from './dialog-apply';
+import { SetSectionPropsCommand } from '@/engine/command';
 
 const HWPUNIT_PER_PT = 100; // 1pt = 100 HWPUNIT (HWP 내부 단위)
 
@@ -161,7 +162,23 @@ export class SectionSettingsDialog extends ModalDialog {
     const apply = () => scope === 'all'
       ? this.wasm.setSectionDefAll(newDef)
       : this.wasm.setSectionDef(this.sectionIdx, newDef);
-    // [구역 설정 이관] snapshot 으로 라우팅(#2077 동형). services 미주입 시 직접 적용 fallback.
+    // [구역 설정 이관 → #5769 Stage 4 역연산화] 현재 구역 적용은 속성쌍 커맨드로
+    // 스냅샷 없이 되돌린다(raw 저널 포함 — SetSectionPropsCommand 참조).
+    // 문서 전체(all)는 다구역 저널이 필요해 기존 snapshot 경로를 유지한다.
+    if (scope !== 'all') {
+      // before 는 변경 전에 읽는다 — undo 가 이 값으로 되돌리고 raw 도 함께 복원한다.
+      const before = this.wasm.getSectionDef(this.sectionIdx);
+      return applyCommandThroughRouter({
+        services: this.services,
+        label: 'SectionSettingsDialog',
+        command: (ih) => ({
+          kind: 'command',
+          command: new SetSectionPropsCommand(this.sectionIdx, before, newDef, ih.getCursorPosition()),
+        }),
+        fallback: () => { if (apply().ok) this.eventBus.emit('document-changed'); },
+      });
+    }
+    // services 미주입 환경(구 호출부)의 직접 적용 fallback.
     return applyThroughRouter({
       services: this.services,
       label: 'SectionSettingsDialog',

--- a/rhwp-studio/tests/dialog-apply-standard.test.ts
+++ b/rhwp-studio/tests/dialog-apply-standard.test.ts
@@ -86,7 +86,7 @@ test('라우터와 fallback 예외를 실제로 false로 바꾼다', () => {
 test('라우팅된 다이얼로그 여섯은 모두 공용 헬퍼를 통과한다', () => {
   for (const rel of ROUTED_DIALOGS) {
     const s = src(rel);
-    assert.match(s, /import \{ applyThroughRouter \} from '\.\/dialog-apply'/, `${rel}: 헬퍼 import`);
+    assert.match(s, /import \{[^}]*applyThroughRouter[^}]*\} from '\.\/dialog-apply'/, `${rel}: 헬퍼 import`);
     assert.match(s, /return applyThroughRouter\(\{/, `${rel}: onConfirm 이 헬퍼 결과를 반환`);
     // 헬퍼 밖에서 직접 라우터를 부르면 표준화가 무너진다.
     assert.doesNotMatch(

--- a/rhwp-studio/tests/issue-5690-block-selection-phase.test.ts
+++ b/rhwp-studio/tests/issue-5690-block-selection-phase.test.ts
@@ -46,7 +46,7 @@ test('[#5690] 삭제 커맨드가 블록 확장 단계를 함께 들고 있다',
 
 test('[#5690] 호출부가 커서에서 단계를 읽어 커맨드에 넘긴다', () => {
   const handler = src('src/engine/input-handler.ts');
-  const del = functionBodyFrom(handler, 'private deleteSelection()');
+  const del = functionBodyFrom(handler, 'private deleteSelection(');
   assert.match(del, /new DeleteSelectionCommand\(sel\.start, sel\.end, this\.cursor\.blockSelectionPhase\(\)\)/,
     '삭제 시점의 블록 단계를 기록해야 한다');
 

--- a/rhwp-studio/tests/undo-delete-selection-multipara.test.ts
+++ b/rhwp-studio/tests/undo-delete-selection-multipara.test.ts
@@ -36,12 +36,15 @@ function classBlock(src: string, name: string): string {
 const block = classBlock(commandSrc, 'DeleteSelectionCommand');
 
 test('undo 는 조각 복원또는 스냅샷 복원에 위임한다', () => {
-  // [#5769] 비셀 선택은 조각 경로, 셀 선택은 스냅샷 경로 — 둘 중 하나를 쓴다.
-  assert.match(block, /FragmentDeleteCommand|new SnapshotCommand\('deleteSelection'/,
-    '조각 또는 스냅샷 커맨드에 위임');
-  assert.match(block,
-    /undo\(wasm: WasmBridge\): DocumentPosition \{[\s\S]{0,300}?return this\.(fragment|snapshot)[\s\S]{0,20}\?\.undo\(wasm\)|this\.snapshot!\.undo\(wasm\)/,
-    'undo 는 조각또는 스냅샷 복원만 한다');
+  // [#5769] 비셀 선택은 조각 경로, 셀 선택은 스냅샷 경로 — 두 분기가 **모두** 살아있어야 한다.
+  // alternation(|) 하나로만 검사하면 한쪽 경로가 통째로 빠져도 green 이 되므로 각각 핀한다.
+  assert.match(block, /new FragmentDeleteCommand\(/, '비셀 경로는 조각 커맨드에 위임');
+  assert.match(block, /new SnapshotCommand\('deleteSelection'/, '셀 경로는 스냅샷 커맨드에 위임');
+  assert.match(
+    block,
+    /undo\(wasm: WasmBridge\): DocumentPosition \{\s*return this\.fragment\s*\?\s*this\.fragment\.undo\(wasm\)\s*:\s*this\.snapshot!\.undo\(wasm\);/,
+    'undo 는 조각 또는 스냅샷 복원에 위임한다',
+  );
 });
 
 test('스냅샷 커서 인자는 (cursorBefore=end, cursorAfter=start) 순서다', () => {
@@ -75,10 +78,17 @@ test('undo 가 텍스트 재조립으로 되돌아가지 않는다', () => {
 });
 
 test('스냅샷 예산에 참여한다', () => {
-  // [#5769] 비셀은 조각으로 0 슬롯, 셀은 스냅샷으로 위임 — 어느 쪽이든
-  // 히스토리가 리소스를 세고 해제할 수 있어야 한다.
-  assert.match(block, /snapshotResourceCount\(\): number \{[\s\S]{0,200}?(this\.fragment|this\.snapshot)/,
-    'id 개수 위임(조각또는 스냅샷)');
-  assert.match(block, /discard\(wasm: WasmBridge\): void \{[\s\S]{0,200}?(this\.fragment|this\.snapshot)/,
-    'discard 위임(조각또는 스냅샷)');
+  // [#5769] 비셀은 조각으로 0 슬롯, 셀은 스냅샷 위임 — 두 경로 모두 히스토리가
+  // 리소스를 세고 해제할 수 있어야 한다(#2328). 느슨한 [\s\S] 윈도우로 검사하면
+  // 위임이 빠져도 green 이 되므로 실제 위임식을 핀한다.
+  assert.match(
+    block,
+    /snapshotResourceCount\(\): number \{\s*return this\.fragment\s*\?\s*this\.fragment\.snapshotResourceCount\(\)\s*:\s*this\.snapshot!\.snapshotResourceCount\(\);/,
+    'id 개수 위임(조각·스냅샷 모두)',
+  );
+  assert.match(
+    block,
+    /discard\(wasm: WasmBridge\): void \{\s*this\.fragment\?\.discard\(wasm\);\s*this\.snapshot\?\.discard\(wasm\);/,
+    'discard 위임(조각·스냅샷 모두)',
+  );
 });

--- a/rhwp-studio/tests/undo-delete-selection-multipara.test.ts
+++ b/rhwp-studio/tests/undo-delete-selection-multipara.test.ts
@@ -35,10 +35,13 @@ function classBlock(src: string, name: string): string {
 
 const block = classBlock(commandSrc, 'DeleteSelectionCommand');
 
-test('undo 는 스냅샷 복원에 위임한다', () => {
-  assert.match(block, /new SnapshotCommand\('deleteSelection'/, '스냅샷 커맨드에 위임');
-  assert.match(block, /undo\(wasm: WasmBridge\): DocumentPosition \{\s*\n\s*return this\.snapshot\.undo\(wasm\);/,
-    'undo 는 스냅샷 복원만 한다');
+test('undo 는 조각 복원또는 스냅샷 복원에 위임한다', () => {
+  // [#5769] 비셀 선택은 조각 경로, 셀 선택은 스냅샷 경로 — 둘 중 하나를 쓴다.
+  assert.match(block, /FragmentDeleteCommand|new SnapshotCommand\('deleteSelection'/,
+    '조각 또는 스냅샷 커맨드에 위임');
+  assert.match(block,
+    /undo\(wasm: WasmBridge\): DocumentPosition \{[\s\S]{0,300}?return this\.(fragment|snapshot)[\s\S]{0,20}\?\.undo\(wasm\)|this\.snapshot!\.undo\(wasm\)/,
+    'undo 는 조각또는 스냅샷 복원만 한다');
 });
 
 test('스냅샷 커서 인자는 (cursorBefore=end, cursorAfter=start) 순서다', () => {
@@ -72,10 +75,10 @@ test('undo 가 텍스트 재조립으로 되돌아가지 않는다', () => {
 });
 
 test('스냅샷 예산에 참여한다', () => {
-  // 위임만 하고 snapshotResourceCount/discard 를 안 넘기면 히스토리가 이 커맨드의 WASM
-  // 스냅샷 id 를 세지 못해 예산이 어긋나고, 축출 시 id 가 반환되지 않아 누수된다(#2328).
-  assert.match(block, /snapshotResourceCount\(\): number \{\s*\n\s*return this\.snapshot\.snapshotResourceCount\(\);/,
-    'id 개수 위임');
-  assert.match(block, /discard\(wasm: WasmBridge\): void \{\s*\n\s*this\.snapshot\.discard\(wasm\);/,
-    'discard 위임');
+  // [#5769] 비셀은 조각으로 0 슬롯, 셀은 스냅샷으로 위임 — 어느 쪽이든
+  // 히스토리가 리소스를 세고 해제할 수 있어야 한다.
+  assert.match(block, /snapshotResourceCount\(\): number \{[\s\S]{0,200}?(this\.fragment|this\.snapshot)/,
+    'id 개수 위임(조각또는 스냅샷)');
+  assert.match(block, /discard\(wasm: WasmBridge\): void \{[\s\S]{0,200}?(this\.fragment|this\.snapshot)/,
+    'discard 위임(조각또는 스냅샷)');
 });

--- a/rhwp-studio/tests/undo-delete-selection-multipara.test.ts
+++ b/rhwp-studio/tests/undo-delete-selection-multipara.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { functionBodyFrom } from './support/source-guard.ts';
 
 // DeleteSelectionCommand.undo 의 복원 방식 가드.
 //
@@ -90,5 +91,19 @@ test('스냅샷 예산에 참여한다', () => {
     block,
     /discard\(wasm: WasmBridge\): void \{\s*this\.fragment\?\.discard\(wasm\);\s*this\.snapshot\?\.discard\(wasm\);/,
     'discard 위임(조각·스냅샷 모두)',
+  );
+});
+
+test('[#5769] deferRecord 는 반환 위치로 JS 커서를 동기한다', () => {
+  // 붙여넣기 스냅샷 콜백 안에서 deleteSelection({deferRecord:true}) 가 실행되면,
+  // 이어지는 paste* 가 getPosition() 으로 좌표를 읽는다. getPosition 은 내부 캐시라
+  // execute() 의 반환 위치를 moveTo 로 옮기지 않으면 삭제 **전** 좌표에 삽입된다
+  // (실측: "AAAABBBBCCCC" 에서 BBBB 선택+붙여넣기 → XYZ 가 문단 끝에 붙는다).
+  const handlerSrc = readFileSync(join(rootDir, 'src/engine/input-handler.ts'), 'utf8');
+  const del = functionBodyFrom(handlerSrc, 'private deleteSelection(');
+  assert.match(
+    del,
+    /const newPos = cmd\.execute\(this\.wasm\);\s*this\.cursor\.moveTo\(newPos\);\s*this\.cursor\.resetPreferredX\(\);/,
+    'deferRecord 분기는 execute 반환 위치를 moveTo+resetPreferredX 로 소비해야 한다',
   );
 });

--- a/rhwp-studio/tests/undo-layout-dialogs.test.ts
+++ b/rhwp-studio/tests/undo-layout-dialogs.test.ts
@@ -44,7 +44,8 @@ for (const { file, op } of DIALOGS) {
     assert.match(s, /services\?:\s*CommandServices/, `${file}: 생성자에 services 주입`);
     assert.match(s, /import type \{ CommandServices \}/, `${file}: CommandServices import`);
     // onConfirm 이 공용 헬퍼 경유로 snapshot 기록(헬퍼가 getInputHandler 도달을 담당).
-    assert.match(s, /import \{ applyThroughRouter \} from '\.\/dialog-apply'/, `${file}: 공용 헬퍼 import`);
+    // [#5769 Stage 4] 헬퍼 계열 확장(applyCommandThroughRouter)을 수용 — 공용 헬퍼 경유 자체를 핀한다.
+    assert.match(s, /import \{[^}]*applyThroughRouter[^}]*\} from '\.\/dialog-apply'/, `${file}: 공용 헬퍼 import`);
     assert.match(s, /return applyThroughRouter\(\{/, `${file}: onConfirm 이 헬퍼 결과를 반환`);
     assert.match(s, new RegExp(`operationType:\\s*'${op}'`), `${file}: ${op} snapshot 라우팅`);
     // services 미주입 환경 호환 fallback(직접 적용 + emit) 유지.
@@ -53,3 +54,23 @@ for (const { file, op } of DIALOGS) {
     assert.doesNotMatch(s, /catch[^\n]*\n[^\n]*적용 실패/, `${file}: 실패 처리는 헬퍼가 담당`);
   });
 }
+
+test('[#5769 Stage 4] section-settings 는 현재 구역 적용을 속성쌍 커맨드로 역연산화한다', () => {
+  const s = src('section-settings-dialog.ts');
+  assert.match(s, /new SetSectionPropsCommand\(/,
+    '현재 구역 적용은 raw 저널 포함 속성쌍 커맨드로 기록해야 한다');
+  assert.match(s, /scope !== 'all'/,
+    "문서 전체(all)는 다구역 저널이 필요해 스냅샷 잔류임을 코드에 명시해야 한다");
+  assert.match(s, /kind: 'command',/, '커맨드 경로는 kind:command 다(snapshot 아님)');
+
+  // 커맨드 본체의 저널 배선 핀 — 캡처→적용 순서와 undo 의 old 재적용→복원 순서.
+  const cmdSrc = readFileSync(join(rootDir, 'src/engine/command.ts'), 'utf8');
+  const cls = cmdSrc.slice(cmdSrc.indexOf('export class SetSectionPropsCommand'));
+  const body = cls.slice(0, cls.indexOf('\nexport class ', 1) === -1 ? undefined : cls.indexOf('\nexport class ', 1));
+  assert.match(body, /wasm\.captureSectionRaw\(this\.sectionIdx\)[\s\S]{0,200}?wasm\.setSectionDef/,
+    'execute 는 캡처 먼저, 적용 나중이어야 한다');
+  assert.match(body, /wasm\.setSectionDef\(this\.sectionIdx, this\.before\)[\s\S]{0,120}?wasm\.restoreSectionRaw/,
+    'undo 는 old 재적용(raw 재무효화) 뒤 raw 를 복원해야 한다');
+  assert.match(body, /snapshotResourceCount\(\): number \{ return 0; \}/,
+    '속성쌍 경로는 스냅샷 예산을 쓰지 않는다');
+});

--- a/src/document_core/commands/delete_fragment.rs
+++ b/src/document_core/commands/delete_fragment.rs
@@ -1,0 +1,217 @@
+//! 선택 삭제 조각(fragment) 저장소 — #5769 Stage 1.
+//!
+//! 삭제의 **참 역연산**: 제거되기 직전의 문단 범위 원본을 통째로 보관하고, undo 시
+//! 그 자리에 되돌려 끼운다(LibreOffice `SwNodes` undo 배열과 동일한 묘지 패턴).
+//! 스냅샷([`Document`] 클론, 문서 크기 비용)과 달리 조각 비용은 **삭제된 내용 +
+//! 뒤따르는 줄 좌표 저널**에만 비례한다.
+//!
+//! # 왜 사전 캡처인가
+//!
+//! [`Paragraph::delete_text_at`] 은 char_shapes 를 클램핑한 뒤 같은 start_pos 에 몰린
+//! ref 를 병합한다(#3576/#4271 — 규약상 의도된 동작). 한 번 병합되면 삭제 전 경계를
+//! 사후에 재구성할 수 없다(ProseMirror `Step.invert(docBefore)` 가 "이전 문서 없이는
+//! 반전 불가"라는 것과 같은 이유). 그래서 캡처는 반드시 삭제 **직전** 에 한다.
+//!
+//! # 왜 꼬리(tail) 줄 좌표 저널이 필요한가
+//!
+//! `delete_range_native` 는 삭제 후 `recalculate_section_vpos` 를 start_para 부터
+//! 구역 끝까지 돌려 뒤따르는 모든 문단의 `line_segs[].vertical_pos` 를 새 흐름에 맞게
+//! 덮어쓴다. HWP5 직렬화기는 그 값을 그대로 기록하므로(`body_text.rs` LINE_SEG),
+//! 범위만 되돌려서는 뒤 문단의 저장 바이트가 원본과 달라진다. 조각은 삭제 범위 뒤
+//! 문단들의 line_segs 스냅샷을 함께 들고 되돌린다.
+//!
+//! # 계약
+//!
+//! - 엄격 LIFO: 캡처와 복원 사이에 같은 구역의 다른 구조 편집이 끼면 안 된다.
+//!   위반을 구조적으로 잡기 위해 복원 시 "현재 문단 수 == 캡처 시 문단 수 − (범위 길이−1)"
+//!   을 검증한다(범위 삭제는 항상 병합으로 잔여 1문단을 남긴다).
+//! - 조각은 TS 히스토리가 스택에서 내보낼 때 `discardDeleteFragment` 로 해제한다.
+//!   코어는 자동 축출하지 않는다 — 스냅샷과 달리 MB 급이 아니므로 무통보 축출(#2328
+//!   클래스)을 만들 이유가 없다.
+//! - 셀 내부 삭제(cell_ctx)는 아직 스냅샷 폴백이다(Stage 3에서 조각 소비자로 확대).
+
+use crate::document_core::DocumentCore;
+use crate::error::HwpError;
+use crate::model::event::DocumentEvent;
+use crate::model::paragraph::{LineSeg, Paragraph};
+use crate::model::raw_provenance::SectionSeal;
+
+/// 선택 삭제 1회분의 복원 조각.
+#[derive(Debug, Clone)]
+pub struct DeleteFragment {
+    /// 대상 구역
+    pub section_idx: usize,
+    /// 삭제 범위 시작 문단 (포함)
+    pub start_para: usize,
+    /// 삭제 범위 끝 문단 (포함)
+    pub end_para: usize,
+    /// 캡처 시점 구역 문단 수 — 복원 전제 검증용
+    pub pre_para_count: usize,
+    /// 삭제 직전 원본 문단들 — `paragraphs[start..=end]` 전체.
+    /// line_segs·char_shapes·controls·ctrl_data_records·range_tags 등
+    /// 문단 소속 전 필드를 통째로 되돌린다.
+    pub captured_paras: Vec<Paragraph>,
+    /// 삭제 범위 **뒤** 문단들의 line_segs 스냅샷 — index 0 이 `end_para+1`.
+    /// `recalculate_section_vpos` 가 start_para 이후 vertical_pos 를 덮어쓰는 것을 되돌린다.
+    pub tail_line_segs: Vec<Vec<LineSeg>>,
+    /// 삭제 직전 구역 raw 스트림(None 이면 원래도 None). delete 가 None 으로 박는 것을 되돌려
+    /// 저장 바이트 왕복 동일성을 지킨다.
+    pub raw_stream: Option<Vec<u8>>,
+    /// raw_stream 출처 봉인 — raw_stream 과 짝으로 복원한다(#4493 계약).
+    pub raw_provenance: Option<SectionSeal>,
+    /// 삭제 직전 캐럿 — delete 가 doc_properties.caret_* 을 옮기는데, DocInfo 봉인
+    /// 다이제스트가 DocProperties 전체를 포함하므로(`raw_provenance.rs`
+    /// `doc_info_model_digest`) 이것도 되돌려야 DocInfo raw 재사용이 살아난다.
+    pub caret: (u32, u32),
+}
+
+impl DocumentCore {
+    /// 삭제 직전 문단 범위 원본을 조각으로 보관하고 조각 ID 를 반환한다.
+    ///
+    /// 반드시 `delete_range_native` **호출 전**에 불린다. 호출 순서:
+    /// capture → delete → (성공 시 조각 보관 / 실패 시 discard).
+    pub fn capture_delete_range_native(
+        &mut self,
+        section_idx: usize,
+        start_para: usize,
+        end_para: usize,
+    ) -> Result<u32, HwpError> {
+        if section_idx >= self.document.sections.len() {
+            return Err(HwpError::RenderError(format!(
+                "구역 인덱스 {} 범위 초과 (총 {}개)",
+                section_idx,
+                self.document.sections.len()
+            )));
+        }
+        let section = &self.document.sections[section_idx];
+        if start_para > end_para {
+            return Err(HwpError::RenderError(format!(
+                "조각 범위 뒤집힘 (start={} > end={})",
+                start_para, end_para
+            )));
+        }
+        if end_para >= section.paragraphs.len() {
+            return Err(HwpError::RenderError(format!(
+                "조각 범위 초과 (end={}, 총 {}문단)",
+                end_para,
+                section.paragraphs.len()
+            )));
+        }
+
+        let captured_paras = section.paragraphs[start_para..=end_para].to_vec();
+        let tail_line_segs = section.paragraphs[end_para + 1..]
+            .iter()
+            .map(|p| p.line_segs.clone())
+            .collect();
+        let fragment = DeleteFragment {
+            section_idx,
+            start_para,
+            end_para,
+            pre_para_count: section.paragraphs.len(),
+            captured_paras,
+            tail_line_segs,
+            raw_stream: section.raw_stream.clone(),
+            raw_provenance: section.raw_provenance.clone(),
+            caret: (
+                self.document.doc_properties.caret_list_id,
+                self.document.doc_properties.caret_para_id,
+            ),
+        };
+
+        let id = self.next_fragment_id;
+        self.next_fragment_id += 1;
+        self.fragment_store.push((id, fragment));
+        Ok(id)
+    }
+
+    /// 조각을 원래 자리에 되돌려 끼운다 — 삭제의 참 역연산.
+    ///
+    /// 범위 앞뒤는 그대로 두고 `[start..=end]` 자리에 캡처 원본을 다시 끼우고,
+    /// 뒤 문단의 line_segs 와 구역 raw 필드를 캡처 시점 값으로 되돌린 뒤
+    /// 파생 상태를 재구성한다(스냅샷 복원과 동일 경로).
+    pub fn restore_delete_fragment_native(&mut self, frag_id: u32) -> Result<String, HwpError> {
+        let pos = self
+            .fragment_store
+            .iter()
+            .position(|(id, _)| *id == frag_id)
+            .ok_or_else(|| HwpError::RenderError(format!("삭제 조각 {} 없음", frag_id)))?;
+        let frag = self.fragment_store.remove(pos).1;
+
+        if frag.section_idx >= self.document.sections.len() {
+            return Err(HwpError::RenderError(format!(
+                "삭제 조각 {} 의 구역 {} 이 현재 문서에 없습니다",
+                frag_id, frag.section_idx
+            )));
+        }
+        let section = &mut self.document.sections[frag.section_idx];
+        // 전제 검증 — 삭제가 적용된 직후 형태(잔여 1문단 병합)인지 확인한다.
+        // 캡처 후 삭제가 실패했거나 다른 편집이 끼었으면 여기서 거부해 무음 중복 삽입을 막는다.
+        let expected_post_count = frag.pre_para_count - (frag.end_para - frag.start_para);
+        if section.paragraphs.len() != expected_post_count {
+            return Err(HwpError::RenderError(format!(
+                "삭제 조각 {} 의 전제가 어긋났습니다 (현재 {}문단 != 예상 {}문단) — \
+                 캡처와 복원 사이에 다른 편집이 끼었거나 삭제가 적용되지 않았습니다",
+                frag_id,
+                section.paragraphs.len(),
+                expected_post_count
+            )));
+        }
+        if frag.start_para >= section.paragraphs.len() {
+            return Err(HwpError::RenderError(format!(
+                "삭제 조각 {} 의 시작 문단 {} 이 현재 문서에 없습니다",
+                frag_id, frag.start_para
+            )));
+        }
+
+        // [start] 자리의 삭제 후 잔여(병합) 문단을 원본으로 교체 + 나머지 원본 재삽입
+        let mut restored: Vec<Paragraph> = Vec::with_capacity(frag.pre_para_count);
+        restored.extend_from_slice(&section.paragraphs[..frag.start_para]);
+        restored.extend(frag.captured_paras.iter().cloned());
+        restored.extend_from_slice(&section.paragraphs[frag.start_para + 1..]);
+        section.paragraphs = restored;
+
+        // 꼬리 줄 좌표 저널 복원 — recalculate_section_vpos 의 덮어쓰기를 되돌린다
+        for (offset, segs) in frag.tail_line_segs.iter().enumerate() {
+            let pi = frag.end_para + 1 + offset;
+            if pi < section.paragraphs.len() {
+                section.paragraphs[pi].line_segs = segs.clone();
+            }
+        }
+
+        // 구역 raw 필드 복원 — 저장 바이트 왕복 동일성의 핵심
+        section.raw_stream = frag.raw_stream.clone();
+        section.raw_provenance = frag.raw_provenance.clone();
+
+        let cursor_para = frag.start_para;
+        let caret = frag.caret;
+
+        // 캐럿 복원 — DocInfo 봉인 다이제스트가 DocProperties 전체를 포함하므로
+        // 되돌리지 않으면 raw 재사용이 깨져 IR 재직렬화 폴백으로 바이트가 어긋난다.
+        self.document.doc_properties.caret_list_id = caret.0;
+        self.document.doc_properties.caret_para_id = caret.1;
+
+        // 파생 상태 재구성 — 스냅샷 복원과 동일 경로(compose·paginate·캐시 비움).
+        // 여기서 recalculate_section_vpos 를 다시 돌리지 않는다 — 원본 캐시 좌표가
+        // 이미 조각으로 복원됐으므로 재계산은 오히려 바이트를 어긋나게 한다.
+        self.rebuild_derived_state();
+
+        self.event_log.push(DocumentEvent::TextInserted {
+            section: frag.section_idx,
+            para: cursor_para,
+            offset: 0,
+            len: 0,
+        });
+        Ok(super::super::helpers::json_ok_with(&format!(
+            "\"paraIdx\":{},\"charOffset\":0",
+            cursor_para
+        )))
+    }
+
+    /// 조각을 저장소에서 제거하여 메모리를 해제한다.
+    ///
+    /// TS 히스토리가 엔트리를 축출·클리어할 때 스냅샷 `discardSnapshot` 과 짝으로
+    /// 호출하는 것이 계약이다. 코어는 자동 축출하지 않는다.
+    pub fn discard_delete_fragment_native(&mut self, frag_id: u32) {
+        self.fragment_store.retain(|(id, _)| *id != frag_id);
+    }
+}

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -202,6 +202,8 @@ impl DocumentCore {
             overflow_links_cache: RefCell::new(HashMap::new()),
             snapshot_store: Vec::new(),
             next_snapshot_id: 0,
+            fragment_store: Vec::new(),
+            next_fragment_id: 0,
             hidden_header_footer: std::collections::HashSet::new(),
             file_name: String::new(),
             active_field: None,

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -204,6 +204,8 @@ impl DocumentCore {
             next_snapshot_id: 0,
             fragment_store: Vec::new(),
             next_fragment_id: 0,
+            section_raw_store: Vec::new(),
+            next_section_raw_id: 0,
             hidden_header_footer: std::collections::HashSet::new(),
             file_name: String::new(),
             active_field: None,

--- a/src/document_core/commands/mod.rs
+++ b/src/document_core/commands/mod.rs
@@ -1,4 +1,7 @@
 mod clipboard;
+// [#5769] 삭제의 참 역연산 — 조각 저장소. DeleteFragment 타입이 DocumentCore
+// 필드로 쓰이므로 pub(crate).
+pub(crate) mod delete_fragment;
 mod document;
 mod footnote_ops;
 mod formatting;

--- a/src/document_core/commands/mod.rs
+++ b/src/document_core/commands/mod.rs
@@ -12,3 +12,6 @@ mod object_ops;
 pub mod page_extract;
 mod table_ops;
 mod text_editing;
+// [#5769] Stage 4 — 구역 raw 저널. SectionRawCapture 타입이 DocumentCore 필드로
+// 쓰이므로 pub(crate).
+pub(crate) mod section_raw_journal;

--- a/src/document_core/commands/section_raw_journal.rs
+++ b/src/document_core/commands/section_raw_journal.rs
@@ -1,0 +1,117 @@
+//! 구역 raw 저널 — #5769 Stage 4.
+//!
+//! set_section_def / set_page_def 는 적용 시 `section.raw_stream = None` 으로
+//! passthrough 를 무효화한다(`apply_section_def_json`, `set_page_def_native`).
+//! 무효화된 채 저장하면 직렬화기가 IR 재구성 경로로 바뀌어 원본 한컴 바이트와
+//! 어긋난다 — **속성을 하나도 바꾸지 않고 같은 값을 한 번 적용만 해도** 저장
+//! 바이트가 달라진다(실측: 표본 hongbo @1144,
+//! `tests/cases/issue_5769_stage4_setter_convergence.rs`).
+//!
+//! 이 저널은 속성 변경 **직전** 의 구역 raw 스트림+출처 봉인을 보관했다가, old
+//! 속성 재적용(raw 재무효화) 뒤 되돌려 "속성쌍 역연산 + passthrough 복원"으로
+//! 스냅샷 없이 저장 바이트를 수렴시킨다.
+//!
+//! # page_def 는 대상이 아니다
+//!
+//! page_def(기하 키)는 wrap 폭 변화 시 본문 전체를 재래핑해 저장 line_segs 를
+//! 통째로 재작성한다([#4956] `reflow_body_paragraphs_in_section`). 원본 파일의
+//! 한컴 줄 나눔은 rhwp 조판값과 다르므로 raw 복원만으로 수렴하지 않는다(같은
+//! 실측에서 len 562176→561664 잔류). page_setup·page_margin 은 스냅샷 잔류다
+//! (그림 회전 선례 준용).
+//!
+//! # 계약
+//!
+//! - 캡처는 반드시 setter 호출 **전**, 복원은 old 재적용 **후** 에 한다. 캡처와
+//!   복원 사이에 그 구역의 다른 편집이 끼면 안 된다(TS 히스토리의 선형
+//!   execute/undo 가 보장하는 엄격 짝).
+//! - 복원 전제 검증: 현재 raw 가 무효화(None) 상태여야 한다 — Some 인 채의 복원
+//!   요청은 이중 undo 같은 배선 버그므로 거부해 무음 중복 복원을 막는다.
+//! - 코어는 자동 축출하지 않는다 — TS 히스토리가 스택에서 내보낼 때
+//!   `discardSectionRaw` 로 해제하는 것이 계약이다(delete fragment 와 동일).
+
+use crate::document_core::DocumentCore;
+use crate::error::HwpError;
+use crate::model::raw_provenance::SectionSeal;
+
+/// 구역 passthrough 1회분 캡처.
+#[derive(Debug, Clone)]
+pub struct SectionRawCapture {
+    /// 대상 구역
+    pub section_idx: usize,
+    /// 변경 직전 구역 raw 스트림(None 이면 원래도 None)
+    pub raw_stream: Option<Vec<u8>>,
+    /// raw_stream 출처 봉인 — raw 와 짝으로 복원한다(#4493 계약)
+    pub raw_provenance: Option<SectionSeal>,
+}
+
+impl DocumentCore {
+    /// 속성 변경 직전 구역 raw 를 보관하고 ID 를 돌려준다.
+    ///
+    /// 반드시 `set_section_def_native` / `set_page_def_native` 호출 **전** 에 불린다.
+    pub fn capture_section_raw_native(&mut self, section_idx: usize) -> Result<u32, HwpError> {
+        let section = self.document.sections.get(section_idx).ok_or_else(|| {
+            HwpError::RenderError(format!(
+                "구역 {} 범위 초과 (총 {}개)",
+                section_idx,
+                self.document.sections.len()
+            ))
+        })?;
+        let capture = SectionRawCapture {
+            section_idx,
+            raw_stream: section.raw_stream.clone(),
+            raw_provenance: section.raw_provenance.clone(),
+        };
+        let id = self.next_section_raw_id;
+        self.next_section_raw_id += 1;
+        self.section_raw_store.push((id, capture));
+        Ok(id)
+    }
+
+    /// 캡처한 구역 raw 를 되돌린다 — old 속성 재적용(raw 재무효화) **뒤** 에 불린다.
+    ///
+    /// 저널 항목은 소비된다(제거). redo 가 다시 execute 하면 그때 다시 캡처한다.
+    pub fn restore_section_raw_native(&mut self, capture_id: u32) -> Result<String, HwpError> {
+        let pos = self
+            .section_raw_store
+            .iter()
+            .position(|(id, _)| *id == capture_id);
+        let capture = match pos {
+            Some(pos) => self.section_raw_store.remove(pos).1,
+            None => {
+                return Err(HwpError::RenderError(format!(
+                    "구역 raw 캡처 {} 없음",
+                    capture_id
+                )))
+            }
+        };
+
+        let section = self
+            .document
+            .sections
+            .get_mut(capture.section_idx)
+            .ok_or_else(|| {
+                HwpError::RenderError(format!(
+                    "캡처 {} 의 구역 {} 이 현재 문서에 없습니다",
+                    capture_id, capture.section_idx
+                ))
+            })?;
+        // 전제 검증 — setter 가 무효화한 직후(None)여야 복원이 성립한다.
+        if section.raw_stream.is_some() {
+            return Err(HwpError::RenderError(format!(
+                "구역 raw 캡처 {} 의 전제가 어긋났습니다 — passthrough 가 이미 살아있다",
+                capture_id
+            )));
+        }
+        section.raw_stream = capture.raw_stream;
+        section.raw_provenance = capture.raw_provenance;
+        Ok("{\"ok\":true}".to_string())
+    }
+
+    /// 저널 항목을 제거하여 메모리를 해제한다.
+    ///
+    /// TS 히스토리가 엔트리를 축출·클리어할 때 `discardDeleteFragment` 와 짝으로
+    /// 호출하는 것이 계약이다.
+    pub fn discard_section_raw_native(&mut self, capture_id: u32) {
+        self.section_raw_store.retain(|(id, _)| *id != capture_id);
+    }
+}

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -3151,7 +3151,7 @@ impl DocumentCore {
 
     // ─── Phase 3 네이티브 구현: 커서 이동 API ─────────────────
 
-    pub(crate) fn delete_range_native(
+    pub fn delete_range_native(
         &mut self,
         section_idx: usize,
         start_para: usize,

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -3151,6 +3151,9 @@ impl DocumentCore {
 
     // ─── Phase 3 네이티브 구현: 커서 이동 API ─────────────────
 
+    // [#5769] 통합 테스트(tests/cases/)에서 직접 호출하기 위해 pub 로 확장.
+    // wasm_api.rs:6331 의 pub fn delete_range 래퍼는 wasm_bindgen 이므로
+    // Rust 테스트에서 호출 불가 — 동일 동작의 native 경로를 공개한다.
     pub fn delete_range_native(
         &mut self,
         section_idx: usize,

--- a/src/document_core/mod.rs
+++ b/src/document_core/mod.rs
@@ -205,6 +205,11 @@ pub struct DocumentCore {
     pub(crate) snapshot_store: Vec<(u32, Document)>,
     /// 다음 스냅샷 ID
     pub(crate) next_snapshot_id: u32,
+    /// [#5769] Undo/Redo용 삭제 조각 저장소 (ID → DeleteFragment).
+    /// 스냅샷과 달리 코어가 자동 축출하지 않는다 — TS 히스토리의 discard 계약 참조.
+    pub(crate) fragment_store: Vec<(u32, commands::delete_fragment::DeleteFragment)>,
+    /// 다음 삭제 조각 ID
+    pub(crate) next_fragment_id: u32,
     /// 머리말/꼬리말 감추기: (global_page_index, is_header) 조합
     pub(crate) hidden_header_footer: std::collections::HashSet<(u32, bool)>,
     /// 파일 이름 (머리말/꼬리말 필드 치환용)
@@ -409,6 +414,8 @@ impl DocumentCore {
             overflow_links_cache: RefCell::new(HashMap::new()),
             snapshot_store: Vec::new(),
             next_snapshot_id: 0,
+            fragment_store: Vec::new(),
+            next_fragment_id: 0,
             hidden_header_footer: std::collections::HashSet::new(),
             file_name: String::new(),
             active_field: None,

--- a/src/document_core/mod.rs
+++ b/src/document_core/mod.rs
@@ -210,6 +210,11 @@ pub struct DocumentCore {
     pub(crate) fragment_store: Vec<(u32, commands::delete_fragment::DeleteFragment)>,
     /// 다음 삭제 조각 ID
     pub(crate) next_fragment_id: u32,
+    /// [#5769] Stage 4 구역 raw 저널 (ID → SectionRawCapture).
+    /// 조각 저장소와 ID 계열을 나눈다. 자동 축출 없음 — discardSectionRaw 계약.
+    pub(crate) section_raw_store: Vec<(u32, commands::section_raw_journal::SectionRawCapture)>,
+    /// 다음 구역 raw 캡처 ID
+    pub(crate) next_section_raw_id: u32,
     /// 머리말/꼬리말 감추기: (global_page_index, is_header) 조합
     pub(crate) hidden_header_footer: std::collections::HashSet<(u32, bool)>,
     /// 파일 이름 (머리말/꼬리말 필드 치환용)
@@ -416,6 +421,8 @@ impl DocumentCore {
             next_snapshot_id: 0,
             fragment_store: Vec::new(),
             next_fragment_id: 0,
+            section_raw_store: Vec::new(),
+            next_section_raw_id: 0,
             hidden_header_footer: std::collections::HashSet::new(),
             file_name: String::new(),
             active_field: None,

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -6720,6 +6720,28 @@ impl HwpDocument {
         self.discard_delete_fragment_native(id)
     }
 
+    /// 속성 변경 직전 구역 raw 스트림+봉인을 보관한다 (#5769 Stage 4).
+    ///
+    /// 반드시 `setSectionDef` 호출 **전**에 불린다. 반환 ID 는
+    /// `restoreSectionRaw`/`discardSectionRaw` 에 쓴다.
+    #[wasm_bindgen(js_name = captureSectionRaw)]
+    pub fn capture_section_raw(&mut self, section_idx: usize) -> Result<u32, JsValue> {
+        self.capture_section_raw_native(section_idx)
+            .map_err(|e| e.into())
+    }
+
+    /// 캡처한 구역 raw 를 되돌린다 — old 속성 재적용(재무효화) **뒤** 에 불린다 (#5769 Stage 4).
+    #[wasm_bindgen(js_name = restoreSectionRaw)]
+    pub fn restore_section_raw(&mut self, id: u32) -> Result<String, JsValue> {
+        self.restore_section_raw_native(id).map_err(|e| e.into())
+    }
+
+    /// 구역 raw 캡처를 제거하여 메모리를 해제한다 — 히스토리 축출·클리어 계약 (#5769 Stage 4).
+    #[wasm_bindgen(js_name = discardSectionRaw)]
+    pub fn discard_section_raw(&mut self, id: u32) {
+        self.discard_section_raw_native(id)
+    }
+
     /// 캐럿 위치의 글자 속성을 조회한다.
     ///
     /// 반환값: JSON 객체 (fontFamily, fontSize, bold, italic, underline, strikethrough, textColor 등)

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -6688,6 +6688,38 @@ impl HwpDocument {
         self.discard_snapshot_native(id)
     }
 
+    /// 삭제 직전 문단 범위 원본을 조각으로 보관한다 (#5769).
+    ///
+    /// 반드시 `deleteRangeNative` 호출 **전**에 불린다. 반환 조각 ID 는
+    /// `restoreDeleteFragment`/`discardDeleteFragment` 에 쓴다.
+    #[wasm_bindgen(js_name = captureDeleteRange)]
+    pub fn capture_delete_range(
+        &mut self,
+        section_idx: usize,
+        start_para: usize,
+        end_para: usize,
+    ) -> Result<u32, JsValue> {
+        self.capture_delete_range_native(section_idx, start_para, end_para)
+            .map_err(|e| e.into())
+    }
+
+    /// 삭제 조각을 원래 자리에 되돌려 끼운다 — 삭제의 참 역연산 (#5769).
+    ///
+    /// 스냅샷 복원과 달리 문서 전체가 아니라 삭제 범위+꼬리 줄 좌표만 되돌린다.
+    /// 성공 시 조각은 소비(제거)된다.
+    #[wasm_bindgen(js_name = restoreDeleteFragment)]
+    pub fn restore_delete_fragment(&mut self, id: u32) -> Result<String, JsValue> {
+        self.restore_delete_fragment_native(id)
+            .map_err(|e| e.into())
+    }
+
+    /// 삭제 조각을 제거하여 메모리를 해제한다 — 히스토리 축출·클리어 시 스냅샷
+    /// `discardSnapshot` 과 짝으로 호출한다(#5769).
+    #[wasm_bindgen(js_name = discardDeleteFragment)]
+    pub fn discard_delete_fragment(&mut self, id: u32) {
+        self.discard_delete_fragment_native(id)
+    }
+
     /// 캐럿 위치의 글자 속성을 조회한다.
     ///
     /// 반환값: JSON 객체 (fontFamily, fontSize, bold, italic, underline, strikethrough, textColor 등)

--- a/tests/cases/issue_5769_delete_fragment_byte_identity.rs
+++ b/tests/cases/issue_5769_delete_fragment_byte_identity.rs
@@ -63,10 +63,13 @@ fn assert_byte_identity(path: &str, sec: usize, s: usize, so: usize, e: usize, e
     // char_shapes 병합이 사후 재구성을 막으므로).
     let mut core = DocumentCore::from_bytes(&bytes).expect("조각 경로 파싱");
     let before = core.export_hwp_native().expect("삭제 전 export");
-    let frag = core.capture_delete_range_native(sec, s, e).expect("조각 캡처");
+    let frag = core
+        .capture_delete_range_native(sec, s, e)
+        .expect("조각 캡처");
     core.delete_range_native(sec, s, so, e, eo, None)
         .expect("범위 삭제");
-    core.restore_delete_fragment_native(frag).expect("조각 복원");
+    core.restore_delete_fragment_native(frag)
+        .expect("조각 복원");
     let after = core.export_hwp_native().expect("복원 후 export");
     assert_eq!(before.len(), after.len(), "바이트 길이 불일치 ({label})");
     let first_diff = before.iter().zip(after.iter()).position(|(a, b)| a != b);
@@ -82,7 +85,9 @@ fn assert_byte_identity(path: &str, sec: usize, s: usize, so: usize, e: usize, e
     snap_core
         .delete_range_native(sec, s, so, e, eo, None)
         .expect("스냅샷 경로 삭제");
-    snap_core.restore_snapshot_native(snap).expect("스냅샷 복원");
+    snap_core
+        .restore_snapshot_native(snap)
+        .expect("스냅샷 복원");
     let after_snap = snap_core.export_hwp_native().expect("스냅샷 경로 export");
     assert_eq!(before, after_snap, "스냅샷 경로 대조 실패 ({label})");
 }
@@ -126,14 +131,7 @@ fn issue_5769_section_tail_boundary_delete_restores_bytes() {
     let sec = 0;
     let last = para_count(&doc, sec) - 1;
     assert!(last >= 2, "3문단 이상 필요");
-    assert_byte_identity(
-        HONGBO,
-        sec,
-        last - 1,
-        0,
-        last,
-        char_len(&doc, sec, last),
-    );
+    assert_byte_identity(HONGBO, sec, last - 1, 0, last, char_len(&doc, sec, last));
 }
 
 #[test]

--- a/tests/cases/issue_5769_delete_fragment_byte_identity.rs
+++ b/tests/cases/issue_5769_delete_fragment_byte_identity.rs
@@ -1,0 +1,158 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! [#5769] Stage 1 게이트 — 선택 삭제 조각(fragment) 복원의 저장 바이트 왕복 동일성.
+//!
+//! capture → delete → restore 뒤 `export_hwp` 결과가 삭제 전과 **완전히 같아야** 하고,
+//! 같은 삭제의 스냅샷 복원 결과와도 같아야 한다. 삭제 형태별 커버:
+//! 단일 문단 부분 삭제 / 문단 중간 범위 삭제 / 표 포함 문단 삭제 /
+//! 구역 선두·끝 경계 삭제.
+//!
+//! 조각이 되돌리는 것(각각이 깨지면 바이트가 어긋난다):
+//! - 범위 문단 전체(`paragraphs[start..=end]` 원본 클론)
+//! - 꼬리 line_segs — `recalculate_section_vpos` 가 start_para 이후 vertical_pos 를
+//!   덮어쓰고 HWP5 직렬화기는 그 값을 그대로 기록한다
+//! - 구역 `raw_stream`/`raw_provenance` — delete 가 None 으로 박는 raw 재사용 경로
+//! - 캐럿 — DocInfo 봉인 다이제스트(`doc_info_model_digest`)가 DocProperties 를
+//!   포함하므로 캐럿만 남겨도 raw 재사용이 깨져 IR 재직렬화 폴백으로 간다
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::model::document::Document;
+use rhwp::parse_document;
+
+const HONGBO: &str = "samples/20250130-hongbo-no.hwp";
+const TABLE_TEST: &str = "samples/hwp_table_test.hwp";
+
+fn load(path: &str) -> Vec<u8> {
+    let full = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(path);
+    std::fs::read(&full).unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+fn inspect(path: &str) -> Document {
+    parse_document(&load(path)).unwrap_or_else(|e| panic!("parse {path}: {e}"))
+}
+
+fn char_len(doc: &Document, sec: usize, p: usize) -> usize {
+    doc.sections[sec].paragraphs[p].text.chars().count()
+}
+
+fn para_count(doc: &Document, sec: usize) -> usize {
+    doc.sections[sec].paragraphs.len()
+}
+
+fn find_para_with_min_text(doc: &Document, sec: usize, min: usize) -> Option<usize> {
+    doc.sections[sec]
+        .paragraphs
+        .iter()
+        .position(|p| p.text.chars().count() >= min)
+}
+
+fn find_table_para(doc: &Document, sec: usize) -> Option<usize> {
+    doc.sections[sec]
+        .paragraphs
+        .iter()
+        .position(|p| p.controls.iter().any(|c| matches!(c, Control::Table(_))))
+}
+
+/// 게이트 본체 — 조각 경로와 스냅샷 경로가 모두 원본 바이트와 일치하는지 확인한다.
+fn assert_byte_identity(path: &str, sec: usize, s: usize, so: usize, e: usize, eo: usize) {
+    let bytes = load(path);
+    let label = format!("{path} sec{sec} [{s}+{so} .. {e}+{eo}]");
+
+    // 조각 경로 — capture 는 반드시 delete 직전에 한다(delete_text_at 의
+    // char_shapes 병합이 사후 재구성을 막으므로).
+    let mut core = DocumentCore::from_bytes(&bytes).expect("조각 경로 파싱");
+    let before = core.export_hwp_native().expect("삭제 전 export");
+    let frag = core.capture_delete_range_native(sec, s, e).expect("조각 캡처");
+    core.delete_range_native(sec, s, so, e, eo, None)
+        .expect("범위 삭제");
+    core.restore_delete_fragment_native(frag).expect("조각 복원");
+    let after = core.export_hwp_native().expect("복원 후 export");
+    assert_eq!(before.len(), after.len(), "바이트 길이 불일치 ({label})");
+    let first_diff = before.iter().zip(after.iter()).position(|(a, b)| a != b);
+    assert!(
+        first_diff.is_none(),
+        "첫 바이트 불일치 @{} ({label})",
+        first_diff.unwrap_or(0)
+    );
+
+    // 스냅샷 경로 대조 — 같은 삭제를 스냅샷으로 되돌려도 원본과 같아야 한다.
+    let mut snap_core = DocumentCore::from_bytes(&bytes).expect("스냅샷 경로 파싱");
+    let snap = snap_core.save_snapshot_native();
+    snap_core
+        .delete_range_native(sec, s, so, e, eo, None)
+        .expect("스냅샷 경로 삭제");
+    snap_core.restore_snapshot_native(snap).expect("스냅샷 복원");
+    let after_snap = snap_core.export_hwp_native().expect("스냅샷 경로 export");
+    assert_eq!(before, after_snap, "스냅샷 경로 대조 실패 ({label})");
+}
+
+#[test]
+fn issue_5769_single_paragraph_partial_delete_restores_bytes() {
+    let doc = inspect(HONGBO);
+    let sec = 0;
+    let p = find_para_with_min_text(&doc, sec, 8).expect("8자 이상 문단 필요");
+    let len = char_len(&doc, sec, p);
+    assert_byte_identity(HONGBO, sec, p, 2, p, (len - 2).min(6));
+}
+
+#[test]
+fn issue_5769_multi_paragraph_range_delete_restores_bytes() {
+    let doc = inspect(HONGBO);
+    let sec = 0;
+    assert!(para_count(&doc, sec) >= 5, "5문단 이상 필요");
+    assert_byte_identity(HONGBO, sec, 1, 0, 3, char_len(&doc, sec, 3));
+}
+
+#[test]
+fn issue_5769_table_containing_selection_delete_restores_bytes() {
+    let doc = inspect(TABLE_TEST);
+    let sec = 0;
+    let tp = find_table_para(&doc, sec).expect("표 문단 필요");
+    assert_byte_identity(TABLE_TEST, sec, tp, 0, tp, char_len(&doc, sec, tp));
+}
+
+#[test]
+fn issue_5769_section_head_boundary_delete_restores_bytes() {
+    let doc = inspect(HONGBO);
+    let sec = 0;
+    assert!(para_count(&doc, sec) >= 3, "3문단 이상 필요");
+    assert_byte_identity(HONGBO, sec, 0, 0, 1, char_len(&doc, sec, 1));
+}
+
+#[test]
+fn issue_5769_section_tail_boundary_delete_restores_bytes() {
+    let doc = inspect(HONGBO);
+    let sec = 0;
+    let last = para_count(&doc, sec) - 1;
+    assert!(last >= 2, "3문단 이상 필요");
+    assert_byte_identity(
+        HONGBO,
+        sec,
+        last - 1,
+        0,
+        last,
+        char_len(&doc, sec, last),
+    );
+}
+
+#[test]
+fn issue_5769_restore_without_delete_is_rejected_for_multi_para_fragment() {
+    let mut core = DocumentCore::from_bytes(&load(HONGBO)).expect("파싱");
+    let frag = core.capture_delete_range_native(0, 1, 3).expect("캡처");
+    // 삭제 없이 복원 시도 → 전제 검증(문단 수 불일치)으로 거부되어 무음 중복 삽입을 막는다
+    let err = core.restore_delete_fragment_native(frag).unwrap_err();
+    assert!(
+        err.to_string().contains("전제가 어긋났"),
+        "의외의 오류: {err}"
+    );
+}
+
+#[test]
+fn issue_5769_discard_removes_fragment() {
+    let mut core = DocumentCore::from_bytes(&load(HONGBO)).expect("파싱");
+    let frag = core.capture_delete_range_native(0, 1, 3).expect("캡처");
+    core.discard_delete_fragment_native(frag);
+    let err = core.restore_delete_fragment_native(frag).unwrap_err();
+    assert!(err.to_string().contains("없음"), "의외의 오류: {err}");
+}

--- a/tests/cases/issue_5769_stage4_setter_convergence.rs
+++ b/tests/cases/issue_5769_stage4_setter_convergence.rs
@@ -1,0 +1,187 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! [#5769] Stage 4 선결 실증 — 페이지/구역 설정 setter 의 속성쌍 역연산 수렴성.
+//!
+//! set_section_def / set_page_def 는 적용 시 `section.raw_stream = None` 으로
+//! passthrough 를 무효화하고, page_def 는 추가로 wrap 폭 변화 시 본문 전체를
+//! 재래핑한다([#4956] `reflow_body_paragraphs_in_section` — 저장 line_segs 전면
+//! 재작성). 같은 setter 로 old 를 다시 적용하면 부작용도 대칭으로 재실행되므로,
+//! "new 적용 → old 복원" 왕복 뒤 저장 바이트가 변경 전으로 돌아오는지가 속성쌍
+//! 커맨드(스냅샷 대체 역연산) 가능 여부의 판정이다.
+//!
+//! 실증 판정(표본 hongbo):
+//! - section_def: 속성쌍만으론 **불수렴** — 속성을 하나도 바꾸지 않고 같은 값을
+//!   한 번 적용만 해도 동일 델타가 난다(raw 무효화 → IR 재구성 직렬화 경로).
+//!   구역 raw 저널(`section_raw_journal.rs`)로 passthrough 를 되돌리면 바이트
+//!   완전 수렴한다 → 구역 설정 다이얼로그의 역연산화 근거.
+//! - page_def: raw 복원으로도 **불수렴** — 재래핑이 한컴 원본 줄 나눔을 rhwp
+//!   조판값으로 교체하기 때문(len 562176→561664 잔류). page_setup·page_margin 은
+//!   스냅샷 잔류다(그림 회전 선례 준용, 계획서 task_m100_5769.md Stage 4).
+//!
+//! 불수렴 단정은 트립와이어다 — 직렬화 충실도 개선(#5890 계열)이나 조판 정합으로
+//! 정반대가 되면 이 시험이 깨져 의식적 설계 갱신을 강제한다.
+
+use rhwp::document_core::DocumentCore;
+
+const HONGBO: &str = "samples/20250130-hongbo-no.hwp";
+
+fn load_core() -> DocumentCore {
+    let bytes = std::fs::read(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(HONGBO))
+        .expect("표본 로드");
+    DocumentCore::from_bytes(&bytes).expect("파싱")
+}
+
+fn first_diff(a: &[u8], b: &[u8]) -> Option<usize> {
+    let n = a.len().min(b.len());
+    (0..n)
+        .find(|&i| a[i] != b[i])
+        .or((a.len() != b.len()).then_some(n))
+}
+
+/// hideHeader 를 뒤집는 최소 변경 JSON — 비-기하 키라 wrap 폭·line_segs 는 불변.
+fn flipped_hide_header(core: &mut DocumentCore, sec: usize) -> (String, String) {
+    let old_json = core.get_section_def_native(sec).expect("get section def");
+    let old: serde_json::Value = serde_json::from_str(&old_json).expect("getter JSON");
+    let new_json = format!(
+        "{{\"hideHeader\":{}}}",
+        !old["hideHeader"].as_bool().expect("hideHeader")
+    );
+    (old_json, new_json)
+}
+
+#[test]
+fn section_def_property_pair_without_raw_restore_diverges() {
+    let mut core = load_core();
+    let before = core.export_hwp_native().expect("변경 전 export");
+    let sec = 0;
+    let (old_json, new_json) = flipped_hide_header(&mut core, sec);
+
+    core.set_section_def_native(sec, &new_json)
+        .expect("변경 적용");
+    core.set_section_def_native(sec, &old_json)
+        .expect("old 복원");
+
+    let after = core.export_hwp_native().expect("복원 후 export");
+    assert!(
+        first_diff(&before, &after).is_some(),
+        "raw 미복원 속성쌍 왕복이 수렴하면 이 시험의 전제(무효화→재직렬화 델타)가 무너진 것이다 — \
+         구역 raw 저널 없이도 역연산화 가능해졌는지 재검토하라"
+    );
+}
+
+#[test]
+fn section_def_property_pair_with_raw_journal_converges_byte_exact() {
+    let mut core = load_core();
+    let before = core.export_hwp_native().expect("변경 전 export");
+    let sec = 0;
+    let (old_json, new_json) = flipped_hide_header(&mut core, sec);
+
+    // undo 경로 — TS SetSectionPropsCommand 가 밟을 순서 그대로:
+    // capture(변경 전) → apply new → apply old → restore raw.
+    let cap = core.capture_section_raw_native(sec).expect("캡처");
+    core.set_section_def_native(sec, &new_json)
+        .expect("변경 적용");
+    core.set_section_def_native(sec, &old_json)
+        .expect("old 복원");
+    core.restore_section_raw_native(cap).expect("raw 복원");
+
+    let after = core.export_hwp_native().expect("복원 후 export");
+    assert_eq!(before.len(), after.len(), "바이트 길이 수렴");
+    let diff = first_diff(&before, &after);
+    assert!(
+        diff.is_none(),
+        "raw 저널 복원 후 저장 바이트 완전 수렴 — 첫 불일치 @{diff:?}"
+    );
+}
+
+#[test]
+fn section_def_double_roundtrip_stays_convergent() {
+    // redo 재실행은 새 캡처를 만든다(undo 가 저널을 소비하므로). 소비·재캡처
+    // 생명주기가 반복 왕복에서도 정합인지 확인한다.
+    let mut core = load_core();
+    let before = core.export_hwp_native().expect("변경 전 export");
+    let sec = 0;
+    let (old_json, new_json) = flipped_hide_header(&mut core, sec);
+
+    for _ in 0..2 {
+        let cap = core.capture_section_raw_native(sec).expect("캡처");
+        core.set_section_def_native(sec, &new_json)
+            .expect("변경 적용");
+        core.set_section_def_native(sec, &old_json)
+            .expect("old 복원");
+        core.restore_section_raw_native(cap).expect("raw 복원");
+    }
+
+    let after = core.export_hwp_native().expect("복원 후 export");
+    let diff = first_diff(&before, &after);
+    assert!(diff.is_none(), "2회 왕복 후에도 수렴 — 첫 불일치 @{diff:?}");
+}
+
+#[test]
+fn section_raw_restore_rejects_when_passthrough_alive() {
+    // 전제 검증 — setter 가 무효화한(None) 직후가 아니면 복원을 거부한다.
+    // 이미 살아있는(Some) 상태에서의 복원 요청은 이중 undo 같은 배선 버그다.
+    let mut core = load_core();
+    let sec = 0;
+    let (_, new_json) = flipped_hide_header(&mut core, sec);
+
+    let cap1 = core.capture_section_raw_native(sec).expect("캡처 1");
+    let cap2 = core.capture_section_raw_native(sec).expect("캡처 2");
+
+    core.set_section_def_native(sec, &new_json)
+        .expect("변경 적용");
+    core.restore_section_raw_native(cap1)
+        .expect("첫 복원은 성공");
+
+    let second = core.restore_section_raw_native(cap2);
+    assert!(
+        second.is_err(),
+        "passthrough 가 살아있는 상태의 중복 복원은 거부돼야 한다"
+    );
+}
+
+#[test]
+fn discarded_capture_is_gone() {
+    let mut core = load_core();
+    let sec = 0;
+    let (_, new_json) = flipped_hide_header(&mut core, sec);
+
+    let cap = core.capture_section_raw_native(sec).expect("캡처");
+    core.discard_section_raw_native(cap);
+    core.set_section_def_native(sec, &new_json)
+        .expect("변경 적용");
+
+    let restore = core.restore_section_raw_native(cap);
+    assert!(restore.is_err(), "discard 된 캡처로는 복원할 수 없다");
+}
+
+#[test]
+fn page_def_property_pair_does_not_converge_reflow_remains() {
+    // 기하 키 — wrap 폭 변동이 재래핑을 트리거해 한컴 원본 line_segs 가 rhwp
+    // 조판값으로 교체되고, old 복원으로도 돌아오지 않는다. page_setup·page_margin
+    // 이 스냅샷에 잔류하는 이유의 실증이다. 수렴하게 됐다면(조판 정합·직렬화
+    // 충실도 개선) 이 시험이 깨진다 — 그때 역연산화로 설계을 갱신하라.
+    let mut core = load_core();
+    let before = core.export_hwp_native().expect("변경 전 export");
+    let sec = 0;
+
+    let old_json = core.get_page_def_native(sec).expect("get page def");
+    let old: serde_json::Value = serde_json::from_str(&old_json).expect("getter JSON");
+    let ml = old["marginLeft"].as_u64().unwrap();
+    let mr = old["marginRight"].as_u64().unwrap();
+    let new_json = format!(
+        "{{\"marginLeft\":{},\"marginRight\":{}}}",
+        ml + 1500,
+        mr + 1500
+    );
+
+    core.set_page_def_native(sec, &new_json).expect("변경 적용");
+    core.set_page_def_native(sec, &old_json).expect("old 복원");
+
+    let after = core.export_hwp_native().expect("복원 후 export");
+    assert!(
+        first_diff(&before, &after).is_some(),
+        "page_def 속성쌍 왕복이 수렴했다 — reflow 부작용이 사라진 것이므로 \
+         page_setup/page_margin 도 역연산화 대상으로 재판정하라"
+    );
+}

--- a/tests/issue_2724_passthrough_invalidation_guard.rs
+++ b/tests/issue_2724_passthrough_invalidation_guard.rs
@@ -204,6 +204,18 @@ const EXEMPT: &[(&str, &str, Exempt, &str)] = &[
         "[#5769] `fragment_store` 에서 조각 제거. 문서 IR 비변경.",
     ),
     (
+        "commands/section_raw_journal.rs",
+        "capture_section_raw_native",
+        Exempt::SessionState,
+        "[#5769] 속성 변경 직전 구역 raw+봉인을 저널에 적재. IR 비변경(읽기 전용).",
+    ),
+    (
+        "commands/section_raw_journal.rs",
+        "discard_section_raw_native",
+        Exempt::SessionState,
+        "[#5769] 구역 raw 저널에서 항목 제거. 문서 IR 비변경.",
+    ),
+    (
         "commands/formatting.rs",
         "get_cell_char_properties_at_by_path",
         Exempt::SessionState,
@@ -270,6 +282,13 @@ const EXEMPT: &[(&str, &str, Exempt, &str)] = &[
         Exempt::WholeDocument,
         "[#5769] 조각 복원 — 캡처 시점의 section raw_stream·raw_provenance·캐럿(DocProperties)을 \
          통째로 되돌린다. 스냅샷 복원과 같은 원리로, 복원 뒤 패스스루는 되돌려진 IR 과 다시 일치한다.",
+    ),
+    (
+        "commands/section_raw_journal.rs",
+        "restore_section_raw_native",
+        Exempt::WholeDocument,
+        "[#5769] 구역 raw 복원 — 캡처 시점의 raw_stream·봉인을 되돌려 passthrough 와 IR 을 \
+         다시 일치시킨다. 문단 등 IR 은 건드리지 않는다(속성 복원은 setter 호출부 몫).",
     ),
     // ── 무효화 대신 원본 스트림 직접 수술 ──────────────────────────────────
     (

--- a/tests/issue_2724_passthrough_invalidation_guard.rs
+++ b/tests/issue_2724_passthrough_invalidation_guard.rs
@@ -192,6 +192,18 @@ const EXEMPT: &[(&str, &str, Exempt, &str)] = &[
         "`snapshot_store` 에서 항목 제거.",
     ),
     (
+        "commands/delete_fragment.rs",
+        "capture_delete_range_native",
+        Exempt::SessionState,
+        "[#5769] 삭제 직전 문단 범위를 `fragment_store` 에 적재. 원본 IR 을 읽기만 하고 바꾸지 않는다.",
+    ),
+    (
+        "commands/delete_fragment.rs",
+        "discard_delete_fragment_native",
+        Exempt::SessionState,
+        "[#5769] `fragment_store` 에서 조각 제거. 문서 IR 비변경.",
+    ),
+    (
         "commands/formatting.rs",
         "get_cell_char_properties_at_by_path",
         Exempt::SessionState,
@@ -251,6 +263,13 @@ const EXEMPT: &[(&str, &str, Exempt, &str)] = &[
         "restore_snapshot_native",
         Exempt::WholeDocument,
         "스냅샷 문서로 통째 복원. 스냅샷은 저장 시점의 패스스루 상태를 그대로 담고 있다.",
+    ),
+    (
+        "commands/delete_fragment.rs",
+        "restore_delete_fragment_native",
+        Exempt::WholeDocument,
+        "[#5769] 조각 복원 — 캡처 시점의 section raw_stream·raw_provenance·캐럿(DocProperties)을 \
+         통째로 되돌린다. 스냅샷 복원과 같은 원리로, 복원 뒤 패스스루는 되돌려진 IR 과 다시 일치한다.",
     ),
     // ── 무효화 대신 원본 스트림 직접 수술 ──────────────────────────────────
     (


### PR DESCRIPTION
#5769 — 스냅샷 슬롯 소모 절감: 선택 삭제·붙여넣기·구역 설정의 역연산화

## 요약

이슈 #5769 변경 목록 ②③④를 하나의 PR 로 구현한다. 각 조작의 undo 를 문서 전체 스냅샷
대신 **참 역연산**(조각·속성쌍+raw 저널)으로 바꿔 예산 소모 속도를 늦춘다.

| 항목 | 내용 | 슬롯 효과 |
|---|---|---|
| ② 선택 삭제 | 삭제 직전 문단 범위 원본을 조각으로 보관 → undo 시 되돌려 끼움 | **2 → 0** |
| ③ 붙여넣기 | `deferRecord` — delete 가 별도 엔트리 없이 paste 스냅샷 안에서 실행 | **4 → 1** |
| ④ 구역 설정 | 속성쌍 커맨드 + 구역 raw 저널(현재 구역 한정) | **스냅샷 → 0** |

①(after 스냅샷 undo 시점 저장, 깊이 49→98)은 선행 반영돼 있다. 진행 현황 원장은 이슈
#5769 본문을 따른다.

## ② 선택 삭제 — 조각(fragment) 저장소

### Rust (`delete_fragment.rs` 신규)

`capture_delete_range` / `restore_delete_fragment` / `discard_delete_fragment` 네이티브와
wasm 바인딩 3건. 조각이 되돌리는 4요소 — 각각이 깨지면 저장 바이트가 어긋난다:

| 요소 | 깨지는 경로 |
|---|---|
| 범위 문단 전체 클론 | `delete_text_at` 의 char_shapes 클램핑·병합(#3576/#4271)이 사후 재구성 불가 |
| 꼬리 line_segs 저널 | `recalculate_section_vpos` 가 start_para 이후 vertical_pos 를 덮어쓰고 직렬화기가 그대로 기록 |
| 구역 raw_stream/provenance | delete 가 None 으로 박아 원본 바이트 재사용 경로 상실 |
| 캐럿(doc_properties) | DocInfo 봉인 다이제스트가 DocProperties 전체 포함 — 미복원 시 raw 재사용 깨짐(@888 실측) |

- `from_bytes_inner` 생성자에 `fragment_store`/`next_fragment_id` 추가 누락 수정
- `delete_range_native` pub 확장(통합 테스트 경로)
- #2724 EXEMPT 등재(capture/discard=SessionState, restore=WholeDocument)

### TS (`FragmentDeleteCommand`)

- 비셀 선택은 조각 경로, 셀 내 삭제는 스냅샷 폴백
- 계약 유지: `type='deleteSelection'`(양식 모드 게이트), `selectionBefore()`(#3416),
  `snapshotResourceCount()=0`(#2328), `isNoOp`(#2370)

## ③ 붙여넣기 원자적 기록

pastePlainText/control/internal/html 4경로에서 `deleteSelection({ deferRecord })` 적용 —
선택 위 붙여넣기가 delete 엔트리 없이 paste 스냅샷 1슬롯으로 기록된다.

셀프리뷰에서 P1 발견: deferRecord 분기가 `cmd.execute()` 반환 위치를 폐기해 JS 커서가
삭제 전 좌표에 남고, 이어지는 paste 가 stale 좌표에 삽입됐다. `ce5148c1d` 에서
`moveTo+resetPreferredX` 배선을 복원하고 소스 가드로 고정했다.

## ④ 구역 설정 역연산화

실증(`tests/cases/issue_5769_stage4_setter_convergence.rs`): setter 왕복의 불수렴 원인은
속성이 아니라 **passthrough(`raw_stream`) 소실**이다 — 같은 값을 한 번 적용만 해도 @1144
불일치가 재현된다.

- **sectionSettings**: `SetSectionPropsCommand`(before/after SectionDef + 구역 raw 저널
  `section_raw_journal.rs`) — old 재적용 후 raw 복원으로 저장 바이트 수렴(diff None)
- **pageSetup/pageMargin**: 재래핑([#4956])이 한컴 line_segs 를 교체해 불수렴(len 잔류) —
  스냅샷 잔류 확정, 트립와이어 테스트로 고정(#5890 개선 시 재판정)

## 검증

- Rust: 바이트 왕복 동일성 게이트 2종(`issue_5769_delete_fragment_byte_identity` 7종 +
  `issue_5769_stage4_setter_convergence` 6종), lib 3,893+ 통과, clippy clean, fmt
- TS: npm test 1067 pass / 0 fail, 브라우저 e2e `undo-delete-fragment-bytes`(Delete 키 →
  Ctrl+Z → exportHwp 13,312B 왕복 동일, MANIFEST 등재)
- CI: 24/24 통과(head `ce5148c1d`)

## 셀프리뷰 기록

- P1(deferRecord JS 커서 미동기): 인라인 리뷰 → `ce5148c1d` 반영 → 스레드 resolve 완료
- P3(교차 구역 선택 폴백): fork 정산 draft(lpaiu-cs/rhwp#1)로 은행 — #5915 병합 후 리베이스

## 참고

- 계획서: `mydocs/plans/task_m100_5769.md`
- 완료 보고: `mydocs/working/task_m100_5769_stage{1..4}.md`
- 진행 현황 원장: 이슈 #5769 본문
