### PR TITLE
fix(serializer): HWPML 출처도 구역당 PAGE_BORDER_FILL 을 3개로 채운다 — 한글이 버리던 본문 4쪽 7,549자 복원 (#5933)

### DIFF
--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1346,7 +1346,13 @@ impl DocumentCore {
     /// 원본은 일반적으로 BOTH 하나만 가지므로, adapter가 채운 EVEN/ODD는 저장 직후
     /// `SectionDef`와 serializer가 읽는 `Control::SectionDef`에서 함께 복원한다.
     fn snapshot_hwpx_page_border_fill_overlay(&self) -> Option<HwpPageBorderFillOverlay> {
-        (self.source_format == crate::parser::FileFormat::Hwpx).then(|| {
+        // [#5933] HML 출처도 저장 직전에 PBF 를 3개로 채우므로(HWP5 스트림 계약),
+        // 저장 뒤 live IR 은 원래 형상(단일 BOTH)으로 되돌린다 — HWPX 와 같은 계약.
+        matches!(
+            self.source_format,
+            crate::parser::FileFormat::Hwpx | crate::parser::FileFormat::Hml
+        )
+        .then(|| {
             self.document
                 .sections
                 .iter()

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -2503,6 +2503,29 @@ fn adapt_cell_list_attr(cell: &mut Cell, report: &mut AdapterReport) {
 ///
 /// 호출자: `DocumentCore::export_hwp_with_adapter()` (Stage 5 에서 추가).
 pub fn convert_if_hwpx_source(doc: &mut Document, source_format: FileFormat) -> AdapterReport {
+    // [#5933] HWPML(HML) 출처는 HWPX 전용 보정을 타면 안 되지만, **HWP5 스트림 계약**인
+    // 구역당 `HWPTAG_PAGE_BORDER_FILL` 3개(#3676)는 출처와 무관하게 지켜야 한다.
+    //
+    // HML 파서는 `extra_page_border_fills` 를 채우지 않아 저장본에 PBF 가 **1개만** 나갔고,
+    // 한글은 그 파일을 열되 본문을 통째로 버렸다(08462: 4쪽 7,428자 → **1쪽 0자**, 컨트롤
+    // 인구조사가 `cold:1,secd:1` 로 붕괴). rhwp 자기 조판은 같은 산출을 4쪽으로 읽으므로
+    // `--verify-pages` 로는 보이지 않는 축이다.
+    //
+    // 한글 2022 오라클 돌연변이 검정(08462) — 이 패딩만이 본문을 되살린다:
+    //
+    // | 변형 | 결과 |
+    // |---|---|
+    // | 현행(PBF 1) | 1쪽 0자 |
+    // | OLE contract 스트림 9개 추가 | 1쪽 0자 |
+    // | 스트림 압축 + `FileHeader` flags bit0 | 1쪽 0자 |
+    // | **PBF 3개** | **4쪽 7,549자** |
+    // | PBF 3개 + 압축 + 스트림 | 4쪽 7,549자 (차이 없음) |
+    //
+    // 저장 시점 보정이라 IR 과 HWPX 산출(단일 BOTH)은 그대로 둔다 — HWPX 출처와 같은 계약.
+    if matches!(source_format, FileFormat::Hml) {
+        normalize_page_border_fills_for_hwp(doc);
+        return AdapterReport::new().no_op("Hml: page_border_fill 3개만 보정");
+    }
     if !matches!(source_format, FileFormat::Hwpx | FileFormat::Hwp3) {
         return AdapterReport::new().no_op("source_format != Hwpx/Hwp3");
     }

--- a/tests/cases/issue_5933_hml_page_border_fill.rs
+++ b/tests/cases/issue_5933_hml_page_border_fill.rs
@@ -1,0 +1,93 @@
+//! [Issue #5933] HWPML(HML) 을 HWP5 로 저장하면 한글이 본문을 통째로 버린다.
+//!
+//! 한컴 저장본과 rhwp 의 HWP5 왕복본은 예외 없이 구역당 `HWPTAG_PAGE_BORDER_FILL` 이
+//! **3개**(양쪽/짝수쪽/홀수쪽)다(#3676). HWPX·HWP3 출처는 저장 어댑터
+//! (`convert_if_hwpx_source` → `normalize_page_border_fills_for_hwp`)가 그 개수를 채우는데,
+//! HML 출처는 어댑터 자체를 타지 않아 **1개만** 나갔다.
+//!
+//! 한글 2022 오라클 실측(08462, 행안부 고시 배포본): 저장본이 **1쪽 0자**로 열리고 컨트롤
+//! 인구조사가 `cold:1,secd:1` 로 붕괴한다(원본은 4쪽 7,428자). rhwp 자기 조판은 같은
+//! 산출을 4쪽으로 읽으므로 `--verify-pages` 로는 보이지 않는다.
+//!
+//! 돌연변이 검정으로 원인을 갈랐다 — OLE contract 스트림 9개를 채워도, 스트림을 압축하고
+//! `FileHeader` flags bit0 을 켜도 1쪽 0자 그대로였고, **PBF 3개**만이 4쪽 7,549자를 되살렸다.
+//!
+//! 판정은 **방출된 레코드 개수**로 한다. HWP5 파서는 `extra_page_border_fills` 를 채우지
+//! 않으므로(HWPX 파서만 채운다) 재파싱 IR 로는 이 계약을 볼 수 없다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::PathBuf;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::parser::cfb_reader::CfbReader;
+use rhwp::parser::record::Record;
+use rhwp::parser::tags::HWPTAG_PAGE_BORDER_FILL;
+
+const SAMPLE: &str = "samples/hml/aligns.hml";
+
+fn open_sample() -> DocumentCore {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    DocumentCore::from_bytes(&bytes).unwrap_or_else(|e| panic!("open {SAMPLE}: {e:?}"))
+}
+
+/// 저장한 HWP5 의 `BodyText/Section0` 에서 PAGE_BORDER_FILL 레코드를 센다.
+fn page_border_fill_records(hwp5: &[u8]) -> usize {
+    let mut reader = CfbReader::open(hwp5).expect("CFB 열기");
+    let header = reader.read_file_header().expect("FileHeader");
+    let compressed = header.len() >= 40 && header[36] & 0x01 != 0;
+    let section = reader
+        .read_body_text_section(0, compressed, false)
+        .expect("BodyText/Section0");
+    Record::read_all(&section)
+        .expect("레코드 파싱")
+        .iter()
+        .filter(|r| r.tag_id == HWPTAG_PAGE_BORDER_FILL)
+        .count()
+}
+
+/// 저장한 HWP5 는 구역마다 PBF 레코드가 3개여야 한다.
+#[test]
+fn saved_hwp5_emits_three_page_border_fill_records() {
+    let mut core = open_sample();
+    let bytes = core.export_hwp_with_adapter().expect("HWP5 저장");
+    assert_eq!(
+        page_border_fill_records(&bytes),
+        3,
+        "PAGE_BORDER_FILL 이 3개로 방출되지 않았다 — 미달이면 한글이 본문을 버린다 (#5933 회귀)"
+    );
+}
+
+/// 두 번 저장해도 개수가 늘지 않는다(멱등).
+#[test]
+fn repeated_saves_stay_at_three_records() {
+    let mut core = open_sample();
+    let first = core.export_hwp_with_adapter().expect("첫 저장");
+    let second = core.export_hwp_with_adapter().expect("둘째 저장");
+    assert_eq!(page_border_fill_records(&first), 3, "첫 저장");
+    assert_eq!(page_border_fill_records(&second), 3, "둘째 저장");
+}
+
+/// 저장은 live IR 을 바꾸지 않는다 — HWPX 출처와 같은 복원 계약이라
+/// 이어지는 HWPX 저장이 원본에 없던 EVEN/ODD `pageBorderFill` 을 만들지 않는다.
+#[test]
+fn saving_does_not_leak_the_padding_into_live_ir() {
+    let mut core = open_sample();
+    let before: Vec<usize> = core
+        .document()
+        .sections
+        .iter()
+        .map(|s| s.section_def.extra_page_border_fills.len())
+        .collect();
+    let _ = core.export_hwp_with_adapter().expect("HWP5 저장");
+    let after: Vec<usize> = core
+        .document()
+        .sections
+        .iter()
+        .map(|s| s.section_def.extra_page_border_fills.len())
+        .collect();
+    assert_eq!(
+        before, after,
+        "저장 보정이 live IR 에 남았다 — 이어지는 HWPX 저장이 없던 EVEN/ODD 를 만든다"
+    );
+}


### PR DESCRIPTION
HWPML(HML) 을 HWP5 로 저장하면 한글이 **본문을 통째로 버리던** 결함을 닫는다.
`08462`(행안부 고시 배포본)가 4쪽 7,428자에서 **1쪽 0자**가 되고 컨트롤 인구조사가
`cold:1,secd:1` 로 붕괴한다.

Closes #5933

## 원인

한컴 저장본과 rhwp 의 HWP5 왕복본은 예외 없이 구역당 `HWPTAG_PAGE_BORDER_FILL` 이
**3개**(양쪽/짝수쪽/홀수쪽)다(#3676). HWPX·HWP3 출처는 저장 어댑터
`convert_if_hwpx_source` → `normalize_page_border_fills_for_hwp` 가 그 개수를 채우는데,
**HML 출처는 어댑터의 출처 필터에서 걸러져** 1개만 나갔다.

rhwp 자기 조판은 같은 산출을 4쪽으로 읽는다 — `--verify-pages` 로는 보이지 않는 축이다.

**이 경로는 지금까지 한 번도 측정된 적이 없다.** 해당 문서는 s36 전수에서 `CONVERT_FAIL`
이었고(#5848 이전에는 열리지도 않았다), #5851 이 열어주면서 s37 전수에서 처음 드러났다.

## 원인 확정 — 한글 2022 오라클 돌연변이 검정 (12.0.0.535)

후보를 하나씩 켜며 여섯 변형을 쟀다(같은 큐에 정상 대조군 11쪽 동반):

| 변형 | 쪽수·글자수 | 읽는 법 |
|---|---|---|
| 현행 (PBF 1) | 1쪽 0자 | 재현 |
| OLE contract 스트림 9개 추가 | 1쪽 0자 | **무죄** |
| 스트림 압축 + `FileHeader` flags bit0 | 1쪽 0자 | **무죄** |
| 압축만(플래그 불일치) | 5쪽 11,829자 | 압축 바이트를 본문으로 읽은 깨진 글자 |
| **PBF 3개** | **4쪽 7,549자** | **복원** |
| PBF 3개 + 압축 + 스트림 | 4쪽 7,549자 | 차이 없음 |

처음에 유력해 보이던 두 가설(OLE 스트림이 4/9 뿐 · 비압축 저장)은 **둘 다 기각**됐다.
PBF 개수 하나가 가른다.

## 수정

`convert_if_hwpx_source` 가 `FileFormat::Hml` 을 받으면
`normalize_page_border_fills_for_hwp` 만 돌리고 나온다 — HWPX 전용 보정은 타지 않는다.

저장 시점 보정이라 IR 과 HWPX 산출은 건드리지 않는다
(`snapshot_hwpx_page_border_fill_overlay` 복원 범위에 `Hml` 을 넣어 live IR 을 원래 형상으로
되돌린다). 실측 확인 — 같은 문서의 `export-hwpx` 산출은 종전대로 `pageBorderFill` 이
BOTH 하나뿐이다. 파서에서 채우면 HWPX 산출에 없던 EVEN/ODD 요소가 생긴다(#2896 계열).

## 수정 전 실패 증명

새 통합 시험 `saved_hwp5_emits_three_page_border_fill_records` 는 저장본
`BodyText/Section0` 에서 `HWPTAG_PAGE_BORDER_FILL` 레코드를 세어 **3**을 요구한다.
수정 전에는 1이다. 실물 축에서는 위 표의 첫 행(1쪽 0자)이 같은 사실이다.

판정을 **레코드 개수**로 한 이유: HWP5 파서는 `extra_page_border_fills` 를 채우지 않아
(HWPX 파서만 채운다) 재파싱 IR 로는 이 계약을 볼 수 없다. 처음에 IR 로 단언했다가
`left: 0 / right: 2` 로 실패해 알았다.

## 남은 것 (이 PR 범위 밖)

원본 7,428자 대비 저장본 7,549자이고 `atno:2, foot:1, gso:3, head:1` 이 여전히 0이다.
HML 어댑터가 HEADER/FOOTER/PICTURE/AUTONUM 을 `UnsupportedElement` 로 건너뛰는 별개
갈래(#5933 본문의 갈래 A)이며, 이 PR 은 본문 폐기(갈래 B)만 닫는다.

## 실행한 검증

```
cargo fmt --all -- --check                                                # OK
node scripts/rust-unit-test-tiers.mjs --check                             # 4225 tests / 299 modules
cargo clippy --locked --all-targets --target-dir <별도> -- -D warnings     # OK
cargo nextest run --locked --cargo-profile release-test --target-dir <별도> \
  --tests --test-threads 4 --no-fail-fast                                 # 8,052 passed / 0 failed
```

`tests/cases/issue_5933_hml_page_border_fill.rs` 는 suite 자동 배정 전이라 임시 `[[test]]`
target 으로 따로 돌려 3건 통과를 확인하고 `Cargo.toml` 은 원복했다(PR 에 미포함).

환경: Windows 11, devel `61e439043` 기준 워크트리. 코퍼스는 비공개 로컬 자료라 파일은
첨부하지 않고 문서 번호(s37 코퍼스 인덱스)와 집계만 적었다.
