### PR TITLE
ci(5769): undo depth 측정 게이트를 frontend-package-gates 에 배선한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -924,6 +924,7 @@ jobs:
           python3 -m unittest scripts/tests/test_proptest_roundtrip_workflow.py
           python3 -m unittest scripts/tests/test_adapter_diff_workflow.py
           python3 -m unittest scripts/tests/test_llm_verifier_workflow.py
+          python3 -m unittest scripts/tests/test_undo_depth_e2e_workflow.py
           python3 -m unittest scripts/tests/test_workflow_contract_wiring.py
 
       - name: Validate gym scorer contracts
@@ -1243,6 +1244,35 @@ jobs:
 
       - name: Run Studio unit tests
         run: npm --prefix rhwp-studio run test
+
+      - name: Install headless Chrome
+        working-directory: rhwp-studio
+        run: |
+          chrome_path="$(command -v google-chrome-stable || command -v google-chrome || command -v chromium-browser || command -v chromium || true)"
+          if [ -z "$chrome_path" ]; then
+            chrome_install_output="$(./node_modules/.bin/browsers install chrome@stable --path "$HOME/.cache/puppeteer" --format '{{path}}' 2>&1)" || {
+              printf '%s\n' "$chrome_install_output" >&2
+              exit 1
+            }
+            chrome_path="$(printf '%s\n' "$chrome_install_output" | tail -n 1)"
+          fi
+          if [ ! -f "$chrome_path" ]; then
+            chrome_path="$(find "$HOME/.cache/puppeteer" -type f \( -name chrome -o -name chrome-headless-shell \) | sort | tail -n 1)"
+          fi
+          if [ -z "$chrome_path" ] || [ ! -f "$chrome_path" ]; then
+            echo "Chrome executable not found under $HOME/.cache/puppeteer" >&2
+            exit 1
+          fi
+          echo "CHROME_PATH=$chrome_path" >> "$GITHUB_ENV"
+          echo "PUPPETEER_EXECUTABLE_PATH=$chrome_path" >> "$GITHUB_ENV"
+
+      # [#5959] 스냅샷 예산 축출 회귀 게이트(#5769) — 실 wasm 과 실 브라우저를
+      # 구동해야 하므로 스텁 wasm 을 쓰는 unit 모드가 아닌 package 모드에서만 단다.
+      - name: Run undo depth measurement gate (#5769)
+        working-directory: rhwp-studio
+        env:
+          VITE_PORT: '7700'
+        run: npm run e2e:undo-depth
 
       - name: Build Studio
         run: npm --prefix rhwp-studio run build

--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -118,6 +118,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `typesetting.test.mjs` | 상시 | active | 조판 품질 검증 (문단부호 표시 상태) | — | 수동 |  |
 | `undo-contracts.test.mjs` | 상시 | active | 편집 undo 계약 실동작 검증 (Task #2301) | — | npm e2e:undo |  |
 | `undo-delete-fragment-bytes.test.mjs` | 상시 | active | [#5769] 다문단 선택 삭제 조각 undo 저장 바이트 왕복 동일성 (Delete 키 → Ctrl+Z → exportHwp 대조) | — | npm e2e:undo-delete-fragment-bytes |  |
+| `undo-depth-issue5769.test.mjs` | 상시 | active | [#5769] 혼합 세션(선택 삭제+재입력 R라운드) 실효 undo 깊이 무축출 계약 — 슬롯 합 0·조각 경로 전 라운드·스택 전량 복원·새 문서 상태 복귀. 회귀 시 예산 축출로 ③④가 깨진다 | — | npm e2e:undo-depth | E2E_DEPTH_ROUNDS 로 스모크 |
 | `undo-object-selection.test.mjs` | 상시 | active | E2E: undo/redo 후 개체/표 선택 stale ref 해제 (Task #2303) /  / 계약: undo/r | — | npm e2e:undo-object-selection |  |
 | `unsaved-changes-guard.test.mjs` | 상시 | active | #886 저장되지 않은 변경사항 보호 모달 | — | npm e2e:unsaved-guard |  |
 | `unsupported-format-error.test.mjs` | 상시 | active | 미지원 문서 오류 알림 후 정상 문서 재로드 | field-01.hwp | 수동 |  |

--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -96,8 +96,10 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `report-generator.mjs` | 유틸 | active | E2E 테스트 HTML 보고서 생성기 | — | 수동 |  |
 | `responsive.test.mjs` | 상시 | active | 반응형 레이아웃 검증 | — | 수동 |  |
 | `run-render-diff.mjs` | 유틸 | active | render-diff CI 러너 (canvas/pdf diff 오케스트레이션) | — | npm+CI |  |
+| `run-with-vite.mjs` | 유틸 | active | Vite dev server 기동 + 임의 명령 실행 공용 러너 (VITE_URL 주입, 종료 코드 전파) | — | npm e2e:undo-depth |  |
 | `save-as-format.test.mjs` | 상시 | active | 저장 출력 포맷 선택 (file:save-as-hwp / file:save-as-hwpx) E2E — #1613 | biz_plan.hwp, hwpx/footnote-01.hwpx | 수동 |  |
 | `scenario-runner.mjs` | 유틸 | active | 시나리오 실행기 + 렌더 트리 측정기 + 규칙 검증기 | — | 수동 |  |
+| `vite-server.mjs` | 유틸 | active | Vite dev server 기동·대기·종료 공용 헬퍼 — node 직접 기동(win32 .cmd EINVAL 우회), taskkill 트리 정리 | — | 수동 | `run-render-diff.mjs`·`run-with-vite.mjs`에서 import |
 | `shape-inline.test.mjs` | 상시 | active | 도형 인라인 컨트롤 — 커서 이동 및 텍스트 삽입 | — | 수동 |  |
 | `shift-end.test.mjs` | 상시 | active | shift-return.hwp Shift+End 블록 선택 | shift-return.hwp | 수동 |  |
 | `table-picture-resize-1282.test.mjs` | 상시 | active | E2E 테스트 (Issue #1282): 회전된 표 셀 내부 picture 리사이즈. | ta-pic-001-r-쪽영역안제한.hwp, ta-pic-001-r-쪽영역안제한 | 수동 |  |

--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -118,7 +118,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `typesetting.test.mjs` | 상시 | active | 조판 품질 검증 (문단부호 표시 상태) | — | 수동 |  |
 | `undo-contracts.test.mjs` | 상시 | active | 편집 undo 계약 실동작 검증 (Task #2301) | — | npm e2e:undo |  |
 | `undo-delete-fragment-bytes.test.mjs` | 상시 | active | [#5769] 다문단 선택 삭제 조각 undo 저장 바이트 왕복 동일성 (Delete 키 → Ctrl+Z → exportHwp 대조) | — | npm e2e:undo-delete-fragment-bytes |  |
-| `undo-depth-issue5769.test.mjs` | 상시 | active | [#5769] 혼합 세션(선택 삭제+재입력 R라운드) 실효 undo 깊이 무축출 계약 — 슬롯 합 0·조각 경로 전 라운드·스택 전량 복원·새 문서 상태 복귀. 회귀 시 예산 축출로 ③④가 깨진다 | — | npm e2e:undo-depth | E2E_DEPTH_ROUNDS 로 스모크 |
+| `undo-depth-issue5769.test.mjs` | 상시 | active | [#5769] 혼합 세션(선택 삭제+재입력 R라운드) 실효 undo 깊이 무축출 계약 — 슬롯 합 0·조각 경로 다수 라운드(≥⌈R/2⌉, 짧아진 문단은 refill 분기)·스택 전량 복원·새 문서 상태 복귀. 회귀 시 예산 축출로 ③④가 깨진다 | — | npm e2e:undo-depth | E2E_DEPTH_ROUNDS 로 스모크 |
 | `undo-object-selection.test.mjs` | 상시 | active | E2E: undo/redo 후 개체/표 선택 stale ref 해제 (Task #2303) /  / 계약: undo/r | — | npm e2e:undo-object-selection |  |
 | `unsaved-changes-guard.test.mjs` | 상시 | active | #886 저장되지 않은 변경사항 보호 모달 | — | npm e2e:unsaved-guard |  |
 | `unsupported-format-error.test.mjs` | 상시 | active | 미지원 문서 오류 알림 후 정상 문서 재로드 | field-01.hwp | 수동 |  |

--- a/rhwp-studio/e2e/run-render-diff.mjs
+++ b/rhwp-studio/e2e/run-render-diff.mjs
@@ -1,91 +1,11 @@
-import { spawn } from 'node:child_process';
-import fs from 'node:fs';
-import net from 'node:net';
-import path from 'node:path';
-import { setTimeout as delay } from 'node:timers/promises';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const studioRoot = path.resolve(__dirname, '..');
-const repoRoot = path.resolve(studioRoot, '..');
-const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-const preferredPort = Number(process.env.VITE_PORT || '7700');
-
-function spawnCommand(args, extraEnv = {}, stdio = 'inherit') {
-  return spawn(npmCmd, args, {
-    cwd: studioRoot,
-    stdio,
-    env: {
-      ...process.env,
-      ...extraEnv,
-    },
-  });
-}
-
-function waitForExit(child, signal) {
-  return new Promise((resolve) => {
-    child.once('exit', () => resolve());
-    child.kill(signal);
-  });
-}
-
-async function stopServer(child) {
-  if (child.exitCode !== null || child.signalCode) {
-    return;
-  }
-  await Promise.race([
-    waitForExit(child, 'SIGTERM'),
-    delay(5000).then(async () => {
-      if (child.exitCode === null && !child.signalCode) {
-        await waitForExit(child, 'SIGKILL');
-      }
-    }),
-  ]);
-}
-
-async function waitForServer(url, child, logPath, timeoutMs = 30000) {
-  const deadline = Date.now() + timeoutMs;
-  let lastError = null;
-
-  while (Date.now() < deadline) {
-    if (child.exitCode !== null || child.signalCode) {
-      const log = fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf8') : '';
-      throw new Error(`Vite dev server exited before ${url} became ready.\n${log}`);
-    }
-    try {
-      const response = await fetch(url);
-      if (response.ok) {
-        return;
-      }
-      lastError = new Error(`server responded with status ${response.status}`);
-    } catch (error) {
-      lastError = error;
-    }
-    await delay(500);
-  }
-
-  const log = fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf8') : '';
-  throw new Error(`${lastError?.message || `timed out waiting for ${url}`}\n${log}`);
-}
-
-async function findAvailablePort(startPort, attempts = 20) {
-  for (let port = startPort; port < startPort + attempts; port += 1) {
-    const available = await new Promise((resolve) => {
-      const server = net.createServer();
-      server.once('error', () => resolve(false));
-      server.listen(port, '127.0.0.1', () => {
-        server.close(() => resolve(true));
-      });
-    });
-    if (available) {
-      return port;
-    }
-  }
-  throw new Error(`failed to find an available port starting at ${startPort}`);
-}
+import {
+  spawnNpm,
+  startViteDevServer,
+  waitForServer,
+} from './vite-server.mjs';
 
 async function runNpmScript(script, serverUrl) {
-  const child = spawnCommand(['run', script], { VITE_URL: serverUrl });
+  const child = spawnNpm(['run', script], { VITE_URL: serverUrl });
   const exitCode = await new Promise((resolve, reject) => {
     child.once('error', reject);
     child.once('exit', (code, signal) => {
@@ -101,34 +21,24 @@ async function runNpmScript(script, serverUrl) {
   }
 }
 
-const serverPort = await findAvailablePort(preferredPort);
-const serverUrl = `http://127.0.0.1:${serverPort}`;
-const logPath = path.join(repoRoot, 'target', 'rhwp-studio-vite.log');
-fs.mkdirSync(path.dirname(logPath), { recursive: true });
-const logFile = fs.openSync(logPath, 'w');
-const devServer = spawnCommand(
-  ['run', 'dev', '--', '--host', '127.0.0.1', '--port', String(serverPort), '--strictPort'],
-  { BROWSER: 'none' },
-  ['ignore', logFile, logFile],
-);
+const server = await startViteDevServer();
 
 try {
-  await waitForServer(serverUrl, devServer, logPath);
+  await waitForServer(server.url, server.child, server.logPath);
   if (process.env.RHWP_RENDER_DIFF_SKIP_CANVAS !== '1') {
-    await runNpmScript('e2e:render-diff', serverUrl);
+    await runNpmScript('e2e:render-diff', server.url);
   }
   if (process.env.RHWP_RENDER_DIFF_PDF === '1') {
     if (process.env.RHWP_RENDER_DIFF_DIRECT_PDF_GATE === '1') {
-      await runNpmScript('e2e:pdf-render-diff', serverUrl);
+      await runNpmScript('e2e:pdf-render-diff', server.url);
     } else {
       try {
-        await runNpmScript('e2e:pdf-render-diff', serverUrl);
+        await runNpmScript('e2e:pdf-render-diff', server.url);
       } catch (error) {
         console.error(`PDF render diff report failed without gating CI: ${error.message || error}`);
       }
     }
   }
 } finally {
-  await stopServer(devServer);
-  fs.closeSync(logFile);
+  await server.stop();
 }

--- a/rhwp-studio/e2e/run-with-vite.mjs
+++ b/rhwp-studio/e2e/run-with-vite.mjs
@@ -1,0 +1,58 @@
+/**
+ * Vite dev server 를 띄운 뒤 그 위에서 인자로 받은 명령을 실행하는 공용 러너.
+ *
+ *   node e2e/run-with-vite.mjs -- <command...>
+ *   node e2e/run-with-vite.mjs --npm <script> [<script args...>]
+ *
+ * 서버는 VITE_PORT(기본 7700)부터 비어 있는 포트를 택해 127.0.0.1 에 바인딩하고
+ * readiness 를 기다린 뒤, VITE_URL 환경변수를 주입해 명령을 실행한다. 명령의
+ * 종료 코드를 그대로 전파하며 성공·실패와 무관하게 서버를 끝낸다. 이미 같은
+ * 포트로 떠 있는 dev server 가 있으면 다음 포트를 택하므로 로컬에서 겹치지 않는다.
+ */
+
+import {
+  spawnNpm,
+  spawnStudioCommand,
+  startViteDevServer,
+  waitForServer,
+} from './vite-server.mjs';
+
+const argv = process.argv.slice(2);
+let mode = 'raw';
+if (argv[0] === '--npm') {
+  mode = 'npm';
+  argv.shift();
+} else if (argv[0] === '--') {
+  argv.shift();
+}
+if (argv.length === 0) {
+  console.error('usage: node e2e/run-with-vite.mjs [--npm <script> | -- <command...>]');
+  process.exit(2);
+}
+
+let exitCode = 1;
+const server = await startViteDevServer();
+try {
+  await waitForServer(server.url, server.child, server.logPath);
+  const extraEnv = { VITE_URL: server.url };
+  const child = mode === 'npm'
+    ? spawnNpm(['run', ...argv], extraEnv)
+    : spawnStudioCommand(argv[0], argv.slice(1), extraEnv);
+  exitCode = await new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (signal) {
+        reject(new Error(`command terminated by signal ${signal}`));
+        return;
+      }
+      resolve(code ?? 1);
+    });
+  });
+} catch (error) {
+  console.error(error?.message || error);
+  exitCode = 1;
+} finally {
+  await server.stop();
+}
+
+process.exit(exitCode);

--- a/rhwp-studio/e2e/undo-depth-issue5769.test.mjs
+++ b/rhwp-studio/e2e/undo-depth-issue5769.test.mjs
@@ -5,10 +5,11 @@
  * 스칼라인 조작이 다시 스냅샷으로 기록되는 순간, 예산 98(SNAPSHOT_ID_BUDGET)을
  * 넘는 세션에서 오래된 엔트리가 축출된다 — 이 게이트는 그 축출을 잡는다.
  *
- *   교정 패턴 R라운드(선택 삭제 + 재입력, 매 라운드 엔트리 2개) →
+ *   교정 패턴 R라운드(선택 삭제 + 재입력) →
  *   ① 전체 스택 스냅샷 슬롯 합 === 0 (역연산 경로만 썼다는 증거)
- *   ② deleteSelection 엔트리 수 === R (전 라운드 조각 경로)
- *   ③ undoStack 길이 === 시딩(11) + 2R (축출 없음 — 회귀 시 예산 초과로 감소)
+ *   ② deleteSelection 엔트리 수 ≥ ⌈R/2⌉ (대다수 라운드가 조각 경로 — 문단이
+ *      짧아진 라운드는 refill 분기로 엔트리 1개라, 정확히 R 이 아니다)
+ *   ③ undoStack 길이 ≥ 시딩(11) + R (축출 없음 — 회귀 시 예산 초과로 감소)
  *   ④ 연속 Ctrl+Z 가 스택 전량을 소진 (최대 깊이 도달)
  *   ⑤ 전량 되돌림 뒤 문서는 새 문서 상태(빈 단일 문단)와 일치
  *
@@ -101,17 +102,20 @@ runTest('#5769 혼합 세션 실효 깊이 — 무축출 계약', async ({ page 
 
   const stats = await stackStats(page);
   assert(stats && stats.len > 0, `스택 조회 (${JSON.stringify(stats)})`);
-  assert.equal(stats.slots, 0,
+  // helpers 의 assert 는 함수 호출 계약이다 — assert.equal·assert.ok 메서드가 없다.
+  assert(stats.slots === 0,
     `전체 스택 스냅샷 슬롯 합은 0 이어야 한다(역연산만) — got ${stats.slots}`);
-  assert.equal(stats.deletes, ROUNDS,
-    `${ROUNDS}라운드 전부 조각 경로로 기록돼야 한다 — deleteSelection ${stats.deletes}`);
+  // 문단이 짧아진 라운드는 refill 분기(deleteSelection 없음)로 빠지므로 deletes 는
+  // R 보다 작다 — 정확 일치 대신 "대다수 라운드가 조각 경로"라는 하한으로 핀한다.
+  assert(stats.deletes >= Math.ceil(ROUNDS / 2),
+    `${ROUNDS}라운드 중 절반 이상이 조각 경로여야 한다 — deleteSelection ${stats.deletes}`);
 
   // ── 축출 판정: 남은 스택이 수행량을 모두 담고 있는가 ──────────────
   // refill 분기(엔트리 1)와 정상 라운드(엔트리 2)가 섞이므로 "최소치"로 판정한다:
   // 시딩 11 + 라운드당 1 이상은 반드시 기록됐어야 하고, 구버전(라운드당 ≥2슬롯)
   // 이라면 98 예산으로 시딩+라운드 대부분이 축출돼 len 이 이 하한 아래로 떨어진다.
   const minExpected = SEED_ENTRIES + ROUNDS;
-  assert.ok(stats.len >= minExpected,
+  assert(stats.len >= minExpected,
     `무축출 위반 — 스택 ${stats.len} < 최소 기대 ${minExpected} (예산 축출 의심)`);
 
   console.log('\n[2] Ctrl+Z 전량 소진...');
@@ -124,14 +128,14 @@ runTest('#5769 혼합 세션 실효 깊이 — 무축출 계약', async ({ page 
     if (d1 < d0) undos++;
     else break;
   }
-  assert.equal(undos, depthStart,
+  assert(undos === depthStart,
     `모든 엔트리가 되돌려져야 한다 — ${undos}/${depthStart}`);
 
   const endLens = await page.evaluate(() => {
     const w = window.__wasm;
     return Array.from({ length: w.getParagraphCount(0) }, (_, i) => w.getParagraphLength(0, i));
   });
-  assert.equal(JSON.stringify(endLens), '[0]',
+  assert(JSON.stringify(endLens) === '[0]',
     `전량 되돌림 뒤 새 문서 상태여야 한다 — got ${JSON.stringify(endLens)}`);
 
   console.log(`\n✓ 스택 ${depthStart} · 슬롯 0 · 연속 undo ${undos} — 무축출 계약 통과`);

--- a/rhwp-studio/e2e/undo-depth-issue5769.test.mjs
+++ b/rhwp-studio/e2e/undo-depth-issue5769.test.mjs
@@ -1,0 +1,138 @@
+/**
+ * E2E 테스트: 실사용 혼합 세션의 실효 undo 깊이 — 무축출 계약 (#5769)
+ *
+ * 역연산 전환(조각 삭제·deferRecord 붙여넣기)의 회귀 방어다. 되돌릴 것이
+ * 스칼라인 조작이 다시 스냅샷으로 기록되는 순간, 예산 98(SNAPSHOT_ID_BUDGET)을
+ * 넘는 세션에서 오래된 엔트리가 축출된다 — 이 게이트는 그 축출을 잡는다.
+ *
+ *   교정 패턴 R라운드(선택 삭제 + 재입력, 매 라운드 엔트리 2개) →
+ *   ① 전체 스택 스냅샷 슬롯 합 === 0 (역연산 경로만 썼다는 증거)
+ *   ② deleteSelection 엔트리 수 === R (전 라운드 조각 경로)
+ *   ③ undoStack 길이 === 시딩(11) + 2R (축출 없음 — 회귀 시 예산 초과로 감소)
+ *   ④ 연속 Ctrl+Z 가 스택 전량을 소진 (최대 깊이 도달)
+ *   ⑤ 전량 되돌림 뒤 문서는 새 문서 상태(빈 단일 문단)와 일치
+ *
+ * 라운드 기본 110 — 구버전 배선(조작당 1슬롯)이라면 98 예산으로 12개 이상
+ * 축출되어 ③④가 깨진다. E2E_DEPTH_ROUNDS 로 줄여 스모크할 수 있다.
+ */
+import {
+  runTest, setTestCase, createNewDocument, clickEditArea, typeText, assert,
+} from './helpers.mjs';
+
+const sleep = (page, ms) => page.evaluate(t => new Promise(r => setTimeout(r, t)), ms);
+
+const ROUNDS = Math.max(10, parseInt(process.env.E2E_DEPTH_ROUNDS || '110', 10));
+const SEED_ENTRIES = 11; // insertText 6 + splitParagraph 5
+
+async function dismissSkinOnboarding(page) {
+  await page.evaluate(() => {
+    const anyCard = document.querySelector('.skin-onboarding-card');
+    if (anyCard) anyCard.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    const ok = [...document.querySelectorAll('button.dialog-btn-primary')]
+      .find(x => x.offsetParent !== null);
+    if (ok) {
+      ok.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      ok.click();
+    }
+  });
+  await sleep(page, 600);
+}
+
+async function stackStats(page) {
+  return await page.evaluate(() => {
+    const s = window.__inputHandler?.history?.undoStack;
+    if (!s) return null;
+    let slots = 0;
+    let deletes = 0;
+    for (const c of s) {
+      slots += (typeof c.snapshotResourceCount === 'function' ? c.snapshotResourceCount() : 0);
+      if (c.type === 'deleteSelection') deletes += 1;
+    }
+    return { len: s.length, slots, deletes };
+  });
+}
+
+async function pressUndo(page) {
+  await page.keyboard.down('Control');
+  await page.keyboard.press('KeyZ');
+  await page.keyboard.up('Control');
+  await sleep(page, 90);
+}
+
+runTest('#5769 혼합 세션 실효 깊이 — 무축출 계약', async ({ page }) => {
+
+  setTestCase(`undo-depth: 교정 ${ROUNDS}라운드 후 전량 복원·슬롯 0`);
+  console.log(`\n[1] 6문단 시딩 + 교정 ${ROUNDS}라운드...`);
+  await createNewDocument(page);
+  await dismissSkinOnboarding(page);
+  await clickEditArea(page);
+
+  for (let p = 0; p < 6; p++) {
+    await typeText(page, `paragraph ${p} the quick brown fox jumps over the lazy dog`);
+    if (p < 5) await page.keyboard.press('Enter');
+  }
+
+  for (let i = 0; i < ROUNDS; i++) {
+    const para = i % 6;
+    // 재입력 패턴 — 같은 자리를 지우고 'fix' 로 대체해 문단 길이를 안정 유지한다.
+    const selLen = await page.evaluate(([pi]) => {
+      const ih = window.__inputHandler;
+      const w = window.__wasm;
+      const len = w.getParagraphLength(0, pi);
+      if (len < 6) return null;
+      const s = 1, e = Math.min(7, len - 1);
+      return ih.cursor.selectRange(
+        { sectionIndex: 0, paragraphIndex: pi, charOffset: s },
+        { sectionIndex: 0, paragraphIndex: pi, charOffset: e },
+        null,
+      ) ? 1 : null;
+    }, [para]);
+
+    if (selLen === null) {
+      // 문단이 짧아졌으면 채워 넣고 이번 라운드는 타이핑만 (엔트리 1개)
+      await typeText(page, 'refill ');
+    } else {
+      await page.keyboard.press('Delete');
+      await sleep(page, 40);
+      await typeText(page, 'fix');
+    }
+  }
+  await sleep(page, 200);
+
+  const stats = await stackStats(page);
+  assert(stats && stats.len > 0, `스택 조회 (${JSON.stringify(stats)})`);
+  assert.equal(stats.slots, 0,
+    `전체 스택 스냅샷 슬롯 합은 0 이어야 한다(역연산만) — got ${stats.slots}`);
+  assert.equal(stats.deletes, ROUNDS,
+    `${ROUNDS}라운드 전부 조각 경로로 기록돼야 한다 — deleteSelection ${stats.deletes}`);
+
+  // ── 축출 판정: 남은 스택이 수행량을 모두 담고 있는가 ──────────────
+  // refill 분기(엔트리 1)와 정상 라운드(엔트리 2)가 섞이므로 "최소치"로 판정한다:
+  // 시딩 11 + 라운드당 1 이상은 반드시 기록됐어야 하고, 구버전(라운드당 ≥2슬롯)
+  // 이라면 98 예산으로 시딩+라운드 대부분이 축출돼 len 이 이 하한 아래로 떨어진다.
+  const minExpected = SEED_ENTRIES + ROUNDS;
+  assert.ok(stats.len >= minExpected,
+    `무축출 위반 — 스택 ${stats.len} < 최소 기대 ${minExpected} (예산 축출 의심)`);
+
+  console.log('\n[2] Ctrl+Z 전량 소진...');
+  const depthStart = stats.len;
+  let undos = 0;
+  while (undos <= depthStart) {
+    const d0 = await page.evaluate(() => window.__inputHandler.history.undoStack.length);
+    await pressUndo(page);
+    const d1 = await page.evaluate(() => window.__inputHandler.history.undoStack.length);
+    if (d1 < d0) undos++;
+    else break;
+  }
+  assert.equal(undos, depthStart,
+    `모든 엔트리가 되돌려져야 한다 — ${undos}/${depthStart}`);
+
+  const endLens = await page.evaluate(() => {
+    const w = window.__wasm;
+    return Array.from({ length: w.getParagraphCount(0) }, (_, i) => w.getParagraphLength(0, i));
+  });
+  assert.equal(JSON.stringify(endLens), '[0]',
+    `전량 되돌림 뒤 새 문서 상태여야 한다 — got ${JSON.stringify(endLens)}`);
+
+  console.log(`\n✓ 스택 ${depthStart} · 슬롯 0 · 연속 undo ${undos} — 무축출 계약 통과`);
+}, { skipLoadApp: false });

--- a/rhwp-studio/e2e/vite-server.mjs
+++ b/rhwp-studio/e2e/vite-server.mjs
@@ -1,0 +1,158 @@
+/**
+ * Vite dev server 기동·대기·종료의 공용 헬퍼.
+ *
+ * run-render-diff.mjs 와 run-with-vite.mjs 가 같은 기동 계약(포트 탐색 →
+ * 127.0.0.1 바인딩 → readiness 폴링 → SIGTERM 뒤 5초 안에 SIGKILL)을 쓰도록
+ * run-render-diff.mjs 에서 추출했다. 로그는 target/rhwp-studio-vite*.log 에
+ * 남기고, 서버가 readiness 전에 죽으면 로그 내용을 함께 던진다.
+ */
+
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const studioRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(studioRoot, '..');
+const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+export function spawnNpm(args, extraEnv = {}, stdio = 'inherit') {
+  return spawn(npmCmd, args, {
+    cwd: studioRoot,
+    stdio,
+    // win32 의 npm 은 npm.cmd 다 — Node 20+ 부터 .cmd 직접 spawn 이 EINVAL 로
+    // 거절되므로 shell 경유로 띄운다(인자는 공백·메타문자 없는 고정값뿐이다).
+    shell: process.platform === 'win32',
+    env: {
+      ...process.env,
+      ...extraEnv,
+    },
+  });
+}
+
+export function spawnStudioCommand(command, args, extraEnv = {}, stdio = 'inherit') {
+  return spawn(command, args, {
+    cwd: studioRoot,
+    stdio,
+    env: {
+      ...process.env,
+      ...extraEnv,
+    },
+  });
+}
+
+export function viteLogPath(suffix = '') {
+  return path.join(repoRoot, 'target', `rhwp-studio-vite${suffix}.log`);
+}
+
+function waitForExit(child, signal) {
+  return new Promise((resolve) => {
+    child.once('exit', () => resolve());
+    child.kill(signal);
+  });
+}
+
+export async function stopServer(child) {
+  if (child.exitCode !== null || child.signalCode) {
+    return;
+  }
+  if (process.platform === 'win32' && child.pid) {
+    // shell 경유로 띄운 자식(cmd.exe 래퍼)은 SIGTERM 으로 트리가 정리되지 않는다.
+    await new Promise((resolve) => {
+      spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' })
+        .once('exit', resolve);
+    });
+    return;
+  }
+  await Promise.race([
+    waitForExit(child, 'SIGTERM'),
+    delay(5000).then(async () => {
+      if (child.exitCode === null && !child.signalCode) {
+        await waitForExit(child, 'SIGKILL');
+      }
+    }),
+  ]);
+}
+
+export async function waitForServer(url, child, logPath, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null || child.signalCode) {
+      const log = fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf8') : '';
+      throw new Error(`Vite dev server exited before ${url} became ready.\n${log}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+      lastError = new Error(`server responded with status ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(500);
+  }
+
+  const log = fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf8') : '';
+  throw new Error(`${lastError?.message || `timed out waiting for ${url}`}\n${log}`);
+}
+
+export async function findAvailablePort(startPort, attempts = 20) {
+  for (let port = startPort; port < startPort + attempts; port += 1) {
+    const available = await new Promise((resolve) => {
+      const server = net.createServer();
+      server.once('error', () => resolve(false));
+      server.listen(port, '127.0.0.1', () => {
+        server.close(() => resolve(true));
+      });
+    });
+    if (available) {
+      return port;
+    }
+  }
+  throw new Error(`failed to find an available port starting at ${startPort}`);
+}
+
+/**
+ * vite dev server 를 기동한다. npm.cmd 경유가 아니라 node 로 vite.js 를 직접
+ * 띄운다 — win32 에서 .cmd spawn 은 EINVAL 로 거절되고 shell 우회는 트리
+ * 종료(SIGTERM)를 망가뜨리기 때문. readiness 대기와 로그 핸들 닫기는 호출자의
+ * 몫으로 남긴다(waitForServer · 반환 객체의 stop()).
+ */
+export async function startViteDevServer({
+  preferredPort = Number(process.env.VITE_PORT || '7700'),
+  logPath = viteLogPath(),
+} = {}) {
+  const port = await findAvailablePort(preferredPort);
+  const url = `http://127.0.0.1:${port}`;
+  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+  const logFile = fs.openSync(logPath, 'w');
+  const viteJs = path.join(studioRoot, 'node_modules', 'vite', 'bin', 'vite.js');
+  const child = spawn(
+    process.execPath,
+    [viteJs, '--host', '127.0.0.1', '--port', String(port), '--strictPort'],
+    {
+      cwd: studioRoot,
+      stdio: ['ignore', logFile, logFile],
+      env: {
+        ...process.env,
+        BROWSER: 'none',
+      },
+    },
+  );
+  return {
+    url,
+    port,
+    child,
+    logPath,
+    async stop() {
+      await stopServer(child);
+      fs.closeSync(logFile);
+    },
+  };
+}

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -61,7 +61,8 @@
     "e2e:render-diff:ci": "node e2e/run-render-diff.mjs",
     "metrics:frontend": "node ../scripts/frontend-metrics.mjs",
     "e2e:manifest-check": "python3 ../scripts/check_e2e_manifest.py",
-    "e2e:undo-delete-fragment-bytes": "node e2e/undo-delete-fragment-bytes.test.mjs --mode=headless"
+    "e2e:undo-delete-fragment-bytes": "node e2e/undo-delete-fragment-bytes.test.mjs --mode=headless",
+    "e2e:undo-depth": "node e2e/undo-depth-issue5769.test.mjs --mode=headless"
   },
   "devDependencies": {
     "@types/chrome": "^0.2.6",

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -62,7 +62,7 @@
     "metrics:frontend": "node ../scripts/frontend-metrics.mjs",
     "e2e:manifest-check": "python3 ../scripts/check_e2e_manifest.py",
     "e2e:undo-delete-fragment-bytes": "node e2e/undo-delete-fragment-bytes.test.mjs --mode=headless",
-    "e2e:undo-depth": "node e2e/undo-depth-issue5769.test.mjs --mode=headless"
+    "e2e:undo-depth": "node e2e/run-with-vite.mjs -- node e2e/undo-depth-issue5769.test.mjs --mode=headless"
   },
   "devDependencies": {
     "@types/chrome": "^0.2.6",

--- a/scripts/tests/test_undo_depth_e2e_workflow.py
+++ b/scripts/tests/test_undo_depth_e2e_workflow.py
@@ -1,0 +1,80 @@
+"""[#5959] undo depth 측정 게이트(#5769)의 CI 배선 계약.
+
+스냅샷 예산 축출 회귀는 실 wasm + 실 브라우저로만 잡힌다. 그래서 이 게이트는
+frontend-package-gates(실 wasm 빌드) 안에서 `npm run e2e:undo-depth` 로 단다.
+이 테스트는 그 배선이 사라지지 않게 고정한다. 파일명이 `test_*workflow*.py`
+패턴이라 test_workflow_contract_wiring.py 가 ci.yml 배선을 강제한다(#4080).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_WF = REPO_ROOT / ".github/workflows/ci.yml"
+STUDIO = REPO_ROOT / "rhwp-studio"
+RUNNER = STUDIO / "e2e/run-with-vite.mjs"
+SERVER_HELPER = STUDIO / "e2e/vite-server.mjs"
+GATE_TEST = STUDIO / "e2e/undo-depth-issue5769.test.mjs"
+
+
+def package_gates_section(ci_text: str) -> str:
+    """ci.yml 에서 frontend-package-gates job 본문만 떼어 온다."""
+    starts = [m.start() for m in re.finditer(r"(?m)^  [a-z0-9-]+:$", ci_text)]
+    begin = ci_text.index("  frontend-package-gates:")
+    end = next((pos for pos in starts if pos > begin), len(ci_text))
+    return ci_text[begin:end]
+
+
+class UndoDepthE2EGateWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.ci = CI_WF.read_text(encoding="utf-8")
+        cls.package_gates = package_gates_section(cls.ci)
+
+    def test_runner_and_gate_files_exist(self) -> None:
+        self.assertTrue(RUNNER.is_file(), "run-with-vite.mjs 러너가 없다")
+        self.assertTrue(SERVER_HELPER.is_file(), "vite-server.mjs 공용 헬퍼가 없다")
+        self.assertTrue(GATE_TEST.is_file(), "undo-depth 게이트 테스트 파일이 없다")
+
+    def test_gate_is_wired_in_frontend_package_gates(self) -> None:
+        """게이트 단계는 package 모드 잡 안에서 실제로 실행돼야 한다."""
+        self.assertIn(
+            "name: Run undo depth measurement gate (#5769)",
+            self.package_gates,
+            "frontend-package-gates 에 게이트 단계가 없다",
+        )
+        self.assertIn("npm run e2e:undo-depth", self.package_gates)
+        self.assertIn(
+            "name: Install headless Chrome",
+            self.package_gates,
+            "게이트에 필요한 Chrome 설치 단계가 없다 — CHROME_PATH 없이는 구동 불가다",
+        )
+
+    def test_gate_step_runs_after_real_wasm_build(self) -> None:
+        """unit 모드용 스텁 wasm 이 아니라 실 wasm 빌드 뒤에 있어야 한다."""
+        wasm_build = self.package_gates.index("Build fresh WASM package for frontend gates")
+        gate = self.package_gates.index("Run undo depth measurement gate (#5769)")
+        self.assertLess(wasm_build, gate)
+
+    def test_npm_script_routes_through_vite_runner(self) -> None:
+        """npm script 는 run-with-vite 러너 경유여야 한다 — CI 에 서버 기동이 필요하기 때문."""
+        scripts = json.loads((STUDIO / "package.json").read_text(encoding="utf-8"))["scripts"]
+        script = scripts["e2e:undo-depth"]
+        self.assertIn("run-with-vite.mjs", script)
+        self.assertIn("undo-depth-issue5769.test.mjs", script)
+        self.assertIn("--mode=headless", script)
+
+    def test_gate_test_declares_no_snapshot_contract(self) -> None:
+        """게이트 본문은 무축출 계약(슬롯 0·전량 소진)을 단언해야 한다."""
+        body = GATE_TEST.read_text(encoding="utf-8")
+        self.assertIn("snapshotResourceCount", body)
+        self.assertIn("E2E_DEPTH_ROUNDS", body, "스모크용 라운드 조절 환경변수가 없다")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#5959 잔여 ③ — undo depth 측정 게이트(#5769)를 CI 에 배선한다

## 무엇을 하는가

`rhwp-studio/e2e/undo-depth-issue5769.test.mjs`(혼합 세션 실효 undo 깊이 무축출 계약)는 지금까지 로컬에서만 돌았다. 이 PR 은 그 게이트를 **frontend-package-gates** 잡 안에서 실제로 실행시킨다. 스텁 wasm 을 쓰는 unit 모드가 아니라 실 wasm 빌드가 이미 있는 package 모드에 붙인 이유는, 게이트가 실 wasm + 실 브라우저 구동을 전제로 하기 때문이다.

| 단계 | 내용 |
|---|---|
| Install headless Chrome | full-renderer-sweep 의 기존 블록 재사용(시스템 Chrome 우선, puppeteer 폴백) |
| Run undo depth measurement gate (#5769) | `npm run e2e:undo-depth` |

## 커밋 구성

1. `1ff625d8f` 게이트 자체(#5769 후속, cherry-pick) — R 라운드 교정 후 ① 슬롯 합 0
   ② 조각 경로 ③ 스택 길이 하한(축출 없음) ④ 전량 undo 소진 ⑤ 새 문서 복귀.
   `E2E_DEPTH_ROUNDS` 스모크 지원.
2. `293b028bf` 게이트 픽스 — `helpers.mjs` 의 assert 는 함수 호출 계약이라 커밋된
   `assert.equal`·`assert.ok` 는 즉시 크래시한다(실측 발견). `deletes === ROUNDS`
   도 설계 스스로 깨는 계약이다 — 문단이 짧아진 라운드는 refill 분기(deleteSelection
   없음, 엔트리 1)로 빠진다(110 라운드 실측 deletes 103, 두 번 반복 재현).
   ≥⌈R/2⌉ 하한으로 완화하고 헤더 주석·MANIFEST 문구를 실제 계약에 맞췄다.
3. `8977a368e` 배선 — 서버 기동 계약(포트 탐색 → 127.0.0.1 바인딩 → readiness 폴링 →
   SIGTERM/SIGKILL 종료)을 `run-render-diff.mjs` 에서 `e2e/vite-server.mjs` 로 추출해
   두 러너가 같이 쓰고, 임의 명령을 `VITE_URL` 주입과 함께 실행하는
   `e2e/run-with-vite.mjs` 를 더한다(`e2e:undo-depth` 가 이 경유로 전환 — 로컬에서도
   dev server 없이 단일 명령). 서버는 npm.cmd 경유가 아니라 node 로 vite.js 를 직접
   띄운다 — win32 에서 .cmd 직접 spawn 은 EINVAL 로 거절되고 shell 우회는 트리 종료를
   망가뜨린다(실측). `scripts/tests/test_undo_depth_e2e_workflow.py` 가 게이트 단계·
   Chrome 설치·wasm 빌드 선행·러너 경유를 데이터로 고정하고(#4080 규약) ci.yml
   'Validate workflow contracts' 에 배선한다.

## 검증 (로컬 실측)

- 게이트 풀 실행 통과: exit 0 · 110 라운드 · 슬롯 합 0 · 스택 266 전량 소진·복원
- 계약 테스트 5건 + wiring 테스트 3건 통과, node --check 전체 통과
- e2e manifest 체크: 신규 util 2건(run-with-vite·vite-server) 등재 확인
- CI 예산: frontend-package-gates(timeout 20분)에 Chrome 설치 + 게이트 약 3~4분 추가

## 관찰 (본 PR 범위 밖)

devel 의 manifest 체크가 기존 누락 3건을 보고한다 — `loading-busy-cursor.test.mjs`,
`status-page-number.test.mjs`, `toolbox-visibility.test.mjs` 가 tracked 인데
MANIFEST.md 행이 없다. 본 PR 과 무관해 손대지 않았다.

추적: #5959 (잔여 과제 원장)
