### PR TITLE
docs: HWP MCP 엔진 검증 기준을 보정

### DIFF
--- a/mydocs/manual/mcp_hwp2024Convert_usage.md
+++ b/mydocs/manual/mcp_hwp2024Convert_usage.md
@@ -67,14 +67,13 @@ archive에 한컴 실행 파일이나 변환 DLL은 포함하지 않는다. 한�
 ## 환경 파일과 client 준비
 
 client archive는 rhwp 저장소의 `tools/` 아래에 두고, endpoint와 token은 Git 밖의 local client
-directory의 `.env.local`에만 둔다. Linux에서는 운영 경로를
-`/home/tsjang/hwp-convert-2024/.env.local`로 사용한다. 다른 POSIX host에서는 같은 구조의
-`$HOME/hwp-convert-2024/.env.local`을 사용하며, 저장소 안에 `.env.local`을 만들지 않는다.
+directory의 `$HOME/hwp-convert-2024/.env.local`에만 둔다. macOS와 Linux를 포함한 POSIX host는
+같은 기본 경로를 사용하며, 저장소 안에 `.env.local`을 만들지 않는다.
 
 | client OS | rhwp archive | 비공개 환경 파일 |
 | --- | --- | --- |
 | macOS | `$HOME/rhwp/tools/hwp-convert-mcp-2024-client-20260824-011002.tar.gz` | `$HOME/hwp-convert-2024/.env.local` |
-| Linux | `/home/tsjang/rhwp/tools/hwp-convert-mcp-2024-client-20260824-011002.tar.gz` | `/home/tsjang/hwp-convert-2024/.env.local` |
+| Linux | `$HOME/rhwp/tools/hwp-convert-mcp-2024-client-20260824-011002.tar.gz` | `$HOME/hwp-convert-2024/.env.local` |
 | Windows | `C:\Users\<사용자>\rhwp\tools\hwp-convert-mcp-2024-client-20260824-011002.tar.gz` | `C:\Users\<사용자>\hwp-convert-2024\.env.local` |
 
 ```env
@@ -85,10 +84,11 @@ HWP2024_MCP_AUTH_TOKEN=<관리자가_제공한_32_byte_이상_token>
 POSIX host에서 새 환경 파일을 만들 때는 먼저 권한을 제한한다.
 
 ```bash
-mkdir -p "$HOME/hwp-convert-2024"
+export HWP2024_MCP_ENV_DIR="$HOME/hwp-convert-2024"
+mkdir -p "$HWP2024_MCP_ENV_DIR"
 umask 077
-${EDITOR:-vi} "$HOME/hwp-convert-2024/.env.local"
-chmod 600 "$HOME/hwp-convert-2024/.env.local"
+${EDITOR:-vi} "$HWP2024_MCP_ENV_DIR/.env.local"
+chmod 600 "$HWP2024_MCP_ENV_DIR/.env.local"
 ```
 
 Windows에서는 `.env.local`을 현재 사용자만 읽을 수 있는 `hwp-convert-2024` directory에 두고,
@@ -442,8 +442,13 @@ server process 전체에서 하나씩 직렬 실행한다. 비동기 요청은 �
 변환 결과에서 다음을 확인한다.
 
 - `status: success`
-- `server.engine`과 `server.engine_profile`: 요청한 `2020` 또는 `2024`
-- `server.hancom_version`: 선택한 Windows 한컴 runtime의 실제 버전
+- `engine`: `start`와 `status` 응답에서 요청한 engine과 일치해야 한다. 2022 이하 저장본은
+  `2020`, 2024 저장본은 `2024`를 명시한다.
+- `server.engine`: 서버가 반환할 수 있는 concrete backend 식별자다. 요청한 engine과의 일치 여부를
+  판정하는 값으로 사용하지 않는다. 현재 배포의 2024 backend는
+  `hancom-2024-direct-host`를 반환한다.
+- `server.engine_profile`, `server.hancom_version`: 서버가 제공하면 선택한 runtime의 추가 증적으로
+  기록한다. 이 필드는 현재 배포 응답에 없을 수 있으므로 부재만으로 변환을 실패로 판단하지 않는다.
 - `server.backend: hwp-managed-direct-dll-host`
 - `server.worker_bits: 32`
 - client가 보고한 `size`, `sha256`과 local file이 일치
@@ -480,6 +485,14 @@ Get-FileHash -Algorithm SHA256 -LiteralPath 'C:\Users\<사용자>\rhwp\pdf\examp
 - 실제 archive CLI의 비동기 `start`가 engine `2020`, 엔진별 기본 파일명, 비공개 암호 파일을 remote argument로 전달
 - 결과 JSON에는 `status`, `job_id`, `engine`만 있고 암호 값은 없음
 
+2026-08-24 실제 배포 MCP server에는 최신 artifact로 engine `2024`의 작은 HWPX를 동기 `convert`와
+비동기 `start → status → download`로 각각 변환했다. 두 경로 모두 `success`, client/server SHA-256 일치와
+PDF 서명을 확인했고, 비동기 `start`와 `status`의 `engine`은 요청값 `2024`와 일치했다. 또한 Hancom Office
+2020 저장본 `kps-ai.hwp`는 `--engine 2020`을 명시한 비동기 흐름에서 `queued → succeeded → success`,
+`start`·`status`의 `engine: "2020"`, PDF 서명 및 SHA-256 일치를 확인했다. `server.engine`은
+`hancom-2024-direct-host` backend 식별자를 반환했고 `server.engine_profile`과 `server.hancom_version`은
+반환하지 않았다.
+
 2026-08-22의 이전 `0.8.0` artifact는 당시 실제 배포 MCP server에 연결해 다음을 확인했다.
 
 - tarball에서 `hwp2024-mcp-convert --help` 실행 성공
@@ -488,7 +501,7 @@ Get-FileHash -Algorithm SHA256 -LiteralPath 'C:\Users\<사용자>\rhwp\pdf\examp
 - 동기 HWP→HWPX: `success`, output 67,709 bytes
 - 비동기 HWP→PDF: `queued → succeeded → success`, output 106,341 bytes
 - 두 경로 모두 client/server output byte 수와 SHA-256 일치
-- engine `hancom-2024-direct-host`, backend `hwp-managed-direct-dll-host`, worker 32-bit
+- server engine `hancom-2024-direct-host`, backend `hwp-managed-direct-dll-host`, worker 32-bit
 
 실제 server 주소와 token은 검증 기록에 포함하지 않았다.
 

--- a/mydocs/manual/pr_review/visual_fixture_evidence.md
+++ b/mydocs/manual/pr_review/visual_fixture_evidence.md
@@ -66,9 +66,13 @@ service에서 engine `2020`을, `hancom-office-2024`이면 같은 service의 eng
   timeout_seconds를 900–1800초로 늘린다.
 - VS Code MCP 호출이 timeout되어도 서버 job이 성공했을 수 있다. CLI로 재호출해 로컬 PDF 수신까지 확인한다.
 
-통합 Windows MCP는 동기 `status: success` 또는 비동기 `succeeded → success`, 요청한
-`engine_profile`, client/server byte 수와 SHA-256 일치를 확인한다. 공통으로 `pdf/` 아래 실제 PDF
-존재와 `file` 또는 `pdfinfo` 확인이 필요하다.
+통합 Windows MCP는 동기 `status: success` 또는 비동기 `succeeded → success`, 요청한 `--engine`과
+비동기 `start`·`status` 응답의 `engine` 일치, client/server byte 수와 SHA-256 일치를 확인한다.
+2022 이하 저장본에는 `--engine 2020`, 2024 저장본에는 `--engine 2024`를 명시한다. `server.engine`은
+concrete backend 식별자일 수 있으므로 저장 버전별 engine 선택의 판정 기준으로 사용하지 않는다.
+`engine_profile`과 `hancom_version`은 서버가 제공할 때만 추가 증적으로 기록하며, 부재만으로 실패로
+판단하지 않는다.
+공통으로 `pdf/` 아래 실제 PDF 존재와 `file` 또는 `pdfinfo` 확인이 필요하다.
 review 문서에는 MCP 선택 전 `info --json`의 `format`·`lastSavedWith` 값, 사용한 서비스 버전, 원본
 경로·가능하면 SHA-256·출처 URL, PDF 경로·SHA-256, MCP job id, 서비스별 status·validation metadata·페이지 수,
 사용한 visual sweep asset과 지표를 적는다.

--- a/mydocs/orders/20260824.md
+++ b/mydocs/orders/20260824.md
@@ -50,3 +50,15 @@ date: 2026-08-24
   `MERGEABLE/CLEAN`을 다시 확인한다.
 - [ ] 메인테이너 merge 승인 뒤 정상 병합하고 #4960을 OPEN으로 유지한 채 merge SHA 반영, issue comment와
   branch·worktree 정리를 `post_merge.md`에 따라 처리한다.
+
+## PR #5985 - HWP MCP 엔진 검증 기준 보정
+
+- [x] 최신 HWP 2024 client에서 요청 `--engine`과 비동기 `start`·`status`의 논리 engine을 일치시키는
+  성공 기준을 문서화하고, concrete backend 식별자인 `server.engine`과 분리했다.
+- [x] Hancom Office 2020 저장본 `kps-ai.hwp`를 `--engine 2020`으로 `queued → succeeded → download`까지
+  변환해 `status.engine: 2020`, PDF 서명, 634,466-byte 출력과 SHA-256 일치를 확인했다.
+- [x] `cargo fmt --all`, `cargo fmt --all -- --check`, `git diff --check`를 통과했다.
+- [ ] self-review·오늘할일 trailing 문서 commit을 push하고, 최신 head의 review-only fast-pass aggregate와
+  `MERGEABLE/CLEAN`을 확인한다.
+- [ ] 작업지시자의 병합 승인 뒤 #5985을 merge하고 merge SHA의 `upstream/devel` 포함 및 local review branch
+  정리를 `post_merge.md`에 따라 처리한다.

--- a/mydocs/pr/archives/pr_5985_review.md
+++ b/mydocs/pr/archives/pr_5985_review.md
@@ -1,0 +1,50 @@
+---
+kind: pr-review
+status: trailing-docs-pending-ci
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-24
+---
+
+# PR #5985 검토 - HWP MCP 엔진 검증 기준 보정
+
+## 접수 메타데이터
+
+| 항목 | 작성 시점 확인값 |
+| --- | --- |
+| PR / 작성자 | [#5985](https://github.com/edwardkim/rhwp/pull/5985) / [@jangster77](https://github.com/jangster77) |
+| 관련 issue | 없음 |
+| base / code candidate | `devel` / `d7a79d400a527ccfed8380c73a33462aacfaa28c` |
+| code candidate 변경 규모 | 2 files, +30 / -13 |
+| 작성 시점 상태 | non-draft; `MERGEABLE`, GitHub Actions는 trailing 문서 push 뒤 최신 head에서 재확인 필요 |
+| reviewer | 작성자 본인 self-review, 별도 reviewer 미지정 |
+
+GitHub mergeability와 CI 상태는 작성 시점 참고값이다. 이 trailing 기록 commit의 최신 head가
+required check를 통과하고 작업지시자가 병합을 승인한 뒤에만 merge한다.
+
+## 변경과 판단
+
+- 최신 HWP 2024 client의 `--engine 2020|2024` 요청값과 비동기 `start`·`status` 응답의
+  `engine` 일치를 논리 엔진 선택 증적으로 정한다.
+- `server.engine`은 concrete backend 식별자일 수 있으므로 논리 엔진 선택의 판정 기준에서 분리한다.
+- Hancom Office 2020 저장본 `samples/kps-ai.hwp`의 실제 비동기 변환 결과를 HWP MCP 사용법과
+  시각 fixture 증적 절차에 반영한다.
+
+renderer, layout, fixture 출력, 기준 PDF는 변경하지 않았다. `visual_fixture_evidence.md`는 검토 절차를
+보정한 문서일 뿐 새 시각 결과를 주장하지 않으므로 visual sweep은 요구하지 않는다.
+
+## 로컬 검증
+
+- `cargo fmt --all`과 `cargo fmt --all -- --check`를 exit code 0으로 통과했다.
+- `git diff --check`를 통과했다.
+- 최신 HWP 2024 client로 `samples/kps-ai.hwp`를 `--engine 2020`으로 비동기 변환했다.
+  - `rhwp info --json`은 `lastSavedWith.product: hancom-office-2020`, 버전 `11.0.0.8808`을 반환했다.
+  - `start`는 `queued`, `status`는 `succeeded`·`completed` 및 `engine: 2020`을 반환했다.
+  - `download`한 PDF는 634,466 bytes였고 `%PDF-` 서명 및 client/server SHA-256 일치를 확인했다.
+
+인증 token, server URL, 환경 파일 내용, 비동기 job ID는 기록하지 않았다.
+
+## 최종 판정
+
+**수용 권고, trailing CI 대기.** 문서가 최신 client의 명시적 논리 엔진과 concrete backend 식별자를
+혼동하지 않도록 보정했다. 최신 trailing head의 GitHub Actions가 성공하고 작업지시자가 병합을 승인한 뒤
+merge한다.


### PR DESCRIPTION
## 요약

- HWP 2024 MCP client에서 `--engine` 요청값과 비동기 `start`·`status` 응답의 `engine` 일치를 엔진 선택 증적으로 명확히 합니다.
- `server.engine`은 concrete backend 식별자일 수 있으므로 논리 엔진 선택 판정에서 분리합니다.
- Hancom Office 2020 저장본의 명시적 `--engine 2020` 비동기 변환과 PDF SHA-256 검증 결과를 가이드와 시각 증적 절차에 반영합니다.

## 검증

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- `kps-ai.hwp`를 최신 HWP 2024 client로 `--engine 2020` 비동기 변환: `queued → succeeded → download`, PDF `%PDF-` 서명 및 SHA-256 일치 확인

인증 토큰, 서버 URL, 환경 파일 내용, 작업 ID는 기록하지 않았습니다.
