### PR TITLE
docs(font): #4960 W7 이후 로드맵을 재정렬한다

### DIFF
--- a/mydocs/orders/20260824.md
+++ b/mydocs/orders/20260824.md
@@ -21,3 +21,17 @@ date: 2026-08-24
 - [ ] 이 trailing review-only head의 fast-pass aggregate와 최신 `MERGEABLE/CLEAN`을 확인한다.
 - [ ] 작업지시자 merge 승인 뒤 #5954를 merge하고, #5907/#5910 auto-close 상태, #5913/#5914의 연결
   comment와 close, merge SHA의 `upstream/devel` 포함 및 review branch 정리를 `post_merge.md`에 따라 처리한다.
+
+## PR #5956 - #4960 W7 이후 폰트 로드맵 방향 수정
+
+- [x] W0~W7 결과를 대사해 W7.5 registry lifecycle gate, W8의 세 운영 lane과 W9·W10의 cohort별 동결
+  조건을 로컬 canonical·report 문서에 반영했다.
+- [x] #5955를 #4960의 W7과 W8 사이 sub-issue로 등록하고 #4960·#4967~#4969 본문과 maintainer
+  comment를 같은 실행 graph로 현행화했다.
+- [x] 변경 7개 문서의 링크·diff·format gate와 GitHub body hash·상태·sub-issue 순서를 재검증했다.
+- [x] code candidate `b97f3708ad2926681554c468e86685ad5a940440`의 CI, CodeQL, Proptest와 Adapter
+  preflight 및 최종 Build & Test가 review-only fast-pass로 성공했다.
+- [ ] self-review·오늘할일 trailing commit을 push하고 최신 head의 fast-pass aggregate와
+  `MERGEABLE/CLEAN`을 다시 확인한다.
+- [ ] 메인테이너 merge 승인 뒤 정상 병합하고 #4960을 OPEN으로 유지한 채 merge SHA 반영, issue comment와
+  branch·worktree 정리를 `post_merge.md`에 따라 처리한다.

--- a/mydocs/plans/task_m100_4960.md
+++ b/mydocs/plans/task_m100_4960.md
@@ -14,7 +14,7 @@
 - **작성일**: 2026-08-24 KST
 - **통합 기준**: `upstream/devel@4e070c632dfc889f329be6a90ef2c1d35f8a7f12`
 - **원격 상태**: #4960 OPEN, 담당자 `edwardkim`, milestone `v1.0.0`, W0~W7 완료
-- **절차 상태**: Stage R1 승인·커밋, Stage R2 GitHub topology 적용 완료·결과 승인 대기
+- **절차 상태**: Stage R1·R2 승인·커밋, Stage R3 정합성 감사 완료·결과 승인 대기
 
 ## 1. 결정과 목표
 

--- a/mydocs/plans/task_m100_4960.md
+++ b/mydocs/plans/task_m100_4960.md
@@ -14,7 +14,7 @@
 - **작성일**: 2026-08-24 KST
 - **통합 기준**: `upstream/devel@4e070c632dfc889f329be6a90ef2c1d35f8a7f12`
 - **원격 상태**: #4960 OPEN, 담당자 `edwardkim`, milestone `v1.0.0`, W0~W7 완료
-- **절차 상태**: 수정 수행계획 승인, Stage R1 로컬 문서 현행화 완료·결과 승인 대기
+- **절차 상태**: Stage R1 승인·커밋, Stage R2 GitHub topology 적용 완료·결과 승인 대기
 
 ## 1. 결정과 목표
 

--- a/mydocs/plans/task_m100_4960.md
+++ b/mydocs/plans/task_m100_4960.md
@@ -1,0 +1,386 @@
+# 수행계획 — Task M100 #4960 W7 이후 폰트 로드맵 방향 수정
+
+- **이슈**: [#4960](https://github.com/edwardkim/rhwp/issues/4960)
+- **완료 선행 작업**: [#4939](https://github.com/edwardkim/rhwp/issues/4939) W0·W1,
+  [#4961](https://github.com/edwardkim/rhwp/issues/4961) W2,
+  [#4962](https://github.com/edwardkim/rhwp/issues/4962) W3·W4,
+  [#4963](https://github.com/edwardkim/rhwp/issues/4963) W5,
+  [#4964](https://github.com/edwardkim/rhwp/issues/4964) W6,
+  [#4966](https://github.com/edwardkim/rhwp/issues/4966) W7
+- **후행 tracker**: [#4967](https://github.com/edwardkim/rhwp/issues/4967) W8,
+  [#4968](https://github.com/edwardkim/rhwp/issues/4968) W9,
+  [#4969](https://github.com/edwardkim/rhwp/issues/4969) W10
+- **브랜치**: `task_m100_4960_direction_revision`
+- **작성일**: 2026-08-24 KST
+- **통합 기준**: `upstream/devel@4e070c632dfc889f329be6a90ef2c1d35f8a7f12`
+- **원격 상태**: #4960 OPEN, 담당자 `edwardkim`, milestone `v1.0.0`, W0~W7 완료
+- **절차 상태**: 수정 수행계획 승인, Stage R1 로컬 문서 현행화 완료·결과 승인 대기
+
+## 1. 결정과 목표
+
+W0~W7의 방향과 산출물은 폐기하지 않는다. 현재 선택을 먼저 설명하고 실제 사용량을 계측한 뒤,
+Oracle evidence와 데이터 계보를 확보하고 backend별 규칙을 canonical registry로 투영한 순서는 타당했다.
+
+수정이 필요한 것은 W7 이후를 하나의 직선 경로로 본 부분이다. 최초 로드맵은 다음을 전제했다.
+
+```text
+W7 canonical projection
+  → W8 face별 교정 반복 완료
+  → W9 kerning
+  → W10 vertical·variation·shaping
+```
+
+W5와 W7의 실제 결과는 이 전제를 그대로 적용할 수 없음을 보여준다.
+
+1. W5의 17개 후보는 모두 disposition을 얻었지만, source·provider·문서 face 기능이 서로 다르다.
+2. W7 schema 1.0은 현재 830개 active rule을 봉인한 read-only canonical authority다.
+3. W8은 source가 새로 발견될 때 다시 열리는 장기 tracker이므로 전체 완료를 W9의 조건으로 삼을 수 없다.
+4. W4의 exact rank는 민감도 변형에서 고정되지 않았으므로 순위 숫자가 곧 구현 순서가 아니다.
+
+따라서 이번 작업의 목표는 W0~W7의 증거를 보존하면서 다음 세 경계를 명시하는 것이다.
+
+- 실제 규칙 변경 전에 registry의 다음 판과 rule 생명주기를 정의하는 **W7.5 선행 게이트**
+- Oracle 관찰 완료와 제품 교정 가능성을 구분하는 **W8 후보 자격 게이트**
+- 장기 W8 전체가 아니라 관련 cohort의 metric·face 선택 동결을 사용하는 **W9 진입 게이트**
+
+이번 작업은 로드맵·이슈 topology와 권위 문서의 방향을 수정하는 문서 작업이다. registry schema, metric,
+fallback, paint, font asset 또는 renderer 동작을 변경하지 않는다.
+
+## 2. Stage 0 감사 기준선
+
+### 2.1 W0~W2 — 현재 동작을 설명하는 기반
+
+| 단계 | 확보한 것 | 이번 판정 |
+| --- | --- | --- |
+| W0·W1 | 30 source boundary, 1,352 candidate, 1,507 ledger rule, unknown 44 | 역사 snapshot과 relation 분리를 보존 |
+| W2 | layout·native·Canvas2D·CanvasKit Font Decision Trace | 변경 전후 선택 근거 대사의 공통 표면으로 재사용 |
+
+W1에는 identity alias로 검증된 행이 0개였고, unknown을 비슷한 이름이나 vendor 추정으로 보충하지 않았다.
+W8 이후에도 이 원칙을 유지하며, 새 evidence는 역사 W1 snapshot을 다시 쓰지 않고 별도 계보로 추가한다.
+
+### 2.2 W3·W4 — 위험 순위의 의미와 한계
+
+| 항목 | 결과 |
+| --- | ---: |
+| 실제 layout / coverage 문자 | 54,399,371 / 54,326,042 |
+| exact·overlay·surrogate 성공 계열 | 52,264,310, 96.2049% |
+| face-miss·char-miss·heuristic 위험 문자 | 2,061,732 |
+| 위험 face | 351 |
+| A+B queue | 17 face, base risk mass 81.0374% |
+| 모든 민감도 변형에서 exact rank가 같은 face | 0 |
+
+W4의 A/B band는 제품 영향의 우선 범위로 유지한다. exact rank는 조사 순서의 보조값이며, 순위가 높은
+face를 evidence 준비도와 변경 가능성보다 먼저 구현하는 강제 순서로 사용하지 않는다.
+
+fixed-context는 실제 frame geometry가 아니라 context proxy이고, stored LineSeg는 존재 lane이지 유효성
+판정이 아니다. 개별 W8은 실제 frame slack·최초 줄 경계 divergence와 stored/fresh LineSeg 유효성을
+별도 fixture에서 다시 판정한다.
+
+### 2.3 W5 — Oracle queue 종료와 W8 후보를 구분
+
+| disposition | 수 | rank | W8 처리 |
+| --- | ---: | --- | --- |
+| `complete-acceptance-ladder` | 3 | 1, 7, 8 | correction hypothesis 심사 가능 |
+| `terminal-source-unavailable` | 10 | 2~6, 11, 12, 14, 15, 17 | source discovery 사건이 있을 때만 재개 |
+| `terminal-protected-partial` | 3 | 9, 10, 13 | provider를 손상하지 않는 새 제어 방법이 생길 때만 재개 |
+| `terminal-read-only-capability-mismatch` | 1 | 16 | localized document face·export subset 연결이 증명될 때만 재개 |
+
+W5 정본의 `actionableRanks=[]`는 추가 Oracle 실행 대기열이 없다는 뜻이다. W8 제품 교정 후보가 0이라는
+뜻으로 해석하지 않는다. rank 1 `문체부 바탕체`, rank 7 `KoPubWorld돋움체 Light`, rank 8
+`KoPubWorld바탕체 Light`는 기존 profile을 재사용할 수 있지만, 다음 질문을 통과해야 실제 W8 자식 이슈가
+된다.
+
+- 현재 rhwp의 어느 decision plane이 어떤 문자·문맥에서 잘못됐는가?
+- 변경 후 portable default와 backend별 opt-in 결과는 각각 무엇이어야 하는가?
+- exact profile과 missing profile 중 무엇을 목표로 하고 무엇을 비교군으로 둘 것인가?
+- source provenance·license·배포·backend 조달 조건이 실제 구현 가능한가?
+- target 개선과 비대상 회귀를 어떤 fixture와 누적 advance로 판정할 것인가?
+
+### 2.4 W6·W7 — 변경 전 구조의 성과와 새 선행 조건
+
+W6는 기존 600 metric entry를 historical generated 595개와 measured/manual overlay 5개로 분리했다.
+fully source-exact로 승격할 수 있는 기존 항목은 0개이며, 원본이 없는 항목을 재생성하거나 exact로
+과장하지 않는다.
+
+W7은 830개 active rule을 canonical registry로 이행하고 Rust 2종·Studio 3종 projection을 만들었다.
+그러나 schema 1.0의 수량·상태·W1/W6 evidence는 의도적으로 봉인됐다. schema 1.0 JSON을 직접 고치거나
+hash만 다시 계산해서 제품 규칙을 변경하는 것은 지원 절차가 아니다.
+
+따라서 최초 원인 계보 보고서의 “W7 뒤 새 규칙 하나를 원장에 기록하고 산출물을 갱신할 수 있다”는 문장은
+다음 schema 판의 승인과 이행을 전제로 하는 표현으로 정정해야 한다.
+
+## 3. 수정할 의존성 구조
+
+```mermaid
+flowchart LR
+    W07[W0~W7 완료] --> W75[W7.5 registry evolution contract]
+    W75 --> Q[W8 correction eligibility]
+    Q --> W8P[W8 face별 product correction]
+    D[source·provider·identity 새 evidence] --> Q
+    W75 --> KF[kerning cohort metric·face freeze]
+    Q --> KF
+    W8P --> KF
+    KF --> W9[W9 kerning]
+    W9 --> W10[W10 vertical·variation·shaping]
+```
+
+이 그림에서 `W8P → KF`는 W8 tracker 전체 완료를 뜻하지 않는다. kerning cohort에 실제로 영향을 주는
+완료된 face correction이나 “해당 cohort에는 교정 없음” disposition만 동결하면 된다. 다른 face의 source
+discovery와 W8 작업은 W9와 병행할 수 있다.
+
+## 4. W7.5 신규 선행 이슈 계약
+
+W7.5는 W8 첫 face에 종속되지 않는 일회성 infrastructure 이슈로 분리한다. 제안 제목은 다음과 같다.
+
+```text
+[font][W7.5] canonical registry 규칙 생명주기와 evidence delta 계약
+```
+
+### 4.1 포함할 설계 질문
+
+- 기존 830개 active rule을 의미 변화 없이 다음 schema 판으로 이행할 수 있는가?
+- 규칙 추가, 의미 수정, retirement를 삭제나 W1 snapshot 재작성 없이 표현할 수 있는가?
+- 기존 `ruleId`를 유지할 수정과 새 rule·successor link가 필요한 변경을 어떻게 구분하는가?
+- 새 evidence가 historical W1/W5/W6 authority와 어떤 parent/digest로 연결되는가?
+- 한 decision plane의 변경이 필요한 backend projection만 바꿨음을 어떻게 증명하는가?
+
+### 4.2 최소 계약 후보
+
+- `active`, `retired`와 후속 rule 참조를 포함한 명시적 lifecycle
+- registry schema version·migration manifest·parent semantic hash
+- 변경 사유, evidence issue/profile/digest와 승인 상태
+- pre/post selection tuple, metric entry와 generated projection semantic delta
+- inactive rule을 runtime projection에서 제외하되 trace·감사에서는 보존하는 규칙
+- generator·validator의 red → green migration test
+
+정확한 schema version과 field 이름은 W7.5 수행계획에서 확정한다. 이 계획은 schema 1.0을 미리
+느슨하게 만들거나 제품 규칙을 변경하지 않는다.
+
+## 5. W8 tracker 수정 계약
+
+### 5.1 세 개 lane
+
+W8은 하나의 대기열이 아니라 다음 lane을 구분한다.
+
+1. **evidence-reopen lane**: source, provider 제어, localized identity 같은 재개 조건을 기다린다.
+2. **correction-qualification lane**: W4 band와 W5 profile을 실제 제품 delta 가설로 변환한다.
+3. **product-correction lane**: W7.5 이후 face 하나·decision plane 하나·PR 하나로 변경한다.
+
+source discovery만 필요한 face에 제품 구현 이슈를 미리 만들지 않는다. 새 evidence가 생기면 W5의 기존
+disposition과 입력 hash를 대사하고 필요한 state만 제한 재실행한다.
+
+### 5.2 자식 이슈 생성 조건 수정
+
+기존 조건에 다음을 추가한다.
+
+- `correctionHypothesis`: 현재 동작, 기대 동작과 첫 divergence
+- `targetDecisionPlane`: layout-name, layout-metric, paint 또는 supply 중 정확히 하나
+- `portablePolicy`: portable default와 설치 exact-font opt-in 경계
+- `registryChange`: 유지 rule, 신규 rule, retirement와 evidence delta
+- `affectedCohort`: 실제 문자량, 장평·자간, fixed frame geometry와 LineSeg lane
+- `backendDisposition`: native, WASM, Canvas2D와 CanvasKit의 적용·비대상·미지원 이유
+- `redistributionDisposition`: source bytes와 파생 metric·webfont의 사용 가능 범위
+
+W4 순위와 W5 profile만 있고 현재 rhwp의 오류와 목표 동작을 설명하지 못하면 조사 완료이지 W8 구현
+준비 완료가 아니다.
+
+### 5.3 첫 pilot 후보
+
+첫 process canary로 rank 8 `KoPubWorld바탕체 Light`의 qualification을 우선 검토한다.
+
+- complete acceptance ladder와 제3자 Hyper-V three-state 재현이 있다.
+- exact와 fallback의 U+AC00 advance가 약 4.3% 다르다.
+- 공개 source와 Canvas2D·CanvasKit 공급 경로를 교차검증할 수 있다.
+- subst-only와 none-related가 같은 fallback projection으로 수렴한 근거가 있다.
+
+이는 risk rank를 재정렬하거나 rank 1보다 사용자 영향이 크다고 주장하는 결정이 아니다. 새 registry
+변경 절차, metric·paint·supply 분리와 누적 advance gate를 가장 재현 가능하게 검증할 수 있는 pilot
+후보다. qualification에서 현 rhwp 오류나 안전한 portable 목표를 증명하지 못하면 변경 없이 종료한다.
+
+rank 1 `문체부 바탕체`는 영향 우선 후보로 유지하되, source provenance와 portable/backend 공급 정책을
+먼저 확정한다. rank 7은 rank 8 pilot 결과가 같은 family에 일반화되는지 추정하지 않고 별도 face로
+다시 심사한다.
+
+## 6. W9·W10 의존성 수정
+
+### 6.1 W9 kerning
+
+W9 진입 조건을 “W8 전체 완료”에서 다음으로 바꾼다.
+
+- W7.5 registry evolution contract 완료
+- W3에서 확인한 kerning cohort와 대표 공개 controlled fixture 고정
+- 해당 cohort가 사용하는 metric face와 진행 중 W8 변경의 겹침 여부 대사
+- 겹치는 face는 correction 완료 또는 no-change disposition까지 동결
+- kerning off 문서의 기존 출력 기준선과 backend capability 준비
+
+이 조건이면 source 발견을 기다리는 다른 W8 face와 독립적으로 W9를 진행할 수 있다. fallback·metric
+변경과 pair positioning 변경은 같은 PR에 넣지 않는다.
+
+### 6.2 W10 vertical·variation·shaping
+
+W10은 W9의 shaping·capability 경계와 provenance schema를 선행 조건으로 유지한다. 다만 모든 W8 face의
+완료를 요구하지 않고, 대상 script·vertical·variation fixture가 사용하는 face 집합의 metric·identity가
+동결됐는지 판정한다. 지원하지 않는 table·script·axis는 버전 분기가 아니라 feature detection으로
+fail-closed한다.
+
+## 7. 문서와 GitHub 변경 범위
+
+### 7.1 로컬 문서
+
+계획 승인 뒤 다음 문서를 최소 범위로 현행화한다.
+
+| 문서 | 수정 내용 |
+| --- | --- |
+| `mydocs/report/font_metrics_fallback_causal_lineage_20260816.md` | W7 이후 단일 경로를 W7.5·W8 lane·W9 cohort gate로 정정 |
+| `mydocs/report/task_m100_4966_report.md` | merge 완료 상태·canonical front matter와 W7.5 인계 경계 정정 |
+| `mydocs/tech/font_fallback_strategy.md` | schema 1.0 read-only와 다음 판 승인 전 직접 수정 금지 명시 |
+| `mydocs/working/task_m100_4960_direction_revision_stage1.md` | 방향 수정 근거·변경 대조·검증 결과 기록 |
+
+역사 W1~W6 JSON과 완료 보고서의 당시 수치·hash는 재생성하거나 현재 상태로 덮어쓰지 않는다.
+
+### 7.2 GitHub topology
+
+별도 원격 mutation 승인 뒤 `gh`로 다음을 수행한다.
+
+- #4960: “단일 임계 경로”를 수정 의존성 graph로 바꾸고 W7.5 checklist를 삽입한다.
+- 신규 W7.5 이슈: 중복 검색 후 등록하고 #4960 sub-issue로 연결한다.
+- #4967: 세 lane, qualification 필드, 현재 disposition과 첫 pilot 후보를 반영한다.
+- #4968: W8 전체가 아니라 kerning cohort 동결을 선행 조건으로 명시한다.
+- #4969: 대상 face 집합 동결과 W9 shaping 경계를 선행 조건으로 명시한다.
+- 각 이슈에 변경 이유와 이 계획·W5/W7 근거를 설명하는 maintainer comment를 한 번만 게시한다.
+
+기존 완료 체크·이슈 관계·댓글을 삭제하지 않고 본문을 보존적으로 수정한다. 게시 뒤 REST API로 checkbox,
+sub-issue, 한글, 선두 BOM, `??` 치환과 literal `\\n` 부재를 검증한다.
+
+## 8. 단계별 수행과 승인 게이트
+
+### Stage R1 — 방향 계약 문서화
+
+1. 원인 계보 보고서의 W7~W10 경로와 우선순위를 수정한다.
+2. W7 최종 보고서의 생명주기 metadata와 W7.5 인계를 현행화한다.
+3. canonical font fallback 전략에 schema 변경 금지선을 짧게 반영한다.
+4. 변경 전후 의존성과 W5 disposition 해석을 stage 보고서에 기록한다.
+
+**종료 게이트**: 메인테이너가 W7.5·W8 lane·W9 cohort gate를 승인해야 GitHub topology 변경으로
+넘어간다.
+
+### Stage R2 — GitHub 이슈 topology 수정
+
+1. 같은 목적의 열린·닫힌 이슈와 PR을 `gh search`로 다시 확인한다.
+2. W7.5 이슈를 등록하고 assignee·milestone·기존 label taxonomy를 적용한다.
+3. #4960과 #4967~#4969 본문을 승인된 계약과 일치시킨다.
+4. sub-issue 관계와 maintainer comment를 게시하고 API로 원문을 검증한다.
+
+**원격 게이트**: 이슈 생성·본문 수정·댓글·metadata는 각각 이 계획 승인과 별도의 명시적 원격 mutation
+승인을 받은 뒤 수행한다.
+
+### Stage R3 — 정합성 감사와 PR 준비
+
+1. 로컬 문서와 GitHub 본문의 checklist·선행·후행 관계를 대사한다.
+2. W0~W7 완료 상태, W7.5 미착수, W8~W10 미착수 상태가 사실과 일치하는지 확인한다.
+3. 변경 Markdown 링크·metadata·diff와 필수 format gate를 검증한다.
+4. stage 보고서에 최종 issue URL·본문 hash·검증 결과를 기록한다.
+5. 커밋, remote push와 PR 생성은 각각 별도 승인을 받는다.
+
+**종료 게이트**: 이 작업은 로드맵 정정만 완료한다. W7.5 계획·구현, W8 pilot qualification, W9 또는
+W10 착수를 자동 승인하지 않는다.
+
+## 9. 검증 계획
+
+### 9.1 문서
+
+```bash
+python3 scripts/check_markdown_links.py \
+  mydocs/plans/task_m100_4960.md \
+  mydocs/report/font_metrics_fallback_causal_lineage_20260816.md \
+  mydocs/report/task_m100_4966_report.md \
+  mydocs/tech/font_fallback_strategy.md \
+  mydocs/working/task_m100_4960_direction_revision_stage1.md
+
+python3 scripts/check_document_metadata.py
+git diff --check
+```
+
+metadata 전체 검사가 이번 변경과 무관한 기존 오류를 보고하면 변경 파일별 결과와 기존 오류를 분리해
+기록하며, 사용자 변경을 임의로 정리하지 않는다.
+
+### 9.2 제품 0-delta
+
+이번 범위는 Markdown과 GitHub tracker뿐이므로 제품 build·renderer visual sweep·private corpus 재계측은
+기본 gate가 아니다. source, registry JSON, generated projection, metric data 또는 fixture가 diff에
+포함되면 범위 이탈로 중단한다.
+
+모든 commit·push 직전 저장소 공통 필수 gate는 그대로 실행한다.
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+```
+
+### 9.3 GitHub 적용 검증
+
+- #4960에 W0~W7 완료와 W7.5·W8~W10 미완료가 정확히 표시되는가
+- W7.5가 #4960 sub-issue이며 #4967보다 선행하는가
+- #4967의 17개 disposition과 rank 1·7·8 상태가 W5 정본과 일치하는가
+- #4968이 W8 전체 완료가 아니라 kerning cohort 동결을 요구하는가
+- #4969가 W9와 대상 face 집합의 안정화를 요구하는가
+- comment와 본문에 private corpus identity, host path와 font bytes가 없는가
+
+## 10. 보호 불변식
+
+- W0~W7의 완료 판정, merge commit, 수치와 historical hash를 다시 쓰지 않는다.
+- W4 band를 보존하고 exact rank를 제품 심각도나 강제 구현 순서로 승격하지 않는다.
+- W5 `actionableRanks=[]`를 W8 후보 0으로도, 17개 모두 구현 가능으로도 해석하지 않는다.
+- exact, missing, document substitution, successor, metric surrogate와 paint substitute를 혼합하지 않는다.
+- layout metric과 paint face의 독립성을 유지한다.
+- Canvas2D availability, webfont plan과 CanvasKit SFNT capability를 별도 상태로 유지한다.
+- W7 schema 1.0 registry와 generated projection을 이번 작업에서 수정하지 않는다.
+- private corpus 원본·본문·식별 목록·절대 경로를 문서나 GitHub에 게시하지 않는다.
+- W8 blocked face를 source 추정이나 반복 계측으로 억지로 actionable하게 만들지 않는다.
+- W9는 fallback·metric 변경과 같은 PR에 섞지 않는다.
+
+## 11. 중단 조건
+
+- W5 profile hash나 queue disposition이 현재 tracked 정본과 일치하지 않음
+- W7 registry가 이미 다른 이슈에서 다음 schema 판으로 이행됐거나 동시 작업 중임
+- 신규 W7.5와 같은 목적의 열린 이슈·PR이 발견됨
+- #4960·#4967~#4969의 원격 본문이 계획 이후 collaborator에 의해 의미상 변경됨
+- 방향 수정 diff에 source·registry·generated projection·metric·font asset 변경이 포함됨
+- rank 1·7·8 중 하나를 qualification 없이 곧바로 구현 대상으로 확정해야만 계획이 성립함
+- W9 진입 조건이 특정 face의 미확정 source 발견을 무기한 기다리도록 되돌아감
+
+중단 조건이 발생하면 해당 단계의 원인과 새 기준 SHA를 보고하고 계획 변경 승인을 받는다.
+
+## 12. 완료 조건
+
+- #4960의 W7 이후 구조가 W7.5, W8 lane과 W9 cohort gate를 설명한다.
+- W7.5의 역할과 W8의 역할이 schema infrastructure와 face product change로 분리된다.
+- W5의 17개 disposition이 재실행 없이 올바르게 라우팅된다.
+- W8 자식 이슈 생성 조건에 correction hypothesis와 decision plane이 포함된다.
+- W9가 장기 W8 tracker 전체 완료에 종속되지 않으면서 겹치는 metric 변경은 동결한다.
+- W10의 선행 조건이 W9 shaping 경계와 대상 face 집합 안정화로 명시된다.
+- local canonical 문서와 GitHub issue topology가 같은 의존성을 표현한다.
+- 제품 source·registry·metric·fallback·renderer output 변경이 0이다.
+- 변경 파일의 링크·metadata·format·diff gate가 통과한다.
+- 후속 W7.5와 W8 pilot은 별도 이슈·계획·승인 없이는 시작하지 않는다.
+
+## 13. 계획 self-review
+
+- **목적 검사**: 구현을 서두르지 않고 W0~W7 결과가 바꾼 전제를 로드맵에 반영한다.
+- **계보 검사**: W4 ranking, W5 disposition과 W7 read-only authority를 서로 다른 의미로 보존한다.
+- **우선순위 검사**: 사용자 영향 band와 process canary 선택을 구분한다.
+- **CQRS 검사**: 조사·진단 산출물과 제품 selection command 변경을 같은 단계에 섞지 않는다.
+- **SOLID 검사**: registry lifecycle, face correction, kerning과 고급 shaping의 변경 이유를 분리한다.
+- **회귀 검사**: 역사 snapshot과 제품 source는 불변이며 문서·tracker 정합성만 바꾼다.
+- **운영 검사**: 로컬 문서, GitHub mutation, commit, push와 PR을 별도 승인 게이트로 둔다.
+- **재현성 검사**: 모든 수치와 candidate disposition은 tracked 정본의 path·hash로 다시 확인할 수 있다.
+
+## 14. 다음 승인 요청
+
+이 계획의 승인 범위는 Stage R1의 로컬 문서 현행화까지다. 승인만으로 다음 행위를 허용하지 않는다.
+
+- GitHub W7.5 이슈 생성 또는 #4960·#4967~#4969 수정
+- registry 다음 schema 판 설계·구현
+- rank 8 또는 다른 face의 W8 qualification·제품 변경
+- private corpus·Hyper-V Oracle 재실행
+- commit, remote push, PR 생성 또는 merge

--- a/mydocs/pr/archives/pr_5956_review.md
+++ b/mydocs/pr/archives/pr_5956_review.md
@@ -1,0 +1,112 @@
+---
+kind: pr-review
+status: self-review-complete
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-24
+---
+
+# PR #5956 self-review — #4960 W7 이후 폰트 로드맵 방향 수정
+
+## 라우팅
+
+- base route: `collaborator_self_merge.md`
+- modifiers: `intake_and_review.md`, `local_validation.md`, `review_only_fast_pass.md`
+- loaded documents: `pr_review_workflow.md`, `pr_review/README.md`, 위 기본·보조 문서
+- 작성자 본인 self-review이므로 reviewer를 지정하지 않는다.
+- code candidate: `b97f3708ad2926681554c468e86685ad5a940440`
+
+renderer·layout·paint, sample, 기준 PDF와 visual fixture 변경은 없어 `visual_fixture_evidence.md`를 적용하지
+않았다. 단일 self PR이고 update branch나 오래된 base도 없어 다수 PR·재작업 경로도 적용하지 않았다.
+
+## 접수 metadata
+
+| 항목 | 작성 시점 참고값 |
+| --- | --- |
+| PR | [#5956](https://github.com/edwardkim/rhwp/pull/5956) |
+| 작성자 | `edwardkim` |
+| 관련 이슈 | parent [#4960](https://github.com/edwardkim/rhwp/issues/4960), W7.5 [#5955](https://github.com/edwardkim/rhwp/issues/5955) |
+| base / head | `devel` / `task_m100_4960_direction_revision` |
+| code candidate 규모 | 7 files, +890 / -55, 3 commits |
+| 작성 시점 상태 | Open, non-draft, `MERGEABLE`, `mergeStateStatus=CLEAN` |
+| reviewer | 작성자 본인 self-review, 별도 reviewer 미지정 |
+
+1,000줄 기준 아래이며 변경 7개가 모두 `mydocs/**`다. PR 본문은 `Refs #4960`을 사용한다. #4960은
+W7.5~W10을 계속 추적해야 하므로 이 PR 병합으로 닫지 않는다.
+
+## 목적과 변경 범위
+
+W0~W7에서 얻은 W4 위험 band, W5 Oracle disposition과 W7 read-only schema 1.0을 반영해 이후 로드맵을
+단일 순차 경로에서 evidence·capability gate 기반 graph로 정정하는 것이 목적이다.
+
+- W7과 W8 사이에 registry lifecycle·migration·evidence delta를 소유하는 W7.5 #5955를 배치했다.
+- W8 #4967을 evidence-reopen, correction-qualification과 product-correction lane으로 분리했다.
+- rank 8 `KoPubWorld바탕체 Light`는 위험 순위 재정렬이나 구현 확정이 아니라 process canary 후보다.
+- W9 #4968은 장기 W8 tracker 전체 대신 kerning cohort와 겹치는 face의 metric·selection 동결을 요구한다.
+- W10 #4969는 W9와 대상 fixture face 집합의 metric·identity 동결 뒤 진행한다.
+- 로컬 canonical·report·stage 문서와 GitHub issue body·sub-issue topology를 같은 graph로 대사했다.
+
+제품 source, schema 1.0 registry, generated projection, metric·fallback·paint, fixture, font asset와 private
+corpus 자료는 변경하지 않았다. W7.5 구현과 W8~W10 착수는 각각 별도 이슈·계획·승인 대상이다.
+
+## self-review findings
+
+### blocker 없음
+
+- #4939, #4961, #4962, #4963, #4964와 #4966은 닫혀 있고, #5955와 #4967~#4969는 열려 있어
+  W0~W7 완료·W7.5~W10 미착수 상태가 로컬 문서와 일치한다.
+- #4960 sub-issue 순서는 W2, W3·W4, W5, W6, W7, W7.5, W8, W9, W10이며 W7.5가 W8보다 앞선다.
+- #4960, #5955와 #4967~#4969 본문 SHA-256 및 maintainer comment 5개의 SHA-256이 Stage R2·R3
+  증적과 일치한다. 게시된 UTF-8 본문에서 BOM, `??` 치환과 literal `\\n`은 검출되지 않았다.
+- W5 정본은 `stage=W5-5C`, `actionableRanks=[]`를 유지한다. 17개 disposition과 rank 1·7·8의
+  acceptance ladder를 다시 계측하거나 현재 제품 교정 확정으로 오해하지 않았다.
+- W7 schema 1.0과 830개 active rule의 의미를 수정하지 않고 다음 판의 생명주기 계약을 별도 W7.5로
+  분리했다.
+
+### 잔여 위험과 후속 경계
+
+- #5955가 완료되기 전에 schema 1.0이나 generated projection을 직접 수정하면 이 PR의 보호 불변식을
+  위반한다.
+- rank 8 qualification은 첫 공정 검증 후보일 뿐이다. 현재 rhwp 오류·목표 decision plane·portable 정책을
+  증명하지 못하면 product change 없이 닫아야 한다.
+- W9는 W8 전체를 기다리지 않지만 kerning cohort와 겹치는 metric·fallback 변경을 pair positioning과 같은
+  PR에 섞어서는 안 된다.
+- #4960은 후속 실행 tracker이므로 이 PR 병합 뒤에도 OPEN으로 유지한다.
+
+## 완료한 로컬 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| 변경 Markdown 링크 | 7개 문서, 상대 링크 이상 없음 |
+| `git diff --check upstream/devel...HEAD` | 통과 |
+| 변경 범위 | `mydocs/**` 7개, 제품·fixture·workflow 변경 0 |
+| integration manifest | 검토 worktree에서 893 sources / 4,165 static test attrs / 32 suites + 9 exceptions 확인 |
+| `cargo fmt --all`·`cargo fmt --all -- --check` | code candidate에서 통과 |
+| 문서 metadata 전수 검사 | 이번 diff 밖 4개 문서의 기존 누락 16건만 재현 |
+
+`local_validation.md`의 mydocs-only 범위에 따라 Cargo test, clippy, WASM, browser와 시각 검증은 실행 대상이
+아니다. format은 저장소 공통 push gate를 충족하기 위해 generated suite를 준비한 임시 review worktree에서
+별도로 통과시켰고, 파생 suite·manifest는 PR에 포함하지 않았다.
+
+## GitHub Actions
+
+code candidate `b97f3708a`는 review-only fast-pass B 경로를 탔다.
+
+| workflow | run | 판정 |
+| --- | --- | --- |
+| CI | [32652141244](https://github.com/edwardkim/rhwp/actions/runs/32652141244) | preflight·Build & Test 성공, heavy job 정책상 skip |
+| CodeQL | [32652141107](https://github.com/edwardkim/rhwp/actions/runs/32652141107) | preflight 성공, Analyze 정책상 skip |
+| Proptest roundtrip | [32652141124](https://github.com/edwardkim/rhwp/actions/runs/32652141124) | preflight 성공, worker 정책상 skip |
+| Adapter inter-diff | [32652141106](https://github.com/edwardkim/rhwp/actions/runs/32652141106) | preflight 성공, worker 정책상 skip |
+
+실패하거나 대기 중인 check는 없었다. 이 self-review와 오늘할일은 code candidate 뒤의 `mydocs/` 한정
+single-parent trailing commit으로 추가한다. push 뒤 exact trailing head의 preflight·Build & Test aggregate,
+`MERGEABLE/CLEAN`과 최신 base를 다시 확인해야 한다.
+
+## 최종 권고
+
+로드맵 정정은 역사 계측과 read-only schema를 보존하면서 registry lifecycle, face 교정, kerning과 고급
+shaping의 변경 이유를 분리한다. 로컬 정본과 GitHub topology의 상태·의존성·본문 hash가 일치하고 제품
+변경은 없다. 추가 blocker는 발견하지 않았다.
+
+self-review는 **완료 / 조건부 merge 권고**다. trailing review-only head의 fast-pass, 최신
+`MERGEABLE/CLEAN`, #4960 OPEN 유지와 메인테이너의 별도 merge 승인을 확인하기 전에는 merge하지 않는다.

--- a/mydocs/report/font_metrics_fallback_causal_lineage_20260816.md
+++ b/mydocs/report/font_metrics_fallback_causal_lineage_20260816.md
@@ -2,7 +2,7 @@
 kind: investigation
 status: active
 canonical: mydocs/tech/font_fallback_strategy.md
-last_verified: 2026-08-16
+last_verified: 2026-08-24
 ---
 
 # 폰트 메트릭·fallback 원인 계보 및 보호 불변식
@@ -14,6 +14,10 @@ last_verified: 2026-08-16
 - 기준 HEAD: `44125461187c158073daf5b6b317b08042e7332a`
 - 장기 정책 authority: [CJK 폰트 폴백 전략](../tech/font_fallback_strategy.md)
 - 사고 진단 절차 authority: [폰트 incident 대응 절차](../manual/font_incident_response.md)
+
+> 2026-08-24 현행화: W0~W7 완료 결과를 반영해 W7 이후의 단일 임계 경로를 registry evolution,
+> face별 correction qualification과 kerning cohort 동결 게이트로 수정했다. 2026-08-16의 역사·수치와
+> FI-01~FI-14는 변경하지 않는다.
 
 ## 1. 결론
 
@@ -441,10 +445,12 @@ font selection test 등가, 생성 산출물 deterministic hash 일치.
 **Stage C 개별 변경 게이트:** target controlled ladder, exact/missing oracle profile 분리, 첫 divergence와
 glyph position 비교, HWP/HWPX 포맷별 corpus cohort, native/WASM parity, Canvas2D/CanvasKit backend별 판정.
 
-## 10. 실제 실행 순서 — 하나씩 닫는 단일 임계 경로
+## 10. 실제 실행 순서 — 증거 기반 게이트와 분기 경로
 
 Stage A~C는 방향을 설명하지만 실제 작업 단위로는 너무 크다. 전체를 한 이슈에서 동시에 고치지
-않고, 아래의 W0~W10을 앞 단계의 산출물이 다음 단계의 입력이 되도록 순서대로 닫는다.
+않고 W0~W7은 앞 단계의 산출물이 다음 단계의 입력이 되는 단일 경로로 닫았다. W7 이후에는 source와
+provider evidence가 사건별로 도착하고 W8이 장기 tracker가 되므로, registry 변경·face 교정·kerning을
+하나의 직선 완료 조건으로 묶지 않는다.
 
 ```mermaid
 flowchart LR
@@ -455,13 +461,21 @@ flowchart LR
     W4 --> W5[W5 상위 후보 oracle]
     W5 --> W6[W6 데이터 계보 분리]
     W6 --> W7[W7 canonical projection]
-    W7 --> W8[W8 face별 교정 반복]
-    W8 --> W9[W9 kerning]
+    W7 --> W75[W7.5 registry evolution]
+    W75 --> Q[W8 correction qualification]
+    Q --> W8[W8 face별 교정 반복]
+    D[source·provider·identity 새 evidence] --> Q
+    W75 --> K[kerning cohort metric·face 동결]
+    Q --> K
+    W8 --> K
+    K --> W9[W9 kerning]
     W9 --> W10[W10 vertical·shaping]
 ```
 
 핵심은 W7까지 제품의 font 선택 결과를 바꾸지 않는 것이다. 먼저 현재 동작을 설명하고 재현할 수
-있게 만든 뒤, W8부터 근거가 확보된 face 하나씩 동작을 바꾼다.
+있게 만든 뒤, W7.5에서 변경 가능한 registry 계약을 별도로 승인한다. W8은 근거가 확보된 face 하나씩
+동작을 바꾸되, source 발견을 기다리는 다른 face 때문에 kerning이 무기한 막히지 않도록 관련 cohort만
+동결해 W9로 진행한다.
 
 ### 10.1 W0 — 현재 기준선과 보호 계약 고정
 
@@ -569,21 +583,41 @@ W4가 끝날 때까지 새로운 metric face를 대량 추가하지 않는다.
 - 제품 동작 변경: 없음
 - 완료 조건: 생성 전후 Rust·TypeScript table과 lookup 결과가 전수 동일하고 산출물 hash가 결정론적
 
-W7까지 끝나면 새로운 규칙 하나를 원장에 기록하고 필요한 backend 산출물만 갱신할 수 있다.
+W7 결과인 schema 1.0은 830개 active rule을 봉인한 read-only canonical authority다. 생성기나 직렬화의
+동일 의미 결함은 semantic bytes를 유지한 채 고칠 수 있지만, 새 규칙·의미 수정·폐기는 schema 1.0을
+직접 편집해 처리하지 않는다.
 
-### 10.9 W8 — font face 하나를 하나의 이슈로 교정
+### 10.9 W7.5 — registry 규칙 생명주기와 evidence delta 계약
+
+**질문:** 역사 snapshot을 거짓으로 갱신하지 않고 제품 규칙을 어떻게 추가·수정·폐기하는가?
+
+- 입력: W1 historical ledger, W5 Oracle evidence, W6 metric lineage와 W7 schema 1.0
+- 산출물: 다음 registry schema 판, migration manifest, rule lifecycle와 semantic delta 계약
+- 최소 계약: `active`·`retired`, 후속 rule, evidence parent/digest, pre/post selection tuple,
+  backend projection별 semantic delta
+- 제품 동작 변경: 없음. 기존 830개 active rule을 의미 변화 없이 다음 판으로 이행한다.
+- 완료 조건: 새 evidence가 W1 snapshot을 다시 쓰지 않고 연결되며, 필요한 backend projection만
+  변경되는 것을 validator와 mutation test가 fail-closed한다.
+
+정확한 schema version과 field 이름은 W7.5 별도 이슈·수행계획에서 확정한다. 이 단계 전에 schema 1.0을
+느슨하게 만들거나 generated Rust·TypeScript 산출물을 직접 편집하지 않는다.
+
+### 10.10 W8 — font face 하나를 하나의 이슈로 교정
 
 **질문:** 어떤 실제 사용자 문서가 이 교정으로 좋아지고 무엇이 그대로 유지되는가?
 
-W4 순위의 face를 한 번에 하나씩 다음 반복으로 처리한다.
+W8은 evidence 재개, correction qualification과 실제 product correction의 세 lane을 구분한다. W4의 A/B
+band와 W5 profile만으로 구현 이슈를 만들지 않고 현재 rhwp의 오류, 목표 decision plane, portable 정책과
+재배포·조달 가능성을 먼저 설명한다. 조건을 통과한 face만 한 번에 하나씩 다음 반복으로 처리한다.
 
 ```text
 후보 선택
   → W5 oracle 재확인
-  → 원장 relation 추가·정정
+  → correction hypothesis·decision plane 확정
+  → W7.5 계약으로 registry relation 추가·정정·retirement
   → exact metric 또는 명시적 surrogate 적용
   → controlled ladder
-  → 압축·고정 프레임 cohort
+  → 장평·자간·실제 fixed frame geometry cohort
   → native/WASM parity
   → Canvas2D/CanvasKit 시각 판정
   → 통과한 face만 merge
@@ -594,32 +628,35 @@ W4 순위의 face를 한 번에 하나씩 다음 반복으로 처리한다.
 - 중단 조건: oracle profile 충돌, source provenance 불명, page count만 맞고 glyph position이 발산
 
 여러 face를 한 PR에 넣지 않는다. 한 face가 실패해도 다른 후보의 증거와 rollback 경계를 오염시키지
-않기 위해서다.
+않기 위해서다. source가 없는 face는 source discovery 사건이 있을 때만 W5 disposition을 재개하며,
+반복 계측으로 억지로 actionable하게 만들지 않는다.
 
-### 10.10 W9 — kerning을 독립 축으로 연결
+### 10.11 W9 — kerning을 독립 축으로 연결
 
 **질문:** 명시된 kerning flag를 적용하면 어떤 문서가 달라지는가?
 
-- 입력: W3에서 식별한 kerning 사용 문서와 안정화된 metric registry
+- 입력: W3에서 식별한 kerning 사용 문서, W7.5 완료 registry와 kerning cohort에서 동결한 metric·face
 - 산출물: `ResolvedCharStyle.kerning` → TextStyle → shaping/measurement의 end-to-end 전달
 - 제품 동작 변경: 있음
 - 완료 조건: kerning on/off controlled pair, LineSeg/fresh layout 분리, 157개 문서 cohort와 backend parity
 
 kerning은 fallback 정리와 함께 구현하지 않는다. pair adjustment가 face advance 교정과 섞이면 원인을
-분리할 수 없기 때문이다.
+분리할 수 없기 때문이다. W8 tracker 전체 완료를 기다리지 않고, kerning cohort와 겹치는 face가 교정
+완료 또는 no-change disposition으로 동결되면 진입할 수 있다.
 
-### 10.11 W10 — vertical metrics·variation·shaping 확장
+### 10.12 W10 — vertical metrics·variation·shaping 확장
 
 **질문:** 가로 단일 glyph advance만으로 설명할 수 없는 조판을 어떻게 지원하는가?
 
-- 입력: W7 registry, W8 안정 metric, W9 shaping 경계
+- 입력: W7.5 registry provenance, 대상 fixture face 집합의 안정 metric과 W9 shaping 경계
 - 산출물: `vhea`·`vmtx`, GPOS·GSUB, variable axis, script/language별 shaping profile
 - 제품 동작 변경: 있음
 - 완료 조건: 세로쓰기와 복합 script 전용 fixture, backend별 glyph positioning, portable replay 계약
 
-이 단계는 현재 fallback 문제의 선결 조건이 아니다. W0~W8을 건너뛰고 먼저 시작하지 않는다.
+이 단계는 현재 fallback 문제의 선결 조건이 아니다. W9 shaping·capability 경계를 건너뛰고 먼저 시작하지
+않으며, 모든 W8 face가 아니라 대상 script·vertical·variation fixture의 face 집합이 안정됐는지 판정한다.
 
-### 10.12 공식 이슈를 나누는 경계
+### 10.13 공식 이슈를 나누는 경계
 
 첫 공식 이슈는 전체 로드맵이 아니라 **W0~W1만** 다룬다. 진단 코드가 필요한 W2, private corpus
 계측인 W3, 구조 변경인 W6~W7, 동작 변경인 W8 이후를 한 이슈에 묶지 않는다.
@@ -632,49 +669,48 @@ kerning은 fallback 정리와 함께 구현하지 않는다. pair adjustment가 
 | Issue D | W5 상위 후보 oracle | font별 근거 자료, 제품 동작 불변 |
 | Issue E | W6 generated/overlay 분리 | 데이터 구조만 변경, 전수 등가 |
 | Issue F | W7 canonical projection | 중복 table 생성화, 전수 등가 |
+| 별도 Issue | W7.5 registry evolution | lifecycle·migration·evidence delta, 제품 규칙 불변 |
 | Issue G1, G2, ... | W8의 face 하나씩 | 근거가 있는 작은 동작 변경 |
-| 별도 Issue | W9 kerning | pair positioning 변경 |
+| 별도 Issue | W9 kerning | 관련 cohort 동결 뒤 pair positioning 변경 |
 | 별도 Issue | W10 vertical·shaping | 고급 조판 변경 |
 
 즉 첫 실행은 “새 fallback을 고른다”가 아니다. **현재 규칙을 하나도 빠뜨리지 않고 원장에 옮기고,
-그 원장이 현재 결과를 설명할 수 있는지 확인하는 것**이다. 그 다음에야 실제 누락을 다시 세고,
-가장 위험한 face 하나를 고른다.
+그 원장이 현재 결과를 설명할 수 있는지 확인하는 것**이다. 그 다음에는 위험 band와 evidence 준비도를
+함께 사용해 correction hypothesis를 세우고, 변경 가능한 registry 계약을 통과한 face만 교정한다.
 
 ## 11. 우선순위 제안
 
 | 우선순위 | 과제 | 이유 |
 | ---: | --- | --- |
-| P0 | Font Rule Ledger와 Decision Trace | 현재 규칙을 잃지 않고 구조를 바꾸기 위한 선결 조건 |
-| P0 | 실제 renderer 기반 문자별 metric coverage 재계측 | 현재 91.16% 잠정치로는 누락 우선순위를 정할 수 없음 |
-| P0 | Oracle Profile schema | #4701과 #4739 유형의 잘못된 정답지 혼합 재발 방지 |
-| P1 | generated metric / measured overlay 분리 | 재생성 안전성과 provenance 확보 |
-| P1 | 상위 실제 사용·압축·고정 프레임 font의 exact profile | 적은 font로 대부분의 조판 위험을 줄일 수 있음 |
-| P1 | 중복 Rust/TS/CanvasKit projection의 canonical registry화 | 의미 drift와 후속 누락 감소 |
-| P2 | kerning end-to-end | 문서 비율은 1.57%지만 현재 명시 flag를 완전히 누락 |
-| P2 | vertical metrics·GPOS·variation 지원 | 세로쓰기·고급 조판·가변 폰트 정확성 |
+| 완료 | W0~W7 기준선·원장·trace·coverage·oracle·lineage·projection | 제품 동작을 바꾸기 전 계보와 0-delta 기반 확보 |
+| P0 | W7.5 registry evolution contract | schema 1.0 직접 수정 없이 최초 제품 규칙 변경을 수용하는 선결 조건 |
+| P1 | rank 1·7·8 correction qualification | W5 완료 profile을 실제 오류·목표 decision plane·portable 정책으로 변환 |
+| P1 | source·provider evidence 재개 lane | blocked face를 반복 계측하지 않고 새 증거가 생길 때만 재개 |
+| P2 | kerning end-to-end | 관련 cohort 동결 뒤 장기 W8 전체 완료와 독립적으로 처리 |
+| P3 | vertical metrics·GPOS·variation 지원 | W9 shaping 경계와 대상 face 집합 안정화 뒤 확장 |
 | P3 | opt-in exact-local fresh layout | portability와 환경 재현성을 분리한 고급 profile |
 
-## 12. 미확정 질문
+## 12. 잔여 질문과 W0~W7 disposition
 
-다음은 공식 이슈의 수행 계획서에서 실험으로 답해야 하며 이 보고서에서 추정으로 닫지 않는다.
+최초 미확정 질문을 지우지 않고 W0~W7이 어디까지 답했는지와 다음 owner를 기록한다.
 
-1. 실제 renderer 경로를 통과한 문자별 exact/alias/overlay/heuristic coverage는 얼마인가?
-2. 상위 20·50개 실사용 font 중 원본 bytes와 합법적 보존 가능한 provenance가 있는 face는 무엇인가?
-3. Hangul 4×6×3 압축 오차가 95% 장평·-5% 자간·고정 셀에서 줄바꿈 임계로 얼마나 증폭되는가?
-4. measured ASCII overlay가 필요한 face와 원본 `hmtx`로 되돌릴 수 있는 face는 각각 무엇인가?
-5. 한컴의 missing-font PDF fallback은 face category, 문서 `substFont`, 설치 집합에 따라 어떤 순서로
-   결정되는가?
-6. kerning flag가 켜진 157개 문서에서 pair positioning을 적용했을 때 LineSeg·fresh layout 차이는
-   어느 정도인가?
-7. HWP와 HWPX의 저장 LineSeg 신뢰도 차이를 font profile 평가에 어떤 cohort로 반영할 것인가?
-8. CanvasKit에 합법적으로 전달 가능한 exact SFNT와 Canvas2D에서만 사용 가능한 local face의 경계는
-   어디인가?
+| 질문 | 현재 disposition | 다음 owner |
+| --- | --- | --- |
+| 실제 renderer 문자별 coverage | W3에서 54,326,042자를 분류하고 2회 hash를 고정해 완료 | 새 corpus 입력 identity가 바뀔 때만 재계측 |
+| 상위 실사용 face의 source·provenance | W5 A+B 17개 중 ladder 완료 3, source unavailable 10, protected partial 3, capability mismatch 1 | evidence reopen lane |
+| 압축 오차의 실제 줄·frame 임계 증폭 | W4 risk mass는 proxy이며 실제 geometry를 완료로 주장하지 않음 | W8 개별 face fixture |
+| measured overlay와 원본 `hmtx` 복귀 가능성 | W6 overlay 5개는 보존했지만 historical generated 595개의 fully source-exact는 0 | W8 qualification·source discovery |
+| 한컴 missing-font 선택 순서 | W5 rank 1·7·8의 controlled ladder는 완료, 전체 category 규칙으로 일반화하지 않음 | 신규 font incident와 W8 |
+| kerning 157개 문서의 pair positioning | flag·cohort만 식별, 제품 연결 미착수 | W9 |
+| HWP/HWPX LineSeg 신뢰도와 font profile | stored/fresh lane을 분리했으나 format/version 규칙으로 일반화하지 않음 | W8·W9 feature detection |
+| CanvasKit exact SFNT와 Canvas2D local face 경계 | W2 trace와 W7 projection이 capability를 분리, 실제 rule 변경은 schema 1.0에서 금지 | W7.5·W8 backend disposition |
 
 ## 13. 다음 승인 지점
 
-메인테이너의 보고서 승인에 따라 동일 증상·선행 이슈 검색을 마치고 Issue #4939를 등록했다. 다음
-단계는 구현이 아니라 W0 기준선과 W1 Font Rule Ledger만 포함하는 수행 계획서 작성과 승인이다.
-W2 이후는 앞 작업의 산출물과 완료 게이트를 확인한 뒤 각각 별도 이슈와 승인으로 진행한다.
+W0~W7은 #4939와 #4961~#4966에서 완료됐다. 다음 승인 지점은
+[#4960 수정 수행계획](../plans/task_m100_4960.md)의 Stage R1 결과다. 승인 뒤 별도 원격 mutation 게이트로
+W7.5 이슈와 #4960·#4967~#4969 topology를 현행화한다. W7.5 구현, W8 face qualification과 W9·W10은
+각각 별도 이슈·계획·승인 전에는 시작하지 않는다.
 
 ## 14. 기술 약어·테이블 태그 미주
 

--- a/mydocs/report/task_m100_4966_report.md
+++ b/mydocs/report/task_m100_4966_report.md
@@ -1,8 +1,8 @@
 ---
 kind: report
-status: active
-canonical: mydocs/plans/task_m100_4966.md
-last_verified: 2026-08-23
+status: completed
+canonical: mydocs/report/task_m100_4966_report.md
+last_verified: 2026-08-24
 ---
 
 # Task M100 #4966 최종 보고서 — W7 canonical font registry
@@ -14,8 +14,9 @@ Canvas2D paint, webfont supply와 CanvasKit SFNT의 유한 규칙을 하나의 c
 맞는 정적 projection으로 생성한다. 전환 전후 선택 결과·순서·metric·renderer output은 동일하다.
 
 최초 로컬 결과와 메인테이너 승인은 있었지만, PR #5950의 CI가 PR-base unit-tier 정책 위반을 발견해
-완료 판정을 철회하고 Stage W7-R 영향도 재감사로 되돌렸다. 이후 근본 정정과 W7-R4 전체 로컬 재검증은
-완료했다. 최신 원격 CI, self-review, merge와 issue close는 후속 승인 게이트다.
+완료 판정을 철회하고 Stage W7-R 영향도 재감사로 되돌렸다. 이후 근본 정정과 W7-R4 전체 로컬·원격
+검증을 완료했고, PR #5950을 일반 merge commit 방식으로 병합했다. Issue #4966은 자동 종료됐으며
+merge commit은 `5057a7fcaf055b928e76115cdee4bc20bf0936f9`다.
 
 ## 2. 단계별 산출
 
@@ -107,14 +108,23 @@ schema 1.0은 W1/W6 일회 이행 결과 830개를 봉인한 read-only canonical
 identity가 바뀌는 수정, 삭제 대신 `retired` 상태·후속 rule·사유를 먼저 계약으로 만든다. 상세 절차는
 [Issue #4966 조사 정본](../tech/investigations/issue-4966/README.md)에 있다.
 
-## 6. W8 인계 조건
+## 6. W7.5와 W8 인계 조건
 
-W8은 개별 mapping의 정확성을 보정하는 단계다. 시작 조건은 다음과 같다.
+schema 1.0은 제품 규칙 변경을 지원하지 않으므로 W8 첫 mapping 보정 전에 별도 W7.5 이슈에서 변경
+가능한 다음 registry 판을 승인하고 기존 830개 active rule을 의미 변화 없이 이행해야 한다. W7.5는
+rule 추가·의미 수정·retirement, evidence parent/digest와 backend별 semantic delta를 계약하되 제품
+선택 결과는 바꾸지 않는다.
 
-1. 변경 가능한 다음 registry schema와 evidence 계보를 승인한다.
+그 뒤 W8은 개별 mapping의 정확성을 보정한다. 시작 조건은 다음과 같다.
+
+1. W7.5의 변경 가능한 다음 registry schema와 evidence 계보가 통합돼 있다.
 2. 한 번에 한 decision plane과 한 backend projection만 의미상 바꾸는 change set을 만든다.
 3. 변경 전후 `ruleId`, metric entry, selection tuple과 renderer output을 대사한다.
 4. Canvas2D availability를 CanvasKit SFNT capability로, plan을 load 성공으로 승격하지 않는다.
 5. public fixture와 필요한 경우 비식별 aggregate만 사용하고 private corpus 식별 정보는 내보내지 않는다.
 
 이 조건 전에는 schema 1.0을 느슨하게 만들거나 generated source를 직접 수정하지 않는다.
+
+W8 tracker 전체 완료는 W9의 조건이 아니다. kerning cohort가 사용하는 metric·face와 진행 중 W8
+변경의 겹침을 대사하고, 겹치는 face가 교정 완료 또는 no-change disposition으로 동결되면 W9를 독립
+진행할 수 있다. 상세 방향은 [#4960 수정 수행계획](../plans/task_m100_4960.md)을 따른다.

--- a/mydocs/tech/font_fallback_strategy.md
+++ b/mydocs/tech/font_fallback_strategy.md
@@ -2,7 +2,7 @@
 kind: canonical
 status: active
 canonical: mydocs/tech/font_fallback_strategy.md
-last_verified: 2026-08-23
+last_verified: 2026-08-24
 ---
 
 # CJK 폰트 폴백 전략 보고서
@@ -21,6 +21,10 @@ last_verified: 2026-08-23
 > 아래 `font-substitution.ts`·`font-loader.ts`의 대형 literal 표 언급은 당시 구현 기록이다. 현재 두
 > 파일은 generated projection을 소비하며, document substitution·local probe·glyph/capability 판정은
 > hand-written 알고리즘으로 남는다.
+>
+> 2026-08-24 현행화: 현재 registry schema 1.0은 W1/W6에서 이행한 830개 active rule을 봉인한
+> read-only authority다. 제품 규칙의 추가·의미 수정·폐기는 schema 1.0 JSON이나 generated projection을
+> 직접 고치지 않고, 별도 승인된 다음 schema 판과 evidence delta 계약을 먼저 마련한다.
 
 ## 목차
 
@@ -94,6 +98,12 @@ canonical source `assets/fonts/`에는 재배포 가능한 WOFF2 36개가 Git으
 같은 source/target 문자열이 보여도 layout, paint, supply와 detection을 합치지 않는다. 특히 Canvas2D
 CSS 사용 가능, webfont URL 계획, CanvasKit SFNT bytes 확보는 서로 다른 사실이다. W2 Font Decision
 Trace는 실제 선택이 끝난 뒤 generated `ruleId`를 설명할 뿐 규칙 선택 권위가 아니다.
+
+schema 1.0은 현재 결과를 재현하는 봉인판이다. 동일 의미의 generator·serialization 결함은 registry
+semantic bytes를 유지한 채 정정할 수 있지만, 제품 규칙 변경을 위해 수량·status·historical evidence
+제약을 느슨하게 만들지 않는다. 새 규칙·의미 수정·폐기는 별도 이슈에서 다음 schema 판, migration
+manifest, `active`·`retired` lifecycle과 pre/post semantic delta를 먼저 승인한다. 폐기된 rule도 삭제하지
+않고 trace·감사 계보에 남긴다.
 
 ---
 
@@ -758,6 +768,9 @@ HWP 문서에서 다음 폰트명들은 FONT_METRICS DB 에 정식 엔트리가 
 
 - [ ] layout-name, layout-metric, paint, supply, detection 중 결정면과 relation을 먼저 확정한다.
 - [ ] `assets/font-rules/font_rule_registry.json`의 현재 schema 판이 그 변경을 허용하는지 확인한다.
+      schema 1.0은 read-only이므로 제품 규칙 변경이면 다음 schema 판의 별도 이슈·계획·승인이 먼저다.
+- [ ] 기존 W1 snapshot을 갱신하지 않고 새 evidence parent·digest와 rule 유지·신규·retirement 판정을
+      migration manifest에 기록한다.
 - [ ] Rust/Studio generated 파일을 직접 편집하지 않고 `font_rule_projection_gen.mjs`로 재생성한다.
 - [ ] layout-name 규칙이면 `rust-layout-name`, metric alias면 `rust-layout-metric` projection만 바뀌는지
       manifest digest로 확인한다.

--- a/mydocs/working/task_m100_4960_direction_revision_stage1.md
+++ b/mydocs/working/task_m100_4960_direction_revision_stage1.md
@@ -1,0 +1,123 @@
+---
+kind: report
+status: active
+canonical: mydocs/plans/task_m100_4960.md
+last_verified: 2026-08-24
+---
+
+# Task M100 #4960 — Stage R1 W7 이후 방향 계약 문서화
+
+## 1. 판정
+
+#4960 수정 수행계획의 Stage R1 범위인 로컬 권위 문서 현행화를 완료했다. W0~W7의 완료 결과와
+historical 수치·hash는 보존하고, W7 이후의 직선 경로를 다음 세 게이트로 수정했다.
+
+1. 제품 규칙 변경 전 W7.5 registry evolution contract
+2. W5 disposition을 실제 제품 delta 가설로 바꾸는 W8 correction qualification
+3. W8 tracker 전체가 아닌 관련 metric·face를 동결하는 W9 kerning cohort gate
+
+이번 단계는 Markdown만 변경했다. registry schema 1.0, generated projection, metric·fallback·paint,
+font asset과 renderer output은 변경하지 않았다.
+
+## 2. 근거 대사
+
+| 근거 | Stage R1 해석 |
+| --- | --- |
+| W3·W4 54,326,042 coverage 문자, 위험 face 351개 | A/B band는 유지하고 exact rank를 강제 구현 순서로 쓰지 않음 |
+| W5 `complete-acceptance-ladder` 3개 | rank 1·7·8을 qualification 가능 후보로 유지 |
+| W5 source unavailable 10개 | source discovery 사건 전 반복 계측·제품 이슈 생성 금지 |
+| W5 protected partial 3개 | provider를 손상하지 않는 새 제어 능력이 생길 때만 재개 |
+| W5 capability mismatch 1개 | localized document face와 export subset 연결 전 exact 승격 금지 |
+| W7 registry 830 active rule | schema 1.0은 read-only로 보존하고 다음 판을 별도 승인 |
+
+W5의 `actionableRanks=[]`는 추가 Oracle 실행 queue가 끝났다는 뜻으로 유지했다. W8 후보가 0이라는
+주장이나 17개 모두가 구현 준비됐다는 주장으로 바꾸지 않았다.
+
+## 3. 문서별 변경
+
+### 원인 계보 보고서
+
+[`font_metrics_fallback_causal_lineage_20260816.md`](../report/font_metrics_fallback_causal_lineage_20260816.md)는
+W0~W7의 역사와 FI-01~FI-14를 그대로 유지하고 다음만 현행화했다.
+
+- 단일 임계 경로를 W7.5·W8 qualification·kerning cohort 분기 graph로 교체
+- W7 schema 1.0 read-only 경계와 W7.5 입력·산출물·완료 조건 추가
+- W8을 evidence reopen·qualification·product correction lane으로 분리
+- W9를 장기 W8 전체가 아닌 겹치는 face 동결 조건으로 변경
+- W10을 W9 shaping 경계와 대상 fixture face 집합 안정화에 연결
+- 우선순위를 완료 W0~W7과 현재 P0~P3으로 재기록
+
+### W7 최종 보고서
+
+[`task_m100_4966_report.md`](../report/task_m100_4966_report.md)는 다음 현재 사실을 반영했다.
+
+- `status: completed`, canonical self-reference, `last_verified: 2026-08-24`
+- PR #5950 일반 merge와 merge commit `5057a7fcaf055b928e76115cdee4bc20bf0936f9`
+- Issue #4966 자동 종료
+- W8 직접 진입 대신 W7.5의 의미 불변 schema 이행 선행
+- W9의 kerning cohort 동결 조건
+
+### canonical fallback 전략
+
+[`font_fallback_strategy.md`](../tech/font_fallback_strategy.md)는 schema 1.0의 운영 경계를 장기 정책에
+반영했다.
+
+- schema 1.0 JSON과 generated projection 직접 수정 금지
+- 다음 schema 판, migration manifest, lifecycle과 semantic delta 선행
+- W1 historical snapshot 대신 새 evidence parent·digest 연결
+- retirement rule을 삭제하지 않고 trace·감사 계보에 보존
+
+## 4. 수정된 의존성
+
+```text
+W0~W7 완료
+  → W7.5 registry evolution
+      ├─ W8 correction qualification → face별 product correction
+      └─ kerning cohort metric·face freeze → W9 → W10
+
+새 source·provider·identity evidence
+  → 해당 W5 disposition만 재개
+  → W8 qualification
+```
+
+W8 face correction이 kerning cohort와 겹치지 않으면 W9는 다른 blocked face의 source 발견을 기다리지
+않는다. 겹치면 해당 face의 correction 완료 또는 no-change disposition까지 동결한다.
+
+## 5. 변경 범위 감사
+
+| 항목 | 결과 |
+| --- | --- |
+| 계획서 | `mydocs/plans/task_m100_4960.md` 신규 |
+| 기존 조사·정책 문서 | 3개 수정 |
+| Stage 보고서 | 이 문서 신규 |
+| Rust·TypeScript·JavaScript source | 변경 0 |
+| registry·projection·metric data | 변경 0 |
+| fixture·font asset | 변경 0 |
+| private corpus·host path·font bytes 공개 | 0 |
+| GitHub mutation | 0 |
+
+## 6. 검증 결과
+
+| 검사 | 결과 |
+| --- | --- |
+| 변경 5개 Markdown 링크 | 통과, 내부 상대 링크 이상 0 |
+| `git diff --check` | 통과 |
+| 변경 범위 | 계획·조사·정책·보고 Markdown 5개뿐 |
+| 저장소 전체 metadata | 기존 4개 문서의 누락 16건으로 실패, 이번 변경 경로 신규 오류 0 |
+
+기존 metadata 오류는 `mydocs/tech/benchmark_vs_alternatives.md`,
+`mydocs/tech/investigations/issue-4964/README.md`, `mydocs/tech/investigations/issue-5511/README.md`와
+`mydocs/tech/investigations/issue-5511/task_m100_5511_cli_surface_inventory.md`의 필수 필드 누락이다.
+이번 Stage R1에서 만든 오류가 아니며 범위를 넓혀 임의 정정하지 않았다.
+
+commit·push 직전 필수 format gate는 별도 승인 뒤 같은 workspace 범위로 실행한다.
+
+## 7. 다음 게이트
+
+메인테이너가 Stage R1 결과를 승인하면 다음 단계는 Stage R2 GitHub topology 수정이다. 별도 원격
+mutation 승인 전에는 다음을 수행하지 않는다.
+
+- W7.5 이슈 생성과 metadata 지정
+- #4960·#4967~#4969 본문·sub-issue·댓글 변경
+- commit, remote push 또는 PR 생성
+- W7.5 schema 구현이나 W8 rank 8 qualification

--- a/mydocs/working/task_m100_4960_direction_revision_stage2.md
+++ b/mydocs/working/task_m100_4960_direction_revision_stage2.md
@@ -1,0 +1,110 @@
+---
+kind: report
+status: active
+canonical: mydocs/plans/task_m100_4960.md
+last_verified: 2026-08-24
+---
+
+# Task M100 #4960 — Stage R2 GitHub 이슈 topology 수정
+
+## 1. 판정
+
+Stage R1에서 승인한 W7 이후 방향 계약을 GitHub issue topology에 적용했다. registry schema 1.0과 제품
+source는 바꾸지 않고, W7.5 선행 이슈를 등록해 #4960의 W7과 W8 사이에 배치했다. #4967~#4969는 W5
+disposition, W8 qualification과 cohort별 동결 조건을 현재 본문에 반영했다.
+
+본문 4개와 maintainer comment 5개는 게시 뒤 API 원문과 로컬 UTF-8 body를 대사했다. 한글 손상, 선두
+BOM, `??` 치환과 literal `\\n`은 0건이다.
+
+## 2. 중복·taxonomy 사전 감사
+
+다음 검색어로 열린·닫힌 이슈와 열린 PR을 확인했다.
+
+- `font rule registry`
+- `font registry schema`
+- `font rule lifecycle`
+- `font rule retirement`
+
+#4939는 historical Font Rule Ledger, #4966은 schema 1.0 canonical projection이다. 추가·수정·retirement의
+lifecycle·migration·evidence delta를 소유하는 동일 이슈나 열린 PR은 없었다.
+
+W7 #4966과 같은 taxonomy를 재사용했다.
+
+| metadata | 값 |
+| --- | --- |
+| assignee | `edwardkim` |
+| milestone | `v1.0.0` |
+| labels | `enhancement`, `rust`, `rendering`, `typescript` |
+
+## 3. W7.5 이슈와 sub-issue 관계
+
+신규 이슈 [#5955](https://github.com/edwardkim/rhwp/issues/5955)를 생성했다.
+
+- 제목: `[font][W7.5] canonical registry 규칙 생명주기와 evidence delta 계약`
+- 상태: OPEN
+- 범위: 기존 830개 active rule의 의미 불변 이행, lifecycle, migration manifest와 evidence delta
+- 비범위: 개별 face metric·fallback·paint·supply 변경
+- issue body SHA-256: `8defc77b2b84faed3c8dfbebcebc3de957163905e5a52fac5846446f0d54ba8c`
+
+#5955를 #4960의 sub-issue로 추가한 뒤 priority API로 #4966 W7과 #4967 W8 사이에 배치했다. 최종 순서는
+다음과 같다.
+
+```text
+#4961 W2  CLOSED
+#4962 W3·W4  CLOSED
+#4963 W5  CLOSED
+#4964 W6  CLOSED
+#4966 W7  CLOSED
+#5955 W7.5  OPEN
+#4967 W8  OPEN
+#4968 W9  OPEN
+#4969 W10  OPEN
+```
+
+## 4. 기존 issue 본문 수정
+
+| 이슈 | 변경 | body SHA-256 |
+| --- | --- | --- |
+| [#4960](https://github.com/edwardkim/rhwp/issues/4960) | 단일 임계 경로를 W7.5·W8 qualification·W9 cohort gate로 교체 | `bf7bd30fb65fa7e432f22701e8c586ad4a0171723dbe8dd94bbeb323c5ce8a31` |
+| [#4967](https://github.com/edwardkim/rhwp/issues/4967) | 17개 disposition, 세 lane, 자식 생성 조건과 rank 8 process canary 반영 | `f7fdfc575a28ca99136d7538f7268308e208d3242515cb9614313725e0c4e2d4` |
+| [#4968](https://github.com/edwardkim/rhwp/issues/4968) | W8 전체 대신 kerning cohort의 겹치는 face 동결을 선행 조건으로 지정 | `c7771d31a3c52222c45b10862a3590b1c8b6b93b1cab1554525c221f4e3d0466` |
+| [#4969](https://github.com/edwardkim/rhwp/issues/4969) | W7.5·W9와 대상 fixture face 집합 동결을 선행 조건으로 지정 | `1cbe21c09ac1c63336603cf662db42f1de40adec93beffe837af7211e11711b1` |
+
+적용 직전 `updatedAt`을 Stage R2 사전 조회값과 대사했다. 네 이슈 모두 collaborator의 동시 변경 없이
+계획에서 확인한 본문을 기반으로 수정했다.
+
+## 5. maintainer comment
+
+| 이슈 | comment | body SHA-256 |
+| --- | --- | --- |
+| #4960 | [방향 수정 기록](https://github.com/edwardkim/rhwp/issues/4960#issuecomment-5386984278) | `f639dbba07934f91af359be618664982f4b71d78594cef06ead1b50720cc5b75` |
+| #5955 | [W7.5 등록 근거](https://github.com/edwardkim/rhwp/issues/5955#issuecomment-5386984365) | `71480f7c282e5ef2f14ea76470c3d2f86512be69de051384d061c32290938ae6` |
+| #4967 | [W8 gate 수정 기록](https://github.com/edwardkim/rhwp/issues/4967#issuecomment-5386984436) | `6b98c16ccaa5c17440917d6a963ca3f98696ac66ee125ca39f4910f4bd4cfa42` |
+| #4968 | [W9 gate 수정 기록](https://github.com/edwardkim/rhwp/issues/4968#issuecomment-5386984522) | `3f36494366a1d5ec296f19d01f109adb699e52cc6db7abc0467f1a9581b7edad` |
+| #4969 | [W10 gate 수정 기록](https://github.com/edwardkim/rhwp/issues/4969#issuecomment-5386984632) | `b2f600f39a99d6cdb286d57fa1fa1d973e05fdaf178cd12c58d0a4816f697655` |
+
+각 comment는 변경 이유와 범위만 한 번 기록했다. W7.5 구현이나 W8 제품 변경을 착수했다고 주장하지
+않는다.
+
+## 6. 보호 불변식 결과
+
+| 불변식 | 결과 |
+| --- | --- |
+| W0~W7 완료·historical evidence 보존 | 충족 |
+| schema 1.0·generated projection 변경 | 0 |
+| metric·fallback·paint·font asset 변경 | 0 |
+| W5 blocked face 재계측·추정 | 0 |
+| private corpus identity·host path·font bytes 공개 | 0 |
+| body/comment 한글·BOM·치환 오류 | 0 |
+| sub-issue 누락·순서 오류 | 0 |
+
+## 7. 다음 게이트
+
+Stage R2 결과 승인 뒤 Stage R3에서 로컬 문서와 GitHub checklist·선행·후행 관계를 최종 대사하고 PR
+제출 구조를 준비한다. 별도 승인 전에는 다음을 수행하지 않는다.
+
+- 이 Stage R2 보고서 commit
+- remote branch push와 PR 생성
+- #5955 수행계획·schema 구현
+- #4967 rank 8 qualification 또는 제품 변경
+- #4968·#4969 착수

--- a/mydocs/working/task_m100_4960_direction_revision_stage3.md
+++ b/mydocs/working/task_m100_4960_direction_revision_stage3.md
@@ -1,0 +1,157 @@
+---
+kind: report
+status: active
+canonical: mydocs/plans/task_m100_4960.md
+last_verified: 2026-08-24
+---
+
+# Task M100 #4960 — Stage R3 정합성 감사와 PR 준비
+
+## 1. 판정
+
+W7 이후 로드맵의 로컬 정본과 GitHub issue topology는 같은 실행 graph를 표현한다. W0~W7의 완료
+판정과 역사 증적은 유지됐고, W7.5는 미착수 선행 gate, W8~W10은 미착수 후행 작업으로 남아 있다.
+이번 branch에는 Markdown 7개 외의 제품 source·registry·metric·fixture·asset 변경이 없다.
+
+상위 #4960은 W7.5~W10을 계속 추적해야 하므로 이 문서 PR이 병합돼도 닫지 않는다. PR 관련 이슈는
+`Refs #4960`으로 기록한다.
+
+## 2. Git 기준선과 제출 범위
+
+2026-08-24 KST에 `git fetch upstream devel --prune` 뒤 확인한 기준은 다음과 같다.
+
+| 항목 | 값 |
+| --- | --- |
+| base | `upstream/devel@4e070c632dfc889f329be6a90ef2c1d35f8a7f12` |
+| Stage R1 commit | `215d56f66` |
+| Stage R2 commit | `ce374f29a` |
+| divergence | base보다 behind 0, ahead 2 |
+| merge risk | base 이동 없음, 현재 commit graph에 재동기화 필요 없음 |
+| remote head | 아직 없음 |
+| 기존 PR | 없음 |
+
+제출 diff는 계획서, 원인 계보 보고서, W7 최종 보고서, canonical fallback 전략과 Stage R1~R3 증적
+문서뿐이다. Rust·TypeScript·workflow·JSON registry·generated projection·font·sample·baseline은 0건이다.
+
+## 3. 로컬 정본과 GitHub 상태 대사
+
+최종 sub-issue 순서와 상태는 다음과 같다.
+
+```text
+#4961 W2     CLOSED
+#4962 W3·W4  CLOSED
+#4963 W5     CLOSED
+#4964 W6     CLOSED
+#4966 W7     CLOSED
+#5955 W7.5   OPEN
+#4967 W8     OPEN
+#4968 W9     OPEN
+#4969 W10    OPEN
+```
+
+- W7.5는 schema 1.0을 직접 수정하지 않고 lifecycle·migration·evidence delta를 준비한다.
+- W8은 evidence-reopen, correction-qualification과 product-correction lane을 분리한다.
+- W9는 W8 전체가 아니라 kerning cohort와 겹치는 face의 metric·selection 동결을 요구한다.
+- W10은 W9와 대상 fixture face 집합의 metric·identity 동결을 요구한다.
+- rank 8은 위험 순위 변경이나 구현 확정이 아니라 W8 qualification의 process canary 후보다.
+
+W5 정본도 다시 대사했다. `oracle_stage5_queue_projection.json`은 `stage=W5-5C`,
+`actionableRanks=[]`이며 SHA-256은
+`7765e060982c672cac8fbd0700f73e21d7488ae2fb25144c8046a4e678e0002d`다. rank 8 acceptance ladder의
+SHA-256은 `d6e8a4371dd049a899a88fb975d6499ed435154b72e1fc804b701addf3cb75ec`다. 기존 17개 disposition과
+rank 1·7·8의 `complete-acceptance-ladder` 판정은 다시 쓰지 않았다.
+
+## 4. GitHub 원문 재검증
+
+Stage R2 뒤 각 issue와 comment를 REST API로 다시 읽었다. 아래 SHA-256은 게시된 body의 UTF-8 byte
+기준이며 Stage R2 기록과 전부 일치한다.
+
+| 이슈 | 상태 | body SHA-256 |
+| --- | --- | --- |
+| [#4960](https://github.com/edwardkim/rhwp/issues/4960) | OPEN | `bf7bd30fb65fa7e432f22701e8c586ad4a0171723dbe8dd94bbeb323c5ce8a31` |
+| [#5955](https://github.com/edwardkim/rhwp/issues/5955) | OPEN | `8defc77b2b84faed3c8dfbebcebc3de957163905e5a52fac5846446f0d54ba8c` |
+| [#4967](https://github.com/edwardkim/rhwp/issues/4967) | OPEN | `f7fdfc575a28ca99136d7538f7268308e208d3242515cb9614313725e0c4e2d4` |
+| [#4968](https://github.com/edwardkim/rhwp/issues/4968) | OPEN | `c7771d31a3c52222c45b10862a3590b1c8b6b93b1cab1554525c221f4e3d0466` |
+| [#4969](https://github.com/edwardkim/rhwp/issues/4969) | OPEN | `1cbe21c09ac1c63336603cf662db42f1de40adec93beffe837af7211e11711b1` |
+
+| 이슈 | comment | body SHA-256 |
+| --- | --- | --- |
+| #4960 | [방향 수정 기록](https://github.com/edwardkim/rhwp/issues/4960#issuecomment-5386984278) | `f639dbba07934f91af359be618664982f4b71d78594cef06ead1b50720cc5b75` |
+| #5955 | [W7.5 등록 근거](https://github.com/edwardkim/rhwp/issues/5955#issuecomment-5386984365) | `71480f7c282e5ef2f14ea76470c3d2f86512be69de051384d061c32290938ae6` |
+| #4967 | [W8 gate 수정 기록](https://github.com/edwardkim/rhwp/issues/4967#issuecomment-5386984436) | `6b98c16ccaa5c17440917d6a963ca3f98696ac66ee125ca39f4910f4bd4cfa42` |
+| #4968 | [W9 gate 수정 기록](https://github.com/edwardkim/rhwp/issues/4968#issuecomment-5386984522) | `3f36494366a1d5ec296f19d01f109adb699e52cc6db7abc0467f1a9581b7edad` |
+| #4969 | [W10 gate 수정 기록](https://github.com/edwardkim/rhwp/issues/4969#issuecomment-5386984632) | `b2f600f39a99d6cdb286d57fa1fa1d973e05fdaf178cd12c58d0a4816f697655` |
+
+본문과 comment에 선두 BOM, `??` 치환, literal `\\n`, private corpus identity·host path와 font bytes는
+없다.
+
+## 5. 검증 결과
+
+| 검사 | 결과 |
+| --- | --- |
+| 변경 Markdown 상대 링크 | 통과 |
+| `git diff --check` | 통과 |
+| 변경 범위 | `mydocs/**`만 존재 |
+| generated integration manifest | 검토 worktree에서 893 sources·4165 static test attrs·32 suites+9 exceptions 확인 |
+| `cargo fmt --all`·`cargo fmt --all -- --check` | 검토 worktree의 `ce374f29a`에서 통과 |
+| 문서 metadata 전수 검사 | 이번 변경 밖 4개 문서의 기존 오류 16건만 재현 |
+| product build·test·visual sweep | 문서 전용 변경이므로 비대상 |
+
+기존 metadata 오류는 `mydocs/tech/benchmark_vs_alternatives.md`,
+`mydocs/tech/investigations/issue-4964/README.md`, `mydocs/tech/investigations/issue-5511/README.md`와
+`mydocs/tech/investigations/issue-5511/task_m100_5511_cli_surface_inventory.md`의 필수 front matter
+누락이다. 이번 diff에서 만들거나 수정한 오류가 아니므로 범위를 확장해 고치지 않았다.
+
+## 6. PR 제출 초안
+
+- 제목: `docs(font): #4960 W7 이후 로드맵을 재정렬한다`
+- base: `devel`
+- head: `task_m100_4960_direction_revision`
+- 관련 이슈: `Refs #4960`
+- 성능 영향: 문서·tracker 정정만 포함하므로 제품 성능 영향 없음
+
+본문 핵심은 다음과 같다.
+
+```markdown
+## 변경 요약
+
+- W7 schema 1.0과 실제 face 교정 사이에 W7.5 registry lifecycle gate를 추가했습니다.
+- W8을 evidence 재개·qualification·제품 교정 lane으로 분리했습니다.
+- W9·W10을 장기 W8 전체가 아니라 대상 cohort·face 동결 조건에 연결했습니다.
+- GitHub sub-issue 순서와 본문을 같은 실행 graph로 현행화하고 검증 해시를 기록했습니다.
+
+## 관련 이슈
+
+Refs #4960
+
+## 테스트
+
+- [x] 변경 Markdown 링크 검사
+- [x] `git diff --check`
+- [x] 변경 범위가 `mydocs/**`뿐임을 확인
+- [x] `cargo fmt --all -- --check` — generated suite를 준비한 검토 worktree에서 통과
+- [x] GitHub issue·comment body 해시와 sub-issue 순서 재검증
+- [ ] Cargo test·clippy·WASM·시각 검증 — 문서 전용 변경이므로 비대상
+
+## 성능 영향 및 측정 결과
+
+- 예상 영향: 없음
+- 재현·측정: 제품 source와 runtime artifact 변경 0건
+
+## 스크린샷
+
+해당 없음
+```
+
+remote branch push와 `gh pr create`는 각각 별도 메인테이너 승인 뒤 수행한다.
+
+## 7. 보호 불변식과 다음 게이트
+
+- #4960은 닫지 않는다.
+- #5955 수행계획·schema 구현을 시작하지 않는다.
+- #4967 rank 8 qualification이나 제품 변경을 시작하지 않는다.
+- #4968·#4969를 시작하지 않는다.
+- remote push와 PR 생성은 자동 수행하지 않는다.
+
+Stage R3 결과 승인 뒤 이 보고서와 계획 상태를 별도 commit으로 고정한다. 그 다음 최신
+`upstream/devel`을 다시 fetch해 exact base를 확인하고, remote push 승인과 PR 생성 승인을 차례로 받는다.


### PR DESCRIPTION
## 변경 요약

- W7 schema 1.0과 실제 face 교정 사이에 W7.5 registry lifecycle gate를 추가했습니다.
- W8을 evidence 재개·correction qualification·제품 교정 lane으로 분리했습니다.
- W9·W10을 장기 W8 tracker 전체가 아니라 대상 cohort·face 동결 조건에 연결했습니다.
- GitHub sub-issue 순서와 본문을 같은 실행 graph로 현행화하고 검증 해시를 기록했습니다.
- 제품 source·registry·metric·fixture·asset은 변경하지 않았습니다.

## 관련 이슈

Refs #4960

후속 이슈: #5955, #4967, #4968, #4969

상위 #4960은 W7.5~W10을 계속 추적해야 하므로 이 PR로 자동 종료하지 않습니다.

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** — generated integration suite를 준비한 검토 worktree에서 실행
- [x] 새 integration test source·generated suite·manifest·Cargo target 변경 없음
- [x] `src/**`의 `#[cfg(test)]` 변경 없음
- [x] 변경 Markdown 7개 상대 링크 검사 통과
- [x] `git diff --check upstream/devel...HEAD` 통과
- [x] 변경 범위가 `mydocs/**`뿐임을 확인
- [x] GitHub issue·comment body SHA-256과 sub-issue 순서 재검증
- [ ] `cargo test`, clippy, WASM, 시각 검증 — 문서·tracker 정정만 포함하므로 비대상

문서 metadata 전수 검사는 이번 diff 밖의 기존 4개 문서에서 누락 16건을 재현했으며, 이번 변경
문서에서는 새 오류가 확인되지 않았습니다.

## 성능 영향 및 측정 결과

- 예상 영향: 없음
- 재현·측정: 제품 source와 runtime artifact 변경 0건

## 스크린샷

해당 없음
