### PR TITLE
feat(5959): 셀 테두리/배경 다이얼로그를 속성쌍 역연산으로 전환한다

### DIFF
--- a/mydocs/working/task_m100_5959_cell_border_bg.md
+++ b/mydocs/working/task_m100_5959_cell_border_bg.md
@@ -1,0 +1,84 @@
+# Task M100 — #5959 잔여: 셀 테두리/배경 다이얼로그 역연산화 판정
+
+- 일자: 2026-08-24
+- 상위: #5959 잔여 과제 (#5769 원장의 "⑤ cell-border-bg-dialog — 후순위, 스냅샷 진입점의 1.2%")
+- 선행 규약: #5769 참인 역연산 판정(변경 실체가 속성 대입뿐이어야 한다) + 저장 바이트 왕복 동일성
+
+## 대상
+
+`CellBorderBgDialog`(ui/cell-border-bg-dialog.ts)의 적용 경로 3종 — 모두
+`ih.executeOperation({ kind:'snapshot', operationType:'objectProps' })` 로 기록되어
+적용 1회당 스냅샷 슬롯 1개를 쓴다.
+
+| 진입 | 적용 네이티브 | 대상 |
+|---|---|---|
+| 각 셀마다 적용(each) | `setCellProperties` × N (`runInBatch`, #4118) | 선택 셀 전부 |
+| 하나의 셀처럼 적용(asOne) | `setCellZoneProperties` | 셀 zone |
+| 단일 셀 | `setCellProperties` | 커서 셀 |
+
+## 변경 실체 분석 (선결 규약 판정)
+
+### set_cell_properties_native (table_ops.rs:1335)
+
+테두리/배경 키(borderLeft~ / fillType / diagonal* / centerLine)가 들어오면:
+
+1. `create_border_fill_from_json`(html_table_import.rs:785) — JSON 으로 BorderFill
+   조립 후 **기존 테이블에서 동일 항목 dedupe**(border_fills_equal), 없으면 append.
+   raw_data 는 비운다(직렬화 필드 경로 강제).
+2. 대상 셀 `border_fill_id = 새 id`.
+3. `update_neighbor_borders`(table_ops.rs:1819) — 공유 엣지를 가진 **이웃 셀마다**
+   이웃의 BorderFill 을 복제해 해당 방향만 교체 → dedupe/append → 이웃 id 재배정.
+4. `doc_info.raw_stream_dirty = true`(append 시), 섹션 `raw_stream = None`,
+   rebuild_resolved_styles, 재조판.
+
+→ 변경 실체는 **셀 1개의 id 대입이 아니라 "대상+이웃 집단의 id 재배정 + 문서 스타일
+테이블 성장"**이다. z 순서(moves[] 선례)와 달리 영향 집단이 Rust 내부에서만 결정된다.
+
+### set_cell_zone_properties_native (table_ops.rs:1746)
+
+bf 생성(dedupe) → zone 신설 또는 기존 zone id 교체(table.zones.push 포함) → raw 무효화.
+
+## 판정 — 3개의 장벽
+
+1. **영향 집단의 Rust 전용 결정**: 이웃 셀 목록/zone 은 코어가 계산한다. TS 가
+   before 를 미리 모은다(all-undo 선례)로는 부족하고, z-order 의 moves[] 처럼
+   **응답에 self-describing 기록**(affected cells/zones 의 before/after id)을 얻어야 한다.
+2. **BorderFill 테이블 성장 vs 저장 바이트 수렴**: serializer/doc_info.rs:212 는 테이블
+   전체를 쓴다. apply 가 append 하면 undo(id 복원) 후에도 고아 항목이 남아 원본 바이트와
+   어긋난다. 현재 스냅샷은 saveSnapshot 이 doc_info 를 통째로 복원하므로 지금은 수렴한다 —
+   역연산화가 오히려 수렴을 깨는 역전 지점.
+3. **DocInfo passthrough**: append 는 `raw_stream_dirty` 를 세운다(#2555). undo 가
+   수렴하려면 이 플래그까지 원상 복구돼야 한다.
+
+## 설계안
+
+Stage A — **Rust 응답 확장**: 두 네이티브가 적용 직전 before 를 스스로 캡처해
+`changes:[{ppi,ci,cellIdx?,zone?,beforeId,afterId}]` + `createdBorderFills:[id…]`
+(이번 호출로 push 된 항목만)를 반환한다. 무변경(dedupe 후 동일 id)은 changes 공백.
+
+Stage B — **TS 커맨드**: `SetCellBorderFillCommand` — execute 는 네이티브 응답으로
+pairs 확보(z-order 선례), undo 는 **직접 id 대입 네이티브**(신규,
+`apply_cell_border_fill_ids`)로 before 복원 → 구역 raw 캡처·복원 재사용.
+redo 는 execute 재실행.
+
+Stage C — **고아 GC**: `discard_unused_border_fill_tails(ids)` — created 항목 중
+"꼬리(tail)이면서 참조 0"인 것만 LIFO 절단. 중간 항목은 절단 불가(id shift 위험).
+undo 마다 호출, 절단 못한 고아가 남으면 게이트가 잡는다.
+
+Stage D — **게이트**: `issue_5959_cell_borderfill_inverse_convergence.rs` —
+실제 표 문서에서 테두리/배경 적용 → undo → 저장 바이트 왕복 동일성 + border_fills
+길이 원복 + 이웃 셀 id 원복. e2e 소스 가드(배선 핀) 추가.
+
+## 리스크
+
+| 리스크 | 대응 |
+|---|---|
+| redo 가 dedupe 로 다른 id 재사용 | after 도 기록해 redo 는 after 직접 대입(execute 재실행 아님) |
+| 중간 삽입 편집으로 꼬리 절단 불가 | 저널 계약(캡처~복원 사이 편집 금지)과 TS 선형 히스토리로 대부분 방어, 잔존 시 게이트 실패로 드러냄 |
+| '각 셀마다' N셀 × 이웃 폭발 | changes 배열은 1회 배치로 모음 — 여전히 슬롯 0 |
+
+## 예상 규모
+
+Rust 응답 확장+신규 네이티브 2건(~200줄), TS 커맨드+배선(~150줄), 게이트 .rs+e2e 가드.
+followup2(section-all)급 — 단, Stage C 가 serializer 계약(#2555)과 맞닿으므로
+구현 전 이 문서 기준으로 착수 승인을 받는다.

--- a/mydocs/working/task_m100_5959_cell_border_bg.md
+++ b/mydocs/working/task_m100_5959_cell_border_bg.md
@@ -82,3 +82,28 @@ Stage D — **게이트**: `issue_5959_cell_borderfill_inverse_convergence.rs` �
 Rust 응답 확장+신규 네이티브 2건(~200줄), TS 커맨드+배선(~150줄), 게이트 .rs+e2e 가드.
 followup2(section-all)급 — 단, Stage C 가 serializer 계약(#2555)과 맞닿으므로
 구현 전 이 문서 기준으로 착수 승인을 받는다.
+
+## 구현 결과 (2026-08-24, 브랜치 feat/5959-cell-borderfill-inverse)
+
+설계안 A~D 전부 착수·완료:
+
+- Stage A: 두 setter 의 응답 확장 — changes[{cellIdx,beforeId,afterId}] +
+  borderFillLenBefore + docInfoDirtyBefore(zone 은 zoneBeforeId). 이웃은
+  id 이동이 있던 셀만 기록(update_neighbor_borders 반환 확장).
+- Stage B: apply_cell_border_fill_ids_native(직접 id 대입, 전수 검증 후 적용,
+  zone null=제거) + wasm 바인딩 applyCellBorderFillIds.
+- Stage C: remove_border_fill_tails_native(fromLen 까지 꼬리 절단, 완전 절단 시
+  dirtyWas 로 원복) + 바인딩 removeBorderFillTails.
+- Stage D: 게이트 tests/cases/issue_5959_cell_borderfill_inverse_convergence.rs
+  (셀 경로·zone 경로 각각 apply->undo->export 가 baseline export 와 바이트 동일 +
+  스타일 테이블 길이 원복), 소스 가드 rhwp-studio/tests/
+  issue-5959-cell-borderfill-inverse.test.ts 6종.
+- TS: SetCellBorderFillCommand + 다이얼로그 배선 전환, table-props-undo 가드를
+  새 계약으로 갱신, 신규 네이티브 둘 MUTATING_METHODS 등재.
+
+### 실측
+
+- 수렴 게이트 2/2 통과 — apply->undo 후 export 가 baseline export 와 바이트 완전
+  동일(스타일 테이블 길이 원복 포함). 표본: 수출입 현황 .hwp 본문 표.
+- npm test 1076 pass / 0 fail(신규 가드 6종 포함, 구 가드 1건 새 계약 갱신).
+- clippy clean / cargo fmt --check 통과.

--- a/rhwp-studio/src/core/mutation-method-registry.ts
+++ b/rhwp-studio/src/core/mutation-method-registry.ts
@@ -35,6 +35,7 @@ export const MUTATING_METHODS: readonly string[] = [
   'insertTableColumn', 'deleteTableRow', 'deleteTableColumn', 'mergeTableCells',
   'splitTableCell', 'splitTableCellInto', 'splitTableCellsInRange', 'resizeTableCells',
   'moveTableOffset', 'setTableProperties', 'setCellProperties', 'setCellZoneProperties',
+  'applyCellBorderFillIds', 'removeBorderFillTails',
   'pasteTableCellsTransposed', 'transposeTableCellsInPlace', 'pasteTableCellsTransposedAsTable',
   'evaluateTableFormula',
   // 그림/도형/수식 개체

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -1728,9 +1728,67 @@ export class WasmBridge {
     return JSON.parse(doc.getCellOwnProperties(sec, parentPara, controlIdx, cellIdx));
   }
 
-  setCellProperties(sec: number, parentPara: number, controlIdx: number, cellIdx: number, props: Partial<CellProperties>): { ok: boolean } {
+  setCellProperties(
+    sec: number,
+    parentPara: number,
+    controlIdx: number,
+    cellIdx: number,
+    props: Partial<CellProperties>,
+  ): {
+    ok: boolean;
+    /** [#5959] borderFillId 전환 기록(target+이웃) — 구버전 wasm 에선 없다. */
+    changes?: Array<{ cellIdx: number; beforeId: number; afterId: number }>;
+    borderFillLenBefore?: number;
+    docInfoDirtyBefore?: boolean;
+  } {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return JSON.parse(this.doc.setCellProperties(sec, parentPara, controlIdx, cellIdx, JSON.stringify(props)));
+  }
+
+  /**
+   * [#5959] 셀 테두리/배경 역연산 경로가 이 wasm 조합에 실려 있는가.
+   *
+   * 구버전 wasm 은 applyCellBorderFillIds 가 없다 — probe 통과 전에 캡처·뮤테이션을
+   * 하면 undo 불능 상태로 문서만 오염된다(#5951 스크우 probe 선례).
+   */
+  hasCellBorderFillInverse(): boolean {
+    const doc = this.doc as unknown as { applyCellBorderFillIds?: unknown };
+    return !!doc && typeof doc.applyCellBorderFillIds === 'function';
+  }
+
+  /** [#5959] execute 의 변경 기록을 되돌린다 — 스타일 테이블은 건드리지 않는다. */
+  applyCellBorderFillIds(
+    sec: number,
+    parentPara: number,
+    controlIdx: number,
+    payload: {
+      cells: Array<{ cellIdx: number; id: number }>;
+      zones: Array<{
+        startRow: number;
+        startCol: number;
+        endRow: number;
+        endCol: number;
+        id: number | null;
+      }>;
+    },
+  ): { ok: boolean } {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    const doc = this.doc as unknown as {
+      applyCellBorderFillIds(sec: number, parentPara: number, controlIdx: number, json: string): string;
+    };
+    return JSON.parse(doc.applyCellBorderFillIds(sec, parentPara, controlIdx, JSON.stringify(payload)));
+  }
+
+  /**
+   * [#5959] 이번 apply 가 push 한 BorderFill 꼬리 항목 절단. 완전 절단에 성공하면
+   * dirty 플래그를 `dirtyWas` 로 원복한다.
+   */
+  removeBorderFillTails(fromLen: number, dirtyWas: boolean): { ok: boolean; discarded: number; fullyDiscarded: boolean } {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    const doc = this.doc as unknown as {
+      removeBorderFillTails(json: string): string;
+    };
+    return JSON.parse(doc.removeBorderFillTails(JSON.stringify({ fromLen, dirtyWas })));
   }
 
   setCellZoneProperties(
@@ -1739,7 +1797,14 @@ export class WasmBridge {
     controlIdx: number,
     range: { startRow: number; startCol: number; endRow: number; endCol: number },
     props: Partial<CellProperties>,
-  ): { ok: boolean; borderFillId: number } {
+  ): {
+    ok: boolean;
+    borderFillId: number;
+    /** [#5959] 적용 전 zone 의 id — null 이면 신설이다. 구버전 wasm 에선 없다. */
+    zoneBeforeId?: number | null;
+    borderFillLenBefore?: number;
+    docInfoDirtyBefore?: boolean;
+  } {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     const doc = this.doc as unknown as {
       setCellZoneProperties(

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -1738,6 +1738,18 @@ export class WasmBridge {
     ok: boolean;
     /** [#5959] borderFillId 전환 기록(target+이웃) — 구버전 wasm 에선 없다. */
     changes?: Array<{ cellIdx: number; beforeId: number; afterId: number }>;
+    /**
+     * [#5959] cellzone origin override(1×1) 전이 기록 — sync 가 zones 를
+     * 만들거나 지울 때 셀 id 기록만으로 undo 가 부족하다. 구버전 wasm 에선 없다.
+     */
+    zones?: Array<{
+      startRow: number;
+      startCol: number;
+      endRow: number;
+      endCol: number;
+      beforeId: number | null;
+      afterId: number | null;
+    }>;
     borderFillLenBefore?: number;
     docInfoDirtyBefore?: boolean;
   } {

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -2285,6 +2285,9 @@ export class SetCellBorderFillCommand implements EditCommand {
     let dirtyBefore = false;
     let zoneBeforeId: number | null = null;
     let changed = false;
+    // 뮤테이션 네이티브가 하나라도 성공했는가 — 전부 실패였다면 롤백 호출 없이
+    // 캡처 해제만으로 충분하다(빈 payload 대입은 table.dirty 만 세운다).
+    let mutated = false;
 
     // redo 도 같은 순서다 — undo 가 저널 항목을 소비하므로 항상 새로 캡처한다.
     this.captureId = wasm.captureSectionRaw(this.sec);
@@ -2294,6 +2297,7 @@ export class SetCellBorderFillCommand implements EditCommand {
           this.sec, this.ppi, this.ci, this.target.range,
           this.props as Partial<CellProperties>,
         );
+        mutated = true;
         lenBefore = r.borderFillLenBefore ?? -1;
         dirtyBefore = r.docInfoDirtyBefore ?? false;
         const beforeId = r.zoneBeforeId ?? null;
@@ -2309,6 +2313,7 @@ export class SetCellBorderFillCommand implements EditCommand {
               this.sec, this.ppi, this.ci, cellIdx,
               this.props as Partial<CellProperties>,
             );
+            mutated = true;
             if (lenBefore === -1) {
               lenBefore = r.borderFillLenBefore ?? -1;
               dirtyBefore = r.docInfoDirtyBefore ?? false;
@@ -2325,7 +2330,7 @@ export class SetCellBorderFillCommand implements EditCommand {
     } catch (applyError) {
       // 최초 execute 실패 시 지금까지의 기록으로라도 원상 복구를 시도한다(#3350 계열).
       try {
-        this.rollback(wasm, cellBefores, zoneBeforeId, lenBefore, dirtyBefore);
+        this.rollback(wasm, cellBefores, zoneBeforeId, lenBefore, dirtyBefore, mutated);
       } catch (rollbackError) {
         console.error(`${this.type} 실패 롤백도 실패:`, rollbackError);
       }
@@ -2386,8 +2391,16 @@ export class SetCellBorderFillCommand implements EditCommand {
     zoneBeforeId: number | null,
     lenBefore: number,
     dirtyBefore: boolean,
+    mutated: boolean,
   ): void {
     if (this.captureId === null) return;
+    if (!mutated) {
+      // 뮤테이션이 하나도 성공하지 못했다 — 문서는 원본 그대로다. 빈 payload
+      // 대입은 table.dirty 만 세우므로 캡처 해제로 끝낸다.
+      wasm.discardSectionRaw(this.captureId);
+      this.captureId = null;
+      return;
+    }
     wasm.applyCellBorderFillIds(this.sec, this.ppi, this.ci, {
       cells: [...cellBefores.entries()].map(([cellIdx, id]) => ({ cellIdx, id })),
       zones: this.target.kind === 'zone'

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -2235,6 +2235,17 @@ interface CellBorderFillUndoState {
   zoneRange: { startRow: number; startCol: number; endRow: number; endCol: number } | null;
   /** null 이면 apply 때 zone 이 신설됐다 → undo 는 zone 을 제거한다. */
   zoneBeforeId: number | null;
+  /**
+   * [#5959] 셀 적용이 cellzone origin override(1×1)를 만들거나 지운 전이 — sync 가
+   * zones 를 건드리면 셀 id 복원만으론 부족하다. before 상태로 되돌린다.
+   */
+  zoneRestores: Array<{
+    startRow: number;
+    startCol: number;
+    endRow: number;
+    endCol: number;
+    id: number | null;
+  }>;
   borderFillLenBefore: number;
   docInfoDirtyBefore: boolean;
 }
@@ -2281,6 +2292,8 @@ export class SetCellBorderFillCommand implements EditCommand {
     }
 
     const cellBefores = new Map<number, number>();
+    // 같은 rect 여러 전이 중 undo 에 필요한 것은 최초(before 원본) 하나다.
+    const zoneBefores = new Map<string, { startRow: number; startCol: number; endRow: number; endCol: number; id: number | null }>();
     let lenBefore = -1;
     let dirtyBefore = false;
     let zoneBeforeId: number | null = null;
@@ -2324,13 +2337,27 @@ export class SetCellBorderFillCommand implements EditCommand {
               // undo 는 원본(첫 기록) 하나면 충분하다.
               if (!cellBefores.has(ch.cellIdx)) cellBefores.set(ch.cellIdx, ch.beforeId);
             }
+            for (const z of r.zones ?? []) {
+              if (z.beforeId === z.afterId) continue;
+              changed = true;
+              const key = `${z.startRow},${z.startCol},${z.endRow},${z.endCol}`;
+              if (!zoneBefores.has(key)) {
+                zoneBefores.set(key, {
+                  startRow: z.startRow,
+                  startCol: z.startCol,
+                  endRow: z.endRow,
+                  endCol: z.endCol,
+                  id: z.beforeId,
+                });
+              }
+            }
           }
         });
       }
     } catch (applyError) {
       // 최초 execute 실패 시 지금까지의 기록으로라도 원상 복구를 시도한다(#3350 계열).
       try {
-        this.rollback(wasm, cellBefores, zoneBeforeId, lenBefore, dirtyBefore, mutated);
+        this.rollback(wasm, cellBefores, zoneBefores, zoneBeforeId, lenBefore, dirtyBefore, mutated);
       } catch (rollbackError) {
         console.error(`${this.type} 실패 롤백도 실패:`, rollbackError);
       }
@@ -2349,6 +2376,7 @@ export class SetCellBorderFillCommand implements EditCommand {
       cellBefores: [...cellBefores.entries()].map(([cellIdx, id]) => ({ cellIdx, id })),
       zoneRange: this.target.kind === 'zone' ? { ...this.target.range } : null,
       zoneBeforeId,
+      zoneRestores: [...zoneBefores.values()],
       borderFillLenBefore: lenBefore,
       docInfoDirtyBefore: dirtyBefore,
     };
@@ -2361,9 +2389,12 @@ export class SetCellBorderFillCommand implements EditCommand {
     }
     wasm.applyCellBorderFillIds(this.sec, this.ppi, this.ci, {
       cells: this.state.cellBefores,
-      zones: this.state.zoneRange
-        ? [{ ...this.state.zoneRange, id: this.state.zoneBeforeId }]
-        : [],
+      zones: [
+        ...(this.state.zoneRange
+          ? [{ ...this.state.zoneRange, id: this.state.zoneBeforeId }]
+          : []),
+        ...this.state.zoneRestores,
+      ],
     });
     wasm.removeBorderFillTails(this.state.borderFillLenBefore, this.state.docInfoDirtyBefore);
     wasm.restoreSectionRaw(this.captureId);
@@ -2388,6 +2419,7 @@ export class SetCellBorderFillCommand implements EditCommand {
   private rollback(
     wasm: WasmBridge,
     cellBefores: Map<number, number>,
+    zoneBefores: Map<string, { startRow: number; startCol: number; endRow: number; endCol: number; id: number | null }>,
     zoneBeforeId: number | null,
     lenBefore: number,
     dirtyBefore: boolean,
@@ -2403,9 +2435,12 @@ export class SetCellBorderFillCommand implements EditCommand {
     }
     wasm.applyCellBorderFillIds(this.sec, this.ppi, this.ci, {
       cells: [...cellBefores.entries()].map(([cellIdx, id]) => ({ cellIdx, id })),
-      zones: this.target.kind === 'zone'
-        ? [{ ...this.target.range, id: zoneBeforeId }]
-        : [],
+      zones: [
+        ...(this.target.kind === 'zone'
+          ? [{ ...this.target.range, id: zoneBeforeId }]
+          : []),
+        ...[...zoneBefores.values()],
+      ],
     });
     if (lenBefore >= 0) wasm.removeBorderFillTails(lenBefore, dirtyBefore);
     wasm.restoreSectionRaw(this.captureId);

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -4,7 +4,7 @@ import type {
   RemovedParaMeta,
   WasmBridge,
 } from '@/core/wasm-bridge';
-import type { DocumentPosition, CharProperties, ParaProperties, CellPathLike, CellPathEntry, SectionDef } from '@/core/types';
+import type { DocumentPosition, CharProperties, ParaProperties, CellPathLike, CellPathEntry, SectionDef, CellProperties } from '@/core/types';
 import { MAX_PAGE_LOCAL_TEXT_EDIT_CHARS } from './input-edit-invalidation';
 import type { LineEndpoints as LineEndpointsLike } from './object-drag-record';
 import { setObjectProps, type ObjectPropsRef } from './object-props';
@@ -2220,6 +2220,183 @@ export class SetSectionPropsCommand implements EditCommand {
       'hideHeader', 'hideFooter', 'hideMasterPage', 'hideBorder', 'hideFill', 'hideEmptyLine',
     ];
     return keys.every((key) => Object.is(this.before[key], this.after[key]));
+  }
+}
+
+/** [#5959] 셀 테두리/배경 적용 대상 — 다이얼로그가 범위를 데이터로 고정해 넘긴다. */
+export type CellBorderFillTarget =
+  | { kind: 'cells'; cellIdxes: number[] }
+  | { kind: 'zone'; range: { startRow: number; startCol: number; endRow: number; endCol: number } };
+
+interface CellBorderFillUndoState {
+  /** cellIdx → 적용 직전 borderFillId(배치 안 첫 기록이 원본이다). */
+  cellBefores: Array<{ cellIdx: number; id: number }>;
+  /** asOne 적용의 범위 — undo 시 id 원복 또는 신설 제거에 쓴다. */
+  zoneRange: { startRow: number; startCol: number; endRow: number; endCol: number } | null;
+  /** null 이면 apply 때 zone 이 신설됐다 → undo 는 zone 을 제거한다. */
+  zoneBeforeId: number | null;
+  borderFillLenBefore: number;
+  docInfoDirtyBefore: boolean;
+}
+
+/**
+ * [#5959] 셀 테두리/배경(테두리·채우기·대각선)의 속성쌍 역연산 커맨드.
+ *
+ * 변경 실체는 대상+이웃 집단의 `border_fill_id` 재배정과 스타일 테이블 append 다
+ * (mydocs/working/task_m100_5959_cell_border_bg.md 판정). Rust 가 self-describing
+ * 기록(changes / zoneBeforeId / borderFillLenBefore / docInfoDirtyBefore)을 응답으로
+ * 돌려주므로 undo 는 세 단계로 원상 복구한다:
+ *
+ *   ① `applyCellBorderFillIds` 로 cell/zone id 를 직접 대입(스타일 테이블 무손상)
+ *   ② `removeBorderFillTails` 로 이번 apply 가 push 한 꼬리 항목 절단(dirty 원복 포함)
+ *   ③ `restoreSectionRaw` 로 passthrough 복원(section_raw_journal 계약)
+ *
+ * 구버전 wasm 조합은 `hasCellBorderFillInverse()` probe 를 캡처 **전에** 통과시킨다
+ * (#5951 스크우 선례) — probe 없이 진행하면 undo 불능 오염만 남는다.
+ *
+ * 생명주기는 SetSectionPropsAllCommand 와 동일하다 — execute 가 raw 를 캡처해 두고,
+ * undo 는 재적용(raw 재무효화) 뒤 복원한다. redo 는 execute 재실행이며, 절단된
+ * 스타일 항목은 dedupe 가 같은 내용을 꼬리에 다시 만들어 id 가 안정적이다.
+ */
+export class SetCellBorderFillCommand implements EditCommand {
+  readonly type = 'setCellBorderFill';
+  readonly timestamp = Date.now();
+
+  private captureId: number | null = null;
+  private noOp = false;
+  private state: CellBorderFillUndoState | null = null;
+
+  constructor(
+    private sec: number,
+    private ppi: number,
+    private ci: number,
+    private target: CellBorderFillTarget,
+    private props: Record<string, unknown>,
+    private cursorPos: DocumentPosition,
+  ) {}
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    if (!wasm.hasCellBorderFillInverse()) {
+      throw new Error(`${this.type} 불가 — 구버전 wasm 에 역연산 경로가 없다`);
+    }
+
+    const cellBefores = new Map<number, number>();
+    let lenBefore = -1;
+    let dirtyBefore = false;
+    let zoneBeforeId: number | null = null;
+    let changed = false;
+
+    // redo 도 같은 순서다 — undo 가 저널 항목을 소비하므로 항상 새로 캡처한다.
+    this.captureId = wasm.captureSectionRaw(this.sec);
+    try {
+      if (this.target.kind === 'zone') {
+        const r = wasm.setCellZoneProperties(
+          this.sec, this.ppi, this.ci, this.target.range,
+          this.props as Partial<CellProperties>,
+        );
+        lenBefore = r.borderFillLenBefore ?? -1;
+        dirtyBefore = r.docInfoDirtyBefore ?? false;
+        const beforeId = r.zoneBeforeId ?? null;
+        changed = beforeId !== (r.borderFillId ?? null);
+        if (changed) zoneBeforeId = beforeId;
+      } else {
+        const target = this.target;
+        if (target.kind !== 'cells') throw new Error(`${this.type} 잘못된 대상`);
+        // 셀 수만큼 setCellProperties 를 호출하므로 재페이지네이션을 묶는다(#4118).
+        wasm.runInBatch(() => {
+          for (const cellIdx of target.cellIdxes) {
+            const r = wasm.setCellProperties(
+              this.sec, this.ppi, this.ci, cellIdx,
+              this.props as Partial<CellProperties>,
+            );
+            if (lenBefore === -1) {
+              lenBefore = r.borderFillLenBefore ?? -1;
+              dirtyBefore = r.docInfoDirtyBefore ?? false;
+            }
+            for (const ch of r.changes ?? []) {
+              changed = true;
+              // 배치 안에서 같은 셀이 이웃 갱신으로 여러 번 기록될 수 있다 —
+              // undo 는 원본(첫 기록) 하나면 충분하다.
+              if (!cellBefores.has(ch.cellIdx)) cellBefores.set(ch.cellIdx, ch.beforeId);
+            }
+          }
+        });
+      }
+    } catch (applyError) {
+      // 최초 execute 실패 시 지금까지의 기록으로라도 원상 복구를 시도한다(#3350 계열).
+      try {
+        this.rollback(wasm, cellBefores, zoneBeforeId, lenBefore, dirtyBefore);
+      } catch (rollbackError) {
+        console.error(`${this.type} 실패 롤백도 실패:`, rollbackError);
+      }
+      throw applyError;
+    }
+
+    if (!changed) {
+      // 문서 무변경(dedupe 수렴 등) — 저널 항목 없이 깨끗한 no-op(#2370).
+      this.noOp = true;
+      wasm.discardSectionRaw(this.captureId);
+      this.captureId = null;
+      return { ...this.cursorPos };
+    }
+
+    this.state = {
+      cellBefores: [...cellBefores.entries()].map(([cellIdx, id]) => ({ cellIdx, id })),
+      zoneRange: this.target.kind === 'zone' ? { ...this.target.range } : null,
+      zoneBeforeId,
+      borderFillLenBefore: lenBefore,
+      docInfoDirtyBefore: dirtyBefore,
+    };
+    return { ...this.cursorPos };
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    if (this.captureId === null || !this.state) {
+      throw new Error(`${this.type} undo 불가 — 살아있는 변경 기록이 없다`);
+    }
+    wasm.applyCellBorderFillIds(this.sec, this.ppi, this.ci, {
+      cells: this.state.cellBefores,
+      zones: this.state.zoneRange
+        ? [{ ...this.state.zoneRange, id: this.state.zoneBeforeId }]
+        : [],
+    });
+    wasm.removeBorderFillTails(this.state.borderFillLenBefore, this.state.docInfoDirtyBefore);
+    wasm.restoreSectionRaw(this.captureId);
+    this.captureId = null;
+    return { ...this.cursorPos };
+  }
+
+  discard(wasm: WasmBridge): void {
+    if (this.captureId !== null) {
+      wasm.discardSectionRaw(this.captureId);
+      this.captureId = null;
+    }
+  }
+
+  snapshotResourceCount(): number { return 0; }
+
+  isNoOp(): boolean { return this.noOp; }
+
+  /** 병합하지 않는다 — 다이얼로그 확인 1회가 되돌리기 단위 1회다(한컴 정합). */
+  mergeWith(): null { return null; }
+
+  private rollback(
+    wasm: WasmBridge,
+    cellBefores: Map<number, number>,
+    zoneBeforeId: number | null,
+    lenBefore: number,
+    dirtyBefore: boolean,
+  ): void {
+    if (this.captureId === null) return;
+    wasm.applyCellBorderFillIds(this.sec, this.ppi, this.ci, {
+      cells: [...cellBefores.entries()].map(([cellIdx, id]) => ({ cellIdx, id })),
+      zones: this.target.kind === 'zone'
+        ? [{ ...this.target.range, id: zoneBeforeId }]
+        : [],
+    });
+    if (lenBefore >= 0) wasm.removeBorderFillTails(lenBefore, dirtyBefore);
+    wasm.restoreSectionRaw(this.captureId);
+    this.captureId = null;
   }
 }
 

--- a/rhwp-studio/src/ui/cell-border-bg-dialog.ts
+++ b/rhwp-studio/src/ui/cell-border-bg-dialog.ts
@@ -1,4 +1,7 @@
 import { ModalDialog } from './dialog';
+import { applyCommandThroughRouter } from './dialog-apply';
+import { SetCellBorderFillCommand } from '@/engine/command';
+import type { CellBorderFillTarget } from '@/engine/command';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { CellBbox, CellProperties } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
@@ -1018,59 +1021,67 @@ export class CellBorderBgDialog extends ModalDialog {
         ? this.diagScopeRadios
         : this.borderScopeRadios;
     const scope = scopeRadios?.find(r => r.checked)?.value ?? 'selected';
-    const applyProps = () => {
+    // [#5959] 적용 대상을 데이터로 고정한다 — 커맨드 execute 가 다시 읽지 않는다.
+    const buildTargets = (): CellBorderFillTarget => {
       if (this.applyMode === 'asOne') {
-        const range = scope === 'all'
-          ? (() => {
-            const dims = this.wasm.getTableDimensions(sec, ppi, ci);
-            return {
+        if (scope === 'all') {
+          const dims = this.wasm.getTableDimensions(sec, ppi, ci);
+          return {
+            kind: 'zone',
+            range: {
               startRow: 0,
               startCol: 0,
               endRow: Math.max(0, dims.rowCount - 1),
               endCol: Math.max(0, dims.colCount - 1),
-            };
-          })()
-          : this.selectionRange;
-        if (range) {
-          this.wasm.setCellZoneProperties(sec, ppi, ci, range, newProps as Partial<CellProperties>);
-        } else {
-          this.wasm.setCellProperties(sec, ppi, ci, this.cellIdx, newProps as Partial<CellProperties>);
+            },
+          };
         }
-      } else if (scope === 'all') {
-        const dims = this.wasm.getTableDimensions(sec, ppi, ci);
-        // 셀 수만큼 setCellProperties 를 호출하므로 재페이지네이션을 묶는다(#4118).
-        this.wasm.runInBatch(() => {
-          for (let i = 0; i < dims.cellCount; i++) {
-            this.wasm.setCellProperties(sec, ppi, ci, i, newProps as Partial<CellProperties>);
-          }
-        });
-      } else if (this.selectionRange) {
-        const cellIndices = this.selectedCellIndicesForRange(this.selectionRange);
-        const targetIndices = cellIndices.length > 0 ? cellIndices : [this.cellIdx];
-        this.wasm.runInBatch(() => {
-          for (const cellIdx of targetIndices) {
-            this.wasm.setCellProperties(sec, ppi, ci, cellIdx, newProps as Partial<CellProperties>);
-          }
-        });
-      } else {
-        this.wasm.setCellProperties(sec, ppi, ci, this.cellIdx, newProps as Partial<CellProperties>);
+        if (this.selectionRange) return { kind: 'zone', range: this.selectionRange };
+        return { kind: 'cells', cellIdxes: [this.cellIdx] };
       }
+      if (scope === 'all') {
+        const dims = this.wasm.getTableDimensions(sec, ppi, ci);
+        const all = Array.from({ length: dims.cellCount }, (_, i) => i);
+        return { kind: 'cells', cellIdxes: all };
+      }
+      if (this.selectionRange) {
+        const cellIndices = this.selectedCellIndicesForRange(this.selectionRange);
+        return { kind: 'cells', cellIdxes: cellIndices.length > 0 ? cellIndices : [this.cellIdx] };
+      }
+      return { kind: 'cells', cellIdxes: [this.cellIdx] };
     };
-    // 셀 테두리/배경 일괄 적용도 undo 대상이다 — 편집 라우터를 통과시켜
-    // 스냅샷 하나로 기록한다 (#1320 계약, picture-props-dialog(#2027)와 동일
-    // 패턴). services 미주입 환경에서만 직접 적용 fallback.
+    // 셀 테두리/배경 일괄 적용도 undo 대상이다 — 속성쌍 역연산 커맨드로 기록해
+    // 스냅샷 슬롯을 쓰지 않는다(#5959). services 미주입 환경(구 호출부)에서만
+    // 직접 적용 fallback(기록 없음 — 종전 계약 유지).
+    // services 미주입 환경의 직접 적용 — 기록 없음(종전 계약 유지).
+    const applyDirect = () => {
+      const t = buildTargets();
+      if (t.kind === 'zone') {
+        this.wasm.setCellZoneProperties(sec, ppi, ci, t.range, newProps as Partial<CellProperties>);
+        return;
+      }
+      // 셀 수만큼 setCellProperties 를 호출하므로 재페이지네이션을 묶는다(#4118).
+      this.wasm.runInBatch(() => {
+        for (const cellIdx of t.cellIdxes) {
+          this.wasm.setCellProperties(sec, ppi, ci, cellIdx, newProps as Partial<CellProperties>);
+        }
+      });
+    };
     const ih = this.services?.getInputHandler();
     if (ih) {
-      ih.executeOperation({
-        kind: 'snapshot',
-        operationType: 'objectProps',
-        operation: () => {
-          applyProps();
-          return ih.getCursorPosition();
-        },
+      applyCommandThroughRouter({
+        services: this.services,
+        label: 'CellBorderBgDialog',
+        command: () => ({
+          kind: 'command',
+          command: new SetCellBorderFillCommand(
+            sec, ppi, ci, buildTargets(), newProps, ih.getCursorPosition(),
+          ),
+        }),
+        fallback: applyDirect,
       });
     } else {
-      applyProps();
+      applyDirect();
       this.eventBus.emit('document-changed');
     }
   }

--- a/rhwp-studio/tests/issue-5959-cell-borderfill-inverse.test.ts
+++ b/rhwp-studio/tests/issue-5959-cell-borderfill-inverse.test.ts
@@ -191,3 +191,23 @@ test('소스 핀 — 다이얼로그는 커맨드 경유, 레지스트리는 신
   const bridgeSrc = readFileSync(join(rootDir, 'src/core/wasm-bridge.ts'), 'utf8');
   assert.match(bridgeSrc, /hasCellBorderFillInverse/, 'probe 가 브리지에 있어야 한다');
 });
+
+test('execute 실패가 아무 뮤테이션 전이면 롤백 호출 없이 캡처만 해제한다', () => {
+  const calls: Call[] = [];
+  const wasm: any = {
+    hasCellBorderFillInverse: () => true,
+    captureSectionRaw: () => { calls.push({ fn: 'captureSectionRaw', args: [] }); return 801; },
+    discardSectionRaw: (...args: unknown[]) => { calls.push({ fn: 'discardSectionRaw', args }); },
+    runInBatch: (fn: () => void) => fn(),
+    setCellProperties: () => { calls.push({ fn: 'setCellProperties', args: [] }); throw new Error('셀 인덱스 초과'); },
+  };
+  const cmd = new SetCellBorderFillCommand(
+    0, 12, 5, { kind: 'cells', cellIdxes: [5] }, { fillType: 'solid' }, { sectionIndex: 0 },
+  );
+  assert.throws(() => cmd.execute(wasm), /셀 인덱스 초과/);
+  const names = calls.map((c) => c.fn);
+  assert.ok(names.includes('discardSectionRaw'), '캡처 해제는 해야 한다');
+  assert.ok(!names.includes('applyCellBorderFillIds'), '뮤테이션 전 실패엔 빈 롤백 대입을 낭비하지 않는다');
+  assert.ok(!names.includes('removeBorderFillTails'), '빈 절단은 table.dirty 만 세운다');
+  assert.throws(() => cmd.undo(wasm), /변경 기록이 없다/);
+});

--- a/rhwp-studio/tests/issue-5959-cell-borderfill-inverse.test.ts
+++ b/rhwp-studio/tests/issue-5959-cell-borderfill-inverse.test.ts
@@ -1,0 +1,193 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'vite';
+
+// `engine/command.ts` 는 constructor parameter property 를 쓰므로 Node 의 타입 스트리핑으로는
+// 못 읽는다(#3230 과 같은 이유·같은 방식으로 vite SSR 로 띄운다).
+const studioRoot = fileURLToPath(new URL('..', import.meta.url));
+const rootDir = studioRoot;
+let SetCellBorderFillCommand: any;
+
+test('모듈 로드', async () => {
+  const vite = await createServer({
+    root: studioRoot,
+    appType: 'custom',
+    logLevel: 'silent',
+    server: { middlewareMode: true },
+  });
+  try {
+    ({ SetCellBorderFillCommand } = await vite.ssrLoadModule('/src/engine/command.ts'));
+  } finally {
+    await vite.close();
+  }
+  assert.equal(typeof SetCellBorderFillCommand, 'function');
+});
+
+// [#5959] 셀 테두리/배경을 스냅샷에서 속성쌍 역연산으로.
+//
+// 변경 실체는 대상+이웃 집단의 border_fill_id 재배정과 스타일 테이블 append 다 —
+// Rust 가 self-describing 기록(changes/borderFillLenBefore/docInfoDirtyBefore)을
+// 응답으로 주고, undo 는 ① id 직접 대입 ② push 분 꼬리 절단 ③ 구역 raw 복원의
+// 3단으로 원상 복구한다(저장 바이트 수렴 실증:
+// tests/cases/issue_5959_cell_borderfill_inverse_convergence.rs).
+//
+// 여기서 고정하는 것은 셋이다 — probe 선차단 배선, 저널 생명주기 순서,
+// 스냅샷 예산을 쓰지 않는다는 것.
+
+interface Call { fn: string; args: unknown[] }
+
+function recordingWasm(responses: {
+  setCellProperties?: any;
+  setCellZoneProperties?: any;
+}): { wasm: any; calls: Call[] } {
+  const calls: Call[] = [];
+  const rec = (fn: string) => (...args: unknown[]) => {
+    calls.push({ fn, args });
+    return { ok: true };
+  };
+  return {
+    calls,
+    wasm: {
+      hasCellBorderFillInverse: (() => {
+        let called = false;
+        return () => { calls.push({ fn: 'hasCellBorderFillInverse', args: [] }); called = true; return true; };
+      })(),
+      captureSectionRaw: (() => {
+        let id = 700;
+        return () => { calls.push({ fn: 'captureSectionRaw', args: [] }); return ++id; };
+      })(),
+      restoreSectionRaw: rec('restoreSectionRaw'),
+      discardSectionRaw: rec('discardSectionRaw'),
+      runInBatch: (fn: () => unknown) => fn(),
+      setCellProperties: (...args: unknown[]) => {
+        calls.push({ fn: 'setCellProperties', args });
+        return responses.setCellProperties;
+      },
+      setCellZoneProperties: (...args: unknown[]) => {
+        calls.push({ fn: 'setCellZoneProperties', args });
+        return responses.setCellZoneProperties;
+      },
+      applyCellBorderFillIds: rec('applyCellBorderFillIds'),
+      removeBorderFillTails: rec('removeBorderFillTails'),
+    },
+  };
+}
+
+test('execute 는 probe → 캡처 순서를 지키고 변경 기록을 모은다', () => {
+  const { wasm, calls } = recordingWasm({
+    setCellProperties: {
+      ok: true,
+      changes: [{ cellIdx: 3, beforeId: 2, afterId: 9 }],
+      borderFillLenBefore: 9,
+      docInfoDirtyBefore: false,
+    },
+  });
+  const cmd = new SetCellBorderFillCommand(
+    0, 12, 5, { kind: 'cells', cellIdxes: [1] }, { fillType: 'solid' }, { sectionIndex: 0 },
+  );
+  cmd.execute(wasm);
+
+  const names = calls.map((c) => c.fn);
+  const probeAt = names.indexOf('hasCellBorderFillInverse');
+  const captureAt = names.indexOf('captureSectionRaw');
+  assert.ok(probeAt !== -1 && captureAt !== -1, 'probe 와 캡처가 있어야 한다');
+  assert.ok(probeAt < captureAt, 'probe 가 캡처보다 먼저여야 한다(구버전 wasm 원천 거절)');
+  assert.match(names.join(','), /setCellProperties/, '적용이 기록돼야 한다');
+  for (const fn of ['saveSnapshot', 'restoreSnapshot']) {
+    assert.ok(!names.includes(fn), `${fn} 을 쓰면 스냅샷 회귀다`);
+  }
+  assert.equal(cmd.snapshotResourceCount(), 0);
+  assert.equal(cmd.isNoOp(), false);
+});
+
+test('undo 는 id 대입 → 꼬리 절단 → raw 복원 순서다', () => {
+  const { wasm, calls } = recordingWasm({
+    setCellProperties: {
+      ok: true,
+      changes: [
+        { cellIdx: 1, beforeId: 2, afterId: 10 },
+        { cellIdx: 0, beforeId: 3, afterId: 10 },
+      ],
+      borderFillLenBefore: 9,
+      docInfoDirtyBefore: false,
+    },
+  });
+  const cmd = new SetCellBorderFillCommand(
+    0, 12, 5, { kind: 'cells', cellIdxes: [1] }, { fillType: 'solid' }, { sectionIndex: 0 },
+  );
+  cmd.execute(wasm);
+  calls.length = 0;
+
+  cmd.undo(wasm);
+  const names = calls.map((c) => c.fn);
+  const applyAt = names.indexOf('applyCellBorderFillIds');
+  const gcAt = names.indexOf('removeBorderFillTails');
+  const restoreAt = names.indexOf('restoreSectionRaw');
+  assert.ok(applyAt !== -1 && gcAt !== -1 && restoreAt !== -1, '3 단계가 모두 있어야 한다');
+  assert.ok(applyAt < gcAt && gcAt < restoreAt, '대입 → 절단 → 복원 순서가 어긋나면 저널 전제가 깨진다');
+
+  const applyCall = calls[applyAt];
+  const payload = applyCall.args[3];
+  // 이웃 재배정으로 같은 셀이 여러 번 기록돼도 undo 는 원본(beforeId) 하나면 충분하다.
+  assert.deepEqual(
+    [...payload.cells].sort((a: any, b: any) => a.cellIdx - b.cellIdx),
+    [{ cellIdx: 0, id: 3 }, { cellIdx: 1, id: 2 }],
+  );
+  const gcCall = calls[gcAt];
+  assert.equal(gcCall.args[0], 9, 'fromLen');
+  assert.equal(gcCall.args[1], false, 'dirtyWas');
+});
+
+test('변경이 없으면 no-op 으로 저널을 남기지 않는다', () => {
+  const { wasm, calls } = recordingWasm({
+    setCellProperties: { ok: true, changes: [], borderFillLenBefore: 9, docInfoDirtyBefore: false },
+  });
+  const cmd = new SetCellBorderFillCommand(
+    0, 12, 5, { kind: 'cells', cellIdxes: [1] }, { fillType: 'solid' }, { sectionIndex: 0 },
+  );
+  cmd.execute(wasm);
+  assert.equal(cmd.isNoOp(), true);
+  const names = calls.map((c) => c.fn);
+  assert.ok(names.includes('discardSectionRaw'), '캡처를 즉시 해제해야 한다');
+  assert.ok(!names.includes('restoreSectionRaw'), 'no-op 에 undo 경로가 남으면 안 된다');
+  assert.throws(() => cmd.undo(wasm), /변경 기록이 없다/);
+});
+
+test('zone(asOne) 적용도 같은 생명주기를 쓴다', () => {
+  const { wasm, calls } = recordingWasm({
+    setCellZoneProperties: {
+      ok: true, borderFillId: 11, zoneBeforeId: null,
+      borderFillLenBefore: 10, docInfoDirtyBefore: true,
+    },
+  });
+  const range = { startRow: 0, startCol: 0, endRow: 1, endCol: 1 };
+  const cmd = new SetCellBorderFillCommand(
+    0, 12, 5, { kind: 'zone', range }, { fillType: 'none' }, { sectionIndex: 0 },
+  );
+  cmd.execute(wasm);
+  cmd.undo(wasm);
+
+  const zoneUndo = calls.find((c) => c.fn === 'applyCellBorderFillIds');
+  assert.ok(zoneUndo, 'zone undo 가 기록돼야 한다');
+  assert.deepEqual(zoneUndo.args[3].zones, [{ ...range, id: null }], '신설 zone 은 제거로 되돌린다');
+  const gcCall = calls.find((c) => c.fn === 'removeBorderFillTails');
+  assert.equal(gcCall.args[0], 10, 'fromLen');
+  assert.equal(gcCall.args[1], true, 'dirtyWas');
+});
+
+test('소스 핀 — 다이얼로그는 커맨드 경유, 레지스트리는 신규 네이티브를 변이로 분류', () => {
+  const dialogSrc = readFileSync(join(rootDir, 'src/ui/cell-border-bg-dialog.ts'), 'utf8');
+  assert.match(dialogSrc, /applyCommandThroughRouter/, '다이얼로그가 커맨드 경유여야 한다');
+  assert.match(dialogSrc, /new SetCellBorderFillCommand/);
+  assert.ok(!dialogSrc.includes("kind: 'snapshot'"), '스냅샷 기록 잔존은 회귀다');
+
+  const registrySrc = readFileSync(join(rootDir, 'src/core/mutation-method-registry.ts'), 'utf8');
+  assert.match(registrySrc, /'applyCellBorderFillIds'/);
+  assert.match(registrySrc, /'removeBorderFillTails'/);
+
+  const bridgeSrc = readFileSync(join(rootDir, 'src/core/wasm-bridge.ts'), 'utf8');
+  assert.match(bridgeSrc, /hasCellBorderFillInverse/, 'probe 가 브리지에 있어야 한다');
+});

--- a/rhwp-studio/tests/table-props-undo.test.ts
+++ b/rhwp-studio/tests/table-props-undo.test.ts
@@ -27,7 +27,7 @@ test('표/셀 속성 다이얼로그 onConfirm은 스냅샷으로 undo 기록된
   );
 });
 
-test('셀 테두리/배경 다이얼로그 onConfirm은 스냅샷으로 undo 기록된다', () => {
+test('셀 테두리/배경 다이얼로그 onConfirm은 속성쌍 역연산 커맨드로 undo 기록된다 (#5959)', () => {
   const dialog = source('src/ui/cell-border-bg-dialog.ts');
   const start = dialog.indexOf('protected onConfirm');
   assert.notEqual(start, -1, 'onConfirm not found');
@@ -35,8 +35,17 @@ test('셀 테두리/배경 다이얼로그 onConfirm은 스냅샷으로 undo 기
 
   assert.match(
     block,
-    /executeOperation\(\{\s*kind: 'snapshot',\s*operationType: 'objectProps'/,
-    '셀 테두리/배경 적용은 snapshot 명령으로 기록되어야 함',
+    /applyCommandThroughRouter/,
+    '셀 테두리/배경 적용은 커맨드 라우터로 기록되어야 함',
+  );
+  assert.match(
+    block,
+    /new SetCellBorderFillCommand/,
+    'SetCellBorderFillCommand 경유여야 함(스냅샷 슬롯 0)',
+  );
+  assert.ok(
+    !/kind: 'snapshot'/.test(block),
+    '스냅샷 기록 잔존은 슬롯 예산 회귀다(#5959)',
   );
 });
 

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -1387,6 +1387,9 @@ impl DocumentCore {
         let border_fill_len_before = self.document.doc_info.border_fills.len();
         let doc_info_dirty_before = self.document.doc_info.raw_stream_dirty;
         let mut bf_changes: Vec<(usize, u16, u16)> = Vec::new();
+        // [#5959] override zone 전이 기록 — sync 가 1×1 cellzone 을 만들거나 지우면
+        // 셀 id 복원만으로는 부족하다(undo 뒤 대각선 유령·소실).
+        let mut zone_changes: Vec<(u16, u16, u16, u16, Option<u16>, Option<u16>)> = Vec::new();
         // 대상 셀의 적용 직전 id — 아래 borrow 블록이 정상 완료되면 채워진다.
         let mut target_bf_before = 0u16;
 
@@ -1528,6 +1531,19 @@ impl DocumentCore {
                     cell.border_fill_id = new_bf_id;
                     (cell.row, cell.col, cell.col_span, cell.row_span)
                 };
+                let origin_override_id = |table: &crate::model::table::Table| -> Option<u16> {
+                    table
+                        .zones
+                        .iter()
+                        .find(|zone| {
+                            zone.start_row == row
+                                && zone.start_col == col
+                                && zone.end_row == row
+                                && zone.end_col == col
+                        })
+                        .map(|zone| zone.border_fill_id)
+                };
+                let override_before = origin_override_id(table);
                 Self::sync_cellzone_origin_cell_diagonal_override(
                     table,
                     row,
@@ -1536,6 +1552,12 @@ impl DocumentCore {
                     new_bf_has_cell_diagonal,
                     &cell_diagonal_bf_ids,
                 );
+                let override_after = origin_override_id(table);
+                if override_before != override_after {
+                    // [#5959] undo 가 이 전이를 되돌려야 한다 — before 가 None 이면
+                    // 신설(제거로 복구), after 가 None 이면 제거(id 로 복구)다.
+                    zone_changes.push((row, col, row, col, override_before, override_after));
+                }
                 (
                     row as usize,
                     col as usize,
@@ -1574,6 +1596,17 @@ impl DocumentCore {
                 .iter()
                 .map(|(cell_idx, before, after)| serde_json::json!({
                     "cellIdx": cell_idx,
+                    "beforeId": before,
+                    "afterId": after,
+                }))
+                .collect::<Vec<_>>(),
+            "zones": zone_changes
+                .iter()
+                .map(|(sr, sc, er, ec, before, after)| serde_json::json!({
+                    "startRow": sr,
+                    "startCol": sc,
+                    "endRow": er,
+                    "endCol": ec,
                     "beforeId": before,
                     "afterId": after,
                 }))
@@ -1911,11 +1944,16 @@ impl DocumentCore {
                 }
             }
             for zone in &payload.zones {
+                // 적용 단계와 같은 min/max 정규화로 존재를 판정한다 — 뒤집힌 좌표가
+                // 들어와도 apply 와 검증이 같은 rect 를 보게 유지한다.
+                let (zsr, zsc, zer, zec) = (
+                    zone.start_row.min(zone.end_row),
+                    zone.start_col.min(zone.end_col),
+                    zone.start_row.max(zone.end_row),
+                    zone.start_col.max(zone.end_col),
+                );
                 let exists = table.zones.iter().any(|z| {
-                    z.start_row == zone.start_row.min(zone.end_row)
-                        && z.end_row == zone.end_row.max(zone.start_row)
-                        && z.start_col == zone.start_col.min(zone.end_col)
-                        && z.end_col == zone.end_col.max(zone.end_col)
+                    z.start_row == zsr && z.end_row == zer && z.start_col == zsc && z.end_col == zec
                 });
                 if let Some(id) = zone.id {
                     if id == 0 || id > max_bf {

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -1974,11 +1974,11 @@ impl DocumentCore {
 
     /// [#5959] 이번 apply 가 push 한 BorderFill 꼬리 항목 절단.
     ///
-    /// 저널 계약(캡처~복원 사이 그 표 편집 금지)과 TS 선형 히스토리 하에서
-    /// `from_len` 위의 항목은 이 커맨드의 apply 가 push 한 것뿐이다 — LIFO undo
-    /// 에서 꼬리부터 사라지므로 `from_len` 까지 자르는 것만으로 안전하다. 잘라내지
-    /// 못하면(중간 삽입 등 계약 위반) 고아가 남으므로 dirty 플래그를 원복하지
-    /// 않는다 — 저장 바이트 게이트가 그 차이를 잡는다.
+    /// 정상 경로(TS 선형 히스토리 + 저널 계약)에서는 `from_len` 위의 항목이 곧
+    /// 이 커맨드의 push 분이다. 그러나 계약 밖 경로(hwpctl 직접 뮤테이션 등)가
+    /// apply 와 undo 사이에 꼬리를 더 push 할 수 있으므로, **문서 어디에서도
+    /// 참조하지 않는 꼬리만** 자른다 — 참조 중인 꼬리를 만나면 거기서 멈추고
+    /// 나머지는 고아로 남긴다. 고아는 저장 바이트 게이트가 잡는다.
     pub fn remove_border_fill_tails_native(&mut self, json: &str) -> Result<String, HwpError> {
         #[derive(serde::Deserialize)]
         #[serde(rename_all = "camelCase")]
@@ -1990,8 +1990,15 @@ impl DocumentCore {
         let payload: Payload = serde_json::from_str(json)
             .map_err(|e| HwpError::RenderError(format!("discard tails 파싱 실패: {}", e)))?;
 
+        let mut referenced = std::collections::HashSet::new();
+        self.collect_border_fill_refs(&mut referenced);
+
         let mut discarded = 0usize;
         while self.document.doc_info.border_fills.len() > payload.from_len {
+            let tail_id = self.document.doc_info.border_fills.len() as u16;
+            if referenced.contains(&tail_id) {
+                break;
+            }
             self.document.doc_info.border_fills.pop();
             discarded += 1;
         }
@@ -2005,6 +2012,48 @@ impl DocumentCore {
             "fullyDiscarded": fully_discarded,
         });
         Ok(response.to_string())
+    }
+
+    /// [#5959] 문서 전역에서 border_fills 참조를 수집한다(보수적 상위집합).
+    ///
+    /// 셀·zone(중첩 표 재귀 포함), 글자/문단 스타일 정의, 구역 쪽 테두리까지 훑는다.
+    /// 스타일 정의는 전부 포함하는 쪽이 안전하다 — 정의가 우리 항목을 참조할 수
+    /// 없다면 스캔이 넓어도 절단이 보수적으로 줄어들 뿐이다.
+    fn collect_border_fill_refs(&self, refs: &mut std::collections::HashSet<u16>) {
+        for cs in &self.document.doc_info.char_shapes {
+            refs.insert(cs.border_fill_id);
+        }
+        for ps in &self.document.doc_info.para_shapes {
+            refs.insert(ps.border_fill_id);
+        }
+        for section in &self.document.sections {
+            for pbf in &section.section_def.extra_page_border_fills {
+                refs.insert(pbf.border_fill_id);
+            }
+            for para in &section.paragraphs {
+                Self::collect_control_border_fill_refs(&para.controls, refs);
+            }
+        }
+    }
+
+    fn collect_control_border_fill_refs(
+        controls: &[Control],
+        refs: &mut std::collections::HashSet<u16>,
+    ) {
+        for control in controls {
+            let Control::Table(table) = control else {
+                continue;
+            };
+            for cell in &table.cells {
+                refs.insert(cell.border_fill_id);
+                for para in &cell.paragraphs {
+                    Self::collect_control_border_fill_refs(&para.controls, refs);
+                }
+            }
+            for zone in &table.zones {
+                refs.insert(zone.border_fill_id);
+            }
+        }
     }
 
     fn strip_center_line_for_cellzone_json(json: &str) -> String {

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -1382,6 +1382,14 @@ impl DocumentCore {
             None
         };
 
+        // [#5959] 역연산 기록 기준선 — 스타일 테이블 길이·dirty 플래그는 이 호출이
+        // 손대기 전 값이다. 응답으로 돌려 TS 커맨드가 undo 때 원상 복구에 쓴다.
+        let border_fill_len_before = self.document.doc_info.border_fills.len();
+        let doc_info_dirty_before = self.document.doc_info.raw_stream_dirty;
+        let mut bf_changes: Vec<(usize, u16, u16)> = Vec::new();
+        // 대상 셀의 적용 직전 id — 아래 borrow 블록이 정상 완료되면 채워진다.
+        let mut target_bf_before = 0u16;
+
         let (needs_reflow, reflow_para_count) = {
             let mut needs_reflow = false;
             let mut size_changed = false;
@@ -1402,6 +1410,7 @@ impl DocumentCore {
             let cell = table.cells.get_mut(cell_idx).ok_or_else(|| {
                 HwpError::RenderError(format!("셀 인덱스 {} 범위 초과", cell_idx))
             })?;
+            target_bf_before = cell.border_fill_id;
 
             if let Some(v) = top_u32("width") {
                 needs_reflow |= cell.width != v;
@@ -1453,6 +1462,9 @@ impl DocumentCore {
                 cell.field_name = if v.is_empty() { None } else { Some(v) };
             }
             if let Some(v) = direct_border_fill_id {
+                if v != target_bf_before {
+                    bf_changes.push((cell_idx, target_bf_before, v));
+                }
                 cell.border_fill_id = v;
             }
             if size_changed {
@@ -1534,7 +1546,7 @@ impl DocumentCore {
 
             // 이웃 셀의 공유 엣지 테두리를 갱신
             // borders 배열: [좌(0), 우(1), 상(2), 하(3)]
-            self.update_neighbor_borders(
+            bf_changes.extend(self.update_neighbor_borders(
                 section_idx,
                 parent_para_idx,
                 control_idx,
@@ -1544,14 +1556,32 @@ impl DocumentCore {
                 target_col_span,
                 target_row_span,
                 &new_borders,
-            );
+            ));
+            if new_bf_id != target_bf_before {
+                bf_changes.push((cell_idx, target_bf_before, new_bf_id));
+            }
         }
 
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();
 
-        Ok("{\"ok\":true}".to_string())
+        // [#5959] self-describing 변경 기록 — TS 커맨드가 undo 때 이대로 되돌린다
+        // (z-order moves[] 선례). changes 는 borderFillId 전환만 담는다.
+        let response = serde_json::json!({
+            "ok": true,
+            "changes": bf_changes
+                .iter()
+                .map(|(cell_idx, before, after)| serde_json::json!({
+                    "cellIdx": cell_idx,
+                    "beforeId": before,
+                    "afterId": after,
+                }))
+                .collect::<Vec<_>>(),
+            "borderFillLenBefore": border_fill_len_before,
+            "docInfoDirtyBefore": doc_info_dirty_before,
+        });
+        Ok(response.to_string())
     }
 
     fn border_fill_has_cell_diagonal(bf: &crate::model::style::BorderFill) -> bool {
@@ -1754,21 +1784,39 @@ impl DocumentCore {
         end_col: u16,
         json: &str,
     ) -> Result<String, HwpError> {
+        // [#5959] 역연산 기록 기준선 — 생성 전 스타일 테이블 길이·dirty 플래그와
+        // 매칭 zone 의 이전 id(None 이면 신설)를 응답으로 돌려 undo 가 쓴다.
+        let border_fill_len_before = self.document.doc_info.border_fills.len();
+        let doc_info_dirty_before = self.document.doc_info.raw_stream_dirty;
+        let (zone_before_id, sr, er, sc, ec) = {
+            let t = self.get_table_mut(section_idx, parent_para_idx, control_idx)?;
+            if t.row_count == 0 || t.col_count == 0 {
+                return Err(HwpError::RenderError(
+                    "빈 표에는 cellzone을 적용할 수 없습니다".to_string(),
+                ));
+            }
+            let max_row = t.row_count.saturating_sub(1);
+            let max_col = t.col_count.saturating_sub(1);
+            let sr = start_row.min(end_row).min(max_row);
+            let er = start_row.max(end_row).min(max_row);
+            let sc = start_col.min(end_col).min(max_col);
+            let ec = start_col.max(end_col).min(max_col);
+            let before = t
+                .zones
+                .iter()
+                .find(|zone| {
+                    zone.start_row == sr
+                        && zone.end_row == er
+                        && zone.start_col == sc
+                        && zone.end_col == ec
+                })
+                .map(|zone| zone.border_fill_id);
+            (before, sr, er, sc, ec)
+        };
+
         let cellzone_json = Self::strip_center_line_for_cellzone_json(json);
         let new_bf_id = self.create_border_fill_from_json(&cellzone_json);
         let table = self.get_table_mut(section_idx, parent_para_idx, control_idx)?;
-        if table.row_count == 0 || table.col_count == 0 {
-            return Err(HwpError::RenderError(
-                "빈 표에는 cellzone을 적용할 수 없습니다".to_string(),
-            ));
-        }
-
-        let max_row = table.row_count.saturating_sub(1);
-        let max_col = table.col_count.saturating_sub(1);
-        let sr = start_row.min(end_row).min(max_row);
-        let er = start_row.max(end_row).min(max_row);
-        let sc = start_col.min(end_col).min(max_col);
-        let ec = start_col.max(end_col).min(max_col);
 
         if let Some(zone) = table.zones.iter_mut().find(|zone| {
             zone.start_row == sr && zone.end_row == er && zone.start_col == sc && zone.end_col == ec
@@ -1789,10 +1837,174 @@ impl DocumentCore {
         self.recompose_section(section_idx);
         self.paginate_if_needed();
 
-        Ok(format!(
-            "{{\"ok\":true,\"startRow\":{},\"startCol\":{},\"endRow\":{},\"endCol\":{},\"borderFillId\":{}}}",
-            sr, sc, er, ec, new_bf_id
-        ))
+        let response = serde_json::json!({
+            "ok": true,
+            "startRow": sr,
+            "startCol": sc,
+            "endRow": er,
+            "endCol": ec,
+            "borderFillId": new_bf_id,
+            "zoneBeforeId": zone_before_id,
+            "borderFillLenBefore": border_fill_len_before,
+            "docInfoDirtyBefore": doc_info_dirty_before,
+        });
+        Ok(response.to_string())
+    }
+
+    /// [#5959] 셀/zone border_fill_id 직접 대입 (undo·redo 전용).
+    ///
+    /// 스타일 테이블(`doc_info.border_fills`)은 절대 건드리지 않는다 — 참조하는
+    /// id 만 바꾼다. execute 의 변경 기록(changes/zone 기록)을 그대로 되돌리는
+    /// 것이 계약이다. 전수 검증 후 적용한다(부분 적용 금지 — z-order 오염 pairs
+    /// 거절 선례).
+    pub fn apply_cell_border_fill_ids_native(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        json: &str,
+    ) -> Result<String, HwpError> {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct CellIdPair {
+            cell_idx: usize,
+            id: u16,
+        }
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct ZoneIdEntry {
+            start_row: u16,
+            start_col: u16,
+            end_row: u16,
+            end_col: u16,
+            /// None 이면 이 범위의 zone 을 제거한다(적용 때 신설됐던 경우).
+            id: Option<u16>,
+        }
+        #[derive(serde::Deserialize)]
+        struct Payload {
+            #[serde(default)]
+            cells: Vec<CellIdPair>,
+            #[serde(default)]
+            zones: Vec<ZoneIdEntry>,
+        }
+
+        let payload: Payload = serde_json::from_str(json)
+            .map_err(|e| HwpError::RenderError(format!("border fill ids 파싱 실패: {}", e)))?;
+
+        let max_bf = self.document.doc_info.border_fills.len() as u16;
+
+        // 1단계 전수 검증 — 하나라도 어긋나면 아무것도 적용하지 않는다.
+        {
+            let table = self.get_table_mut(section_idx, parent_para_idx, control_idx)?;
+            for pair in &payload.cells {
+                if pair.cell_idx >= table.cells.len() {
+                    return Err(HwpError::RenderError(format!(
+                        "셀 인덱스 {} 범위 초과",
+                        pair.cell_idx
+                    )));
+                }
+                if pair.id == 0 || pair.id > max_bf {
+                    return Err(HwpError::RenderError(format!(
+                        "borderFillId {} 범위 초과 (최대 {})",
+                        pair.id, max_bf
+                    )));
+                }
+            }
+            for zone in &payload.zones {
+                let exists = table.zones.iter().any(|z| {
+                    z.start_row == zone.start_row.min(zone.end_row)
+                        && z.end_row == zone.end_row.max(zone.start_row)
+                        && z.start_col == zone.start_col.min(zone.end_col)
+                        && z.end_col == zone.end_col.max(zone.end_col)
+                });
+                if let Some(id) = zone.id {
+                    if id == 0 || id > max_bf {
+                        return Err(HwpError::RenderError(format!(
+                            "zone borderFillId {} 범위 초과 (최대 {})",
+                            id, max_bf
+                        )));
+                    }
+                } else if !exists {
+                    return Err(HwpError::RenderError(
+                        "제거할 zone 이 없다 — 변경 기록이 현재 문서와 어긋났다".to_string(),
+                    ));
+                }
+            }
+        }
+
+        // 2단계 적용
+        {
+            let table = self.get_table_mut(section_idx, parent_para_idx, control_idx)?;
+            for pair in &payload.cells {
+                table.cells[pair.cell_idx].border_fill_id = pair.id;
+            }
+            for zone in &payload.zones {
+                let sr = zone.start_row.min(zone.end_row);
+                let er = zone.start_row.max(zone.end_row);
+                let sc = zone.start_col.min(zone.end_col);
+                let ec = zone.start_col.max(zone.end_col);
+                let pos = table.zones.iter().position(|z| {
+                    z.start_row == sr && z.end_row == er && z.start_col == sc && z.end_col == ec
+                });
+                match (pos, zone.id) {
+                    (Some(pos), Some(id)) => table.zones[pos].border_fill_id = id,
+                    (Some(pos), None) => {
+                        table.zones.remove(pos);
+                    }
+                    (None, Some(id)) => table.zones.push(crate::model::table::TableZone {
+                        start_col: sc,
+                        start_row: sr,
+                        end_col: ec,
+                        end_row: er,
+                        border_fill_id: id,
+                    }),
+                    (None, None) => {}
+                }
+            }
+            table.dirty = true;
+        }
+        self.rebuild_resolved_styles();
+
+        self.document.sections[section_idx].raw_stream = None;
+        self.recompose_section(section_idx);
+        self.paginate_if_needed();
+
+        Ok("{\"ok\":true}".to_string())
+    }
+
+    /// [#5959] 이번 apply 가 push 한 BorderFill 꼬리 항목 절단.
+    ///
+    /// 저널 계약(캡처~복원 사이 그 표 편집 금지)과 TS 선형 히스토리 하에서
+    /// `from_len` 위의 항목은 이 커맨드의 apply 가 push 한 것뿐이다 — LIFO undo
+    /// 에서 꼬리부터 사라지므로 `from_len` 까지 자르는 것만으로 안전하다. 잘라내지
+    /// 못하면(중간 삽입 등 계약 위반) 고아가 남으므로 dirty 플래그를 원복하지
+    /// 않는다 — 저장 바이트 게이트가 그 차이를 잡는다.
+    pub fn remove_border_fill_tails_native(&mut self, json: &str) -> Result<String, HwpError> {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Payload {
+            from_len: usize,
+            /// apply 직전의 raw_stream_dirty 값 — 완전 절단에 성공했을 때만 원복한다.
+            dirty_was: bool,
+        }
+        let payload: Payload = serde_json::from_str(json)
+            .map_err(|e| HwpError::RenderError(format!("discard tails 파싱 실패: {}", e)))?;
+
+        let mut discarded = 0usize;
+        while self.document.doc_info.border_fills.len() > payload.from_len {
+            self.document.doc_info.border_fills.pop();
+            discarded += 1;
+        }
+        let fully_discarded = self.document.doc_info.border_fills.len() == payload.from_len;
+        if fully_discarded {
+            self.document.doc_info.raw_stream_dirty = payload.dirty_was;
+        }
+        let response = serde_json::json!({
+            "ok": true,
+            "discarded": discarded,
+            "fullyDiscarded": fully_discarded,
+        });
+        Ok(response.to_string())
     }
 
     fn strip_center_line_for_cellzone_json(json: &str) -> String {
@@ -1827,15 +2039,19 @@ impl DocumentCore {
         target_col_span: usize,
         target_row_span: usize,
         new_borders: &[crate::model::style::BorderLine; 4],
-    ) {
+    ) -> Vec<(usize, u16, u16)> {
         use crate::model::style::BorderLine;
+
+        // [#5959] 되돌림 기록 — (셀 인덱스, 이전 id, 새 id). id 이동이 없던 이웃은
+        // 기록하지 않는다(복제 후 dedupe 가 원래 id 로 수렴한 경우).
+        let mut neighbor_changes: Vec<(usize, u16, u16)> = Vec::new();
 
         // 1단계: 이웃 셀 탐색 — (셀 인덱스, old_bf_id, 갱신할 방향, 새 테두리)
         let mut updates: Vec<(usize, u16, usize, BorderLine)> = Vec::new();
         {
             let table = match self.get_table_mut(section_idx, parent_para_idx, control_idx) {
                 Ok(t) => t,
-                Err(_) => return,
+                Err(_) => return neighbor_changes,
             };
             for (ci, cell) in table.cells.iter().enumerate() {
                 if ci == skip_cell_idx {
@@ -1887,7 +2103,6 @@ impl DocumentCore {
             if bf_idx >= self.document.doc_info.border_fills.len() {
                 continue;
             }
-
             let mut new_bf = self.document.doc_info.border_fills[bf_idx].clone();
             new_bf.borders[dir] = new_border;
             // 파싱된 문서의 BorderFill 은 원본 BORDER_FILL 레코드 바이트를 raw_data 로
@@ -1928,13 +2143,17 @@ impl DocumentCore {
 
             let table = match self.get_table_mut(section_idx, parent_para_idx, control_idx) {
                 Ok(t) => t,
-                Err(_) => return,
+                Err(_) => return neighbor_changes,
             };
+            if bf_id != old_bf_id {
+                neighbor_changes.push((ci, old_bf_id, bf_id));
+            }
             table.cells[ci].border_fill_id = bf_id;
         }
 
         // 스타일 재계산
         self.rebuild_resolved_styles();
+        neighbor_changes
     }
 
     /// 여러 셀의 width/height를 한 번에 조절한다 (네이티브).

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -3092,7 +3092,9 @@ impl HwpDocument {
 
     /// 셀 속성을 수정한다.
     ///
-    /// 반환: JSON `{"ok":true}`
+    /// 반환: JSON `{"ok":true,"changes":[{cellIdx,beforeId,afterId}...],
+    /// "borderFillLenBefore":N,"docInfoDirtyBefore":bool}` — changes 는 [#5959]
+    /// borderFillId 전환 기록(target+이웃)이다.
     #[wasm_bindgen(js_name = setCellProperties)]
     pub fn set_cell_properties(
         &mut self,
@@ -3114,7 +3116,8 @@ impl HwpDocument {
 
     /// 선택 영역을 하나의 셀처럼 취급하는 cellzone 테두리/배경 속성을 적용한다.
     ///
-    /// 반환: JSON `{"ok":true,"startRow":...,"borderFillId":...}`
+    /// 반환: JSON `{"ok":true,"startRow":...,"borderFillId":...,"zoneBeforeId":...,
+    /// "borderFillLenBefore":...,"docInfoDirtyBefore":...}`
     #[wasm_bindgen(js_name = setCellZoneProperties)]
     pub fn set_cell_zone_properties(
         &mut self,
@@ -3138,6 +3141,40 @@ impl HwpDocument {
             json,
         )
         .map_err(|e| e.into())
+    }
+
+    /// [#5959] 셀/zone border_fill_id 직접 대입 (undo·redo 전용).
+    ///
+    /// 스타일 테이블을 건드리지 않고 execute 의 변경 기록을 되돌린다.
+    /// json: `{"cells":[{"cellIdx":0,"id":3}],"zones":[{"startRow":..,"startCol":..,
+    /// "endRow":..,"endCol":..,"id":5}]}` — zone `id` 가 null 이면 그 범위의 zone 을
+    /// 제거한다. 반환: JSON `{"ok":true}`
+    #[wasm_bindgen(js_name = applyCellBorderFillIds)]
+    pub fn apply_cell_border_fill_ids(
+        &mut self,
+        section_idx: u32,
+        parent_para_idx: u32,
+        control_idx: u32,
+        json: &str,
+    ) -> Result<String, JsValue> {
+        self.apply_cell_border_fill_ids_native(
+            section_idx as usize,
+            parent_para_idx as usize,
+            control_idx as usize,
+            json,
+        )
+        .map_err(|e| e.into())
+    }
+
+    /// [#5959] 이번 apply 가 push 한 BorderFill 꼬리 항목을 절단한다.
+    ///
+    /// json: `{"fromLen":12,"dirtyWas":false}` — `from_len` 위 항목을 모두 잘라내고,
+    /// 원래 길이로 돌아왔으면 dirty 플래그를 `dirtyWas` 로 원복한다.
+    /// 반환: JSON `{"ok":true,"discarded":N,"fullyDiscarded":bool}`
+    #[wasm_bindgen(js_name = removeBorderFillTails)]
+    pub fn remove_border_fill_tails(&mut self, json: &str) -> Result<String, JsValue> {
+        self.remove_border_fill_tails_native(json)
+            .map_err(|e| e.into())
     }
 
     /// 여러 셀의 width/height를 한 번에 조절한다 (배치).

--- a/tests/cases/issue_5959_cell_borderfill_inverse_convergence.rs
+++ b/tests/cases/issue_5959_cell_borderfill_inverse_convergence.rs
@@ -1,0 +1,234 @@
+//! [#5959] 셀 테두리/배경 속성쌍 역연산의 저장 바이트 수렴 계약.
+//!
+//! 셀 테두리·배경 적용(`set_cell_properties` / `set_cell_zone_properties`)의 변경
+//! 실체는 대상+이웃 집단의 `border_fill_id` 재배정과 스타일 테이블 append 다
+//! (mydocs/working/task_m100_5959_cell_border_bg.md 판정). 이 시험은 TS 커맨드가
+//! 수행하는 것과 같은 3단 복구 — ① `apply_cell_border_fill_ids` 로 id 직접 대입,
+//! ② `remove_border_fill_tails` 로 push 분 절단(dirty 원복), ③ 구역 raw 저널 복원 —
+//! 을 네이티브에서 그대로 재현하고, 원본 파일과의 저장 바이트 왕복 동일성을 단언한다.
+//!
+//! 수렴이 깨지면 역연산화는 스냅샷(전체 복원) 대체 자격을 잃는다 — 고아 BorderFill,
+//! dirty 플래그 잔존, 이웃 id 미복원 중 무엇이 원인인지 first_diff 로 좁힐 수 있게
+//! 스타일 테이블 길이도 함께 단정한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+use rhwp::document_core::queries::table_extract::extract_tables;
+use rhwp::model::control::Control;
+use rhwp::wasm_api::HwpDocument;
+
+/// 표가 있는 .hwp 표본 후보 — 순서대로 훑어 첫 본문 최상위 표(4셀 이상)를 쓴다.
+const CANDIDATES: &[&str] = &[
+    "samples/156457617_240617 2024년 5월 월간 수출입 현황(확정치).hwp",
+    "samples/156457624_210622 7월부터 해외직구 구매대행업체 등록제 시행.hwp",
+    "samples/20250130-hongbo-no.hwp",
+];
+
+struct BodyTable {
+    section: usize,
+    paragraph: usize,
+    control: usize,
+    rows: u32,
+    cols: u32,
+}
+
+fn load_with_body_table() -> (Vec<u8>, HwpDocument, BodyTable) {
+    for rel in CANDIDATES {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+        let Ok(bytes) = std::fs::read(&path) else {
+            continue;
+        };
+        let Ok(doc) = HwpDocument::from_bytes(&bytes) else {
+            continue;
+        };
+        for g in extract_tables(doc.document()) {
+            if !g.container_path.is_empty() {
+                continue;
+            }
+            let Some(Control::Table(table)) = doc.document().sections[g.section].paragraphs
+                [g.paragraph]
+                .controls
+                .get(g.control)
+            else {
+                continue;
+            };
+            if table.cells.len() < 4 || table.row_count < 2 || table.col_count < 2 {
+                continue;
+            }
+            let info = BodyTable {
+                section: g.section,
+                paragraph: g.paragraph,
+                control: g.control,
+                rows: table.row_count as u32,
+                cols: table.col_count as u32,
+            };
+            return (bytes, doc, info);
+        }
+    }
+    panic!("표가 있는 본문 표본을 찾지 못했다 — CANDIDATES 를 갱신하라");
+}
+
+fn first_diff(a: &[u8], b: &[u8]) -> Option<usize> {
+    let n = a.len().min(b.len());
+    (0..n)
+        .find(|&i| a[i] != b[i])
+        .or((a.len() != b.len()).then_some(n))
+}
+
+/// 다이얼로그가 보내는 것과 같은 모양의 테두리+배경 변경 JSON.
+/// 색상 값의 `"#` 이 raw string 종결자와 겹치지 않게 ## 을 쓴다.
+fn border_bg_json() -> &'static str {
+    r##"{"fillType":"solid","fillColor":"#FFFF00","patternColor":"#000000","patternType":0,"diagonalLine":0,"diagonalSlash":false,"diagonalBackSlash":false,"diagonalWidth":0,"diagonalColor":"#000000","centerLine":"NONE","borderLeft":{"type":1,"width":1,"color":"#000000"},"borderRight":{"type":1,"width":1,"color":"#000000"},"borderTop":{"type":1,"width":1,"color":"#000000"},"borderBottom":{"type":1,"width":1,"color":"#000000"}}"##
+}
+
+/// undo payload 조립 — execute 의 changes 를 cellIdx/beforeId 쌍으로 변환한다.
+fn undo_cells(resp: &serde_json::Value) -> Vec<serde_json::Value> {
+    resp["changes"]
+        .as_array()
+        .expect("changes 배열")
+        .iter()
+        .map(|c| serde_json::json!({ "cellIdx": c["cellIdx"], "id": c["beforeId"] }))
+        .collect()
+}
+
+#[test]
+fn cell_border_apply_undo_converges_to_original_bytes() {
+    let (_original, mut doc, grid) = load_with_body_table();
+    // 수렴 기준은 원본 파일 바이트가 아니라 같은 문서의 무변경 export 다 —
+    // 헤더 필드 재계산 등 로드↔저장 고정 델타와 게이트를 섞지 않는다.
+    let baseline = doc.export_hwp().expect("변경 전 export");
+    let style_len_before = doc.document().doc_info.border_fills.len();
+    // 0. 적용 **직전** 구역 raw 캡처 — TS 커맨드의 execute 첫 걸음이다.
+    let capture = doc
+        .capture_section_raw(grid.section as usize)
+        .expect("캡처");
+
+    // 1. 적용 — 응답의 self-describing 기록을 받는다.
+    let resp: serde_json::Value = serde_json::from_str(
+        &doc.set_cell_properties(
+            grid.section as u32,
+            grid.paragraph as u32,
+            grid.control as u32,
+            0,
+            border_bg_json(),
+        )
+        .expect("적용 성공"),
+    )
+    .expect("응답 JSON");
+
+    let len_before = resp["borderFillLenBefore"]
+        .as_u64()
+        .expect("borderFillLenBefore 가 응답에 없다 — 구버전 경로로 돌아갔다")
+        as usize;
+    let dirty_before = resp["docInfoDirtyBefore"].as_bool().expect("dirty 플래그");
+    assert!(
+        !resp["changes"].as_array().expect("changes 배열").is_empty(),
+        "변경 기록이 비었다 — dedupe 수렴으로 실질 변경이 없던 표본이다"
+    );
+    assert!(
+        doc.document().doc_info.border_fills.len() > style_len_before,
+        "새 스타일이 push 됐어야 한다(기존에 동일 스타일이 있었다면 표본·JSON 을 바꿔라)"
+    );
+
+    // 2. undo ① — id 직접 대입(스타일 테이블 무손상).
+    doc.apply_cell_border_fill_ids(
+        grid.section as u32,
+        grid.paragraph as u32,
+        grid.control as u32,
+        &serde_json::to_string(&serde_json::json!({ "cells": undo_cells(&resp) })).unwrap(),
+    )
+    .expect("id 직접 대입이 성공해야 함");
+
+    // 3. undo ② — push 분 꼬리 절단 + dirty 원복.
+    doc.remove_border_fill_tails(
+        &serde_json::to_string(&serde_json::json!({
+            "fromLen": len_before, "dirtyWas": dirty_before
+        }))
+        .unwrap(),
+    )
+    .expect("꼬리 절단이 성공해야 함");
+    assert_eq!(
+        doc.document().doc_info.border_fills.len(),
+        style_len_before,
+        "스타일 테이블 길이가 원복돼야 한다 — 고아 BorderFill 이 남았다"
+    );
+
+    // 4. undo ③ — 구역 raw 저널 복원(TS 커맨드와 같은 순서).
+    doc.restore_section_raw(capture)
+        .expect("raw 는 applyIds 가 무효화한 상태여야 한다");
+
+    // 5. 저장 바이트 왕복 동일성.
+    let after = doc.export_hwp().expect("복원 후 export");
+    match first_diff(&baseline, &after) {
+        None => {}
+        Some(pos) => panic!(
+            "undo 후 저장 바이트가 원본과 어긋난다(first_diff @{pos}) — 고아 BorderFill·dirty 잔존·이웃 미복원 중 무엇인지 확인하라"
+        ),
+    }
+}
+
+#[test]
+fn cell_zone_apply_undo_converges_to_original_bytes() {
+    let (_original, mut doc, grid) = load_with_body_table();
+    let baseline = doc.export_hwp().expect("변경 전 export");
+    // 적용 직전 캡처 — 위와 동일 계약.
+    let capture = doc
+        .capture_section_raw(grid.section as usize)
+        .expect("캡처");
+
+    // 2×2 zone 에 배경만 다른 스타일을 asOne 적용한다.
+    let resp: serde_json::Value = serde_json::from_str(
+        &doc.set_cell_zone_properties(
+            grid.section as u32,
+            grid.paragraph as u32,
+            grid.control as u32,
+            0,
+            0,
+            1,
+            1,
+            r##"{"fillType":"solid","fillColor":"#00FF00","patternColor":"#000000","patternType":0}"##,
+        )
+        .expect("zone 적용 성공"),
+    )
+    .expect("응답 JSON");
+
+    let len_before = resp["borderFillLenBefore"].as_u64().expect("길이 기록") as usize;
+    let dirty_before = resp["docInfoDirtyBefore"].as_bool().expect("dirty 플래그");
+    let before_id = resp["zoneBeforeId"].as_u64();
+    let after_id = resp["borderFillId"].as_u64().expect("적용 id");
+    if before_id == Some(after_id) {
+        panic!("동일 스타일 재적용이라 실질 변경이 없다 — JSON 을 바꿔라");
+    }
+
+    // undo — 신설(null)이면 zone 제거, 교체면 id 원복.
+    doc.apply_cell_border_fill_ids(
+        grid.section as u32,
+        grid.paragraph as u32,
+        grid.control as u32,
+        &serde_json::to_string(&serde_json::json!({
+            "zones": [{
+                "startRow": 0, "startCol": 0, "endRow": 1, "endCol": 1,
+                "id": before_id.map(|v| v as u32),
+            }]
+        }))
+        .unwrap(),
+    )
+    .expect("zone id 원복이 성공해야 함");
+    doc.remove_border_fill_tails(
+        &serde_json::to_string(&serde_json::json!({
+            "fromLen": len_before, "dirtyWas": dirty_before
+        }))
+        .unwrap(),
+    )
+    .expect("꼬리 절단이 성공해야 함");
+    doc.restore_section_raw(capture).expect("raw 복원");
+
+    let after = doc.export_hwp().expect("복원 후 export");
+    match first_diff(&baseline, &after) {
+        None => {}
+        Some(pos) => panic!(
+            "zone undo 후 저장 바이트가 원본과 어긋난다(first_diff @{pos}) — zone 제거·고아·raw 잔존 순으로 확인하라"
+        ),
+    }
+}

--- a/tests/cases/issue_5959_cell_borderfill_inverse_convergence.rs
+++ b/tests/cases/issue_5959_cell_borderfill_inverse_convergence.rs
@@ -92,6 +92,37 @@ fn undo_cells(resp: &serde_json::Value) -> Vec<serde_json::Value> {
         .collect()
 }
 
+fn snapshot_zones(doc: &HwpDocument, grid: &BodyTable) -> Vec<(u16, u16, u16, u16, u16)> {
+    let table = match doc.document().sections[grid.section].paragraphs[grid.paragraph]
+        .controls
+        .get(grid.control)
+    {
+        Some(Control::Table(t)) => t,
+        _ => panic!("표 컨트롤이어야 함"),
+    };
+    let mut rows: Vec<(u16, u16, u16, u16, u16)> = table
+        .zones
+        .iter()
+        .map(|z| {
+            (
+                z.start_row.min(z.end_row),
+                z.start_col.min(z.end_col),
+                z.start_row.max(z.end_row),
+                z.start_col.max(z.end_col),
+                z.border_fill_id,
+            )
+        })
+        .collect();
+    rows.sort_unstable();
+    rows
+}
+
+fn has_origin_override(doc: &HwpDocument, grid: &BodyTable) -> bool {
+    snapshot_zones(doc, grid)
+        .iter()
+        .any(|&(sr, sc, er, ec, _)| sr == er && sc == ec && sr == 0 && sc == 0)
+}
+
 #[test]
 fn cell_border_apply_undo_converges_to_original_bytes() {
     let (_original, mut doc, grid) = load_with_body_table();
@@ -305,4 +336,126 @@ fn foreign_tail_is_not_truncated_by_earlier_apply_undo() {
     doc.restore_section_raw(capture).expect("raw 복원");
     doc.export_hwp()
         .expect("계약 위반 시나리오에서도 export 는 성공해야 함");
+}
+
+/// [#5959] origin 대각선 cellzone override 의 zone 전이도 기록·복원돼야 한다 —
+/// 셀 id 복원만으로는 sync 가 만들거나 지운 1×1 zone 이 유령·소실로 남는다.
+#[test]
+fn cell_apply_sync_zone_override_undo_restores_zone_state() {
+    let (_original, mut doc, grid) = load_with_body_table();
+
+    // 1. 2×2 대각선 cellzone(asOne) — origin 은 (0,0).
+    doc.set_cell_zone_properties(
+        grid.section as u32,
+        grid.paragraph as u32,
+        grid.control as u32,
+        0,
+        0,
+        1,
+        1,
+        &border_bg_json()
+            .replace("\"diagonalLine\":0", "\"diagonalLine\":1")
+            .replace("\"diagonalSlash\":false", "\"diagonalSlash\":true"),
+    )
+    .expect("대각선 zone 적용이 성공해야 함");
+    let zones_baseline = snapshot_zones(&doc, &grid);
+
+    // 2. origin 셀에 개별 대각선 — 1×1 override 가 생긴다(sync push).
+    let resp_push: serde_json::Value = serde_json::from_str(
+        &doc.set_cell_properties(
+            grid.section as u32,
+            grid.paragraph as u32,
+            grid.control as u32,
+            0,
+            &border_bg_json()
+                .replace("\"diagonalLine\":0", "\"diagonalLine\":2")
+                .replace("\"diagonalSlash\":false", "\"diagonalSlash\":true")
+                .replace("#000000\"}", "#00CC44\"}"),
+        )
+        .expect("개별 대각선 적용이 성공해야 함"),
+    )
+    .expect("응답 JSON");
+    let push_zones = resp_push["zones"].as_array().cloned().unwrap_or_default();
+    assert!(
+        push_zones
+            .iter()
+            .any(|z| z["beforeId"].is_null() && z["afterId"].is_u64()),
+        "override 신설 전이가 기록돼야 한다 — got {push_zones:?}"
+    );
+    assert_eq!(
+        snapshot_zones(&doc, &grid).len(),
+        zones_baseline.len() + 1,
+        "1×1 override zone 을 포함해야 한다"
+    );
+    let zones_pre_execute = snapshot_zones(&doc, &grid);
+    let bytes_pre_execute = doc.export_hwp().expect("execute 직전 export");
+
+    // 3. 같은 셀에 대각선 없는 배경·테두리 — execute 가 override 를 지운다(TS undo 표적).
+    let capture = doc
+        .capture_section_raw(grid.section as usize)
+        .expect("캡처");
+    let resp: serde_json::Value = serde_json::from_str(
+        &doc.set_cell_properties(
+            grid.section as u32,
+            grid.paragraph as u32,
+            grid.control as u32,
+            0,
+            border_bg_json(),
+        )
+        .expect("재적용이 성공해야 함"),
+    )
+    .expect("응답 JSON");
+    let len_before = resp["borderFillLenBefore"].as_u64().expect("len") as usize;
+    let dirty_before = resp["docInfoDirtyBefore"].as_bool().expect("dirty");
+    let remove_entry = resp["zones"]
+        .as_array()
+        .and_then(|a| {
+            a.iter()
+                .find(|z| z["beforeId"].is_u64() && z["afterId"].is_null())
+        })
+        .cloned()
+        .expect("override 제거 전이가 기록돼야 한다 — 이것이 이 테스트의 요점이다");
+    assert!(
+        !has_origin_override(&doc, &grid),
+        "execute 뒤 override 는 제거됐어야 한다"
+    );
+
+    // 4. undo — cells 와 zones 를 함께 재생해야 제거된 override 가 돌아온다.
+    doc.apply_cell_border_fill_ids(
+        grid.section as u32,
+        grid.paragraph as u32,
+        grid.control as u32,
+        &serde_json::to_string(&serde_json::json!({
+            "cells": undo_cells(&resp),
+            "zones": [{
+                "startRow": remove_entry["startRow"],
+                "startCol": remove_entry["startCol"],
+                "endRow": remove_entry["endRow"],
+                "endCol": remove_entry["endCol"],
+                "id": remove_entry["beforeId"],
+            }],
+        }))
+        .unwrap(),
+    )
+    .expect("id 직접 대입이 성공해야 함");
+    doc.remove_border_fill_tails(
+        &serde_json::to_string(
+            &serde_json::json!({ "fromLen": len_before, "dirtyWas": dirty_before }),
+        )
+        .unwrap(),
+    )
+    .expect("절단이 성공해야 함");
+    doc.restore_section_raw(capture).expect("raw 복원");
+
+    assert_eq!(
+        snapshot_zones(&doc, &grid),
+        zones_pre_execute,
+        "undo 뒤 zone 상태가 execute 직전(override 존재)과 같아야 한다 — \
+         셀 id 만 되돌리면 여기서 갈라진다"
+    );
+    let bytes_after_undo = doc.export_hwp().expect("undo 후 export");
+    assert_eq!(
+        bytes_after_undo, bytes_pre_execute,
+        "undo 뒤 저장 바이트가 execute 직전과 같아야 한다"
+    );
 }

--- a/tests/cases/issue_5959_cell_borderfill_inverse_convergence.rs
+++ b/tests/cases/issue_5959_cell_borderfill_inverse_convergence.rs
@@ -232,3 +232,77 @@ fn cell_zone_apply_undo_converges_to_original_bytes() {
         ),
     }
 }
+
+#[test]
+fn foreign_tail_is_not_truncated_by_earlier_apply_undo() {
+    let (_original, mut doc, grid) = load_with_body_table();
+    let capture = doc
+        .capture_section_raw(grid.section as usize)
+        .expect("캡처");
+
+    // A 적용 — push 가 일어나고 fromLen 을 기록한다.
+    let resp: serde_json::Value = serde_json::from_str(
+        &doc.set_cell_properties(
+            grid.section as u32,
+            grid.paragraph as u32,
+            grid.control as u32,
+            0,
+            border_bg_json(),
+        )
+        .expect("적용 성공"),
+    )
+    .expect("응답 JSON");
+    let len_before_a = resp["borderFillLenBefore"].as_u64().expect("길이 기록") as usize;
+    let dirty_before_a = resp["docInfoDirtyBefore"].as_bool().expect("dirty 플래그");
+
+    // 계약 밖 직접 뮤테이션(hwpctl류) — 저널 항목 없이 꼬리를 하나 더 push 한다.
+    let foreign: serde_json::Value = serde_json::from_str(
+        &doc.set_cell_zone_properties(
+            grid.section as u32,
+            grid.paragraph as u32,
+            grid.control as u32,
+            1, 1, 1, 1,
+            r##"{"fillType":"solid","fillColor":"#00FF00","patternColor":"#000000","patternType":0}"##,
+        )
+        .expect("외부 적용 성공"),
+    )
+    .expect("외부 응답 JSON");
+    let foreign_id = foreign["borderFillId"].as_u64().expect("외부 id") as usize;
+    assert!(
+        foreign_id > len_before_a,
+        "외부 push 가 A 의 항목 아래에 겹치면 이 시나리오가 성립하지 않는다"
+    );
+
+    // A undo — 참조 스캔이 외부 꼬리를 살리고 거기서 멈춰야 한다.
+    doc.apply_cell_border_fill_ids(
+        grid.section as u32,
+        grid.paragraph as u32,
+        grid.control as u32,
+        &serde_json::to_string(&serde_json::json!({ "cells": undo_cells(&resp) })).unwrap(),
+    )
+    .expect("id 직접 대입이 성공해야 함");
+    let gc: serde_json::Value = serde_json::from_str(
+        &doc.remove_border_fill_tails(
+            &serde_json::to_string(&serde_json::json!({
+                "fromLen": len_before_a, "dirtyWas": dirty_before_a
+            }))
+            .unwrap(),
+        )
+        .expect("절단이 성공해야 함"),
+    )
+    .expect("절단 응답 JSON");
+    assert_eq!(
+        gc["discarded"].as_u64(),
+        Some(0),
+        "참조 중인 외부 꼬리는 절단되지 않아야 한다"
+    );
+    assert!(
+        doc.document().doc_info.border_fills.len() >= foreign_id,
+        "외부 스타일 항목이 살아 있어야 한다 — 잘라내면 붙여넣기·삽입물의 스타일이 깨진다"
+    );
+
+    // raw 복원 전제(A 의 applyIds 가 무효화)와 export 성공까지 확인.
+    doc.restore_section_raw(capture).expect("raw 복원");
+    doc.export_hwp()
+        .expect("계약 위반 시나리오에서도 export 는 성공해야 함");
+}

--- a/tests/issue_2724_passthrough_invalidation_guard.rs
+++ b/tests/issue_2724_passthrough_invalidation_guard.rs
@@ -382,6 +382,14 @@ const EXEMPT: &[(&str, &str, Exempt, &str)] = &[
         "열 폭 계산만 하고 실제 반영은 열 폭 설정 뮤테이터가 한다.",
     ),
     (
+        "commands/table_ops.rs",
+        "remove_border_fill_tails_native",
+        Exempt::CallerResponsibility,
+        "[#5959] doc_info.border_fills 의 고아 꼬리 절단 + dirty 플래그 원복만 한다 — \
+         섹션 본문 IR 무변경이며 passthrough 무효화·복원은 호출자(TS undo 의 \
+         applyIds → restoreSectionRaw 3단)가 담당한다.",
+    ),
+    (
         "commands/text_editing.rs",
         "insert_text_in_cell_native",
         Exempt::DelegatesTo("replace_text_in_cell_native_impl"),


### PR DESCRIPTION
#5959 잔여 ① — 셀 테두리/배경 다이얼로그를 속성쌍 역연산으로 전환한다

## 무엇을 하는가

셀 테두리/배경 다이얼로그(각 셀마다 적용 / 하나의 셀처럼 적용 / 단일 셀)의 적용이
`kind:'snapshot'` 슬롯 1개를 쓰던 마지막 표 진입점을 **속성쌍 역연산 커맨드**(슬롯 0)
으로 전환한다. #5769 원장의 "⑤ cell-border-bg-dialog — 후순위, 스냅샷 진입점의 1.2%" 과제.

## 왜 어려웠나 — 변경 실체가 스칼라 대입이 아니다 (#5769 선결 규약)

`set_cell_properties` 의 테두리/배경 경로는 대상 셀의 id 대입 외에 두 가지 부작용이 있다:

1. **이웃 집단 재배정** — 공유 엣지를 가진 이웃 셀의 BorderFill 을 복제·엣지 교체해
   id 를 다시 배정한다(`update_neighbor_borders`). 영향 집단은 Rust 만 안다.
2. **스타일 테이블 성장** — `doc_info.border_fills` 에 새 항목을 push 하고(dedupe 있음)
   `raw_stream_dirty` 를 세운다(#2555). undo 에서 고아로 남으면 저장 바이트가 어긋난다.
   현재 스냅샷은 doc_info 를 통째로 복원하므로 지금은 수렴한다 — 역연산화가 오히려
   수렴을 깨는 역전 지점이었다.

## 해법 — self-describing 기록 + 3단 복구

- **Rust**: 두 setter 가 적용 직전 기준선(`changes[{cellIdx,beforeId,afterId}]`,
  `zoneBeforeId`, `borderFillLenBefore`, `docInfoDirtyBefore`)을 응답으로 돌려준다
  (z-order moves[] 선례). undo 전용 네이티브 신설:
  - `applyCellBorderFillIds` — cell/zone id 를 **스타일 테이블 무손상**으로 직접 대입
    (전수 검증 후 적용, zone null=신설 제거).
  - `removeBorderFillTails` — 문서 전역 참조 스캔(셀·zone 재귀, 글자/문단 스타일
    정의, 쪽 테두리) 후 **참조되지 않는 꼬리만** 절단 + 완전 절단 시 dirty 원복.
    apply~undo 사이 저널 계약 밖 push(hwpctl 직접 뮤테이션 등)가 있어도 타
    커맨드의 스타일을 지우지 않는다 — 고아는 게이트가 잡는다.
- **TS**: `SetCellBorderFillCommand` — execute 는 probe 선차단(구버전 wasm 원천 거절,
  #5951 스큐 선례) → 구역 raw 캡처 → 적용. undo 는 **id 직접 대입 → 꼬리 절단 → raw
  복원**의 3단. redo 는 execute 재실행(절단된 스타일은 dedupe 가 꼬리에 재생성해 id 안정).
  실패 시 지금까지의 changes 로 롤백 시도(#3350 계열). 무변경은 no-op 으로 저널 미기록(#2370).

## 검증

- **저장 바이트 수렴 게이트** `tests/cases/issue_5959_cell_borderfill_inverse_convergence.rs`
  — 셀 경로·zone(asOne) 경로의 바이트 수렴 + 외부 push 삽입 시나리오에서 참조 중인
  꼬리 보존까지 **3/3 통과**
- **소스 가드** `rhwp-studio/tests/issue-5959-cell-borderfill-inverse.test.ts` 6종 —
  probe 선차단, 3단 undo 순서, no-op 무저널, zone 제거 원복, 다이얼로그/레지스트리 소스 핀
- npm test **1077 pass / 0 fail**(자기 리뷰 정정 `ff033bb5b` 포함) — 기존 가드 `table-props-undo` 는 새 계약으로 갱신,
  신규 네이티브 둘 MUTATING_METHODS 등재(#2327), #4118 배치 계약 회귀 없음
- clippy `-D warnings` clean · cargo fmt --check 통과
- 설계·판정 보고: `mydocs/working/task_m100_5959_cell_border_bg.md`

## 참고

- 추적: #5959 (잔여: pageSetup/pageMargin — #5890 개선 전제로 계속 보류)
- 선행: #5951(z순서+section-all 역연산화), draft #5962(측정 게이트 CI 배선)
