### PR TITLE
feat: info에 한컴오피스 마지막 저장 버전 표시

### DIFF
--- a/mydocs/manual/agent_knowledge_map.md
+++ b/mydocs/manual/agent_knowledge_map.md
@@ -24,7 +24,7 @@ rhwp 를 도구로 부리는 AI 에이전트·스크립트가 **첫 번째로 �
 | 측정일 | 2026-08-11 |
 | 자기서술 출처 | `rhwp capabilities` · `rhwp capabilities --mcp` · `mcp-serve` 의 `tools/list` |
 | 표면 규모 | CLI 명령 **98개**(그중 `--json` 계약 **65개**, batch 축 **9개**) · MCP 도구 **181개**(무상태 163 + 세션 전용 18) |
-| 봉투 필드 | `capabilities.commands[].recordFields` 합집합 **324개** · §2 전수 사전 **332개**(자기서술 밖 실측·참조 필드 포함) |
+| 봉투 필드 | `capabilities.commands[].recordFields` 합집합 **325개** · §2 전수 사전 **333개**(자기서술 밖 실측·참조 필드 포함) |
 | 표본 | `samples/` tracked 파일 **781개** 중 실측한 것만 §7 에 적었다 |
 
 **재확인하는 법** — 이 지도를 믿기 전에 손에 든 바이너리로 다시 찍어 본다.
@@ -56,7 +56,7 @@ IR·provenance·plan 네 축을 한 번에 조립하고, 빠진 축은 `missingA
 | 하려는 일 | 명령 (MCP 도구) | 판정 필드 | 권위 |
 |---|---|---|---|
 | 요청에 어떤 스킬이 필요한가 | `python tools/skill_router/route.py "<요청>" --json` | `intent`·`requiredCapabilities`·`skillSelection`·`executionGraph` | [스킬 라우터](agent_skill_router.md) |
-| 규모·형식 파악 | `info --json` (`hwp_info`) | `format`·`pageCount`·`paraCount` | [CLI 매뉴얼](cli_commands.md) §info |
+| 규모·형식 파악 | `info --json` (`hwp_info`) | `format`·`pageCount`·`paraCount`·`lastSavedWith` | [CLI 매뉴얼](cli_commands.md) §info |
 | 한 호출로 전체 감 잡기 | `digest --json` (`hwp_digest`) | `outline`·`excerpt`·`nextStep` | [초소형 모델 매크로](../tech/tiny_model_macro_tools.md) |
 | 절 단위로 훑기 | `digest --sections --json` | `sections[]`·`sectionsMode` | 같은 문서 |
 | 쪽 범위만 발췌 | `digest --pages a..b --json` | `pages{from,to}`·`nextStep` | 같은 문서 |
@@ -302,10 +302,10 @@ IR·provenance·plan 네 축을 한 번에 조립하고, 빠진 축은 `missingA
 를 싣고 `--dry-run` 에서는 싣지 않는다. `edit set-cell` 은 `oldText` 때문에
 `untrustedContent:true`, `edit fill-fields`·`replace-text` 는 `false` 다(실측).
 
-### 2-2. 전수 사전 — 332개 필드
+### 2-2. 전수 사전 — 333개 필드
 
-`capabilities` 의 `recordFields` 고유 **324개**와 그 밖의 실측·참조 필드를 합친
-332개다. `등장 명령` 은 자기서술
+`capabilities` 의 `recordFields` 고유 **325개**와 그 밖의 실측·참조 필드를 합친
+333개다. `등장 명령` 은 자기서술
 기준이며, 실제 봉투에는 조건부로 더 실리는 필드가 있다(§2-5).
 
 #### 신원·스키마
@@ -380,6 +380,7 @@ IR·provenance·plan 네 축을 한 번에 조립하고, 빠진 축은 `missingA
 | `headersFooters` | array | 머리말/꼬리말 목록 `{sectionIdx,isHeader,applyTo,label}` | `headers-footers` |
 | `fonts` | string[] | 문서가 참조하는 글꼴 이름 — **문서 파생** | `info` |
 | `title` | string | 요약정보의 제목 — **문서 파생** | `info` |
+| `lastSavedWith` | object\|null | HWP5 `HwpSummaryInformation.revisionNumber`에서 읽은 마지막 저장 제품 `{product,version,confidence}`. `product`는 알려진 주버전만 `hancom-office-2018`·`hancom-office-2022`·`hancom-office-2024`로 분류하고, 알 수 없는 주버전은 `null`; HWP3/HWPX, 요약정보 부재·손상은 필드 전체가 `null`. 원 작성 제품이 아니라 수정 가능한 마지막 저장 메타데이터다 | `info` |
 | `warnings` | string[] | 파싱 경고 목록 — 빈 배열이면 깨끗이 읽었다는 뜻 | `info` |
 | `summary` | string | 사람용 여러 줄 요약(형식·쪽수·표·누름틀·각주) — **문서 파생** | `explain` |
 | `encrypted` | bool | 암호화 문서 여부 | `explain` |

--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -618,8 +618,12 @@ rhwp 를 **실제 MCP 서버**로 실행한다. 전송은 MCP 표준 stdio(줄 �
 ### `info <파일> [--json]`
 HWP 파일 정보 표시(버전/구역 수/암호화 등).
 - `--json` (#3237): stdout 에 순수 JSON 하나 —
-  `{"schemaVersion":"1.0","source","format":"hwp5|hwpx|hwp3|hml","sizeBytes","version","sections","pageCount","paraCount","fonts"}`.
-  `version` 은 HML 이면 null. 스키마 계약은 `export-text --json` 항목과 동일 규칙.
+  `{"schemaVersion":"1.0","source","format":"hwp5|hwpx|hwp3|hml","sizeBytes","version","sections","pageCount","paraCount","fonts","title","lastSavedWith","warnings"}`.
+  `version` 은 HML 이면 null. `lastSavedWith`는 HWP5 `HwpSummaryInformation.revisionNumber`를
+  해석한 마지막 저장 제품 메타데이터다. 예: `{"product":"hancom-office-2024","version":"13.0.0.3457","confidence":"metadata"}`.
+  2018/2022/2024 매핑 근거가 없는 버전은 `product:null`, HWP3·HWPX·메타데이터 없음·손상은
+  `lastSavedWith:null`이다. 원 작성 제품의 증명이 아니며, 재저장·삭제·변조될 수 있다. 스키마 계약은
+  `export-text --json` 항목과 동일 규칙.
 
 ### `word-count <파일> [--json]` (#4999)
 IR 본문에서 구역·문단·글자·어절·쪽 수를 센다. 새 파서는 없다.

--- a/mydocs/orders/20260823.md
+++ b/mydocs/orders/20260823.md
@@ -1,0 +1,13 @@
+# 2026-08-23 오늘할일
+
+## #5931 HWP5 마지막 저장 한컴오피스 버전 판별
+
+- [x] HWP5 FileHeader `5.1.1.0`만으로는 2022/2024를 구분할 수 없음을 확인하고,
+  `HwpSummaryInformation.revisionNumber`의 주버전 12/13을 각각 2022/2024로 분류하도록 구현했다.
+- [x] HWP 2018/2022/2024, HWP3, HWPX 계약과 지식 지도 필드 사전을 보완했다.
+- [x] focused 계약, 전체 release-test 8,173건, clippy, fmt, manifest, unit-tier와 diff check를 통과했다.
+- [x] 이슈 [#5931](https://github.com/edwardkim/rhwp/issues/5931)과 code candidate PR
+  [#5932](https://github.com/edwardkim/rhwp/pull/5932)을 만들고 archive self-review를 준비했다.
+- [ ] review·오늘할일 trailing head의 GitHub Actions와 최신 mergeability를 확인한다.
+- [ ] 작업지시자 승인 뒤 PR을 merge하고, merge SHA의 `upstream/devel` 포함·issue close·PR/issue comment·
+  branch 정리를 `post_merge.md`에 따라 처리한다.

--- a/mydocs/pr/archives/pr_5932_review.md
+++ b/mydocs/pr/archives/pr_5932_review.md
@@ -1,0 +1,65 @@
+---
+kind: pr-review
+status: trailing-docs-pending-ci
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-23
+---
+
+# PR #5932 검토 - HWP5 마지막 저장 한컴오피스 버전
+
+## 접수 메타데이터
+
+| 항목 | 작성 시점 확인값 |
+| --- | --- |
+| PR / 작성자 | [#5932](https://github.com/edwardkim/rhwp/pull/5932) / [@jangster77](https://github.com/jangster77) |
+| 관련 issue | [#5931](https://github.com/edwardkim/rhwp/issues/5931) |
+| base / code candidate | `devel` `2078a2629c0d1cfd85437383cbbfb7b72418fe7b` / `f78fcad44abc8aa77dc7bea34b524f9c244407bb` |
+| 변경 규모 | 8 files, +227 / -10 |
+| 작성 시점 상태 | non-draft, `MERGEABLE`, `BLOCKED` (GitHub checks 대기) |
+| reviewer | 작성자 본인 self-review, 별도 reviewer 미지정 |
+
+GitHub mergeability와 CI 상태는 작성 시점 참고값이다. 이 trailing 기록 commit의 최신 head가
+required check를 통과하고 작업지시자가 승인한 뒤에만 merge한다.
+
+## 변경과 판단
+
+- HWP5 FileHeader의 `5.1.1.0`은 2022와 2024 모두에서 나타나므로 저장 제품 연도 판정 근거로 쓰지
+  않는다.
+- HWP5 `HwpSummaryInformation.revisionNumber`의 주버전 12와 13을 각각
+  `hancom-office-2022`, `hancom-office-2024`로 반환한다. 10은 2018로 함께 식별한다.
+- `info --json`, MCP `hwp_info`, capabilities, CLI 매뉴얼과 에이전트 지식지도가
+  `lastSavedWith:{product,version,confidence}` 계약을 같이 선언한다.
+- HWP3/HWPX, 요약정보 누락·손상, 알 수 없는 주버전은 제품 연도를 추정하지 않는다. 전자는
+  `lastSavedWith:null`, 후자는 `product:null`이다.
+- 이 값은 원 작성 제품이 아니라 수정 가능한 마지막 저장 메타데이터다.
+
+renderer, typeset, layout, fixture, 기준 PDF는 바뀌지 않았다. 이번 변경은 메타데이터 읽기와 JSON
+계약이므로 visual sweep은 요구하지 않았다.
+
+## 로컬 검증
+
+- `node scripts/run-rust-test.mjs info_hancom_save_version_contract -- --locked --cargo-profile release-test --target-dir target/pr-review`를 통과했다.
+  - 저장소 표본의 HWP 2018/2022/2024는 각각 다른 `lastSavedWith.product`와 버전을 반환했다.
+  - HWP3와 HWPX는 `lastSavedWith:null`을 반환했다.
+- `node scripts/run-rust-test.mjs knowledge_map_field_dictionary_contract -- --locked --cargo-profile release-test --target-dir target/pr-review`를 통과했다.
+- `cargo nextest run --locked --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast`:
+  `8173 passed, 5 slow, 39 skipped` (217.261s).
+- `cargo clippy --locked --all-targets --target-dir target/pr-review -- -D warnings`,
+  `cargo fmt --all -- --check`, `git diff --check`를 통과했다.
+- `node scripts/rust-test-suite-manifest.mjs --prepare` 및 `--check`를 통과했다.
+- `node scripts/rust-unit-test-tiers.mjs --check`를 통과했다.
+
+모든 Cargo 검증은 `--locked`와 공유 검토 산출물 `target/pr-review`로 실행했다. 파생 harness와
+manifest는 검증에만 사용했고 PR diff에 포함하지 않는다.
+
+## 발견 사항과 보정
+
+초기 전체 회귀에서 새 capabilities `recordFields`의 `lastSavedWith`가 에이전트 지식 지도 전수 사전에
+누락된 것을 발견했다. `mydocs/manual/agent_knowledge_map.md`의 필드 행과 합계를 325/333으로 보정한
+뒤 해당 계약 및 전체 회귀를 다시 실행해 통과했다.
+
+## 최종 판정
+
+**수용 권고, trailing CI 대기.** 2022와 2024를 FileHeader로 추정하지 않고 실제 마지막 저장
+메타데이터로 구분하며, 불확실한 입력에는 제품 연도를 부여하지 않는다. 최신 trailing head의 GitHub
+Actions가 모두 성공하고 작업지시자 승인을 받은 뒤 merge한다.

--- a/src/cli/metadata/capabilities/core.rs
+++ b/src/cli/metadata/capabilities/core.rs
@@ -5,7 +5,7 @@ pub(super) fn extend(commands: &mut Vec<serde_json::Value>) {
         // ── 기계 계약(--json) 명령 ──
         cmd_json(
             "info",
-            "문서 메타(포맷·버전·페이지/문단 수·폰트·제목) 표시",
+            "문서 메타(포맷·버전·마지막 저장 제품·페이지/문단 수·폰트·제목) 표시",
             &["--json"],
             &[
                 "schemaVersion",
@@ -18,6 +18,7 @@ pub(super) fn extend(commands: &mut Vec<serde_json::Value>) {
                 "paraCount",
                 "fonts",
                 "title",
+                "lastSavedWith",
                 "warnings",
             ],
         ),

--- a/src/cli/metadata/mcp/read.rs
+++ b/src/cli/metadata/mcp/read.rs
@@ -7,11 +7,11 @@ pub(super) fn extend(tools: &mut Vec<serde_json::Value>) {
     tools.extend([
         tool(
             "hwp_info",
-            "HWP/HWPX/HML 문서의 메타데이터(포맷·구역/페이지/문단 수·폰트·제목)를 조회한다. 문서를 열기 전에 규모와 형식을 파악할 때 쓴다.",
+            "HWP/HWPX/HML 문서의 메타데이터(포맷·마지막 저장 제품·구역/페이지/문단 수·폰트·제목)를 조회한다. 문서를 열기 전에 규모와 형식을 파악할 때 쓴다.",
             path_schema(serde_json::json!({})),
             "info",
             serde_json::json!(["info", "--json", "{path}"]),
-            &["format", "sizeBytes", "sections", "pageCount", "paraCount", "fonts", "title", "warnings"],
+            &["format", "sizeBytes", "sections", "pageCount", "paraCount", "fonts", "title", "lastSavedWith", "warnings"],
         ),
         tool(
             "hwp_word_count",

--- a/src/main.rs
+++ b/src/main.rs
@@ -755,6 +755,17 @@ fn info_json_value(
         .map(|face| face.name.clone())
         .collect();
     let para_count: usize = document.sections.iter().map(|s| s.paragraphs.len()).sum();
+    let last_saved_with = if detected_format == rhwp::parser::FileFormat::Hwp {
+        rhwp::parser::hwp_summary::last_saved_with(&document.extra_streams).map(|save_version| {
+            serde_json::json!({
+                "product": save_version.product,
+                "version": save_version.version,
+                "confidence": "metadata",
+            })
+        })
+    } else {
+        None
+    };
     provenance::marked(
         serde_json::json!({
             "schemaVersion": ENVELOPE_SCHEMA_VERSION,
@@ -768,6 +779,9 @@ fn info_json_value(
             "fonts": fonts,
             // [#3407] best-effort 문서 제목 — 없으면 null. batch info 로 자동 전파.
             "title": document_title(doc),
+            // HWP5 summary metadata only. This identifies the last saving product,
+            // not the original authoring product, and can be absent or modified.
+            "lastSavedWith": last_saved_with,
             // [#3880 T1] 파싱 중 건너뛴 것을 봉투가 스스로 밝힌다.
             //
             // 인간 출력은 `warnings: N` 과 상세를 stderr 로 내는데 JSON 분기는 그

--- a/src/parser/hwp_summary.rs
+++ b/src/parser/hwp_summary.rs
@@ -1,0 +1,125 @@
+//! HWP5 `HwpSummaryInformation`에서 읽는 저장 프로그램 메타데이터.
+//!
+//! 이 스트림은 사용자가 지울 수 있는 OLE 요약 정보다. 따라서 여기서 얻는 값은
+//! 문서의 원 작성 도구가 아니라 **마지막 저장 도구의 메타데이터**로만 취급한다.
+
+/// `HwpSummaryInformation`의 `PIDSI_REVNUMBER` 속성 ID.
+const REVISION_NUMBER_PID: u32 = 0x0000_0009;
+const VT_LPSTR: u32 = 0x001E;
+const VT_LPWSTR: u32 = 0x001F;
+
+/// HWP5 요약 정보가 가리키는 마지막 저장 한컴오피스 제품.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HancomOfficeSaveVersion {
+    /// `HwpSummaryInformation.revisionNumber`에서 읽은 네 자리 빌드 버전.
+    pub version: String,
+    /// 알려진 한컴오피스 연도. 매핑 근거가 없는 주 버전은 `None`이다.
+    pub product: Option<&'static str>,
+}
+
+/// HWP5 extra stream에서 마지막 저장 제품 메타데이터를 읽는다.
+///
+/// 요약 정보가 없거나 손상됐거나 version 형식을 해석하지 못하면 `None`이다. 이 경우
+/// 호출자는 저장 제품을 추정하지 않아야 한다.
+pub fn last_saved_with(extra_streams: &[(String, Vec<u8>)]) -> Option<HancomOfficeSaveVersion> {
+    let summary = extra_streams
+        .iter()
+        .find(|(path, _)| {
+            path.trim_start_matches('/') == "\u{5}HwpSummaryInformation"
+                || path.trim_start_matches(['/', '\u{5}']) == "HwpSummaryInformation"
+        })
+        .map(|(_, data)| data.as_slice())?;
+    let revision_number = summary_property_string(summary, REVISION_NUMBER_PID)?;
+    let parts = parse_revision_number(&revision_number)?;
+    let version = format!("{}.{}.{}.{}", parts[0], parts[1], parts[2], parts[3]);
+    let product = match parts[0] {
+        10 => Some("hancom-office-2018"),
+        12 => Some("hancom-office-2022"),
+        13 => Some("hancom-office-2024"),
+        _ => None,
+    };
+
+    Some(HancomOfficeSaveVersion { version, product })
+}
+
+fn summary_property_string(data: &[u8], target_pid: u32) -> Option<String> {
+    if data.get(..2) != Some(&[0xFE, 0xFF]) {
+        return None;
+    }
+    let section_offset = u32_at(data, 44)? as usize;
+    let property_count = u32_at(data, section_offset + 4)? as usize;
+    if property_count > 4096
+        || section_offset.checked_add(8 + property_count.checked_mul(8)?)? > data.len()
+    {
+        return None;
+    }
+
+    for index in 0..property_count {
+        let entry_offset = section_offset + 8 + index * 8;
+        let pid = u32_at(data, entry_offset)?;
+        if pid != target_pid {
+            continue;
+        }
+        let relative_offset = u32_at(data, entry_offset + 4)? as usize;
+        let value_offset = section_offset.checked_add(relative_offset)?;
+        let value_type = u32_at(data, value_offset)?;
+        let length = u32_at(data, value_offset + 4)? as usize;
+        let payload_offset = value_offset.checked_add(8)?;
+
+        return match value_type {
+            VT_LPWSTR => decode_utf16le(
+                data.get(payload_offset..payload_offset.checked_add(length.checked_mul(2)?)?)?,
+            ),
+            VT_LPSTR => {
+                decode_lpstr(data.get(payload_offset..payload_offset.checked_add(length)?)?)
+            }
+            _ => None,
+        };
+    }
+    None
+}
+
+fn u32_at(data: &[u8], offset: usize) -> Option<u32> {
+    let bytes: [u8; 4] = data.get(offset..offset.checked_add(4)?)?.try_into().ok()?;
+    Some(u32::from_le_bytes(bytes))
+}
+
+fn decode_utf16le(data: &[u8]) -> Option<String> {
+    let units = data
+        .chunks_exact(2)
+        .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+        .take_while(|unit| *unit != 0)
+        .collect::<Vec<_>>();
+    String::from_utf16(&units).ok()
+}
+
+fn decode_lpstr(data: &[u8]) -> Option<String> {
+    let bytes = data.split(|byte| *byte == 0).next()?;
+    std::str::from_utf8(bytes).ok().map(str::to_owned)
+}
+
+fn parse_revision_number(value: &str) -> Option<[u32; 4]> {
+    let mut chars = value.chars().peekable();
+    let mut parts = [0u32; 4];
+
+    for (index, part) in parts.iter_mut().enumerate() {
+        while chars.peek().is_some_and(|ch| ch.is_whitespace()) {
+            chars.next();
+        }
+
+        let mut digits = String::new();
+        while chars.peek().is_some_and(|ch| ch.is_ascii_digit()) {
+            digits.push(chars.next()?);
+        }
+        *part = digits.parse().ok()?;
+
+        while chars.peek().is_some_and(|ch| ch.is_whitespace()) {
+            chars.next();
+        }
+        if index < 3 && chars.next()? != ',' {
+            return None;
+        }
+    }
+
+    Some(parts)
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -25,6 +25,7 @@ pub mod doc_info;
 pub mod header;
 pub mod hml;
 pub mod hwp3;
+pub mod hwp_summary;
 pub mod hwpx;
 pub mod ingest;
 pub mod ole_container;

--- a/tests/cases/info_hancom_save_version_contract.rs
+++ b/tests/cases/info_hancom_save_version_contract.rs
@@ -1,0 +1,71 @@
+//! `info --json`의 마지막 저장 한컴오피스 제품 메타데이터 계약.
+//!
+//! FileHeader의 HWP 형식 버전은 2022와 2024가 모두 `5.1.1.0`일 수 있으므로,
+//! `HwpSummaryInformation.revisionNumber`에서 마지막 저장 제품을 별도로 판별한다.
+//! 이 값은 원 작성 제품이 아니라 사용자가 지울 수 있는 저장 메타데이터다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const HWP3: &str = "samples/hwp3-sample16.hwp";
+const HWP2018: &str = "samples/hwp3-sample16-hwp5-2018.hwp";
+const HWP2022: &str = "samples/hwp3-sample16-hwp5-2022.hwp";
+const HWP2024: &str = "samples/hwp3-sample16-hwp5-2024.hwp";
+const HWPX: &str = "samples/task2136/neartop_reset_sb2500.hwpx";
+
+fn sample_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn info_json(relative: &str) -> serde_json::Value {
+    let sample = sample_path(relative);
+    let output = Command::new(rhwp_bin())
+        .args(["info", "--json", sample.to_str().expect("UTF-8 경로")])
+        .output()
+        .expect("rhwp 실행 실패");
+    assert!(
+        output.status.success(),
+        "info 실패: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    serde_json::from_slice(&output.stdout).expect("info JSON")
+}
+
+#[test]
+fn info_distinguishes_hancom_office_save_editions() {
+    for (sample, product, version) in [
+        (HWP2018, "hancom-office-2018", "10.0.0.14727"),
+        (HWP2022, "hancom-office-2022", "12.0.0.535"),
+        (HWP2024, "hancom-office-2024", "13.0.0.3457"),
+    ] {
+        let info = info_json(sample);
+        assert_eq!(info["format"], "hwp5", "{sample}: {info}");
+        assert_eq!(
+            info["lastSavedWith"]["product"], product,
+            "{sample}: {info}"
+        );
+        assert_eq!(
+            info["lastSavedWith"]["version"], version,
+            "{sample}: {info}"
+        );
+        assert_eq!(
+            info["lastSavedWith"]["confidence"], "metadata",
+            "{sample}: {info}"
+        );
+    }
+}
+
+#[test]
+fn info_does_not_guess_a_non_hwp5_saving_product() {
+    for (sample, format) in [(HWP3, "hwp3"), (HWPX, "hwpx")] {
+        let info = info_json(sample);
+        assert_eq!(info["format"], format, "{sample}: {info}");
+        assert!(info["lastSavedWith"].is_null(), "{sample}: {info}");
+    }
+}
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}


### PR DESCRIPTION
## 요약

- HWP5 `HwpSummaryInformation.revisionNumber`를 읽어 `info --json`의 `lastSavedWith`로 노출합니다.
- 주버전 12와 13을 각각 `hancom-office-2022`, `hancom-office-2024`로 명확히 구분합니다. 2018도 함께 식별합니다.
- HWP3/HWPX, 누락 또는 손상 메타데이터는 제품 연도를 추정하지 않고 `lastSavedWith: null`을 반환합니다.
- MCP `hwp_info`, capabilities, CLI 매뉴얼 및 지식 지도에 같은 계약을 반영합니다.

`lastSavedWith`는 원 작성 제품이 아니라 수정 가능한 마지막 저장 메타데이터입니다.

## 로컬 검증

- `cargo nextest run --locked --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast`
  - 8,173 passed, 39 skipped
- `cargo clippy --locked --all-targets --target-dir target/pr-review -- -D warnings`
- `cargo fmt --all -- --check`
- test-suite manifest / unit-test tier / diff check

Closes #5931
