### PR TITLE
perf: 셀 서식 뮤테이터가 배치 중 전체 재조판을 end_batch 로 미룬다 (#4118)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,7 +1496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
-name = "llm-verifier-criteria-decomp"
+name = "llm-verifier-claim-bind"
 version = "0.1.0"
 dependencies = [
  "serde",
@@ -1504,7 +1504,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "llm-verifier-claim-bind"
+name = "llm-verifier-criteria-decomp"
 version = "0.1.0"
 dependencies = [
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,7 +1496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
-name = "llm-verifier-claim-bind"
+name = "llm-verifier-criteria-decomp"
 version = "0.1.0"
 dependencies = [
  "serde",
@@ -1504,7 +1504,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "llm-verifier-criteria-decomp"
+name = "llm-verifier-claim-bind"
 version = "0.1.0"
 dependencies = [
  "serde",

--- a/mydocs/working/task_m100_4118_stage1.md
+++ b/mydocs/working/task_m100_4118_stage1.md
@@ -1,0 +1,77 @@
+# Task M100 #4118 — 셀 뮤테이터 O(n²) 배치 지연 재페이지네이션
+
+## 무엇을
+
+셀 블록 전체 서식·속성 적용(`applyParaFormatInCell`·`applyCharFormatInCell`·
+`setCellProperties`를 셀 수만큼 호출)이 표가 커질수록 제곱으로 느려지는 결함
+(#4118, 1000셀 정렬 ~5.2초 · 1500셀 12.8초)을 고친다.
+
+## 왜 — 근본 원인
+
+- 코어에는 이미 두 가지 지연 계약이 있었다.
+  - `batch_mode` 플래그와 이를 존중하는 `paginate_if_needed()`(rendering.rs),
+    `begin_batch_native`/`end_batch_native`(document.rs), wasm 표면
+    `beginBatch`/`endBatch`.
+  - 셀 **텍스트** 편집의 deferred pagination(#2424): `mark_section_pagination_dirty`
+    만 하고 paginate 를 flush 로 미룬다.
+- 그런데 셀 **서식** 뮤테이터 꼬리는 이 게이트들을 우회해 매 호출
+  `rebuild_section`(resolve_styles + recompose_section + paginate 전체 패스)을
+  했다. studio 는 beginBatch 를 한 번도 쓰지 않으므로 호출 수 × O(문서) = O(n²).
+- setCellProperties 는 이미 `paginate_if_needed`(table_ops.rs)라 배치로만 묶으면
+  되었고, 서식 뮤테이터는 꼬리 자체가 계약 밖이었다.
+
+## 어떻게
+
+1. **코어**(formatting.rs): 공통 꼬리 헬퍼
+   `rebuild_section_deferred_in_batch(sec)` 추가 — batch_mode 면
+   `resolve_styles` 즉시 갱신(새 서식 id 반영, O(스타일 수))+`mark_section_dirty`
+   로 미루고, 아니면 종전대로 전체 rebuild. 다음 6곳의 꼬리를 이 헬퍼로 교체:
+   - `apply_char_format_in_cell_native`
+   - `apply_char_format_in_cell_by_path` (깊이≥2 분기)
+   - `apply_para_format_in_cell_native`
+   - `apply_cell_style_native` (두 분기)
+   - `set_char_shape_id_in_cell_by_path` (undo 복원 루프가 셀 수만큼 부른다)
+2. **studio**: bridge 에 `runInBatch(fn)`(begin/endBatch try-finally 묶음, 낡은
+   pkg 호환 폴백) 추가하고 블록 적용 루프 5곳을 묶음:
+   - input-handler: `applyCharFormatToCellBlock`, `applyCopiedCellPropsToSelection`
+   - command: `ApplyCharFormatCommand.execute`(셀 분기), `ApplyParaFormatCommand.execute`
+   - cell-border-bg-dialog: 전체/선택 범위 스코프 루프
+
+비배치 단일 호출 경로는 동작이 완전히 동일하다(else 분기가 종전 코드).
+
+## 검증 실측
+
+- 신규 통합 테스트 `tests/cases/issue_4118_cell_format_batch_deferral.rs`:
+  실제 샘플 문서의 본문 표 전체 셀에 서식 3종 적용 시 — 배치 여부와 무관하게
+  **쪽 수·1쪽 지오메트리(getPageInfo)·1쪽 SVG 렌더 바이트·저장 바이트가 동일**.
+- `cargo test --lib`: 3,893 passed / 0 failed
+- `cargo clippy --lib -- -D warnings`: clean
+- `cargo fmt --all -- --check`: pass
+- manifest `--prepare`/`--check`: pass(신규 source 등록)
+- `rust-unit-test-tiers --check`: 4225 유지(source-side 테스트 증가 없음 —
+  신규 테스트는 tests/cases 원본으로만 추가)
+- rhwp-studio `npm test`: 1,065 passed / 0 failed / 1 skipped(기존 skip)
+- tsc: 변경 파일 오류 없음(devel 원래 존재하는 5건 제외)
+
+## 성능 실측
+
+네이티브 release 빌드, 이슈 프로브와 동일 형태(샘플 문서에 100×10 표 생성,
+셀마다 "AB" 입력, 1000셀 × `apply_para_format_in_cell({"alignment":"center"})`):
+
+| 경로 | 총 시간 | 호출당 |
+|---|---|---|
+| 종전(호출마다 rebuild_section) | **5.854s** | 5.854ms |
+| 수정(begin_batch~end_batch) | **0.130s** | 0.130ms |
+
+- **약 45배 단축**, 호출당 비용이 셀 수에 더 이상 비례하지 않는다(평탄).
+- 두 경로의 결과는 동일하다 — 쪽 수 동일(assert). 저장 바이트·1쪽 지오메트리
+  동일성은 통합 테스트 `issue_4118_cell_format_batch_deferral` 이 보장한다.
+- WASM 브라우저 수치는 리뷰 환경에서 wasm-pack 재빌드 후 이슈 프로브로
+  재측정해 첨부할 것(이슈 보고자의 재측정 관례 준용).
+
+## 잔여 / 후속
+
+- body 경로 서식 뮤테이터(`apply_para_format_native` 등 formatting.rs 잔여
+  rebuild_section 꼬리)와 `restoreCharShapeIds` undo 루프의 배치 묶음 — 동일
+  클래스이나 블록 루프 표적이 아니어서 이번 범위에서 제외.
+- 중첩 표 블록 적용은 applyCharFormatToCellBlock 의 byPath 경로가 함께 묶인다.

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -740,6 +740,30 @@ export class WasmBridge {
     return JSON.parse(d.flushDeferredPagination());
   }
 
+  /**
+   * 여러 뮤테이션을 한 번의 재페이지네이션으로 묶는다 (#4118).
+   *
+   * begin_batch~end_batch 사이의 뮤테이터는 파생 재계산을 end_batch 의 paginate()
+   * 1회로 미루므로, 셀 블록 전체 적용처럼 셀 수만큼 뮤테이터를 호출하는 경로의
+   * O(n²) 재조판을 O(n) 으로 만든다. fn 도중 예외가 나도 batch 가 새지 않게
+   * finally 에서 닫는다. pkg 가 낡아 beginBatch 가 없으면 묶음 없이 실행한다 —
+   * 결과는 동일하고 느릴 뿐이다.
+   */
+  runInBatch<T>(fn: () => T): T {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    const d = this.doc as unknown as { beginBatch?: () => string; endBatch?: () => string };
+    const batchable = typeof d.beginBatch === 'function' && typeof d.endBatch === 'function';
+    if (!batchable) {
+      return fn();
+    }
+    this.doc.beginBatch();
+    try {
+      return fn();
+    } finally {
+      this.doc.endBatch();
+    }
+  }
+
   getSectionCount(): number {
     return this.doc?.getSectionCount() ?? 0;
   }

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -964,19 +964,22 @@ export class ApplyCharFormatCommand implements EditCommand {
       const endPara = cellParaIndexOf(end);
 
       this.entries = [];
-      for (let p = startPara; p <= endPara; p++) {
-        const pathP = cellPathJsonForPara(start, p);
-        const from = p === startPara ? start.charOffset : 0;
-        const to = p === endPara ? end.charOffset : wasm.getCellParagraphLengthByPath(sec, ppi, pathP);
-        if (to <= from) continue;
+      // 대상 문단 수만큼 뮤테이터를 호출하므로 재페이지네이션을 묶는다(#4118).
+      wasm.runInBatch(() => {
+        for (let p = startPara; p <= endPara; p++) {
+          const pathP = cellPathJsonForPara(start, p);
+          const from = p === startPara ? start.charOffset : 0;
+          const to = p === endPara ? end.charOffset : wasm.getCellParagraphLengthByPath(sec, ppi, pathP);
+          if (to <= from) continue;
 
-        const prevProps = wasm.getCellCharPropertiesAtByPath(sec, ppi, pathP, from);
-        this.entries.push({ paraIndex: p, startOffset: from, endOffset: to, beforeCharShapeId: prevProps.charShapeId });
+          const prevProps = wasm.getCellCharPropertiesAtByPath(sec, ppi, pathP, from);
+          this.entries.push({ paraIndex: p, startOffset: from, endOffset: to, beforeCharShapeId: prevProps.charShapeId });
 
-        wasm.applyCharFormatInCellByPath(sec, ppi, pathP, from, to, propsJson);
-        const afterProps = wasm.getCellCharPropertiesAtByPath(sec, ppi, pathP, from);
-        this.entries[this.entries.length - 1].afterCharShapeId = afterProps.charShapeId;
-      }
+          wasm.applyCharFormatInCellByPath(sec, ppi, pathP, from, to, propsJson);
+          const afterProps = wasm.getCellCharPropertiesAtByPath(sec, ppi, pathP, from);
+          this.entries[this.entries.length - 1].afterCharShapeId = afterProps.charShapeId;
+        }
+      });
     } else {
       const sec = start.sectionIndex;
       const startPara = start.paragraphIndex;
@@ -1111,9 +1114,12 @@ export class ApplyParaFormatCommand implements EditCommand {
       beforeParaShapeId: getParaShapeId(wasm, target),
     }));
 
-    for (const entry of entries) {
-      applyParaFormatToTarget(wasm, entry.target, propsJson);
-    }
+    // 대상 수만큼 뮤테이터를 호출하므로 재페이지네이션을 묶는다(#4118).
+    wasm.runInBatch(() => {
+      for (const entry of entries) {
+        applyParaFormatToTarget(wasm, entry.target, propsJson);
+      }
+    });
     for (const entry of entries) {
       entry.afterParaShapeId = getParaShapeId(wasm, entry.target);
     }

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2008,25 +2008,28 @@ export class InputHandler {
       kind: 'snapshot',
       operationType: 'applyCharFormatCellBlock',
       operation: (wasm) => {
-        for (const cellIdx of block.cellIndices) {
-          if (block.cellPath) {
-            const path = block.cellPath;
-            const paraCount = wasm.getCellParagraphCountByPath(block.sec, block.ppi, JSON.stringify(withCellPathTarget(path, cellIdx)));
-            for (let cellParaIdx = 0; cellParaIdx < paraCount; cellParaIdx++) {
-              const pathJson = JSON.stringify(withCellPathTarget(path, cellIdx, cellParaIdx));
-              const len = wasm.getCellParagraphLengthByPath(block.sec, block.ppi, pathJson);
-              if (len <= 0) continue;
-              wasm.applyCharFormatInCellByPath(block.sec, block.ppi, pathJson, 0, len, propsJson);
+        // 셀 수만큼 뮤테이터를 호출하므로 재페이지네이션을 묶는다(#4118).
+        wasm.runInBatch(() => {
+          for (const cellIdx of block.cellIndices) {
+            if (block.cellPath) {
+              const path = block.cellPath;
+              const paraCount = wasm.getCellParagraphCountByPath(block.sec, block.ppi, JSON.stringify(withCellPathTarget(path, cellIdx)));
+              for (let cellParaIdx = 0; cellParaIdx < paraCount; cellParaIdx++) {
+                const pathJson = JSON.stringify(withCellPathTarget(path, cellIdx, cellParaIdx));
+                const len = wasm.getCellParagraphLengthByPath(block.sec, block.ppi, pathJson);
+                if (len <= 0) continue;
+                wasm.applyCharFormatInCellByPath(block.sec, block.ppi, pathJson, 0, len, propsJson);
+              }
+              continue;
             }
-            continue;
+            const paraCount = wasm.getCellParagraphCount(block.sec, block.ppi, block.ci, cellIdx);
+            for (let cellParaIdx = 0; cellParaIdx < paraCount; cellParaIdx++) {
+              const len = wasm.getCellParagraphLength(block.sec, block.ppi, block.ci, cellIdx, cellParaIdx);
+              if (len <= 0) continue;
+              wasm.applyCharFormatInCell(block.sec, block.ppi, block.ci, cellIdx, cellParaIdx, 0, len, propsJson);
+            }
           }
-          const paraCount = wasm.getCellParagraphCount(block.sec, block.ppi, block.ci, cellIdx);
-          for (let cellParaIdx = 0; cellParaIdx < paraCount; cellParaIdx++) {
-            const len = wasm.getCellParagraphLength(block.sec, block.ppi, block.ci, cellIdx, cellParaIdx);
-            if (len <= 0) continue;
-            wasm.applyCharFormatInCell(block.sec, block.ppi, block.ci, cellIdx, cellParaIdx, 0, len, propsJson);
-          }
-        }
+        });
         return { ...cursorBefore };
       },
     });
@@ -4990,9 +4993,12 @@ export class InputHandler {
           range,
           this.cursor.getExcludedCells(),
         );
-        for (const cellIdx of cellIndices) {
-          wasm.setCellProperties(ctx.sec, ctx.ppi, ctx.ci, cellIdx, props);
-        }
+        // 셀 수만큼 setCellProperties 를 호출하므로 재페이지네이션을 묶는다(#4118).
+        wasm.runInBatch(() => {
+          for (const cellIdx of cellIndices) {
+            wasm.setCellProperties(ctx.sec, ctx.ppi, ctx.ci, cellIdx, props);
+          }
+        });
         return this.cursor.getPosition();
       },
     });

--- a/rhwp-studio/src/ui/cell-border-bg-dialog.ts
+++ b/rhwp-studio/src/ui/cell-border-bg-dialog.ts
@@ -1038,15 +1038,20 @@ export class CellBorderBgDialog extends ModalDialog {
         }
       } else if (scope === 'all') {
         const dims = this.wasm.getTableDimensions(sec, ppi, ci);
-        for (let i = 0; i < dims.cellCount; i++) {
-          this.wasm.setCellProperties(sec, ppi, ci, i, newProps as Partial<CellProperties>);
-        }
+        // 셀 수만큼 setCellProperties 를 호출하므로 재페이지네이션을 묶는다(#4118).
+        this.wasm.runInBatch(() => {
+          for (let i = 0; i < dims.cellCount; i++) {
+            this.wasm.setCellProperties(sec, ppi, ci, i, newProps as Partial<CellProperties>);
+          }
+        });
       } else if (this.selectionRange) {
         const cellIndices = this.selectedCellIndicesForRange(this.selectionRange);
         const targetIndices = cellIndices.length > 0 ? cellIndices : [this.cellIdx];
-        for (const cellIdx of targetIndices) {
-          this.wasm.setCellProperties(sec, ppi, ci, cellIdx, newProps as Partial<CellProperties>);
-        }
+        this.wasm.runInBatch(() => {
+          for (const cellIdx of targetIndices) {
+            this.wasm.setCellProperties(sec, ppi, ci, cellIdx, newProps as Partial<CellProperties>);
+          }
+        });
       } else {
         this.wasm.setCellProperties(sec, ppi, ci, this.cellIdx, newProps as Partial<CellProperties>);
       }

--- a/src/document_core/commands/formatting.rs
+++ b/src/document_core/commands/formatting.rs
@@ -1151,6 +1151,24 @@ impl DocumentCore {
         Ok("{\"ok\":true}".to_string())
     }
 
+    /// 셀 서식 뮤테이터의 공통 꼬리 — raw 스트림 무효화와 파생 재계산.
+    ///
+    /// 배치 중(`begin_batch`~`end_batch`)에는 재구성·재페이지네이션을 `end_batch_native`
+    /// 의 paginate() 1회로 미루고 구역만 dirty 로 표시한다 — 셀 텍스트 편집의 지연
+    /// 계약(#2424)과 같은 모양이다. 서식 변경은 composed 구조를 바꾸지 않으므로
+    /// 재구성 없이 flush 시점 재처리로 충분하다. 새 서식 id 가 doc_info 에 추가됐을
+    /// 수 있으므로 스타일 해석만 즉시 갱신한다(O(스타일 수) — 재조판 비용과 무관).
+    /// 배치 밖에서는 종전대로 전체 rebuild 이다(#4118).
+    pub(crate) fn rebuild_section_deferred_in_batch(&mut self, sec_idx: usize) {
+        self.document.sections[sec_idx].raw_stream = None;
+        if self.batch_mode {
+            self.styles = resolve_styles(&self.document.doc_info, self.dpi);
+            self.mark_section_dirty(sec_idx);
+        } else {
+            self.rebuild_section(sec_idx);
+        }
+    }
+
     /// 글자 서식 적용 (네이티브) — 셀 내 문단
     pub fn apply_char_format_in_cell_native(
         &mut self,
@@ -1212,8 +1230,7 @@ impl DocumentCore {
             self.mark_cell_control_dirty(sec_idx, parent_para_idx, control_idx);
         }
 
-        self.document.sections[sec_idx].raw_stream = None;
-        self.rebuild_section(sec_idx);
+        self.rebuild_section_deferred_in_batch(sec_idx);
         self.event_log.push(DocumentEvent::CharFormatChanged {
             section: sec_idx,
             para: parent_para_idx,
@@ -1278,8 +1295,7 @@ impl DocumentCore {
         }
         let outer_ctrl = path[0].0;
         self.mark_cell_control_dirty(sec_idx, parent_para_idx, outer_ctrl);
-        self.document.sections[sec_idx].raw_stream = None;
-        self.rebuild_section(sec_idx);
+        self.rebuild_section_deferred_in_batch(sec_idx);
         self.event_log.push(DocumentEvent::CharFormatChanged {
             section: sec_idx,
             para: parent_para_idx,
@@ -1350,8 +1366,7 @@ impl DocumentCore {
         self.reflow_cell_paragraph_by_path(sec_idx, parent_para_idx, path, inner_cpi);
         let outer_ctrl = path[0].0;
         self.mark_cell_control_dirty(sec_idx, parent_para_idx, outer_ctrl);
-        self.document.sections[sec_idx].raw_stream = None;
-        self.rebuild_section(sec_idx);
+        self.rebuild_section_deferred_in_batch(sec_idx);
         self.event_log.push(DocumentEvent::CharFormatChanged {
             section: sec_idx,
             para: parent_para_idx,
@@ -1660,8 +1675,7 @@ impl DocumentCore {
         // 표 dirty 마킹 — measure_section_incremental이 셀 높이를 재계산하도록
         self.mark_cell_control_dirty(sec_idx, parent_para_idx, control_idx);
 
-        self.document.sections[sec_idx].raw_stream = None;
-        self.rebuild_section(sec_idx);
+        self.rebuild_section_deferred_in_batch(sec_idx);
         self.event_log.push(DocumentEvent::ParaFormatChanged {
             section: sec_idx,
             para: parent_para_idx,
@@ -2074,8 +2088,7 @@ impl DocumentCore {
                 cell_para_idx,
             );
             self.mark_cell_control_dirty(sec_idx, parent_para_idx, control_idx);
-            self.document.sections[sec_idx].raw_stream = None;
-            self.rebuild_section(sec_idx);
+            self.rebuild_section_deferred_in_batch(sec_idx);
             self.event_log.push(DocumentEvent::CharFormatChanged {
                 section: sec_idx,
                 para: parent_para_idx,
@@ -2118,8 +2131,7 @@ impl DocumentCore {
             cell_para_idx,
         );
         self.mark_cell_control_dirty(sec_idx, parent_para_idx, control_idx);
-        self.document.sections[sec_idx].raw_stream = None;
-        self.rebuild_section(sec_idx);
+        self.rebuild_section_deferred_in_batch(sec_idx);
         self.event_log.push(DocumentEvent::ParaFormatChanged {
             section: sec_idx,
             para: parent_para_idx,

--- a/src/document_core/commands/formatting.rs
+++ b/src/document_core/commands/formatting.rs
@@ -1151,7 +1151,8 @@ impl DocumentCore {
         Ok("{\"ok\":true}".to_string())
     }
 
-    /// 셀 서식 뮤테이터의 공통 꼬리 — raw 스트림 무효화와 파생 재계산.
+    /// 셀 서식 뮤테이터의 파생 재계산 꼬리 — 배치 여부에 따라 재구성·재페이지네이션을
+    /// 지연하거나 즉시 전체 rebuild 로 마친다.
     ///
     /// 배치 중(`begin_batch`~`end_batch`)에는 재구성·재페이지네이션을 `end_batch_native`
     /// 의 paginate() 1회로 미루고 구역만 dirty 로 표시한다 — 셀 텍스트 편집의 지연
@@ -1159,8 +1160,10 @@ impl DocumentCore {
     /// 재구성 없이 flush 시점 재처리로 충분하다. 새 서식 id 가 doc_info 에 추가됐을
     /// 수 있으므로 스타일 해석만 즉시 갱신한다(O(스타일 수) — 재조판 비용과 무관).
     /// 배치 밖에서는 종전대로 전체 rebuild 이다(#4118).
+    ///
+    /// 패스스루(raw_stream) 무효화는 #2724 가드가 뮤테이터 본문의 직접 토큰을 요구하므로
+    /// 호출자가 하고, 이 헬퍼는 파생 상태 정리만 소유한다.
     pub(crate) fn rebuild_section_deferred_in_batch(&mut self, sec_idx: usize) {
-        self.document.sections[sec_idx].raw_stream = None;
         if self.batch_mode {
             self.styles = resolve_styles(&self.document.doc_info, self.dpi);
             self.mark_section_dirty(sec_idx);
@@ -1230,6 +1233,7 @@ impl DocumentCore {
             self.mark_cell_control_dirty(sec_idx, parent_para_idx, control_idx);
         }
 
+        self.document.sections[sec_idx].raw_stream = None;
         self.rebuild_section_deferred_in_batch(sec_idx);
         self.event_log.push(DocumentEvent::CharFormatChanged {
             section: sec_idx,
@@ -1295,6 +1299,7 @@ impl DocumentCore {
         }
         let outer_ctrl = path[0].0;
         self.mark_cell_control_dirty(sec_idx, parent_para_idx, outer_ctrl);
+        self.document.sections[sec_idx].raw_stream = None;
         self.rebuild_section_deferred_in_batch(sec_idx);
         self.event_log.push(DocumentEvent::CharFormatChanged {
             section: sec_idx,
@@ -1366,6 +1371,7 @@ impl DocumentCore {
         self.reflow_cell_paragraph_by_path(sec_idx, parent_para_idx, path, inner_cpi);
         let outer_ctrl = path[0].0;
         self.mark_cell_control_dirty(sec_idx, parent_para_idx, outer_ctrl);
+        self.document.sections[sec_idx].raw_stream = None;
         self.rebuild_section_deferred_in_batch(sec_idx);
         self.event_log.push(DocumentEvent::CharFormatChanged {
             section: sec_idx,
@@ -1675,6 +1681,7 @@ impl DocumentCore {
         // 표 dirty 마킹 — measure_section_incremental이 셀 높이를 재계산하도록
         self.mark_cell_control_dirty(sec_idx, parent_para_idx, control_idx);
 
+        self.document.sections[sec_idx].raw_stream = None;
         self.rebuild_section_deferred_in_batch(sec_idx);
         self.event_log.push(DocumentEvent::ParaFormatChanged {
             section: sec_idx,
@@ -2088,6 +2095,7 @@ impl DocumentCore {
                 cell_para_idx,
             );
             self.mark_cell_control_dirty(sec_idx, parent_para_idx, control_idx);
+            self.document.sections[sec_idx].raw_stream = None;
             self.rebuild_section_deferred_in_batch(sec_idx);
             self.event_log.push(DocumentEvent::CharFormatChanged {
                 section: sec_idx,
@@ -2131,6 +2139,7 @@ impl DocumentCore {
             cell_para_idx,
         );
         self.mark_cell_control_dirty(sec_idx, parent_para_idx, control_idx);
+        self.document.sections[sec_idx].raw_stream = None;
         self.rebuild_section_deferred_in_batch(sec_idx);
         self.event_log.push(DocumentEvent::ParaFormatChanged {
             section: sec_idx,

--- a/tests/cases/issue_4118_cell_format_batch_deferral.rs
+++ b/tests/cases/issue_4118_cell_format_batch_deferral.rs
@@ -9,7 +9,7 @@
 //! 낮춘다.
 #![cfg(not(target_arch = "wasm32"))]
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use rhwp::document_core::queries::table_extract::extract_tables;
 use rhwp::model::control::Control;
@@ -110,7 +110,6 @@ fn run(batched: bool, sample_path: &str) -> (u32, String, String, Vec<u8>) {
 #[test]
 fn batched_cell_formats_match_eager_rebuild() {
     let sample_path = sample();
-    let _ = PathBuf::from(&sample_path);
 
     let eager = run(false, &sample_path);
     let batched = run(true, &sample_path);

--- a/tests/cases/issue_4118_cell_format_batch_deferral.rs
+++ b/tests/cases/issue_4118_cell_format_batch_deferral.rs
@@ -1,0 +1,134 @@
+//! #4118 — 셀 서식 뮤테이터의 배치 지연 재페이지네이션 동등성 계약.
+//!
+//! `begin_batch`~`end_batch` 사이에서 셀 서식 뮤테이터(`apply_para_format_in_cell`,
+//! `apply_char_format_in_cell`, `set_cell_properties`)는 재구성·재페이지네이션을
+//! `end_batch` 의 paginate() 1회로 미룬다. 이 테스트는 같은 시작 문서에 대해
+//! (a) 호출마다 전체 rebuild 한 결과와 (b) 배치로 묶은 결과가 쪽 수와 저장
+//! 바이트까지 동일함을 확인한다 — 지연이 관측 가능한 결과를 바꾸지 않는다는
+//! 계약이다. 배치는 호출마다 O(문서) 재조판을 없애 #4118 의 O(n²) 를 O(n) 으로
+//! 낮춘다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+
+use rhwp::document_core::queries::table_extract::extract_tables;
+use rhwp::model::control::Control;
+use rhwp::wasm_api::HwpDocument;
+
+fn sample() -> String {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx")
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// 본문 최상위 표 하나의 좌표와 셀 수.
+struct BodyTable {
+    section: usize,
+    paragraph: usize,
+    control: usize,
+    cell_count: usize,
+}
+
+fn first_body_table(path: &str) -> BodyTable {
+    let bytes = std::fs::read(path).expect("sample");
+    let doc = HwpDocument::from_bytes(&bytes).expect("parse");
+    for g in extract_tables(doc.document()) {
+        if !g.container_path.is_empty() {
+            continue;
+        }
+        let Some(Control::Table(table)) = doc.document().sections[g.section].paragraphs
+            [g.paragraph]
+            .controls
+            .get(g.control)
+        else {
+            continue;
+        };
+        if table.cells.len() >= 4 {
+            return BodyTable {
+                section: g.section,
+                paragraph: g.paragraph,
+                control: g.control,
+                cell_count: table.cells.len(),
+            };
+        }
+    }
+    panic!("본문 최상위 표가 없다");
+}
+
+fn run(batched: bool, sample_path: &str) -> (u32, String, String, Vec<u8>) {
+    let bytes = std::fs::read(sample_path).expect("sample");
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("parse");
+    let grid = first_body_table(sample_path);
+
+    if batched {
+        doc.begin_batch().expect("배치 시작이 성공해야 함");
+    }
+    for cell_idx in 0..grid.cell_count {
+        doc.apply_para_format_in_cell(
+            grid.section,
+            grid.paragraph,
+            grid.control,
+            cell_idx,
+            0,
+            r#"{"alignment":"center","lineSpacing":130}"#,
+        )
+        .expect("셀 문단 서식 적용이 성공해야 함");
+        doc.apply_char_format_in_cell(
+            grid.section,
+            grid.paragraph,
+            grid.control,
+            cell_idx,
+            0,
+            0,
+            2,
+            r#"{"bold":true}"#,
+        )
+        .expect("셀 글자 서식 적용이 성공해야 함");
+        doc.set_cell_properties(
+            grid.section as u32,
+            grid.paragraph as u32,
+            grid.control as u32,
+            cell_idx as u32,
+            r#"{"verticalAlign":1}"#,
+        )
+        .expect("셀 속성 적용이 성공해야 함");
+    }
+    if batched {
+        doc.end_batch().expect("배치 종료가 성공해야 함");
+    }
+
+    let pages = doc.page_count();
+    let first_page = doc.get_page_info(1).expect("1쪽 정보 조회가 성공해야 함");
+    // 표가 놓이는 1쪽만 렌더 비교한다 — 네이티브 JsValue 변환은 렌더 Err 경로가
+    // 미구현이라(panics as non-unwinding) 실패 가능성이 있는 전 쪽 순회는 피한다.
+    let first_page_svg = doc.render_page_svg(1).expect("1쪽 SVG 렌더가 성공해야 함");
+    let exported = doc.export_hwp().expect("내보내기가 성공해야 함");
+    (pages, first_page, first_page_svg, exported)
+}
+
+#[test]
+fn batched_cell_formats_match_eager_rebuild() {
+    let sample_path = sample();
+    let _ = PathBuf::from(&sample_path);
+
+    let eager = run(false, &sample_path);
+    let batched = run(true, &sample_path);
+
+    assert_eq!(
+        eager.0, batched.0,
+        "배치 여부와 무관하게 쪽 수가 같아야 한다"
+    );
+    assert_eq!(
+        eager.1, batched.1,
+        "배치 여부와 무관하게 1쪽 지오메트리가 같아야 한다"
+    );
+    assert_eq!(
+        eager.2, batched.2,
+        "배치 여부와 무관하게 1쪽 SVG 렌더가 같아야 한다"
+    );
+    assert_eq!(
+        eager.3, batched.3,
+        "배치 여부와 무관하게 저장 바이트가 같아야 한다"
+    );
+}


### PR DESCRIPTION
> PR base 브랜치가 `devel` 인지 확인했습니다. 작업 브랜치는 `origin/devel` @ `61e439043` 에서 생성했습니다.

## 변경 요약

#4118 — 셀 블록 전체 서식·속성 적용이 표가 커질수록 제곱으로 느려지는 결함을 고칩니다. 이슈에서 "어느 코어 함수가 재계산을 유발하는지 특정하지 못했다"던 근본 원인을 특정했고, 기존 지연 계약을 재사용해 수정했습니다.

**근본 원인**: 코어에는 `batch_mode` 게이트(`paginate_if_needed`)와 셀 텍스트 편집의 deferred pagination(#2424)이라는 두 지연 계약이 이미 있는데, **셀 서식 뮤테이터 꼬리만 이 게이트들을 우회해 매 호출 `rebuild_section`(resolve_styles + recompose_section + paginate 전체 패스)을 했습니다.** studio 는 `beginBatch`를 한 번도 쓰지 않으므로 호출 수 × O(문서) = O(n²).

**수정** (재발명 없이 기존 계약에 편입):

- `formatting.rs`: 공통 꼬리 `rebuild_section_deferred_in_batch(sec)` 추가 — 배치 중이면 `resolve_styles` 즉시 갱신(새 서식 id 반영) + `mark_section_dirty` 만 하고 재구성·재페이지네이션을 `end_batch_native` 의 paginate 1회로 미룸. 비배치 경로는 종전 동작 그대로. 적용: `apply_char_format_in_cell(_by_path)` · `apply_para_format_in_cell` · `apply_cell_style_native` · `set_char_shape_id_in_cell_by_path`(undo 복원 루프가 셀 수만큼 호출).
- `rhwp-studio`: bridge 에 `runInBatch(fn)`(begin/endBatch try-finally 묶음, 낡은 pkg 폴백 포함) 추가 후 블록 적용 루프 5곳 배선 — 셀 블록 글자서식(`applyCharFormatToCellBlock`), 모양 붙여넣기(`applyCopiedCellPropsToSelection`), `ApplyCharFormatCommand`·`ApplyParaFormatCommand`, 셀 테두리/배경 다이얼로그 전체·선택 스코프.

`setCellProperties` 는 이미 `paginate_if_needed`(table_ops.rs:1552)라 배치 묶음만으로 효과가 있습니다.

## 관련 이슈

closes #4118

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음
- [x] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (신규 테스트는 source-side 추가 대신 tests/cases 원본으로 넣어 4225 유지)
- [x] `cargo test` 통과 — lib 3,893 passed / 0 failed. 신규 `tests/cases/issue_4118_cell_format_batch_deferral.rs`: 실샘플 본문 표 전체 셀에 서식 3종 적용 시 배치 여부와 무관하게 **쪽 수·1쪽 지오메트리(getPageInfo)·1쪽 SVG 렌더 바이트·저장 바이트 동일**
- [x] `cargo clippy -- -D warnings` 통과 (lib)
- [x] 관련 샘플 파일로 SVG 내보내기 확인 — 위 통합 테스트의 1쪽 SVG 바이트 동등 비교가 대용
- [ ] 웹(WASM) 렌더링 확인 — 로컬 wasm-pack 재빌드 환경 부재로 미실행. 출력 동등성은 네이티브 바이트 비교로 대체 검증했으며, 리뷰 환경에서 이슈 프로브 재측정 권장
- [x] rhwp-studio 편집·UI 변경: `npm test` 1,065 passed / 0 failed / 1 skipped(기존 skip), tsc 변경 파일 오류 없음
- [ ] (에이전트 보조 작업 권장) 작업 증빙 — 코드 변경이라 문서 편집 영수증 대상 아님. 검증 게이트 실측이 증빙
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 없음

## 성능 영향 및 측정 결과

- 예상 영향: **개선** — 블록 적용 O(n²) → O(n). 비배치 단일 호출 경로는 변경 없음(else 분기가 종전 코드).
- 재현·측정: 네이티브 release 빌드, 이슈 프로브와 동일 형태(100×10=1000셀, 셀마다 "AB", `apply_para_format_in_cell({"alignment":"center"})` 1000회):

| 경로 | 총 시간 | 호출당 |
|---|---|---|
| 종전(호출마다 rebuild_section) | 5.854s | 5.854ms |
| 수정(begin_batch~end_batch) | **0.130s** | 0.130ms |

약 **45배 단축**, 호출당 비용이 더 이상 셀 수에 비례하지 않습니다. WASM 브라우저 수치는 리뷰 환경에서 `wasm-pack build` 후 #4118 본문 프로브로 재측정해 주시면 같은 형태로 나타날 것입니다.

상세 분석과 잔여 후속(body 경로 서식 꼬리·undo 복원 루프 묶음)은 `mydocs/working/task_m100_4118_stage1.md` 참조.
