### PR TITLE
docs: PR 검토 PDF 기준 MCP 선택을 명확화

### DIFF
--- a/mydocs/manual/pr_review/visual_fixture_evidence.md
+++ b/mydocs/manual/pr_review/visual_fixture_evidence.md
@@ -40,11 +40,23 @@ PR 또는 관련 issue 본문·comment에 첨부된 HWP/HWPX/PDF/PNG와 외부�
 
 ## 3.5.1 기준 PDF 미첨부 시 버전별 HWP MCP
 
-PR에 기준 PDF가 없지만 원본 HWP/HWPX가 있으면, PDF 업로드 요청보다 먼저 문서를 저장한 한컴오피스
-버전을 확인해 해당 MCP로 기준 PDF를 산출한다. 2022 이하에서 저장한 `.hwp`는
-[HWP 2020 MCP 사용법](../mcp_hwp2020Convert_usage.md)의 `hwp-convert-2020`, 2024에서 저장한 `.hwp`는
+PR에 기준 PDF가 없지만 원본 HWP/HWPX가 있으면, PDF 업로드 요청보다 먼저 다음 명령으로 마지막 저장
+제품 메타데이터를 확인해 해당 MCP로 기준 PDF를 산출한다.
+
+```bash
+rhwp info --json <원본 HWP 또는 HWPX>
+```
+
+`lastSavedWith.product`가 `hancom-office-2010`·`hancom-office-2018`·`hancom-office-2020`·
+`hancom-office-2022`이면 [HWP 2020 MCP 사용법](../mcp_hwp2020Convert_usage.md)의
+`hwp-convert-2020`을, `hancom-office-2024`이면
 [HWP 2024 MCP 사용법](../mcp_hwp2024Convert_usage.md)의 `hwp-convert-2024`를 사용한다.
-확장자가 같다는 이유로 서비스를 자동 선택하지 않는다.
+이 판정은 HWP5 `HwpSummaryInformation.revisionNumber`와 HWPX `version.xml/appVersion`의 마지막 저장
+메타데이터를 사용한다. 확장자와 파일 포맷 `version`만으로 서비스를 선택하지 않는다.
+
+`lastSavedWith`가 `null`이거나 `product`가 `null`이면 서비스를 자동 선택하지 않는다. 기준 PDF, 제출자·원
+저장 환경의 확인 등 별도 근거를 확보하고 그 판단을 review 문서에 기록한다. 이 메타데이터는 원 작성 제품의
+증명이 아니며 재저장·삭제·변조될 수 있다.
 
 - 최종 기준 PDF는 output에만 두지 않고 2020 계열은 `pdf/{원본 stem}-2020.pdf`, 2024 계열은
   `pdf/{원본 stem}-2024.pdf`에 저장한다.
@@ -58,8 +70,9 @@ PR에 기준 PDF가 없지만 원본 HWP/HWPX가 있으면, PDF 업로드 요청
 HWP 2020 MCP의 성공 조건은 CLI `status: success`, server `run_status: 0`, `validation: ok`다.
 HWP 2024 MCP는 동기 `status: success` 또는 비동기 `succeeded → success`, client/server byte 수와
 SHA-256 일치를 확인한다. 공통으로 `pdf/` 아래 실제 PDF 존재와 `file` 또는 `pdfinfo` 확인이 필요하다.
-review 문서에는 사용한 서비스 버전, 원본 경로·가능하면 SHA-256·출처 URL, PDF 경로·SHA-256, MCP job id,
-서비스별 status·validation metadata·페이지 수, 사용한 visual sweep asset과 지표를 적는다.
+review 문서에는 MCP 선택 전 `info --json`의 `format`·`lastSavedWith` 값, 사용한 서비스 버전, 원본
+경로·가능하면 SHA-256·출처 URL, PDF 경로·SHA-256, MCP job id, 서비스별 status·validation metadata·페이지 수,
+사용한 visual sweep asset과 지표를 적는다.
 
 ## 대표 asset과 안정 URL
 

--- a/mydocs/orders/20260823.md
+++ b/mydocs/orders/20260823.md
@@ -83,3 +83,15 @@ date: 2026-08-23
 - [ ] review·오늘할일 trailing head의 review-only fast-pass와 최신 `MERGEABLE/CLEAN`을 확인한다.
 - [ ] exact trailing head를 squash merge하고 merge SHA의 `upstream/devel` 포함, PR comment와
   local·remote branch 정리를 `post_merge.md`에 따라 완료한다.
+
+## PR #5945 — PR 검토 PDF 기준 MCP 선택 명확화
+
+- [x] #5944의 HWP5/HWPX `lastSavedWith` 계약과 HWP 2020/2024 MCP 사용 문서가 갱신된 것을 확인했다.
+- [x] 기준 PDF 미첨부 시각 검증 절차에 `rhwp info --json` 선택 근거, 2020/2024 제품 매핑, `null` 보류와
+  review 증적 기록을 추가했다.
+- [x] `git diff --check`, `cargo fmt --all`, `cargo fmt --all -- --check`를 통과하고 문서 candidate
+  `948cd3419`를 Open PR [#5945](https://github.com/edwardkim/rhwp/pull/5945)로 생성했다.
+- [x] archive self-review와 오늘할일 trailing 기록을 준비했다.
+- [ ] 최신 trailing head의 review-only fast-pass 집계와 `MERGEABLE/CLEAN`을 확인한다.
+- [ ] 작업지시자 merge 승인 뒤 squash merge하고 merge SHA의 `upstream/devel` 포함, PR comment와 branch
+  정리를 `post_merge.md`에 따라 완료한다.

--- a/mydocs/pr/archives/pr_5945_review.md
+++ b/mydocs/pr/archives/pr_5945_review.md
@@ -1,0 +1,54 @@
+---
+kind: pr-review
+status: trailing-docs-pending-ci
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-23
+---
+
+# PR #5945 검토 - PR 검토 PDF 기준 MCP 선택 명확화
+
+## 접수 메타데이터
+
+| 항목 | 작성 시점 확인값 |
+| --- | --- |
+| PR / 작성자 | [#5945](https://github.com/edwardkim/rhwp/pull/5945) / [@jangster77](https://github.com/jangster77) |
+| base / 문서 candidate | `devel` `d78cb44798ddfc5c0bd061f5faa9a7e54a756b54` / `948cd34191a9a3df49b06e9938e4ab7c56acb26d` |
+| 변경 규모 | 1 file, +19 / -6 |
+| 작성 시점 상태 | non-draft, `MERGEABLE`, `BLOCKED`; required check 집계 전 |
+| reviewer | 작성자 본인 self-review, 별도 reviewer 미지정 |
+
+적용 경로는 `collaborator_self_merge`이며, `intake_and_review`와 `review_only_fast_pass`를 보조 경로로
+선택했다. GitHub mergeability와 CI 상태는 작성 시점 참고값이다. 이 review·오늘할일 trailing commit의 최신
+head가 required check를 통과하고, merge 직전에 같은 head SHA와 `MERGEABLE/CLEAN`을 다시 확인한 뒤에만 merge한다.
+
+## 변경과 판단
+
+- #5944가 HWP5 `HwpSummaryInformation.revisionNumber`와 HWPX `version.xml/appVersion`에서
+  `lastSavedWith`를 반환하도록 구현하고, HWP 2020/2024 MCP 사용 문서를 갱신했다.
+- 이 PR은 기준 PDF가 없는 PR의 상위 시각 검증 절차에도 `rhwp info --json <원본>`을 명시해, 실제 MCP
+  선택 근거가 구현·서비스별 사용 문서와 일치하도록 한다.
+- `hancom-office-2010`·`2018`·`2020`·`2022`는 HWP 2020 MCP, `hancom-office-2024`는 HWP 2024 MCP를
+  선택한다. 확장자와 HWP 포맷 `version`은 제품 연도 판정 근거가 아니다.
+- `lastSavedWith` 또는 `product`가 `null`인 경우에는 자동 선택하지 않고, 기준 PDF 또는 저장 환경 같은 별도
+  근거를 확보해 review 문서에 기록하도록 fail-closed 규칙을 추가했다.
+- MCP 선택 전 `format`·`lastSavedWith`와 이후 서비스·PDF·job 식별자를 같은 review 기록에 보존하게 했다.
+
+이 PR은 renderer, parser, MCP client, fixture 또는 기준 PDF를 변경하지 않는다. 따라서 실제 변환이나 visual
+sweep은 수행 대상이 아니며, #5944에서 검증한 저장 메타데이터 계약을 문서 절차에 연결하는 범위다.
+
+## 로컬 검증
+
+- `git diff --check`를 통과했다.
+- `cargo fmt --all`과 `cargo fmt --all -- --check`를 통과했다.
+- 변경은 `mydocs/` 문서 한 파일뿐이다. 문서 링크 대상인 HWP 2020/2024 MCP 사용 문서의 존재를 확인했다.
+- 일반 Markdown 수정에는 자동 전체 검증을 실행하지 않는 문서·Git 절차에 따라 Cargo 회귀, MCP 변환, visual
+  sweep은 실행하지 않았다.
+
+## GitHub Actions와 최종 판정
+
+이 PR 전체는 `mydocs/`만 변경하는 review-only 범위다. 최신 head의 preflight와 branch protection 집계가
+성공하면 heavy job의 skip은 정상이다. CI 완료 뒤 exact trailing head의 check, `MERGEABLE/CLEAN`, source
+repository와 SHA를 다시 확인한다.
+
+**수용 권고, trailing CI 대기.** #5944의 HWP5/HWPX 저장 제품 판별 계약을 상위 PR 검토 절차에 빠짐없이
+연결하며, 메타데이터 누락 시 서비스 선택을 추정하지 않는다.


### PR DESCRIPTION
## 변경 사항

- 시각 검증의 기준 PDF 미첨부 절차에서 `rhwp info --json` 실행을 필수 선택 근거로 명시합니다.
- HWP5/HWPX의 `lastSavedWith.product`에 따라 HWP 2020 또는 2024 MCP를 선택합니다.
- 메타데이터가 없거나 알 수 없는 제품이면 자동 선택하지 않고 별도 근거를 review 문서에 남기도록 합니다.
- review 문서에 `format`과 `lastSavedWith`를 MCP 선택 증적으로 기록하도록 보완합니다.

## 검증

- `git diff --check`
- `cargo fmt --all`
- `cargo fmt --all -- --check`