### PR TITLE
fix(serializer): HWPX 저장 lineseg 의 textpos 를 HWPX 슬롯 축으로 내린다 (#5943)

### DIFF
--- a/src/serializer/hwpx/context.rs
+++ b/src/serializer/hwpx/context.rs
@@ -131,6 +131,18 @@ pub struct SerializeContext {
     /// 방출했으므로 중복 방지를 위해 건너뛴다. `write_section` 이 첫 문단 렌더 직전
     /// true 로 설정하고, 첫 본문 ColumnDef 방출 시 `render_control_slot` 이 소거한다.
     pub body_coldef_template_pending: bool,
+    /// [#5943] 저장 lineseg 의 `textpos` 가 이미 HWPX 슬롯 축인지 여부.
+    ///
+    /// `LineSeg::text_start` 는 파서가 파일 값을 그대로 담으므로 **출처마다 축이 다르다**
+    /// — HWP5·HWP3·HML 출처는 확장 제어 하나당 8유닛을 주는 HWP5 축이고, HWPX 출처는
+    /// `hp:secPr`·`hp:colPr` 을 세지 않는 HWPX 축이다. 이 값이 참이면 재기준화하지
+    /// 않는다(이중으로 빼면 aift.hwpx 왕복이 `textpos 24 → 8` 로 깨진다).
+    /// 판정은 "이 lineseg 가 HWPX 컨테이너에서 나왔는가" — 출처 포맷이 HWPX 이거나
+    /// rhwp HWPX→HWP5 변환본(`hwpx_lineage`)이다. `hwpx_stored_layout()` 은 쓸 수 없다.
+    /// 그쪽은 rhwp 가 HWP5 에서 낸 HWPX(`META-INF/rhwp-hwp5-origin`)를 제외하는데, 그
+    /// 파일의 `textpos` 는 이 수정 이후 **HWPX 축**이라 다시 내리면 재수출 고정점이
+    /// 깨진다(02502 재수출: 32 → 16 실측).
+    pub line_segs_on_hwpx_axis: bool,
     /// 이번 HWPX 산출물에서 발생한 사용자 내용 손실 (#4430).
     ///
     /// ID 풀과 마찬가지로 한 번의 직렬화 생명주기에만 속하며, 완료 시 바이트와 함께
@@ -142,6 +154,7 @@ impl Default for SerializeContext {
     fn default() -> Self {
         Self {
             char_shape_ids: IdPool::default(),
+            line_segs_on_hwpx_axis: false,
             para_shape_ids: IdPool::default(),
             border_fill_ids: IdPool::default(),
             tab_pr_ids: IdPool::default(),
@@ -173,6 +186,9 @@ impl SerializeContext {
     /// 각 writer가 추가되면서 `reference()` 호출과 스캔 범위가 확장된다.
     pub fn collect_from_document(doc: &Document) -> Self {
         let mut ctx = Self::default();
+        ctx.line_segs_on_hwpx_axis = doc.provenance.format
+            == crate::model::provenance::SourceFormat::Hwpx
+            || doc.provenance.hwpx_lineage;
 
         // CharShape, ParaShape, BorderFill, TabDef, Numbering, Style, Font
         // 목록은 배열 인덱스가 곧 HWPX `id` 속성이 된다.

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -1097,6 +1097,20 @@ fn axis_comparable_line_segs(
     crate::serializer::body_text::line_segs_within_text_axis(&para.line_segs, axis_end)
 }
 
+/// [#5943] 이 문단에서 HWPX 슬롯 축 재기준화로 설명 가능한 `textpos` 이동 상한.
+///
+/// `hp:secPr`·`hp:colPr` 은 HWPX 문단 슬롯 축을 차지하지 않으므로 슬롯당 8유닛씩만
+/// 내려갈 수 있다. 그 문단이 실제로 들고 있는 개수로 상한을 잡으므로, secd·cold 가
+/// 없는 평범한 문단은 0 — 허용치가 전혀 생기지 않는다.
+fn axis_rebase_cap(pa: &crate::model::paragraph::Paragraph) -> u32 {
+    use crate::model::control::Control;
+    8 * pa
+        .controls
+        .iter()
+        .filter(|c| matches!(c, Control::SectionDef(_) | Control::ColumnDef(_)))
+        .count() as u32
+}
+
 /// 문단 1쌍의 lineseg 비교 + 컨트롤 내부 문단 재귀 (`diff_paragraph_char_shapes` 와
 /// 동일 경로 순회).
 fn diff_paragraph_linesegs(
@@ -1153,9 +1167,24 @@ fn diff_paragraph_linesegs_with_axis(
             },
         });
     }
+    // [#5943] HWP5 축 ↔ HWPX 축 교차 비교의 `textpos` 허용치.
+    //
+    // `hp:secPr`·`hp:colPr` 은 HWPX 문단 슬롯 축을 차지하지 않으므로, HWP5 출처를 HWPX 로
+    // 내면 저장 lineseg 의 `textpos` 가 그만큼 내려간다(그렇게 내지 않으면 한글 2024 가
+    // 본문을 폐기한다 — #5943). 그 산출을 다시 읽어 원본 IR 과 대면 비교하는 `--verify`
+    // 에서는 두 축이 정당하게 다르므로, **그 문단에 실제로 있는 secd·cold 슬롯으로
+    // 설명되는 만큼만** 봐준다. 위양성을 없애되 임의의 어긋남은 그대로 잡는다.
+    let axis_rebase_cap = axis_rebase_cap(pa);
     for (idx, (sa, sb)) in la.iter().zip(lb.iter()).enumerate() {
+        // 줄 하나가 내려간 폭이 8의 배수이고 상한 안이면 재기준화로 설명된다.
+        let shift = sa.text_start.checked_sub(sb.text_start).unwrap_or(u32::MAX);
+        let text_start_a = if shift > 0 && shift % 8 == 0 && shift <= axis_rebase_cap {
+            sb.text_start
+        } else {
+            sa.text_start
+        };
         let fields: [(&'static str, i64, i64); 9] = [
-            ("textpos", sa.text_start as i64, sb.text_start as i64),
+            ("textpos", text_start_a as i64, sb.text_start as i64),
             ("vertpos", sa.vertical_pos as i64, sb.vertical_pos as i64),
             ("vertsize", sa.line_height as i64, sb.line_height as i64),
             ("textheight", sa.text_height as i64, sb.text_height as i64),

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -744,7 +744,8 @@ pub(crate) fn render_paragraph_parts(
     vert_start: u32,
     ctx: &mut SerializeContext,
 ) -> (String, String, u32) {
-    let (runs_xml, position_axis_intact, serialized_axis_end) = render_runs(para, ctx);
+    let (runs_xml, position_axis_intact, serialized_axis_end, mut hwp5_only_slot_positions) =
+        render_runs(para, ctx);
 
     // [#4778] 위치 축이 무너진 문단(파서가 담지 못한 8유닛 슬롯 — 예: 차례표지
     // 0x0008 — 이 있거나 mismatch 폴백으로 컨트롤을 말미에 몰아쓴 문단)에는 저장
@@ -769,15 +770,54 @@ pub(crate) fn render_paragraph_parts(
     // 직렬화기는 그 Field 슬롯과 안내문을 다시 방출한다. 이때 IR `char_count`만
     // 상한으로 쓰면 필드 뒤의 정상 lineseg까지 잘려 셀 세로 정렬이 달라진다
     // (issue1893의 `textpos=25`). 실제 방출한 축 끝도 함께 써야 한다.
-    let line_seg_axis_end = para.char_count.max(serialized_axis_end);
+    //
+    // [#5943] 그 상한을 쓰기 전에 **축을 HWPX 쪽으로 내린다**. HWP5 문단 축은 구역 정의와
+    // 템플릿 흡수 단 정의에도 8유닛씩을 주지만 HWPX 문단에는 그 자리가 없다(`hp:secPr` 은
+    // 구역 머리 run 소속). 그래서 구역 첫 문단에서 두 축이 16유닛 어긋나고, 원본 그대로 실은
+    // `textpos` 가 한글이 세는 자리보다 뒤를 가리킨다. 한글 2024 는 그 문단부터 본문을
+    // 폐기한다(02502.h2x: 9쪽 6,040자 → 1쪽 423자. `textpos` 를 48→40 으로 내리면 여전히
+    // 실패, **32 로 내리면 완전 복원** — 축이 16 짧다는 직접 증거다). 2022 는 관대했다.
+    // `char_count` 도 HWP5 축이므로 상한에서 같은 폭을 뺀다.
+    //
+    // 단 **HWPX 출처는 손대지 않는다**. `LineSeg::text_start` 는 파서가 파일 값을 그대로
+    // 담으므로 출처마다 축이 다르다 — HWPX 원본의 `textpos` 는 이미 HWPX 축이라 한 번 더
+    // 빼면 왕복이 깨진다(aift.hwpx 문단 0: `textpos 24 → 8`).
+    let hwp5_only_units = if ctx.line_segs_on_hwpx_axis {
+        hwp5_only_slot_positions.clear();
+        0
+    } else {
+        8 * hwp5_only_slot_positions.len() as u32
+    };
+    let rebased_line_segs: Option<Vec<LineSeg>> =
+        (!hwp5_only_slot_positions.is_empty() && !para.line_segs.is_empty()).then(|| {
+            para.line_segs
+                .iter()
+                .map(|seg| {
+                    let shift = 8 * hwp5_only_slot_positions
+                        .iter()
+                        .filter(|&&pos| pos < seg.text_start)
+                        .count() as u32;
+                    LineSeg {
+                        text_start: seg.text_start.saturating_sub(shift),
+                        ..seg.clone()
+                    }
+                })
+                .collect()
+        });
+    let source_line_segs = rebased_line_segs.as_deref().unwrap_or(&para.line_segs);
+
+    let line_seg_axis_end = para
+        .char_count
+        .max(serialized_axis_end)
+        .saturating_sub(hwp5_only_units);
     let axis_line_segs = if para.stored_text_partition_is_dirty() {
         // The retained rows are an edit-reflow template, not a partition of
         // the current text. Omit the cache and let the consumer recompute it.
-        &para.line_segs[..0]
+        &source_line_segs[..0]
     } else if line_seg_axis_end > 0 {
-        line_segs_within_text_axis(&para.line_segs, line_seg_axis_end)
+        line_segs_within_text_axis(source_line_segs, line_seg_axis_end)
     } else {
-        &para.line_segs[..]
+        source_line_segs
     };
 
     // [#5847] 줄 전체가 reflow 합성(bit31)인 문단 — 원본에 linesegarray 가 없어
@@ -1263,15 +1303,38 @@ fn split_text_into(splitter: &mut RunSplitter, para: &Paragraph, cursor: &mut In
     flush_trailing_title_marks(&mut splitter.content, &para.tab_extended, cursor);
 }
 
+/// [#5943] 슬롯을 방출하되 **XML 을 한 글자도 내지 않았으면** 그 위치를 기록한다.
+///
+/// HWP5 문단 축에서 확장 제어는 예외 없이 8유닛을 차지하지만, HWPX 에는 대응 요소가
+/// 문단 안에 없는 컨트롤이 있다 — 구역 정의(`hp:secPr` 은 문단이 아니라 구역 머리 run 이
+/// 싣는다)와 첫 문단이 템플릿에 흡수시킨 첫 단 정의가 그것이다. 이 슬롯들은 위치 계산을
+/// 위해 축을 8씩 전진시키지만 방출 XML 은 비어 있으므로, **한글이 세는 HWPX 축은 그만큼
+/// 짧다**. 어느 컨트롤이 비는지는 arm 유무와 consume-once 상태에 함께 걸려 있어 종류로
+/// 판정하면 틀리므로, 실제 방출 길이 변화로 본다.
+fn render_control_slot_tracked(
+    out: &mut String,
+    control: &Control,
+    ctx: &mut SerializeContext,
+    hwp5_pos: u32,
+    hwp5_only_slot_positions: &mut Vec<u32>,
+) {
+    let before = out.len();
+    render_control_slot(out, control, ctx);
+    if out.len() == before {
+        hwp5_only_slot_positions.push(hwp5_pos);
+    }
+}
+
 /// Paragraph 본문을 완전한 `<hp:run>` 시퀀스로 직렬화한다 (#1378 다중 run 분할).
 ///
-/// 반환: (run 시퀀스 XML, **위치 축 보존 여부**, 실제 방출한 UTF-16 축 끝).
+/// 반환: (run 시퀀스 XML, **위치 축 보존 여부**, 실제 방출한 UTF-16 축 끝,
+/// [#5943] HWP5 축에서만 자리를 차지한 슬롯들의 위치).
 ///
 /// [#4778] 두 번째 값이 `false` 면 방출된 텍스트 스트림이 원본 8유닛 슬롯 축과
 /// 어긋난 상태다(파서 미수용 슬롯 또는 mismatch 폴백). 호출부는 이때 저장
 /// lineseg 방출을 억제해야 한다 — textpos 사다리와 어긋난 lineseg 는 한글이
 /// 그 문단부터 본문을 통째 폐기하는 트리거다.
-fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool, u32) {
+fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool, u32, Vec<u32>) {
     // ID 참조 무결성 (구현계획서 1.5): 실제 char_shapes entry 만 reference.
     // 빈 IR 의 fallback 0 은 제외 — char_shapes 미등록 문서(`Document::default()`)의
     // 직렬화를 깨지 않도록.
@@ -1292,7 +1355,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool, u
         && para.title_marks.is_empty()
     {
         // 방출할 것이 없는 문단 — 옮길 슬롯도 없으므로 위치 축은 그대로다.
-        return (String::new(), true, 0);
+        return (String::new(), true, 0, Vec::new());
     }
 
     let mut splitter = RunSplitter::new(para);
@@ -1434,6 +1497,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool, u
             splitter.finish(),
             slot_count == 0 || marker_count >= slot_count,
             0,
+            Vec::new(),
         );
     }
 
@@ -1478,6 +1542,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool, u
             splitter.finish(),
             marker_count >= shortfall || text_unshifted_and_in_range,
             0,
+            Vec::new(),
         );
     }
 
@@ -1490,6 +1555,9 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool, u
     let mut text_buf = String::new();
     let mut slot_idx = 0usize;
     let mut expected_utf16_pos = 0u32;
+    // [#5943] XML 을 한 글자도 내지 않은 슬롯의 **HWP5 축** 위치. 저장 lineseg 의
+    // `textpos` 를 HWPX 축으로 내릴 때 쓴다 — 아래 `render_control_slot_tracked` 주석.
+    let mut hwp5_only_slot_positions: Vec<u32> = Vec::new();
     let mut field_end_emitted = vec![false; para.field_ranges.len()];
     // [Task #1556] 고아 fieldEnd 방출 추적.
     let mut orphan_emitted = vec![false; para.orphan_field_ends.len()];
@@ -1502,7 +1570,13 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool, u
     if para.text.is_empty() {
         while slot_idx < slots.len() {
             splitter.cut_before(expected_utf16_pos);
-            render_control_slot(&mut splitter.content, slots[slot_idx], ctx);
+            render_control_slot_tracked(
+                &mut splitter.content,
+                slots[slot_idx],
+                ctx,
+                expected_utf16_pos,
+                &mut hwp5_only_slot_positions,
+            );
             let emitted_ctrl_idx = slot_ctrl_indices[slot_idx];
             slot_idx += 1;
             expected_utf16_pos = expected_utf16_pos.saturating_add(8);
@@ -1601,7 +1675,13 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool, u
             );
             // 슬롯 시작 위치의 경계 — 슬롯은 새 run 소속 (규칙 1)
             splitter.cut_before(expected_utf16_pos);
-            render_control_slot(&mut splitter.content, slots[slot_idx], ctx);
+            render_control_slot_tracked(
+                &mut splitter.content,
+                slots[slot_idx],
+                ctx,
+                expected_utf16_pos,
+                &mut hwp5_only_slot_positions,
+            );
             let emitted_ctrl_idx = slot_ctrl_indices[slot_idx];
             slot_idx += 1;
             expected_utf16_pos = expected_utf16_pos.saturating_add(8);
@@ -1659,7 +1739,13 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool, u
                 &mut cursor,
             );
             splitter.cut_before(expected_utf16_pos);
-            render_control_slot(&mut splitter.content, slots[slot_idx], ctx);
+            render_control_slot_tracked(
+                &mut splitter.content,
+                slots[slot_idx],
+                ctx,
+                expected_utf16_pos,
+                &mut hwp5_only_slot_positions,
+            );
             slot_idx += 1;
             expected_utf16_pos = expected_utf16_pos.saturating_add(8);
             continue;
@@ -1713,7 +1799,13 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool, u
                 &mut cursor,
             );
             splitter.cut_before(expected_utf16_pos);
-            render_control_slot(&mut splitter.content, slots[slot_idx], ctx);
+            render_control_slot_tracked(
+                &mut splitter.content,
+                slots[slot_idx],
+                ctx,
+                expected_utf16_pos,
+                &mut hwp5_only_slot_positions,
+            );
             slot_idx += 1;
             expected_utf16_pos = expected_utf16_pos.saturating_add(8);
             continue;
@@ -1810,7 +1902,13 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool, u
 
     while slot_idx < slots.len() {
         splitter.cut_before(expected_utf16_pos);
-        render_control_slot(&mut splitter.content, slots[slot_idx], ctx);
+        render_control_slot_tracked(
+            &mut splitter.content,
+            slots[slot_idx],
+            ctx,
+            expected_utf16_pos,
+            &mut hwp5_only_slot_positions,
+        );
         let emitted_ctrl_idx = slot_ctrl_indices[slot_idx];
         slot_idx += 1;
         expected_utf16_pos = expected_utf16_pos.saturating_add(8);
@@ -1844,7 +1942,12 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool, u
             field_end_emitted[i] = true;
         }
     }
-    (splitter.finish(), axis_faithful, expected_utf16_pos)
+    (
+        splitter.finish(),
+        axis_faithful,
+        expected_utf16_pos,
+        hwp5_only_slot_positions,
+    )
 }
 
 fn inferred_control_slot_count(para: &Paragraph) -> usize {

--- a/tests/cases/issue_5943_hwpx_lineseg_axis_rebase.rs
+++ b/tests/cases/issue_5943_hwpx_lineseg_axis_rebase.rs
@@ -93,15 +93,14 @@ fn section_first_paragraph_document() -> Document {
         char_count: 57,
         ..Default::default()
     };
-    para.controls
-        .push(Control::SectionDef(Box::new(secdef())));
-    para.controls
-        .push(Control::ColumnDef(ColumnDef::default()));
+    para.controls.push(Control::SectionDef(Box::new(secdef())));
+    para.controls.push(Control::ColumnDef(ColumnDef::default()));
     for _ in 0..4 {
         para.controls
             .push(Control::PageNumberPos(PageNumberPos::default()));
     }
-    para.controls.push(Control::Table(Box::new(one_cell_table())));
+    para.controls
+        .push(Control::Table(Box::new(one_cell_table())));
     para.line_segs = vec![line_seg(0), line_seg(48)];
 
     let mut section = Section {

--- a/tests/cases/issue_5943_hwpx_lineseg_axis_rebase.rs
+++ b/tests/cases/issue_5943_hwpx_lineseg_axis_rebase.rs
@@ -1,0 +1,225 @@
+//! [Issue #5943] HWPX 저장 lineseg 의 `textpos` 가 HWP5 축 그대로 나간다.
+//!
+//! HWP5 문단 축에서 확장 제어는 예외 없이 8 UTF-16 유닛을 차지한다 — 구역 정의(`secd`)와
+//! 단 정의(`cold`)도 그렇다. 그런데 HWPX 문단에는 그 두 자리가 없다. `hp:secPr` 은
+//! 문단이 아니라 **구역 머리 run** 이 싣고, 구역 첫 문단의 첫 `hp:colPr` 은 그 템플릿에
+//! 흡수된다. 그래서 구역 첫 문단에서 두 축이 슬롯 개수 × 8 만큼 어긋난다.
+//!
+//! 저장 lineseg 의 `textpos` 를 HWP5 값 그대로 실으면 한글이 세는 자리보다 뒤를 가리키고,
+//! 한글 2024 는 그 문단부터 본문을 통째로 폐기한다. 코퍼스 02502 의 h2x 산출은
+//! **9쪽 6,040자 → 1쪽 423자**(`secd:2→1, tbl:16→2`)였다. 그 문단의 슬롯 사다리는
+//! `secd@0 · cold@8 · pgnp@16,24,32,40 · tbl@48` 이고 원본 lineseg 는 `[0, 48]` 이다.
+//!
+//! 축이 얼마나 짧은지는 오라클로 직접 쟀다 — `textpos` 를 48 그대로 두면 실패, 40 으로
+//! 내려도 실패, **32 로 내리면 원본과 완전히 같아진다**(9쪽 6,040자, 본문 텍스트 SHA-256
+//! 과 컨트롤 인구조사까지 일치). 즉 한글이 쓰는 HWPX 축에서 표는 32 — `secd`·`cold`
+//! 두 자리 16유닛만큼 짧다. 한글 2022 는 같은 파일을 관대하게 열었다.
+//!
+//! 계약: 방출 XML 을 한 글자도 내지 않은 슬롯은 HWPX 축을 차지하지 않으므로, 그 뒤의
+//! `textpos` 는 슬롯당 8 씩 내려서 낸다. **단 HWPX 출처는 예외다** — `LineSeg::text_start`
+//! 는 파서가 파일 값을 그대로 담으므로 출처마다 축이 다르고, HWPX 원본의 `textpos` 는
+//! 이미 HWPX 축이다. 한 번 더 빼면 왕복이 깨진다(`aift.hwpx` 문단 0: `textpos 24 → 8`,
+//! `task1391_aift_memo_roundtrips` 가 잡는다).
+
+use std::io::Read;
+
+use rhwp::model::control::{Control, PageNumberPos};
+use rhwp::model::document::{Document, Section, SectionDef};
+use rhwp::model::page::ColumnDef;
+use rhwp::model::page::PageDef;
+use rhwp::model::paragraph::{LineSeg, Paragraph};
+use rhwp::model::style::{CharShape, ParaShape};
+use rhwp::model::table::{Cell, Table};
+
+fn secdef() -> SectionDef {
+    SectionDef {
+        page_def: PageDef {
+            width: 59528,
+            height: 84188,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn text_para(text: &str) -> Paragraph {
+    Paragraph {
+        text: text.to_string(),
+        char_count: text.chars().count() as u32,
+        ..Default::default()
+    }
+}
+
+fn line_seg(text_start: u32) -> LineSeg {
+    LineSeg {
+        text_start,
+        vertical_pos: 320,
+        line_height: 20629,
+        text_height: 20629,
+        baseline_distance: 17535,
+        line_spacing: 600,
+        column_start: 0,
+        segment_width: 49108,
+        // bit17|bit18 — 줄의 첫/마지막 세그먼트. 구현 편의(bit31)가 아니어야
+        // `render_paragraph_parts` 가 원본 캐시로 보고 방출한다.
+        tag: 393216,
+    }
+}
+
+fn one_cell_table() -> Table {
+    Table {
+        col_count: 1,
+        row_count: 1,
+        cells: vec![Cell {
+            col: 0,
+            row: 0,
+            col_span: 1,
+            row_span: 1,
+            width: 20000,
+            paragraphs: vec![text_para("표 안 문단")],
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+/// 02502 문단 0 의 슬롯 사다리를 그대로 옮긴 최소 문서.
+///
+/// `secd@0 · cold@8 · pgnp@16,24,32,40 · tbl@48 · 문단부호@56` = `char_count` 57,
+/// 원본 lineseg `[0, 48]`.
+fn section_first_paragraph_document() -> Document {
+    let mut para = Paragraph {
+        text: String::new(),
+        char_count: 57,
+        ..Default::default()
+    };
+    para.controls
+        .push(Control::SectionDef(Box::new(secdef())));
+    para.controls
+        .push(Control::ColumnDef(ColumnDef::default()));
+    for _ in 0..4 {
+        para.controls
+            .push(Control::PageNumberPos(PageNumberPos::default()));
+    }
+    para.controls.push(Control::Table(Box::new(one_cell_table())));
+    para.line_segs = vec![line_seg(0), line_seg(48)];
+
+    let mut section = Section {
+        section_def: secdef(),
+        ..Default::default()
+    };
+    section.paragraphs.push(para);
+    section.paragraphs.push(text_para("둘째 문단"));
+
+    let mut doc = Document::default();
+    doc.doc_info.para_shapes = vec![ParaShape::default()];
+    doc.doc_info.char_shapes = vec![CharShape::default()];
+    doc.doc_properties.section_count = 1;
+    doc.sections.push(section);
+    doc
+}
+
+fn section_xml(doc: &Document) -> String {
+    let bytes = rhwp::serializer::hwpx::serialize_hwpx(doc).expect("serialize hwpx");
+    let mut zin = zip::ZipArchive::new(std::io::Cursor::new(bytes)).expect("zip 열기");
+    let mut out = String::new();
+    for i in 0..zin.len() {
+        let mut f = zin.by_index(i).expect("zip 항목");
+        let name = f.name().to_string();
+        if name.starts_with("Contents/section") && name.ends_with(".xml") {
+            let mut s = String::new();
+            f.read_to_string(&mut s).expect("section xml 읽기");
+            out.push_str(&s);
+        }
+    }
+    out
+}
+
+fn textpos_values(xml: &str) -> Vec<u32> {
+    let mut out = Vec::new();
+    for (idx, _) in xml.match_indices("<hp:lineseg ") {
+        let tail = &xml[idx..];
+        let Some(at) = tail.find("textpos=\"") else {
+            continue;
+        };
+        let rest = &tail[at + "textpos=\"".len()..];
+        let end = rest.find('"').expect("textpos 닫는 따옴표");
+        out.push(rest[..end].parse().expect("textpos 는 정수"));
+    }
+    out
+}
+
+/// 방출되지 않는 `secd`·`cold` 두 슬롯만큼 축을 내려야 한다 — 48 이 아니라 32.
+#[test]
+fn section_first_paragraph_line_seg_rebases_to_the_hwpx_axis() {
+    let xml = section_xml(&section_first_paragraph_document());
+    let positions = textpos_values(&xml);
+
+    assert!(
+        positions.contains(&32),
+        "구역 첫 문단 lineseg 가 HWPX 축으로 내려오지 않았다 (#5943 회귀). \
+         `secd`·`cold` 는 HWPX 문단 축을 차지하지 않으므로 표는 48 이 아니라 32 다. \
+         실측 textpos={positions:?}\n{xml}"
+    );
+    assert!(
+        !positions.contains(&48),
+        "HWP5 축 값 48 이 그대로 나갔다 — 한글 2024 가 이 문단부터 본문을 폐기한다. \
+         실측 textpos={positions:?}"
+    );
+}
+
+/// 첫 줄(0)은 그대로다 — 앞선 빈-방출 슬롯이 없으므로 내릴 것이 없다.
+#[test]
+fn the_first_line_keeps_position_zero() {
+    let xml = section_xml(&section_first_paragraph_document());
+    let positions = textpos_values(&xml);
+    assert!(
+        positions.first() == Some(&0),
+        "첫 줄의 textpos 가 0 이 아니다 — 재기준화가 앞선 슬롯 수를 잘못 셌다. \
+         실측 textpos={positions:?}"
+    );
+}
+
+/// 구역 정의가 없는 평범한 문단은 축을 건드리지 않는다.
+#[test]
+fn a_plain_paragraph_axis_is_untouched() {
+    let mut para = text_para("가나다라마바사아자차카타파하");
+    para.line_segs = vec![line_seg(0), line_seg(7)];
+
+    let mut section = Section {
+        section_def: secdef(),
+        ..Default::default()
+    };
+    // 구역 첫 문단이 secd/cold 를 흡수하므로, 시험 대상은 둘째 문단에 둔다.
+    section.paragraphs.push(text_para("구역 첫 문단"));
+    section.paragraphs.push(para);
+
+    let mut doc = Document::default();
+    doc.doc_info.para_shapes = vec![ParaShape::default()];
+    doc.doc_info.char_shapes = vec![CharShape::default()];
+    doc.doc_properties.section_count = 1;
+    doc.sections.push(section);
+
+    let positions = textpos_values(&section_xml(&doc));
+    assert!(
+        positions.contains(&7),
+        "빈-방출 슬롯이 없는 문단의 textpos 가 움직였다 — 재기준화가 과잉 적용됐다. \
+         실측 textpos={positions:?}"
+    );
+}
+
+/// HWPX 출처의 `textpos` 는 이미 HWPX 축이므로 건드리지 않는다.
+///
+/// 같은 IR 을 출처만 HWPX 로 바꿔 낸다 — 재기준화가 무조건 걸리면 48 이 32 로 내려가
+/// HWPX 왕복이 고정점을 잃는다.
+#[test]
+fn an_hwpx_source_keeps_its_own_axis() {
+    let mut doc = section_first_paragraph_document();
+    doc.provenance.format = rhwp::model::provenance::SourceFormat::Hwpx;
+
+    let positions = textpos_values(&section_xml(&doc));
+    assert!(
+        positions.contains(&48),
+        "HWPX 출처의 textpos 를 또 내렸다 — 이미 HWPX 축인 값이라 왕복이 깨진다.          실측 textpos={positions:?}"
+    );
+}


### PR DESCRIPTION
## 무엇을 고치나

HWP5 문단 축에서 확장 제어는 예외 없이 8 UTF-16 유닛을 차지한다 — 구역 정의(`secd`)와 단 정의(`cold`)도 그렇다. 그런데 HWPX 문단에는 그 두 자리가 없다. `hp:secPr` 은 문단이 아니라 **구역 머리 run** 이 싣고, 구역 첫 문단의 첫 `hp:colPr` 은 그 템플릿에 흡수된다. 그래서 구역 첫 문단에서 두 축이 슬롯 개수 × 8 만큼 어긋나는데, 저장 lineseg 의 `textpos` 는 HWP5 값 그대로 나갔다.

**한글 2024 는 그 문단부터 본문을 통째로 폐기한다.** 코퍼스 02502 의 h2x 산출은 9쪽 6,040자 → **1쪽 423자**(`secd:2→1, tbl:16→2`). 한글 2022 는 관대해 s37 까지 드러나지 않았고, s38(한글 2024 전수)에서 유일한 실물 결함으로 나왔다.

## 축이 얼마나 짧은지 — 오라클로 직접 쟀다

02502 문단 0 의 슬롯 사다리는 `secd@0 · cold@8 · pgnp@16,24,32,40 · tbl@48` 이고 원본 `LINE_SEG` 은 `[0, 48]` 이다(원본은 옳다). 산출의 `textpos` 만 바꿔 가며 한글 2024 로 열었다.

| `textpos` | 결과 |
|---|---|
| 48 (현행) | 1쪽 423자 |
| 40 | 실패 |
| **32** | **9쪽 6,040자 — 원본과 완전 일치** |

즉 한글이 쓰는 HWPX 축에서 표는 32 다. `secd`·`cold` 두 자리 16유닛만큼 짧다.

문단 단위 이분법이 원인 귀속의 결정타였다 — 문단 2~26 을 한컴 저장본 것으로 갈아도 실패하고, **문단 0 만** 갈면 성공했다. 그전에 기각한 가설이 다섯이다(`hp:pageNum` 중복 4→1 · `hc:img` 자식 순서 · `numberingType` NONE · 미정의 `borderFillIDRef="0"` 참조 · OLE contract 스트림). 눈에 띄는 이상값이 전부 무죄였다.

## 수정

**1. 축 재기준화** (`serializer/hwpx/section.rs`)

슬롯을 방출하되 XML 을 한 글자도 내지 않았으면 그 HWP5 축 위치를 모아 두고, lineseg 의 `textpos` 를 앞선 빈-방출 슬롯 수 × 8 만큼 내려서 낸다. 상한 `char_count.max(serialized_axis_end)` 도 HWP5 축이므로 같은 폭을 뺀다.

어느 컨트롤이 비는지는 **종류로 판정하면 틀린다** — 첫 `ColumnDef` 억제가 consume-once 상태에 걸려 있고, 템플릿은 `hp:colPr` 을 문단 머리 run 에 실제로 방출하는데도 한글은 그 자리를 축에서 세지 않는다. 그래서 실제 방출 길이 변화로 본다.

**2. 출처 축 판정** (`serializer/hwpx/context.rs`)

`LineSeg::text_start` 는 파서가 파일 값을 그대로 담으므로 **출처마다 축이 다르다**. HWPX 원본의 `textpos` 는 이미 HWPX 축이라 한 번 더 빼면 왕복이 깨진다(`aift.hwpx` 문단 0: `textpos 24 → 8`). 판정은 "이 lineseg 가 HWPX 컨테이너에서 나왔는가" — 출처 포맷이 HWPX 이거나 rhwp HWPX→HWP5 변환본(`hwpx_lineage`)이다.

`hwpx_stored_layout()` 은 쓸 수 없다. 그쪽은 rhwp 가 HWP5 에서 낸 HWPX(`META-INF/rhwp-hwp5-origin`)를 제외하는데, 그 파일의 `textpos` 는 이 수정 이후 HWPX 축이라 다시 내리면 재수출 고정점이 깨진다(02502 재수출 `32 → 16` 실측).

**3. `--verify` 교차 축 허용치** (`serializer/hwpx/roundtrip.rs`)

HWP5 출처를 HWPX 로 내면 두 축이 정당하게 달라지므로, 원본 IR ↔ 재파싱 IR 비교에서 **그 문단에 실제로 있는 `secd`·`cold` 슬롯으로 설명되는 만큼만** 봐준다(8의 배수 + 슬롯 수 × 8 이하). 그런 컨트롤이 없는 문단은 상한이 0 이라 허용치가 전혀 생기지 않는다.

## 검증 — 한글 2024 (HOffice130, ProductVersion 13.0.0.564, major 13)

기준선은 s37 의 h2x 산출물을 썼다. s37 baseline 과 이 브랜치 base 사이에 `src/serializer/hwpx/` 변경이 없음을 확인했고, 실제로 6,376건이 바이트 동일하게 나와 그 가정이 실측으로 확인됐다.

| 단계 | 결과 |
|---|---|
| 코퍼스 HWP5 6,582건 h2x 재변환 | 산출 변경 **164건** · 신규 변환 실패 **0**(실패 42건은 baseline 과 동일 집합) |
| 164건 diff 형태 전수 | 전부 `hp:lineseg/@textpos` 하나뿐 · 감소폭 8(23줄)·16(459줄) · zip 항목 변화 0 · 다른 XML 변화 0 |
| 164건 × (원본/수정전/수정후) **492회 개방** | 불변 163 · **복원 1(02502)** · **회귀 0** · 그 밖의 변화 0 |
| HWPX 출처 3,418건 x2x 재변환 | 진짜 HWPX 출처 산출 **변경 0** |
| 재수출 고정점 | h2x 산출을 다시 내보내 바이트 동일 |

복원된 02502 는 쪽수·글자수뿐 아니라 **본문 텍스트 SHA-256 과 컨트롤 인구조사(`cold:2,gso:7,pgnp:1,secd:2,tbl:16`)까지 원본과 일치**한다.

x2x 에서 유일하게 바뀐 1건은 확장자만 `.hwpx` 인 **실제 HWP5 파일**(매직 `d0cf11e0`, `rhwp info --json` → `format: hwp5`)이라 재기준화가 걸리는 게 옳다. 오라클에서 원본과 완전히 일치했다(2쪽 1,448자).

**바이트가 바뀐 164건 중 관측 가능한 동작이 바뀐 건 1건뿐**이다 — 한글은 과도한 `textpos` 대부분을 관대히 넘긴다. "바뀐 문서 수"로 위험을 재면 과대평가한다는 뜻이다.

## 시험

`tests/cases/issue_5943_hwpx_lineseg_axis_rebase.rs` 4건 — 02502 문단 0 의 슬롯 사다리를 옮긴 최소 문서로 `textpos 48 → 32` 를 단언하고, 첫 줄 0 유지 · 평범한 문단 무변화 · HWPX 출처 무변화를 함께 건다. 수정을 되돌리면 첫 시험이 `textpos=[0, 48]` 로 실패한다(음성 대조 확인).

## 남은 것 — 후속 이슈로 올린다

이번에 드러난 더 깊은 사실은 **`LineSeg::text_start` 의 축이 IR 안에서 통일돼 있지 않다**는 것이다(파서가 파일 값을 그대로 담는다). 정공법은 HWPX 파서가 읽을 때 HWP5 축으로 정규화하고 직렬화기가 되돌리는 것인데, 그러면 x2h 산출이 통째로 바뀌어 별도 전수가 필요하다. 이번 PR 은 직렬화 시점 보정으로 막고 그 정규화는 후속으로 분리한다.
