### PR TITLE
fix(ci): 분리된 CLI render-output adapter의 영향 분류 누락을 복구한다

### DIFF
--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -11,6 +11,9 @@ on:
       - 'src/model/**'
       - 'src/renderer/**'
       - 'src/document_core/queries/rendering.rs'
+      # [#5776] PDF report가 native CLI export-pdf와 shared output helper를 직접 소비한다.
+      - 'src/cli/outputs/mod.rs'
+      - 'src/cli/outputs/pdf.rs'
       - 'src/wasm_api.rs'
       - 'src/main.rs'
       - 'assets/fonts/**'

--- a/mydocs/feedback/task_m100_5776_hyper_waterfall_audit_correction.md
+++ b/mydocs/feedback/task_m100_5776_hyper_waterfall_audit_correction.md
@@ -1,0 +1,51 @@
+---
+kind: feedback
+status: completed
+canonical: mydocs/manual/github_operations.md
+last_verified: 2026-08-24
+---
+
+# Task M100 #5776 Hyper-Waterfall 감사 판단 정정
+
+## 정정 대상
+
+#5776 로컬 candidate가 Hyper-Waterfall 문서 규칙을 준수했는지 검토하는 과정에서, 처음에는 일반
+Issue Workflow와 #4080 승인 게이트 사고를 우선 적용해 수행·구현·Stage·최종 문서가 모두 필요하다고
+판단했다. 그 판단에 따라 7종 문서를 소급 작성하는 복구안을 제안했다.
+
+## 놓친 더 구체적인 규칙
+
+루트 `AGENTS.md`는 GitHub Actions·저장소 설정·path filter 운영에
+[`github_operations.md`](../manual/github_operations.md)를 우선 적용하도록 지정한다. 이 문서 §3은
+trigger·path filter·비용 라우팅을 O2로 분류하고, §3.1의 조건을 만족하는 작은 O1/O2 변경은 단일 운영
+변경 기록으로 처리하며 별도 수행·구현·Stage·최종 문서 묶음을 형식적으로 만들지 말라고 명시한다.
+
+#5776 candidate는 다음 조건을 모두 만족한다.
+
+- 제품 소스·제품 테스트·package lock·공개 API를 변경하지 않는다.
+- secret, branch protection, release·publish, runner를 변경하지 않는다.
+- workflow path 2개와 classifier·policy 매핑을 고치는 작고 결정적인 diff다.
+- 기존 #5776과 작업지시자의 명시적 로컬 진행 지시가 근거다.
+- baseline, 검증, 기대 run/no-run, rollback을 한 기록에 담을 수 있다.
+
+따라서 일반 절차를 적용해 “비준수”라고 단정한 최초 감사 판단과 7종 소급 문서 제안은 과잉이었다.
+원인은 변경 대상을 먼저 등급화하지 않고 일반 지침과 과거 사고 기록을 더 구체적인 운영 정본보다 먼저
+적용한 데 있다.
+
+## 정정된 판정과 실제 보완점
+
+- 로컬 구현 착수는 작업지시자가 승인했고, O2 단축 경로에는 별도 Stage 승인 묶음이 필요하지 않다.
+- remote push·PR 생성·merge는 실행하지 않아 별도 원격 승인 게이트를 침범하지 않았다.
+- 기존 #5776 문서는 원인·consumer 매핑·검증 결과를 담았지만, O2 등급, live baseline, expected
+  run/no-run, 적용 승인·상태, 관찰 완료 조건, rollback이 부족했다.
+- 일일 작업 문서의 #5776 상태를 Actions 관찰 전인데도 `완료`로 적은 것은 잘못이었다.
+
+## 적용한 교정
+
+1. 기존 #5776 문서를 단일 O2 운영 변경 기록으로 보강했다.
+2. 수행·구현·Stage·최종 문서를 추가 생성하지 않았다.
+3. 일일 작업 상태를 `진행중`으로 되돌리고 remote 적용·관찰을 완료 조건으로 명시했다.
+4. remote push·PR 생성·merge 승인은 계속 별도 게이트로 남겼다.
+
+앞으로 GitHub 운영 작업은 먼저 `AGENTS.md`의 라우팅에 따라 O0~O4 등급을 확정하고, 해당 정본의
+단축·확장 경로를 선택한 뒤 일반 Hyper-Waterfall 지침을 보조 규칙으로 적용한다.

--- a/mydocs/feedback/task_m100_5776_hyper_waterfall_audit_correction.md
+++ b/mydocs/feedback/task_m100_5776_hyper_waterfall_audit_correction.md
@@ -38,13 +38,15 @@ trigger·path filter·비용 라우팅을 O2로 분류하고, §3.1의 조건을
 - remote push·PR 생성·merge는 실행하지 않아 별도 원격 승인 게이트를 침범하지 않았다.
 - 기존 #5776 문서는 원인·consumer 매핑·검증 결과를 담았지만, O2 등급, live baseline, expected
   run/no-run, 적용 승인·상태, 관찰 완료 조건, rollback이 부족했다.
-- 일일 작업 문서의 #5776 상태를 Actions 관찰 전인데도 `완료`로 적은 것은 잘못이었다.
+- 일일 작업 문서의 #5776 상태를 Actions 관찰 전인데도 `완료`로 적은 것은 잘못이었다. 또한
+  collaborator self-PR의 오늘할일 항목은 PR 번호가 확정된 뒤 trailing review commit에서 반영해야 한다.
 
 ## 적용한 교정
 
 1. 기존 #5776 문서를 단일 O2 운영 변경 기록으로 보강했다.
 2. 수행·구현·Stage·최종 문서를 추가 생성하지 않았다.
-3. 일일 작업 상태를 `진행중`으로 되돌리고 remote 적용·관찰을 완료 조건으로 명시했다.
+3. PR 번호 전 오늘할일 변경은 초기 candidate에서 제거하고, 번호 확정 뒤 `진행중` 항목으로 다시
+   반영하도록 정정했다.
 4. remote push·PR 생성·merge 승인은 계속 별도 게이트로 남겼다.
 
 앞으로 GitHub 운영 작업은 먼저 `AGENTS.md`의 라우팅에 따라 O0~O4 등급을 확정하고, 해당 정본의

--- a/mydocs/orders/20260824.md
+++ b/mydocs/orders/20260824.md
@@ -4,7 +4,7 @@ status: active
 date: 2026-08-24
 ---
 
-# 오늘 할일 - 2026년 8월 24일
+# 2026-08-24 오늘할 일
 
 ## PR #5957 - Windows HWP MCP 클라이언트 0.9.0
 
@@ -50,9 +50,3 @@ date: 2026-08-24
   `MERGEABLE/CLEAN`을 다시 확인한다.
 - [ ] 메인테이너 merge 승인 뒤 정상 병합하고 #4960을 OPEN으로 유지한 채 merge SHA 반영, issue comment와
   branch·worktree 정리를 `post_merge.md`에 따라 처리한다.
-
-## 공통 — 운영 작업
-
-| Issue | 타스크 | 상태 | 비고 |
-| ------ | ------ | ---- | ---- |
-| #5776 | 분리된 CLI render-output adapter의 CI 영향 분류 누락 제거 | 진행중 | O2 운영 기록 보강; local candidate `ff22d8bc6`, remote push·PR 승인 및 적용 후 관찰 대기 |

--- a/mydocs/orders/20260824.md
+++ b/mydocs/orders/20260824.md
@@ -55,7 +55,8 @@ date: 2026-08-24
 
 | Issue | 타스크 | 상태 | 비고 |
 | ------ | ------ | ---- | ---- |
-| #5776 | PR #5989 CLI render-output adapter CI 영향 분류 복구 | 진행중 | initial `a0733fef4` Full Actions 및 trailing review head 검증 대기 |
+| #5776 | PR #5989 CLI render-output adapter CI 영향 분류 복구 | 진행중 | 리뷰 보정 candidate `bacec40ee` 및 trailing head Actions 검증 대기 |
+
 ## PR #5985 - HWP MCP 엔진 검증 기준 보정
 
 - [x] 최신 HWP 2024 client에서 요청 `--engine`과 비동기 `start`·`status`의 논리 engine을 일치시키는

--- a/mydocs/orders/20260824.md
+++ b/mydocs/orders/20260824.md
@@ -4,7 +4,7 @@ status: active
 date: 2026-08-24
 ---
 
-# 2026-08-24 오늘할 일
+# 오늘 할일 - 2026년 8월 24일
 
 ## PR #5957 - Windows HWP MCP 클라이언트 0.9.0
 
@@ -54,5 +54,5 @@ date: 2026-08-24
 ## 공통 — 운영 작업
 
 | Issue | 타스크 | 상태 | 비고 |
-|---|---|---|---|
-| #5776 | 분리된 CLI render-output adapter의 CI 영향 분류 누락 제거 | 완료 | 최신 `upstream/devel@ad2867708` 기준; Node 64/64, Python 48/48, actionlint·fmt·diff 통과 |
+| ------ | ------ | ---- | ---- |
+| #5776 | 분리된 CLI render-output adapter의 CI 영향 분류 누락 제거 | 진행중 | O2 운영 기록 보강; local candidate `ff22d8bc6`, remote push·PR 승인 및 적용 후 관찰 대기 |

--- a/mydocs/orders/20260824.md
+++ b/mydocs/orders/20260824.md
@@ -4,7 +4,7 @@ status: active
 date: 2026-08-24
 ---
 
-# 2026-08-24 오늘할 일
+# 오늘 할일 - 2026년 8월 24일
 
 ## PR #5957 - Windows HWP MCP 클라이언트 0.9.0
 
@@ -50,3 +50,9 @@ date: 2026-08-24
   `MERGEABLE/CLEAN`을 다시 확인한다.
 - [ ] 메인테이너 merge 승인 뒤 정상 병합하고 #4960을 OPEN으로 유지한 채 merge SHA 반영, issue comment와
   branch·worktree 정리를 `post_merge.md`에 따라 처리한다.
+
+## 공통 — 운영 작업
+
+| Issue | 타스크 | 상태 | 비고 |
+| ------ | ------ | ---- | ---- |
+| #5776 | PR #5989 CLI render-output adapter CI 영향 분류 복구 | 진행중 | initial `a0733fef4` Full Actions 및 trailing review head 검증 대기 |

--- a/mydocs/orders/20260824.md
+++ b/mydocs/orders/20260824.md
@@ -50,3 +50,9 @@ date: 2026-08-24
   `MERGEABLE/CLEAN`을 다시 확인한다.
 - [ ] 메인테이너 merge 승인 뒤 정상 병합하고 #4960을 OPEN으로 유지한 채 merge SHA 반영, issue comment와
   branch·worktree 정리를 `post_merge.md`에 따라 처리한다.
+
+## 공통 — 운영 작업
+
+| Issue | 타스크 | 상태 | 비고 |
+|---|---|---|---|
+| #5776 | 분리된 CLI render-output adapter의 CI 영향 분류 누락 제거 | 완료 | 최신 `upstream/devel@ad2867708` 기준; Node 64/64, Python 48/48, actionlint·fmt·diff 통과 |

--- a/mydocs/plans/task_m100_5776.md
+++ b/mydocs/plans/task_m100_5776.md
@@ -1,59 +1,113 @@
-# 수행 계획서 — Task M100-5776: CLI render output adapter CI 영향 분류 복구
+# O2 운영 변경 기록 — Task M100-5776: CLI render output adapter CI 영향 분류 복구
 
-- 이슈: https://github.com/edwardkim/rhwp/issues/5776
-- 작성일: 2026-08-24
+- 이슈: [#5776](https://github.com/edwardkim/rhwp/issues/5776)
+- 상태: 로컬 candidate 완료 — remote push·PR 승인 및 적용 후 관찰 대기
+- 작성·재검증일: 2026-08-24
 - 브랜치: `codex/task-m100-5776-render-impact`
 - 기준선: `upstream/devel` `ad28677080929bc88e9beb286e482ce646a62ced`
+- 로컬 candidate: `ff22d8bc624563efdc8b3db94c878dff2e362498`
+- 권위 문서: [`github_operations.md` §3.1](../manual/github_operations.md#31-운영-단축-경로)
 
-## 1. 문제와 원인
+이 문서는 `github_operations.md`의 **O2 운영 단축 경로**에 따른 단일 운영 변경 기록이다. 변경은
+CI trigger·trusted classifier·policy mirror와 그 운영 계약 테스트에 한정되며 제품 소스·제품 테스트,
+package lock, 공개 API, secret, branch protection, release·publish, runner를 바꾸지 않는다. 기존 Issue와
+작업지시자의 명시적 로컬 작업 지시가 있고 변경·rollback이 작고 결정적이므로 별도 수행·구현·Stage·최종
+문서 묶음을 만들지 않는다. remote push·PR 생성·merge 승인은 각각 별도 게이트로 유지한다.
 
-#5511의 `refactor(cli): move render output adapters`(`836d4f233`)가 `src/main.rs`의 출력
-handler를 `src/cli/outputs/`로 옮겼지만 Render Diff workflow, trusted classifier, policy mirror의
-경로 소유 목록은 이동 전 `src/main.rs` 경계에 남았다. 그 결과 새 adapter만 고치는 PR은 필요한
-Render Diff 또는 Native Skia lane을 생략할 수 있다.
+## 1. GitHub 운영 변경
 
-## 2. 실제 consumer 기준 영향 매핑
+- **등급**: O2 라우팅·비용
+- **근거**: #5776과 작업지시자의 “먼저 fast-forward하고 #5776 작업을 진행” 지시
+- **기준 시각 / SHA**: 2026-08-24 12:52 KST / `upstream/devel@ad2867708`
+- **대상 workflow·설정**: `.github/workflows/render-diff.yml`의 PR path trigger,
+  `scripts/ci-impact-classifier.cjs`의 trusted 영향 분류, `scripts/ci-impact-policy.cjs`의 policy mirror
+- **현재 상태**: #5511의 `836d4f233`에서 render output adapter가 `src/main.rs`에서
+  `src/cli/outputs/`로 이동했지만 세 경로 소유 목록은 이동 전 경계에 남아 있다.
+- **기대 상태**: 실제 consumer에 따라 PDF/shared helper는 Render Diff와 Native Skia, raster는
+  Native Skia, vector는 일반 Rust 검증을 선택한다. 기존 `src/main.rs` fail-closed 경계는 유지한다.
+- **영향 event·branch·required check**: `pull_request` → `devel`의 변경 경로에 따라 run/no-run이
+  달라진다. 조회 시점의 `devel`에는 classic branch protection rule, repository ruleset, required status
+  check가 없으므로 `Render Diff`를 GitHub-enforced required check라고 간주하지 않는다.
+- **변경 파일**: workflow 1개, classifier·policy 2개, 운영 계약 test·fixture 5개, 문서 2개
+- **로컬 검증**: Node 64/64, Python workflow contract 48/48, `actionlint`,
+  `cargo fmt --all -- --check`, `git diff --check` 통과
+- **적용 승인**: 로컬 candidate 작성만 승인됨. remote push·PR 생성·merge는 아직 승인·실행하지 않음
+- **적용 결과와 run URL**: 로컬 candidate `ff22d8bc6`; upstream 미적용이므로 candidate Actions run 없음
+- **관찰 창과 완료 조건**: PR head의 분류·workflow 실행을 확인하고, merge 뒤 아래 대표 경로별 예상
+  run/no-run을 실제 PR event에서 확인할 때 완료한다.
+- **rollback 조건과 명령**: 기대한 run이 빠지거나 반대 경로에서 불필요한 run이 생기거나 기존 check가
+  사라지면 적용을 중단한다. merge 전에는 candidate를 수정하거나 폐기하고, merge 뒤에는
+  `git revert <integration-SHA>`를 최신 `upstream/devel` 기반 PR로 적용한다.
 
-| 경로 | 실제 consumer | 필요한 영향축 |
-|---|---|---|
-| `src/cli/outputs/mod.rs` | PDF·raster·vector가 공유하는 sibling resource 판정 | Rust + Render Diff + Native Skia |
-| `src/cli/outputs/pdf.rs` | Render Diff의 `pdf-render-diff-report.mjs`; Native Skia의 direct PDF CLI test | Rust + Render Diff + Native Skia |
-| `src/cli/outputs/raster.rs` | Native Skia의 `cli_exit_codes_native`가 `export-png` 직접 실행 | Rust + Native Skia |
-| `src/cli/outputs/vector.rs` | 기본 Rust integration test가 `export-svg` 등을 실행; 현재 Render Diff의 readiness-only 경로는 native capture를 생략 | Rust |
+## 2. 적용 전 live baseline
 
-`vector.rs`에는 비렌더 `export-structure`도 공존하므로 파일명만 보고 Render Diff 전체를 켜지 않는다.
-향후 Render Diff가 renderer baseline의 native capture를 실제 실행하면 그 workflow consumer 변경과 함께
-분류를 다시 넓힌다.
+| 관찰 항목 | 2026-08-24 관찰값 |
+| --- | --- |
+| 저장소·권한 | `edwardkim/rhwp`, public, default `main`, 현재 사용자 `WRITE` |
+| 이슈 | #5776 OPEN, assignee `postmelee`, labels `enhancement`, `ci`, milestone `v1.0.0` |
+| Git 기준선 | local `devel` = `upstream/devel` = `ad28677080929bc88e9beb286e482ce646a62ced` |
+| 보호 규칙 | `devel` branch protection API 404, repository ruleset `[]`, GraphQL branch protection rule `[]` |
+| 최근 Render Diff | PR event [run 32684364163](https://github.com/edwardkim/rhwp/actions/runs/32684364163) 성공 |
+| 기준 SHA checks | check-runs API에서 CI·CodeQL·Proptest·Adapter 계열 완료; GitHub-enforced required context 없음 |
 
-## 3. 구현
+`gh run list --branch devel`의 `--branch`는 PR base가 아니라 head branch를 필터링하므로 이 작업의 최근
+PR 실행 기준선으로 쓰지 않았다. 최근 `pull_request` event의 workflow run을 직접 확인했다.
 
-1. classifier에서 PDF와 shared helper를 render 영향으로, raster를 Native Skia 영향으로 등록한다.
-2. Render Diff의 `pull_request.paths`와 policy mirror에는 직접 consumer인 PDF와 shared helper만
-   같은 순서로 등록한다.
-3. classifier version을 올리고 기존 fixture의 version 계약을 동기화한다.
-4. adapter별 영향 행렬, workflow trigger의 포함·제외, policy mirror 일치를 회귀 테스트로 고정한다.
-5. `src/main.rs` fail-closed와 Render Diff trigger는 #3789 전까지 유지한다.
+## 3. 원인과 실제 consumer 매핑
 
-## 4. 검증
+#5511의 `refactor(cli): move render output adapters`(`836d4f233`)가 `src/main.rs`의 출력 handler를
+`src/cli/outputs/`로 옮겼지만 Render Diff workflow, trusted classifier, policy mirror의 경로 소유 목록은
+이동 전 `src/main.rs` 경계에 남았다. 그 결과 새 adapter만 고치는 PR은 필요한 Render Diff 또는 Native
+Skia lane을 생략할 수 있다.
 
-- `node --test scripts/tests/ci-impact-classifier.test.cjs`
-- `node --test scripts/tests/ci-impact-policy.test.cjs`
-- `python3 -m unittest scripts/tests/test_ci_impact_workflow.py`
-- `python3 -m unittest scripts/tests/test_render_diff_workflow.py`
-- `actionlint .github/workflows/render-diff.yml`
-- `cargo fmt --all` 및 `cargo fmt --all -- --check`
-- `git diff --check`
+| 경로 | 실제 consumer | 현재 분류 | candidate 분류 |
+| --- | --- | --- | --- |
+| `src/cli/outputs/mod.rs` | PDF·raster·vector의 sibling resource 판정 | 일반 Rust | Rust + Render Diff + Native Skia |
+| `src/cli/outputs/pdf.rs` | PDF Render Diff report, direct PDF CLI test | 일반 Rust | Rust + Render Diff + Native Skia |
+| `src/cli/outputs/raster.rs` | `cli_exit_codes_native`의 `export-png` | 일반 Rust | Rust + Native Skia |
+| `src/cli/outputs/vector.rs` | 기본 Rust integration의 `export-svg` 등 | 일반 Rust | 일반 Rust 유지 |
 
-이번 변경은 workflow와 분류 계약만 수정하며 Rust 제품 source, renderer 출력, baseline fixture는
-변경하지 않는다. 따라서 release-test, WASM build, 시각 sweep은 대상이 아니다.
+`vector.rs`에는 비렌더 `export-structure`도 공존하며 현재 Render Diff readiness-only 경로는 native
+capture를 실행하지 않으므로 파일명만 보고 Render Diff 전체를 켜지 않는다. 향후 workflow consumer가
+native capture를 실제 실행하면 그 변경과 함께 분류를 넓힌다.
 
-## 5. 완료 결과
+## 4. 변경과 예상 run/no-run
 
-- classifier version `4`에서 PDF/shared는 `rust-render`, raster는 `native-skia-rust`, vector는
-  일반 `rust`로 분류된다.
-- Render Diff trigger와 policy mirror는 `src/cli/outputs/mod.rs`, `pdf.rs`만 포함하고
-  `raster.rs`, `vector.rs`는 포함하지 않는다.
-- #5776 regression fixture와 adapter별 영향 행렬 테스트를 추가했다.
-- Node classifier·policy 64/64, Python CI·policy·Render Diff workflow 48/48,
-  `actionlint`, `cargo fmt --all -- --check`, `git diff --check`가 통과했다.
-- 포맷 검사용 generated suite 32개와 manifest는 검증 뒤 제거했고 제출 변경에 포함하지 않았다.
+1. classifier version을 `4`로 올리고 PDF/shared helper는 `rust-render`, raster는
+   `native-skia-rust`, vector는 일반 `rust`로 고정한다.
+2. Render Diff `pull_request.paths`와 policy mirror에는 직접 consumer인 `mod.rs`, `pdf.rs`만 같은
+   순서로 등록한다.
+3. adapter별 영향 행렬, workflow trigger 포함·제외, policy mirror 일치를 회귀 계약으로 고정한다.
+4. #3789의 더 넓은 경계 재설계 전까지 `src/main.rs`의 fail-closed trigger·분류를 유지한다.
+
+| PR의 대표 변경 경로 | Render Diff workflow | classifier 기대값 |
+| --- | --- | --- |
+| `src/cli/outputs/mod.rs` | run | `rust=true`, `render=true`, `native=true` |
+| `src/cli/outputs/pdf.rs` | run | `rust=true`, `render=true`, `native=true` |
+| `src/cli/outputs/raster.rs` | no-run | `rust=true`, `render=false`, `native=true` |
+| `src/cli/outputs/vector.rs` | no-run | `rust=true`, `render=false`, `native=false` |
+| `src/main.rs` | run | 기존 fail-closed full 영향 유지 |
+
+여러 경로가 섞이면 classifier 영향축은 합집합으로 계산한다.
+
+## 5. 변경 파일과 로컬 검증
+
+| 범위 | 파일 |
+| --- | --- |
+| workflow | `.github/workflows/render-diff.yml` |
+| classifier·mirror | `scripts/ci-impact-classifier.cjs`, `scripts/ci-impact-policy.cjs` |
+| 운영 계약 tests | `scripts/tests/ci-impact-classifier.test.cjs`, `scripts/tests/ci-impact-policy.test.cjs`, `scripts/tests/test_render_diff_workflow.py` |
+| fixture | `scripts/tests/fixtures/ci-impact-classifier-output-adapters.json`, `scripts/tests/fixtures/ci-impact-classifier-prs.json` |
+| 작업 기록 | 이 문서, `mydocs/orders/20260824.md` |
+
+실행 결과:
+
+- classifier·policy Node tests: 64/64 통과
+- CI·policy·Render Diff Python workflow contracts: 48/48 통과
+- `actionlint .github/workflows/render-diff.yml`: 통과
+- `cargo fmt --all` 및 `cargo fmt --all -- --check`: 통과
+- `git diff --check`: 통과
+- 검증용 generated suite 32개와 manifest: 검증 후 제거, candidate에 미포함
+
+Rust 제품 source, renderer 출력, baseline fixture는 바뀌지 않으므로 release-test, WASM build, 시각
+sweep은 대상이 아니다. 적용 뒤 실제 Actions 관찰 전에는 이 기록과 #5776을 완료로 바꾸지 않는다.

--- a/mydocs/plans/task_m100_5776.md
+++ b/mydocs/plans/task_m100_5776.md
@@ -1,0 +1,59 @@
+# 수행 계획서 — Task M100-5776: CLI render output adapter CI 영향 분류 복구
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/5776
+- 작성일: 2026-08-24
+- 브랜치: `codex/task-m100-5776-render-impact`
+- 기준선: `upstream/devel` `ad28677080929bc88e9beb286e482ce646a62ced`
+
+## 1. 문제와 원인
+
+#5511의 `refactor(cli): move render output adapters`(`836d4f233`)가 `src/main.rs`의 출력
+handler를 `src/cli/outputs/`로 옮겼지만 Render Diff workflow, trusted classifier, policy mirror의
+경로 소유 목록은 이동 전 `src/main.rs` 경계에 남았다. 그 결과 새 adapter만 고치는 PR은 필요한
+Render Diff 또는 Native Skia lane을 생략할 수 있다.
+
+## 2. 실제 consumer 기준 영향 매핑
+
+| 경로 | 실제 consumer | 필요한 영향축 |
+|---|---|---|
+| `src/cli/outputs/mod.rs` | PDF·raster·vector가 공유하는 sibling resource 판정 | Rust + Render Diff + Native Skia |
+| `src/cli/outputs/pdf.rs` | Render Diff의 `pdf-render-diff-report.mjs`; Native Skia의 direct PDF CLI test | Rust + Render Diff + Native Skia |
+| `src/cli/outputs/raster.rs` | Native Skia의 `cli_exit_codes_native`가 `export-png` 직접 실행 | Rust + Native Skia |
+| `src/cli/outputs/vector.rs` | 기본 Rust integration test가 `export-svg` 등을 실행; 현재 Render Diff의 readiness-only 경로는 native capture를 생략 | Rust |
+
+`vector.rs`에는 비렌더 `export-structure`도 공존하므로 파일명만 보고 Render Diff 전체를 켜지 않는다.
+향후 Render Diff가 renderer baseline의 native capture를 실제 실행하면 그 workflow consumer 변경과 함께
+분류를 다시 넓힌다.
+
+## 3. 구현
+
+1. classifier에서 PDF와 shared helper를 render 영향으로, raster를 Native Skia 영향으로 등록한다.
+2. Render Diff의 `pull_request.paths`와 policy mirror에는 직접 consumer인 PDF와 shared helper만
+   같은 순서로 등록한다.
+3. classifier version을 올리고 기존 fixture의 version 계약을 동기화한다.
+4. adapter별 영향 행렬, workflow trigger의 포함·제외, policy mirror 일치를 회귀 테스트로 고정한다.
+5. `src/main.rs` fail-closed와 Render Diff trigger는 #3789 전까지 유지한다.
+
+## 4. 검증
+
+- `node --test scripts/tests/ci-impact-classifier.test.cjs`
+- `node --test scripts/tests/ci-impact-policy.test.cjs`
+- `python3 -m unittest scripts/tests/test_ci_impact_workflow.py`
+- `python3 -m unittest scripts/tests/test_render_diff_workflow.py`
+- `actionlint .github/workflows/render-diff.yml`
+- `cargo fmt --all` 및 `cargo fmt --all -- --check`
+- `git diff --check`
+
+이번 변경은 workflow와 분류 계약만 수정하며 Rust 제품 source, renderer 출력, baseline fixture는
+변경하지 않는다. 따라서 release-test, WASM build, 시각 sweep은 대상이 아니다.
+
+## 5. 완료 결과
+
+- classifier version `4`에서 PDF/shared는 `rust-render`, raster는 `native-skia-rust`, vector는
+  일반 `rust`로 분류된다.
+- Render Diff trigger와 policy mirror는 `src/cli/outputs/mod.rs`, `pdf.rs`만 포함하고
+  `raster.rs`, `vector.rs`는 포함하지 않는다.
+- #5776 regression fixture와 adapter별 영향 행렬 테스트를 추가했다.
+- Node classifier·policy 64/64, Python CI·policy·Render Diff workflow 48/48,
+  `actionlint`, `cargo fmt --all -- --check`, `git diff --check`가 통과했다.
+- 포맷 검사용 generated suite 32개와 manifest는 검증 뒤 제거했고 제출 변경에 포함하지 않았다.

--- a/mydocs/plans/task_m100_5776.md
+++ b/mydocs/plans/task_m100_5776.md
@@ -1,12 +1,15 @@
 # O2 운영 변경 기록 — Task M100-5776: CLI render output adapter CI 영향 분류 복구
 
 - 이슈: [#5776](https://github.com/edwardkim/rhwp/issues/5776)
-- 상태: Open PR #5989 — initial Full Actions 및 trailing review head 관찰 대기
+- 상태: Open PR #5989 — review correction candidate와 trailing 기록의 Actions 관찰 대기
 - 작성·재검증일: 2026-08-24
 - 브랜치: `codex/task-m100-5776-render-impact`
-- 기준선: `upstream/devel` `ad28677080929bc88e9beb286e482ce646a62ced`
+- 초기 기준선: `upstream/devel` `ad28677080929bc88e9beb286e482ce646a62ced`
+- current-base merge 기준선: `upstream/devel` `01e2e74224968be256ad2d97d5d0e6b3cb490d0a`
 - 로컬 candidate: `ff22d8bc624563efdc8b3db94c878dff2e362498`
 - initial PR head: `a0733fef459b6bc45729a2266e1da09ce47a8576`
+- current-base merge head: `7ebf6fe50c0c36b0f8dc298547e0e3e3b96a752d`
+- review correction candidate: `bacec40ee5f9a15e086e0f82e6edb9c074f9d3ec`
 - PR: [#5989](https://github.com/edwardkim/rhwp/pull/5989)
 - 권위 문서: [`github_operations.md` §3.1](../manual/github_operations.md#31-운영-단축-경로)
 
@@ -20,7 +23,8 @@ package lock, 공개 API, secret, branch protection, release·publish, runner를
 
 - **등급**: O2 라우팅·비용
 - **근거**: #5776과 작업지시자의 “먼저 fast-forward하고 #5776 작업을 진행” 지시
-- **기준 시각 / SHA**: 2026-08-24 12:52 KST / `upstream/devel@ad2867708`
+- **기준 시각 / SHA**: 초기 2026-08-24 12:52 KST / `upstream/devel@ad2867708`;
+  current-base 재확인 `upstream/devel@01e2e7422`
 - **대상 workflow·설정**: `.github/workflows/render-diff.yml`의 PR path trigger,
   `scripts/ci-impact-classifier.cjs`의 trusted 영향 분류, `scripts/ci-impact-policy.cjs`의 policy mirror
 - **현재 상태**: #5511의 `836d4f233`에서 render output adapter가 `src/main.rs`에서
@@ -30,17 +34,18 @@ package lock, 공개 API, secret, branch protection, release·publish, runner를
 - **영향 event·branch·required check**: `pull_request` → `devel`의 변경 경로에 따라 run/no-run이
   달라진다. 조회 시점의 `devel`에는 classic branch protection rule, repository ruleset, required status
   check가 없으므로 `Render Diff`를 GitHub-enforced required check라고 간주하지 않는다.
-- **변경 파일**: workflow 1개, classifier·policy 2개, 운영 계약 test·fixture 5개, 문서 2개
-- **로컬 검증**: Node 64/64, Python workflow contract 48/48, `actionlint`,
+- **변경 파일**: workflow 1개, classifier·policy 2개, 운영 계약 test·fixture 5개, 문서 3개
+- **로컬 검증**: Node 65/65, Python workflow contract 68/68, `actionlint`,
   `cargo fmt --all -- --check`, `git diff --check` 통과
 - **적용 승인**: 작업지시자가 remote push와 Open PR 생성, 번호 기반 trailing review 반영을 승인함.
   merge는 아직 승인되지 않음
-- **적용 결과와 run URL**: PR #5989 initial head `a0733fef4`; CI
-  [32688977374](https://github.com/edwardkim/rhwp/actions/runs/32688977374), CodeQL
-  [32688977353](https://github.com/edwardkim/rhwp/actions/runs/32688977353), Render Diff
-  [32688977262](https://github.com/edwardkim/rhwp/actions/runs/32688977262), Proptest
-  [32688977203](https://github.com/edwardkim/rhwp/actions/runs/32688977203), Adapter inter-diff
-  [32688977139](https://github.com/edwardkim/rhwp/actions/runs/32688977139) 실행 중
+- **적용 결과와 run URL**: current-base merge head `7ebf6fe50`; CI
+  [32691575411](https://github.com/edwardkim/rhwp/actions/runs/32691575411), CodeQL
+  [32691575234](https://github.com/edwardkim/rhwp/actions/runs/32691575234), Render Diff
+  [32691575207](https://github.com/edwardkim/rhwp/actions/runs/32691575207), Proptest
+  [32691575200](https://github.com/edwardkim/rhwp/actions/runs/32691575200), Adapter inter-diff
+  [32691575198](https://github.com/edwardkim/rhwp/actions/runs/32691575198) 모두 성공. review correction
+  candidate `bacec40ee`와 trailing 기록은 push 뒤 새 Actions를 확인한다.
 - **관찰 창과 완료 조건**: PR head의 분류·workflow 실행을 확인하고, merge 뒤 아래 대표 경로별 예상
   run/no-run을 실제 PR event에서 확인할 때 완료한다.
 - **rollback 조건과 명령**: 기대한 run이 빠지거나 반대 경로에서 불필요한 run이 생기거나 기존 check가
@@ -53,7 +58,8 @@ package lock, 공개 API, secret, branch protection, release·publish, runner를
 | --- | --- |
 | 저장소·권한 | `edwardkim/rhwp`, public, default `main`, 현재 사용자 `WRITE` |
 | 이슈 | #5776 OPEN, assignee `postmelee`, labels `enhancement`, `ci`, milestone `v1.0.0` |
-| Git 기준선 | local `devel` = `upstream/devel` = `ad28677080929bc88e9beb286e482ce646a62ced` |
+| 초기 Git 기준선 | local `devel` = `upstream/devel` = `ad28677080929bc88e9beb286e482ce646a62ced` |
+| current-base 갱신 | `upstream/devel@01e2e7422`을 merge한 PR head `7ebf6fe50`의 merge tree와 Full Actions 성공 |
 | 보호 규칙 | `devel` branch protection API 404, repository ruleset `[]`, GraphQL branch protection rule `[]` |
 | 최근 Render Diff | PR event [run 32684364163](https://github.com/edwardkim/rhwp/actions/runs/32684364163) 성공 |
 | 기준 SHA checks | check-runs API에서 CI·CodeQL·Proptest·Adapter 계열 완료; GitHub-enforced required context 없음 |
@@ -86,7 +92,9 @@ native capture를 실제 실행하면 그 변경과 함께 분류를 넓힌다.
 2. Render Diff `pull_request.paths`와 policy mirror에는 직접 consumer인 `mod.rs`, `pdf.rs`만 같은
    순서로 등록한다.
 3. adapter별 영향 행렬, workflow trigger 포함·제외, policy mirror 일치를 회귀 계약으로 고정한다.
-4. #3789의 더 넓은 경계 재설계 전까지 `src/main.rs`의 fail-closed trigger·분류를 유지한다.
+4. `src/cli/outputs/**/*.rs` 전수와 세 영향 버킷의 일치를 검사해 새·중첩 adapter의 미등록을 실패시킨다.
+5. `classified + render=true`이면 Render Diff가 반드시 실행된다는 추적 파일 전수 불변식을 검사한다.
+6. #3789의 더 넓은 경계 재설계 전까지 `src/main.rs`의 fail-closed trigger·분류를 유지한다.
 
 | PR의 대표 변경 경로 | Render Diff workflow | classifier 기대값 |
 | --- | --- | --- |
@@ -110,12 +118,12 @@ native capture를 실제 실행하면 그 변경과 함께 분류를 넓힌다.
 
 실행 결과:
 
-- classifier·policy Node tests: 64/64 통과
-- CI·policy·Render Diff Python workflow contracts: 48/48 통과
+- classifier·policy Node tests: 65/65 통과
+- CI·CodeQL·policy·Render Diff Python workflow contracts: 68/68 통과
 - `actionlint .github/workflows/render-diff.yml`: 통과
 - `cargo fmt --all` 및 `cargo fmt --all -- --check`: 통과
 - `git diff --check`: 통과
-- 검증용 generated suite 32개와 manifest: 검증 후 제거, candidate에 미포함
+- 검증용 generated suite 32개와 ignored manifest: 검증 후 제거, candidate에 미포함
 
 Rust 제품 source, renderer 출력, baseline fixture는 바뀌지 않으므로 release-test, WASM build, 시각
 sweep은 대상이 아니다. 적용 뒤 실제 Actions 관찰 전에는 이 기록과 #5776을 완료로 바꾸지 않는다.

--- a/mydocs/plans/task_m100_5776.md
+++ b/mydocs/plans/task_m100_5776.md
@@ -1,11 +1,13 @@
 # O2 운영 변경 기록 — Task M100-5776: CLI render output adapter CI 영향 분류 복구
 
 - 이슈: [#5776](https://github.com/edwardkim/rhwp/issues/5776)
-- 상태: 로컬 candidate 완료 — remote push·PR 승인 및 적용 후 관찰 대기
+- 상태: Open PR #5989 — initial Full Actions 및 trailing review head 관찰 대기
 - 작성·재검증일: 2026-08-24
 - 브랜치: `codex/task-m100-5776-render-impact`
 - 기준선: `upstream/devel` `ad28677080929bc88e9beb286e482ce646a62ced`
 - 로컬 candidate: `ff22d8bc624563efdc8b3db94c878dff2e362498`
+- initial PR head: `a0733fef459b6bc45729a2266e1da09ce47a8576`
+- PR: [#5989](https://github.com/edwardkim/rhwp/pull/5989)
 - 권위 문서: [`github_operations.md` §3.1](../manual/github_operations.md#31-운영-단축-경로)
 
 이 문서는 `github_operations.md`의 **O2 운영 단축 경로**에 따른 단일 운영 변경 기록이다. 변경은
@@ -31,8 +33,14 @@ package lock, 공개 API, secret, branch protection, release·publish, runner를
 - **변경 파일**: workflow 1개, classifier·policy 2개, 운영 계약 test·fixture 5개, 문서 2개
 - **로컬 검증**: Node 64/64, Python workflow contract 48/48, `actionlint`,
   `cargo fmt --all -- --check`, `git diff --check` 통과
-- **적용 승인**: 로컬 candidate 작성만 승인됨. remote push·PR 생성·merge는 아직 승인·실행하지 않음
-- **적용 결과와 run URL**: 로컬 candidate `ff22d8bc6`; upstream 미적용이므로 candidate Actions run 없음
+- **적용 승인**: 작업지시자가 remote push와 Open PR 생성, 번호 기반 trailing review 반영을 승인함.
+  merge는 아직 승인되지 않음
+- **적용 결과와 run URL**: PR #5989 initial head `a0733fef4`; CI
+  [32688977374](https://github.com/edwardkim/rhwp/actions/runs/32688977374), CodeQL
+  [32688977353](https://github.com/edwardkim/rhwp/actions/runs/32688977353), Render Diff
+  [32688977262](https://github.com/edwardkim/rhwp/actions/runs/32688977262), Proptest
+  [32688977203](https://github.com/edwardkim/rhwp/actions/runs/32688977203), Adapter inter-diff
+  [32688977139](https://github.com/edwardkim/rhwp/actions/runs/32688977139) 실행 중
 - **관찰 창과 완료 조건**: PR head의 분류·workflow 실행을 확인하고, merge 뒤 아래 대표 경로별 예상
   run/no-run을 실제 PR event에서 확인할 때 완료한다.
 - **rollback 조건과 명령**: 기대한 run이 빠지거나 반대 경로에서 불필요한 run이 생기거나 기존 check가

--- a/mydocs/pr/archives/pr_5989_review.md
+++ b/mydocs/pr/archives/pr_5989_review.md
@@ -1,0 +1,97 @@
+---
+kind: pr-review
+status: trailing-docs-pending-ci
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-24
+---
+
+# PR #5989 self-review — 분리된 CLI render output adapter CI 영향 분류 복구
+
+## 라우팅과 접수 메타데이터
+
+- base route: `collaborator_self_merge.md`
+- modifiers: `intake_and_review.md`, `local_validation.md`, `review_only_fast_pass.md`
+- loaded documents: `pr_review_workflow.md`, `pr_review/README.md`, 위 기본·보조 문서
+- 작성자 본인 self-review이므로 reviewer를 지정하지 않는다.
+- initial full candidate: `a0733fef459b6bc45729a2266e1da09ce47a8576`
+
+| 항목 | 작성 시점 참고값 |
+| --- | --- |
+| PR / 작성자 | [#5989](https://github.com/edwardkim/rhwp/pull/5989) / [@postmelee](https://github.com/postmelee) |
+| base / head | `devel` / `codex/task-m100-5776-render-impact` |
+| 초기 규모 | 10 files, +264 / -13, 3 commits |
+| 상태 | Open, non-draft, `MERGEABLE`, initial full Actions 실행 중 |
+| 관련 issue | `Closes #5776`; related #3789, #5511 |
+
+단일 self PR이고 최신 `upstream/devel@ad2867708`을 직접 조상으로 가지므로 update branch·오래된 base 경로는
+적용하지 않았다. renderer·layout·paint, 제품 source, sample, 기준 PDF와 visual fixture를 변경하지 않으므로
+시각 증적 경로도 적용하지 않았다. 이 PR은 workflow와 impact policy를 바꾸므로 trailing commit의 재사용은
+`review_only_fast_pass.md` A.1의 trusted controller 조건을 적용한다.
+
+## 변경 범위와 self-review
+
+#5511에서 render output handler가 `src/main.rs`에서 `src/cli/outputs/`로 이동했지만 Render Diff trigger,
+trusted classifier와 policy mirror의 소유 경계가 따라가지 않아 adapter-only PR의 검증이 빠질 수 있었다.
+
+| 경로 | 확인한 실제 consumer | candidate 영향축 |
+| --- | --- | --- |
+| `src/cli/outputs/mod.rs` | PDF·raster·vector의 sibling resource 판정 | Rust + Render Diff + Native Skia |
+| `src/cli/outputs/pdf.rs` | PDF report와 direct `export-pdf` CLI test | Rust + Render Diff + Native Skia |
+| `src/cli/outputs/raster.rs` | Native Skia `cli_exit_codes_native`의 `export-png` | Rust + Native Skia |
+| `src/cli/outputs/vector.rs` | 일반 Rust integration의 vector·structure export | 일반 Rust 유지 |
+
+검토 결과:
+
+- Render Diff `pull_request.paths`와 policy mirror에는 직접 consumer인 `mod.rs`, `pdf.rs`가 같은 순서로
+  추가됐다. raster와 vector는 workflow trigger에서 제외돼 불필요한 Canvas lane을 만들지 않는다.
+- classifier version `4`에서 mod/PDF는 `classified:rust-render`, raster는
+  `classified:native-skia-rust`, vector는 `classified:rust`로 고정됐다.
+- adapter별 fixture, classifier 행렬, workflow 포함·제외와 mirror 일치 테스트가 같은 계약을 검증한다.
+- #3789가 정리할 `src/main.rs`의 blanket 경계는 이번 false-negative 수정에서 제거하지 않고
+  `fail-closed:main-render-boundary`로 유지한다.
+- Rust 제품 source와 renderer output을 바꾸지 않으며 cache, runner, secret, branch protection과
+  baseline도 변경하지 않는다.
+
+추가 blocker는 발견하지 않았다. 향후 Render Diff가 vector native capture를 실제 소비하게 되면 그
+workflow consumer 변경과 함께 `vector.rs` 영향축을 다시 넓혀야 한다.
+
+## 완료한 로컬 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| classifier·policy Node tests | 64/64 통과 |
+| CI·policy·Render Diff Python workflow contracts | 48/48 통과 |
+| `actionlint .github/workflows/render-diff.yml` | 통과 |
+| `cargo fmt --all` / `cargo fmt --all -- --check` | 검증용 generated suite 준비 후 모두 통과 |
+| `git diff --check` | 통과 |
+| generated artifacts | 32 harnesses와 manifest 제거, PR에 미포함 |
+
+O2 CI workflow 범위에 따라 workflow 구문·정책·required check 영향을 검증했다. Rust source, renderer,
+fixture가 없어 release-test, clippy, WASM, sample SVG와 시각 sweep은 실행 대상이 아니다. 조회 시점의
+`devel`에는 classic branch protection rule, repository ruleset 또는 GitHub-enforced required status
+context가 없었으며, 이 사실을 workflow 자체의 성공 조건이 없다는 뜻으로 확대 해석하지 않았다.
+
+## GitHub Actions
+
+initial full candidate `a0733fef4`의 preflight는 모두 성공했고 full worker는 작성 시점 실행 중이다.
+
+| workflow | run | 작성 시점 상태 |
+| --- | --- | --- |
+| CI | [32688977374](https://github.com/edwardkim/rhwp/actions/runs/32688977374) | preflight 성공, full jobs 실행 중 |
+| CodeQL | [32688977353](https://github.com/edwardkim/rhwp/actions/runs/32688977353) | preflight 성공, Analyze 실행·대기 중 |
+| Render Diff | [32688977262](https://github.com/edwardkim/rhwp/actions/runs/32688977262) | preflight 성공, Canvas visual diff 대기 중 |
+| Proptest roundtrip | [32688977203](https://github.com/edwardkim/rhwp/actions/runs/32688977203) | preflight 성공, worker 실행 중 |
+| Adapter inter-diff | [32688977139](https://github.com/edwardkim/rhwp/actions/runs/32688977139) | preflight 성공, worker 실행 중 |
+
+이 self-review와 오늘할일은 initial candidate 뒤의 `mydocs/` 한정 single-parent trailing commit이다.
+원 PR이 CI execution surface를 바꾸므로, initial candidate의 Full CI·CodeQL·Render Diff가 같은 PR·branch·SHA에서
+성공하고 기본 branch의 `CI Impact Policy Controller`가 exact trailing head에 trusted status를 발행해야만
+A.1 재사용으로 판정한다. 조건이 불완전하면 Full CI fallback 결과를 기다린다.
+
+## 최종 권고
+
+경로별 분류는 파일명 추정이 아니라 실제 consumer와 일치하며 workflow·classifier·policy의 세 경계를 계약
+테스트로 고정했다. #3789의 false-positive 경계를 이번 PR에 섞지 않았고 기존 fail-closed도 보존했다.
+
+self-review는 **완료 / CI 대기 조건부 merge 권고**다. initial candidate와 trailing head의 trusted
+Actions, 최신 `MERGEABLE/CLEAN`, 작업지시자의 별도 merge 승인을 확인하기 전에는 merge하지 않는다.

--- a/mydocs/pr/archives/pr_5989_review.md
+++ b/mydocs/pr/archives/pr_5989_review.md
@@ -1,6 +1,6 @@
 ---
 kind: pr-review
-status: trailing-docs-pending-ci
+status: correction-pending-ci
 canonical: mydocs/manual/pr_review_workflow.md
 last_verified: 2026-08-24
 ---
@@ -14,19 +14,23 @@ last_verified: 2026-08-24
 - loaded documents: `pr_review_workflow.md`, `pr_review/README.md`, 위 기본·보조 문서
 - 작성자 본인 self-review이므로 reviewer를 지정하지 않는다.
 - initial full candidate: `a0733fef459b6bc45729a2266e1da09ce47a8576`
+- current-base merge head: `7ebf6fe50c0c36b0f8dc298547e0e3e3b96a752d`
+- review correction candidate: `bacec40ee5f9a15e086e0f82e6edb9c074f9d3ec`
 
 | 항목 | 작성 시점 참고값 |
 | --- | --- |
 | PR / 작성자 | [#5989](https://github.com/edwardkim/rhwp/pull/5989) / [@postmelee](https://github.com/postmelee) |
 | base / head | `devel` / `codex/task-m100-5776-render-impact` |
-| 초기 규모 | 10 files, +264 / -13, 3 commits |
-| 상태 | Open, non-draft, `MERGEABLE`, initial full Actions 실행 중 |
+| 보정 candidate 기준 규모 | 12 files, +447 / -18, 6 commits |
+| 상태 | Open, non-draft, 직전 head `MERGEABLE/CLEAN`; 보정 head Actions 재확인 필요 |
 | 관련 issue | `Closes #5776`; related #3789, #5511 |
 
-단일 self PR이고 최신 `upstream/devel@ad2867708`을 직접 조상으로 가지므로 update branch·오래된 base 경로는
-적용하지 않았다. renderer·layout·paint, 제품 source, sample, 기준 PDF와 visual fixture를 변경하지 않으므로
-시각 증적 경로도 적용하지 않았다. 이 PR은 workflow와 impact policy를 바꾸므로 trailing commit의 재사용은
-`review_only_fast_pass.md` A.1의 trusted controller 조건을 적용한다.
+`upstream/devel@01e2e7422`을 두 번째 parent로 병합한 `7ebf6fe50`에서 current-base merge tree와 Full
+Actions가 통과했다. 리뷰 피드백 보정은 그 위의 `bacec40ee`에 코드·계약 테스트만 분리하고, 이 문서는 그
+candidate 뒤의 review-only 기록으로 잇는다. renderer·layout·paint, 제품 source, sample, 기준 PDF와 visual
+fixture를 변경하지 않으므로 시각 증적 경로는 적용하지 않았다. 이 PR은 workflow와 impact policy를 바꾸므로
+trailing commit의 재사용은 `review_only_fast_pass.md` A.1의 trusted controller 조건을 적용하며, 조건이
+불완전하면 Full CI fallback 결과를 기다린다.
 
 ## 변경 범위와 self-review
 
@@ -47,6 +51,14 @@ trusted classifier와 policy mirror의 소유 경계가 따라가지 않아 adap
 - classifier version `4`에서 mod/PDF는 `classified:rust-render`, raster는
   `classified:native-skia-rust`, vector는 `classified:rust`로 고정됐다.
 - adapter별 fixture, classifier 행렬, workflow 포함·제외와 mirror 일치 테스트가 같은 계약을 검증한다.
+- `src/cli/outputs/**/*.rs` 전수 inventory는 현재 adapter 8개가 render+native, native-only, plain-Rust의
+  서로 겹치지 않는 세 버킷과 정확히 일치하는지 확인한다. 향후 중첩 모듈 또는 새 adapter가 생기면 명시적
+  버킷 갱신 전까지 테스트가 실패한다.
+- 추적 파일 전수에서 `classification_status=classified`이고 `render_required=true`인 경로는 반드시
+  Render Diff workflow가 실행된다는 일반 불변식을 추가했다. fail-closed인 `full` 분류는 이 조건에서
+  의도적으로 제외했다.
+- `NATIVE_SKIA_RUST_FILES` 주석은 제품 raster 경계와 integration target·support를 함께 소유한다는 현재
+  집합의 역할에 맞게 고쳤다.
 - #3789가 정리할 `src/main.rs`의 blanket 경계는 이번 false-negative 수정에서 제거하지 않고
   `fail-closed:main-render-boundary`로 유지한다.
 - Rust 제품 source와 renderer output을 바꾸지 않으며 cache, runner, secret, branch protection과
@@ -59,12 +71,12 @@ workflow consumer 변경과 함께 `vector.rs` 영향축을 다시 넓혀야 한
 
 | 검증 | 결과 |
 | --- | --- |
-| classifier·policy Node tests | 64/64 통과 |
-| CI·policy·Render Diff Python workflow contracts | 48/48 통과 |
+| classifier·policy Node tests | 65/65 통과 |
+| CI·CodeQL·policy·Render Diff Python workflow contracts | 68/68 통과 |
 | `actionlint .github/workflows/render-diff.yml` | 통과 |
-| `cargo fmt --all` / `cargo fmt --all -- --check` | 검증용 generated suite 준비 후 모두 통과 |
+| suite manifest / `cargo fmt --all` / `cargo fmt --all -- --check` | 검증용 generated suite 32개 준비 후 모두 통과 |
 | `git diff --check` | 통과 |
-| generated artifacts | 32 harnesses와 manifest 제거, PR에 미포함 |
+| generated artifacts | 32 harnesses와 ignored manifest 제거, PR에 미포함 |
 
 O2 CI workflow 범위에 따라 workflow 구문·정책·required check 영향을 검증했다. Rust source, renderer,
 fixture가 없어 release-test, clippy, WASM, sample SVG와 시각 sweep은 실행 대상이 아니다. 조회 시점의
@@ -73,25 +85,27 @@ context가 없었으며, 이 사실을 workflow 자체의 성공 조건이 없�
 
 ## GitHub Actions
 
-initial full candidate `a0733fef4`의 preflight는 모두 성공했고 full worker는 작성 시점 실행 중이다.
+current-base merge head `7ebf6fe50`의 Full Actions는 모두 성공했다.
 
-| workflow | run | 작성 시점 상태 |
+| workflow | run | `7ebf6fe50` 결과 |
 | --- | --- | --- |
-| CI | [32688977374](https://github.com/edwardkim/rhwp/actions/runs/32688977374) | preflight 성공, full jobs 실행 중 |
-| CodeQL | [32688977353](https://github.com/edwardkim/rhwp/actions/runs/32688977353) | preflight 성공, Analyze 실행·대기 중 |
-| Render Diff | [32688977262](https://github.com/edwardkim/rhwp/actions/runs/32688977262) | preflight 성공, Canvas visual diff 대기 중 |
-| Proptest roundtrip | [32688977203](https://github.com/edwardkim/rhwp/actions/runs/32688977203) | preflight 성공, worker 실행 중 |
-| Adapter inter-diff | [32688977139](https://github.com/edwardkim/rhwp/actions/runs/32688977139) | preflight 성공, worker 실행 중 |
+| CI | [32691575411](https://github.com/edwardkim/rhwp/actions/runs/32691575411) | 성공 — Build & Test 포함 |
+| CodeQL | [32691575234](https://github.com/edwardkim/rhwp/actions/runs/32691575234) | 성공 — Rust·Python·JavaScript/TypeScript 포함 |
+| Render Diff | [32691575207](https://github.com/edwardkim/rhwp/actions/runs/32691575207) | 성공 — Canvas visual diff 포함 |
+| Proptest roundtrip | [32691575200](https://github.com/edwardkim/rhwp/actions/runs/32691575200) | 성공 |
+| Adapter inter-diff | [32691575198](https://github.com/edwardkim/rhwp/actions/runs/32691575198) | 성공 |
 
-이 self-review와 오늘할일은 initial candidate 뒤의 `mydocs/` 한정 single-parent trailing commit이다.
-원 PR이 CI execution surface를 바꾸므로, initial candidate의 Full CI·CodeQL·Render Diff가 같은 PR·branch·SHA에서
-성공하고 기본 branch의 `CI Impact Policy Controller`가 exact trailing head에 trusted status를 발행해야만
-A.1 재사용으로 판정한다. 조건이 불완전하면 Full CI fallback 결과를 기다린다.
+리뷰 보정 candidate `bacec40ee`는 classifier와 계약 테스트를 바꾼 새 code head다. 이 문서와 오늘할일은
+그 뒤의 `mydocs/` 한정 single-parent trailing 기록으로 push한다. 원 PR이 CI execution surface를 바꾸므로,
+`bacec40ee`의 Full CI·CodeQL·Render Diff가 같은 PR·branch·SHA에서 성공하고 기본 branch의
+`CI Impact Policy Controller`가 exact trailing head에 trusted status를 발행해야만 A.1 재사용으로 판정한다.
+조건이 불완전하면 최신 trailing head의 Full CI fallback 결과를 기다린다.
 
 ## 최종 권고
 
 경로별 분류는 파일명 추정이 아니라 실제 consumer와 일치하며 workflow·classifier·policy의 세 경계를 계약
 테스트로 고정했다. #3789의 false-positive 경계를 이번 PR에 섞지 않았고 기존 fail-closed도 보존했다.
 
-self-review는 **완료 / CI 대기 조건부 merge 권고**다. initial candidate와 trailing head의 trusted
-Actions, 최신 `MERGEABLE/CLEAN`, 작업지시자의 별도 merge 승인을 확인하기 전에는 merge하지 않는다.
+self-review 보정은 **완료 / 새 head CI 대기 조건부 merge 권고**다. `bacec40ee`와 trailing head의 trusted
+Actions 또는 Full fallback, 최신 `MERGEABLE/CLEAN`, 작업지시자의 별도 merge 승인을 확인하기 전에는
+merge하지 않는다.

--- a/scripts/ci-impact-classifier.cjs
+++ b/scripts/ci-impact-classifier.cjs
@@ -26,10 +26,10 @@ const RENDER_RUST_FILES = new Set([
   'src/document_core/queries/rendering.rs',
 ]);
 
-// [#4040/#4132] Native Skia job 이 명시적으로 실행하는 integration target 과
-// 그 target 이 #[path] 로 공유하는 support 의 소유 목록. 여기 없으면 해당 파일을
-// 고치는 PR 에서 native_skia_required=false 로 판정되어 정작 그 테스트를 돌릴
-// job 이 skip 된다. test_ci_impact_workflow.py 가 workflow·support 양쪽을 강제한다.
+// Native Skia 제품 경계와 [#4040/#4132] job 이 명시적으로 실행하는 integration
+// target·공유 support 의 소유 목록. 여기 없으면 해당 파일을 고치는 PR 에서
+// native_skia_required=false 로 판정되어 정작 그 경계를 검증할 job 이 skip 된다.
+// test_ci_impact_workflow.py 가 workflow·support 양쪽을 강제한다.
 const NATIVE_SKIA_RUST_FILES = new Set([
   // [#5776] Native Skia job의 cli_exit_codes_native가 export-png를 직접 실행한다.
   // Render Diff는 현재 raster adapter를 소비하지 않으므로 Canvas 축은 켜지 않는다.

--- a/scripts/ci-impact-classifier.cjs
+++ b/scripts/ci-impact-classifier.cjs
@@ -2,7 +2,7 @@
 
 const fs = require('node:fs');
 
-const CLASSIFIER_VERSION = '3';
+const CLASSIFIER_VERSION = '4';
 const CODEQL_LANGUAGE_ORDER = ['javascript-typescript', 'python', 'rust'];
 const FRONTEND_MODE_RANK = { none: 0, unit: 1, package: 2 };
 
@@ -19,6 +19,10 @@ const RENDER_RUST_PREFIXES = [
 ];
 
 const RENDER_RUST_FILES = new Set([
+  // [#5776] Render Diff의 PDF report가 native CLI export-pdf를 직접 실행한다.
+  // outputs/mod.rs의 sibling-resource 판정도 같은 PDF 입력 경계다.
+  'src/cli/outputs/mod.rs',
+  'src/cli/outputs/pdf.rs',
   'src/document_core/queries/rendering.rs',
 ]);
 
@@ -27,6 +31,9 @@ const RENDER_RUST_FILES = new Set([
 // 고치는 PR 에서 native_skia_required=false 로 판정되어 정작 그 테스트를 돌릴
 // job 이 skip 된다. test_ci_impact_workflow.py 가 workflow·support 양쪽을 강제한다.
 const NATIVE_SKIA_RUST_FILES = new Set([
+  // [#5776] Native Skia job의 cli_exit_codes_native가 export-png를 직접 실행한다.
+  // Render Diff는 현재 raster adapter를 소비하지 않으므로 Canvas 축은 켜지 않는다.
+  'src/cli/outputs/raster.rs',
   'tests/cli_exit_codes_native.rs',
   'tests/issue_1144_native.rs',
   'tests/issue_2083_hide_fill_page_background.rs',

--- a/scripts/ci-impact-policy.cjs
+++ b/scripts/ci-impact-policy.cjs
@@ -114,6 +114,8 @@ const RENDER_DIFF_PULL_REQUEST_PATHS = [
   'src/model/**',
   'src/renderer/**',
   'src/document_core/queries/rendering.rs',
+  'src/cli/outputs/mod.rs',
+  'src/cli/outputs/pdf.rs',
   'src/wasm_api.rs',
   'src/main.rs',
   'assets/fonts/**',

--- a/scripts/tests/ci-impact-classifier.test.cjs
+++ b/scripts/tests/ci-impact-classifier.test.cjs
@@ -25,6 +25,18 @@ const REGRESSION_FIXTURE_PATH = path.join(
 const REGRESSION_FIXTURES = JSON.parse(
   fs.readFileSync(REGRESSION_FIXTURE_PATH, 'utf8'),
 );
+const REPOSITORY_ROOT = path.join(__dirname, '..', '..');
+const OUTPUT_ADAPTER_ROOT = path.join(REPOSITORY_ROOT, 'src', 'cli', 'outputs');
+
+function rustFilesUnder(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true })
+    .flatMap((entry) => {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) return rustFilesUnder(entryPath);
+      if (!entry.isFile() || !entry.name.endsWith('.rs')) return [];
+      return [path.relative(REPOSITORY_ROOT, entryPath).split(path.sep).join('/')];
+    });
+}
 
 for (const fixture of HISTORICAL_PRS) {
   test(`historical PR #${fixture.pr}: ${fixture.title}`, () => {
@@ -102,12 +114,45 @@ test('Rust renderer changes require Rust, Native Skia, Canvas, and Rust CodeQL',
   assert.equal(result.classification_status, 'classified');
 });
 
-test('CLI output adapters follow their actual render and Native Skia consumers', () => {
+test('every CLI output adapter belongs to one explicit impact bucket', () => {
+  const buckets = {
+    renderAndNative: [
+      'src/cli/outputs/mod.rs',
+      'src/cli/outputs/pdf.rs',
+    ],
+    nativeOnly: [
+      'src/cli/outputs/raster.rs',
+    ],
+    plainRust: [
+      'src/cli/outputs/doclang.rs',
+      'src/cli/outputs/preview.rs',
+      'src/cli/outputs/tabular.rs',
+      'src/cli/outputs/text.rs',
+      'src/cli/outputs/vector.rs',
+    ],
+  };
+  const expected = Object.values(buckets).flat();
+  assert.equal(
+    new Set(expected).size,
+    expected.length,
+    'CLI output impact buckets must be disjoint',
+  );
+  assert.deepEqual(
+    rustFilesUnder(OUTPUT_ADAPTER_ROOT).sort(),
+    expected.sort(),
+    'new or moved CLI output adapters require an explicit impact bucket',
+  );
+
   for (const [filename, renderRequired, nativeSkiaRequired, reason] of [
-    ['src/cli/outputs/mod.rs', 'true', 'true', 'classified:rust-render'],
-    ['src/cli/outputs/pdf.rs', 'true', 'true', 'classified:rust-render'],
-    ['src/cli/outputs/raster.rs', 'false', 'true', 'classified:native-skia-rust'],
-    ['src/cli/outputs/vector.rs', 'false', 'false', 'classified:rust'],
+    ...buckets.renderAndNative.map((filename) => (
+      [filename, 'true', 'true', 'classified:rust-render']
+    )),
+    ...buckets.nativeOnly.map((filename) => (
+      [filename, 'false', 'true', 'classified:native-skia-rust']
+    )),
+    ...buckets.plainRust.map((filename) => (
+      [filename, 'false', 'false', 'classified:rust']
+    )),
   ]) {
     const result = classifyChanges({
       eventName: 'pull_request',

--- a/scripts/tests/ci-impact-classifier.test.cjs
+++ b/scripts/tests/ci-impact-classifier.test.cjs
@@ -17,9 +17,26 @@ const FIXTURE_PATH = path.join(
   'ci-impact-classifier-prs.json',
 );
 const HISTORICAL_PRS = JSON.parse(fs.readFileSync(FIXTURE_PATH, 'utf8'));
+const REGRESSION_FIXTURE_PATH = path.join(
+  __dirname,
+  'fixtures',
+  'ci-impact-classifier-output-adapters.json',
+);
+const REGRESSION_FIXTURES = JSON.parse(
+  fs.readFileSync(REGRESSION_FIXTURE_PATH, 'utf8'),
+);
 
 for (const fixture of HISTORICAL_PRS) {
   test(`historical PR #${fixture.pr}: ${fixture.title}`, () => {
+    assert.deepEqual(
+      classifyChanges({ eventName: 'pull_request', files: fixture.files }),
+      fixture.expected,
+    );
+  });
+}
+
+for (const fixture of REGRESSION_FIXTURES) {
+  test(`regression fixture: ${fixture.title}`, () => {
     assert.deepEqual(
       classifyChanges({ eventName: 'pull_request', files: fixture.files }),
       fixture.expected,
@@ -43,7 +60,7 @@ test('review-only changes require no code worker', () => {
       native_skia_required: 'false',
       codeql_languages: 'none',
       classification_status: 'classified',
-      classifier_version: '3',
+      classifier_version: '4',
       reason: 'classified:review-only',
     },
   );
@@ -65,7 +82,7 @@ test('mixed Studio package and Rust changes union modes and CodeQL languages', (
       native_skia_required: 'false',
       codeql_languages: 'javascript-typescript,rust',
       classification_status: 'classified',
-      classifier_version: '3',
+      classifier_version: '4',
       reason: 'classified:rust+studio-package',
     },
   );
@@ -83,6 +100,28 @@ test('Rust renderer changes require Rust, Native Skia, Canvas, and Rust CodeQL',
   assert.equal(result.native_skia_required, 'true');
   assert.equal(result.codeql_languages, 'rust');
   assert.equal(result.classification_status, 'classified');
+});
+
+test('CLI output adapters follow their actual render and Native Skia consumers', () => {
+  for (const [filename, renderRequired, nativeSkiaRequired, reason] of [
+    ['src/cli/outputs/mod.rs', 'true', 'true', 'classified:rust-render'],
+    ['src/cli/outputs/pdf.rs', 'true', 'true', 'classified:rust-render'],
+    ['src/cli/outputs/raster.rs', 'false', 'true', 'classified:native-skia-rust'],
+    ['src/cli/outputs/vector.rs', 'false', 'false', 'classified:rust'],
+  ]) {
+    const result = classifyChanges({
+      eventName: 'pull_request',
+      files: [{ filename, status: 'modified' }],
+    });
+    assert.equal(result.rust_required, 'true', filename);
+    assert.equal(result.frontend_mode, 'none', filename);
+    assert.equal(result.render_required, renderRequired, filename);
+    assert.equal(result.native_skia_required, nativeSkiaRequired, filename);
+    assert.equal(result.codeql_languages, 'rust', filename);
+    assert.equal(result.classification_status, 'classified', filename);
+    assert.equal(result.classifier_version, '4', filename);
+    assert.equal(result.reason, reason, filename);
+  }
 });
 
 test('Native Skia integration test and support changes run Rust and Native Skia without Canvas', () => {
@@ -106,7 +145,7 @@ test('Native Skia integration test and support changes run Rust and Native Skia 
     assert.equal(result.native_skia_required, 'true', filename);
     assert.equal(result.codeql_languages, 'rust', filename);
     assert.equal(result.classification_status, 'classified', filename);
-    assert.equal(result.classifier_version, '3', filename);
+    assert.equal(result.classifier_version, '4', filename);
     assert.equal(result.reason, 'classified:native-skia-rust', filename);
   }
 });
@@ -126,7 +165,7 @@ test('Rust test input changes keep default Rust tests alongside render gates', (
     assert.equal(result.native_skia_required, 'true', filename);
     assert.equal(result.codeql_languages, 'none', filename);
     assert.equal(result.classification_status, 'classified', filename);
-    assert.equal(result.classifier_version, '3', filename);
+    assert.equal(result.classifier_version, '4', filename);
     assert.equal(result.reason, 'classified:rust-test-input', filename);
   }
 });
@@ -204,7 +243,7 @@ test('new review reference assets require no product or CodeQL worker', () => {
     assert.equal(result.native_skia_required, 'false', filename);
     assert.equal(result.codeql_languages, 'none', filename);
     assert.equal(result.classification_status, 'classified', filename);
-    assert.equal(result.classifier_version, '3', filename);
+    assert.equal(result.classifier_version, '4', filename);
     assert.equal(result.reason, 'classified:review-only', filename);
   }
 });

--- a/scripts/tests/ci-impact-policy.test.cjs
+++ b/scripts/tests/ci-impact-policy.test.cjs
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -35,6 +36,7 @@ const CI_WORKFLOW = fs.readFileSync(
   path.join(__dirname, '../../.github/workflows/ci.yml'),
   'utf8',
 );
+const REPOSITORY_ROOT = path.join(__dirname, '..', '..');
 
 const HEAD_SHA = 'a'.repeat(40);
 const BASE_SHA = 'b'.repeat(40);
@@ -427,6 +429,27 @@ test('mirrored trigger contracts match CI, CodeQL, and Render Diff workflows', (
   assert.equal(workflowRunExpected('Render Diff', [{ filename: 'src/cli/outputs/pdf.rs' }]), true);
   assert.equal(workflowRunExpected('Render Diff', [{ filename: 'src/cli/outputs/raster.rs' }]), false);
   assert.equal(workflowRunExpected('Render Diff', [{ filename: 'src/cli/outputs/vector.rs' }]), false);
+});
+
+test('every classified render-impacting tracked path starts Render Diff', () => {
+  const trackedFiles = execFileSync('git', ['ls-files', '-z'], {
+    cwd: REPOSITORY_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+  }).split('\0').filter(Boolean);
+  const missing = trackedFiles.filter((filename) => {
+    const files = [{ filename, status: 'modified' }];
+    const classification = classificationFor(files);
+    return classification.classification_status === 'classified'
+      && classification.render_required === 'true'
+      && !workflowRunExpected('Render Diff', files);
+  });
+
+  assert.deepEqual(
+    missing,
+    [],
+    'classified render paths must be covered by the Render Diff trigger',
+  );
 });
 
 test('every impact-conditioned CI job is covered by the audit allowlist', () => {

--- a/scripts/tests/ci-impact-policy.test.cjs
+++ b/scripts/tests/ci-impact-policy.test.cjs
@@ -367,7 +367,7 @@ test('compact status description round-trips workflow and impact axes', () => {
   assert.ok(policy.status_description.length <= 140);
   assert.deepEqual(parseStatusDescription(policy.status_description), {
     v: '5',
-    cv: '3',
+    cv: '4',
     mode: 'selective',
     rfp: '0',
     wf: '111',
@@ -423,6 +423,10 @@ test('mirrored trigger contracts match CI, CodeQL, and Render Diff workflows', (
   assert.equal(workflowRunExpected('CI', [{ filename: 'samples/new-reference.hwp' }]), true);
   assert.equal(workflowRunExpected('CodeQL', [{ filename: 'samples/new-reference.hwp' }]), true);
   assert.equal(workflowRunExpected('Render Diff', [{ filename: 'rhwp-studio/tests/a.ts' }]), true);
+  assert.equal(workflowRunExpected('Render Diff', [{ filename: 'src/cli/outputs/mod.rs' }]), true);
+  assert.equal(workflowRunExpected('Render Diff', [{ filename: 'src/cli/outputs/pdf.rs' }]), true);
+  assert.equal(workflowRunExpected('Render Diff', [{ filename: 'src/cli/outputs/raster.rs' }]), false);
+  assert.equal(workflowRunExpected('Render Diff', [{ filename: 'src/cli/outputs/vector.rs' }]), false);
 });
 
 test('every impact-conditioned CI job is covered by the audit allowlist', () => {

--- a/scripts/tests/fixtures/ci-impact-classifier-output-adapters.json
+++ b/scripts/tests/fixtures/ci-impact-classifier-output-adapters.json
@@ -1,0 +1,21 @@
+[
+  {
+    "title": "post-#5511 CLI output adapter-only change",
+    "files": [
+      { "filename": "src/cli/outputs/mod.rs", "status": "modified" },
+      { "filename": "src/cli/outputs/pdf.rs", "status": "modified" },
+      { "filename": "src/cli/outputs/raster.rs", "status": "modified" },
+      { "filename": "src/cli/outputs/vector.rs", "status": "modified" }
+    ],
+    "expected": {
+      "rust_required": "true",
+      "frontend_mode": "none",
+      "render_required": "true",
+      "native_skia_required": "true",
+      "codeql_languages": "rust",
+      "classification_status": "classified",
+      "classifier_version": "4",
+      "reason": "classified:native-skia-rust+rust+rust-render"
+    }
+  }
+]

--- a/scripts/tests/fixtures/ci-impact-classifier-prs.json
+++ b/scripts/tests/fixtures/ci-impact-classifier-prs.json
@@ -19,7 +19,7 @@
       "native_skia_required": "false",
       "codeql_languages": "javascript-typescript",
       "classification_status": "classified",
-      "classifier_version": "3",
+      "classifier_version": "4",
       "reason": "classified:studio-unit"
     }
   },
@@ -37,7 +37,7 @@
       "native_skia_required": "false",
       "codeql_languages": "javascript-typescript",
       "classification_status": "classified",
-      "classifier_version": "3",
+      "classifier_version": "4",
       "reason": "classified:studio-unit"
     }
   },
@@ -59,7 +59,7 @@
       "native_skia_required": "false",
       "codeql_languages": "javascript-typescript",
       "classification_status": "classified",
-      "classifier_version": "3",
+      "classifier_version": "4",
       "reason": "classified:studio-package+studio-unit"
     }
   },
@@ -78,7 +78,7 @@
       "native_skia_required": "false",
       "codeql_languages": "javascript-typescript",
       "classification_status": "classified",
-      "classifier_version": "3",
+      "classifier_version": "4",
       "reason": "classified:studio-render-package+studio-unit"
     }
   },
@@ -144,7 +144,7 @@
       "native_skia_required": "true",
       "codeql_languages": "javascript-typescript,python,rust",
       "classification_status": "full",
-      "classifier_version": "3",
+      "classifier_version": "4",
       "reason": "fail-closed:cargo-contract"
     }
   },
@@ -163,7 +163,7 @@
       "native_skia_required": "true",
       "codeql_languages": "rust",
       "classification_status": "classified",
-      "classifier_version": "3",
+      "classifier_version": "4",
       "reason": "classified:native-skia-rust"
     }
   }

--- a/scripts/tests/test_render_diff_workflow.py
+++ b/scripts/tests/test_render_diff_workflow.py
@@ -38,6 +38,15 @@ class RenderDiffTriggerPolicyTests(unittest.TestCase):
             self.workflow,
         )
 
+    def test_cli_output_adapter_trigger_follows_direct_workflow_consumers(self) -> None:
+        pull_request_trigger = self.workflow.split("  workflow_dispatch:", maxsplit=1)[0]
+
+        self.assertIn("      - 'src/cli/outputs/mod.rs'", pull_request_trigger)
+        self.assertIn("      - 'src/cli/outputs/pdf.rs'", pull_request_trigger)
+        self.assertNotIn("      - 'src/cli/outputs/raster.rs'", pull_request_trigger)
+        self.assertNotIn("      - 'src/cli/outputs/vector.rs'", pull_request_trigger)
+        self.assertIn("      - 'src/main.rs'", pull_request_trigger)
+
     def test_label_events_do_not_restart_render_diff_and_manual_dispatch_is_full(self) -> None:
         self.assertIn(
             "types: [opened, reopened, synchronize]",


### PR DESCRIPTION
## 변경 요약

#5511에서 CLI render output handler가 `src/main.rs`에서 `src/cli/outputs/`로 분리됐지만,
Render Diff workflow·trusted impact classifier·policy mirror의 경로 소유 목록은 이동 전 경계에
남아 있었습니다. 이 때문에 분리된 adapter만 수정하는 PR이 필요한 Render Diff 또는 Native Skia
검증을 생략할 수 있었습니다.

이 PR은 실제 consumer를 기준으로 경로별 영향축을 복구합니다.

- `outputs/mod.rs`, `outputs/pdf.rs`: Rust + Render Diff + Native Skia
- `outputs/raster.rs`: Rust + Native Skia
- `outputs/vector.rs`: 일반 Rust 유지
- Render Diff의 PR path trigger와 policy mirror에는 직접 consumer인 `mod.rs`, `pdf.rs`만 추가
- classifier version을 `4`로 올리고 adapter별 양성 fixture와 workflow·policy 계약 테스트 추가
- O2 운영 변경 기록에 live baseline, 예상 run/no-run, 관찰 조건과 rollback 기록

`src/main.rs`의 기존 `main-render-boundary` fail-closed 경계는 유지합니다. blanket trigger 제거와
`test-caption`·`export-structure` 책임 재분리는 #3789의 범위입니다.

## 관련 이슈

Closes #5776

Related: #3789, #5511

## CI 라우팅 계약

| 변경 경로 | Render Diff workflow | classifier 기대값 |
| --- | --- | --- |
| `src/cli/outputs/mod.rs` | run | `rust=true`, `render=true`, `native=true` |
| `src/cli/outputs/pdf.rs` | run | `rust=true`, `render=true`, `native=true` |
| `src/cli/outputs/raster.rs` | no-run | `rust=true`, `render=false`, `native=true` |
| `src/cli/outputs/vector.rs` | no-run | `rust=true`, `render=false`, `native=false` |
| `src/main.rs` | run | 기존 fail-closed full 영향 유지 |

## 테스트

- [x] `node --test scripts/tests/ci-impact-classifier.test.cjs` 및
  `scripts/tests/ci-impact-policy.test.cjs` — 64/64 통과
- [x] CI·policy·Render Diff Python workflow contracts — 48/48 통과
- [x] `actionlint .github/workflows/render-diff.yml` 통과
- [x] `cargo fmt --all` 및 `cargo fmt --all -- --check` 통과
- [x] `git diff --check` 통과
- [x] 검증용 generated suite 32개와 manifest를 제거했고 제출 변경에 포함하지 않음
- [x] 새 `tests/cases/*.rs` 및 `src/**`의 `#[cfg(test)]` 변경 없음
- [x] Rust 제품 source·renderer output·baseline fixture 변경 없음 — release-test, clippy, WASM,
  sample SVG 및 시각 sweep은 적용 대상이 아님
- [x] O2 운영 증빙: `mydocs/plans/task_m100_5776.md`

PR 생성 후에는 최신 PR head의 CI, CodeQL, Render Diff 등 실제 GitHub Actions 결과와 mergeable 상태를
별도로 확인합니다. workflow 자체를 변경하므로 PR head의 분류 결과만으로 trusted 정책의 정합성을
단정하지 않습니다.

## 성능 영향 및 측정 결과

- 제품 runtime 영향: 없음
- CI 비용 영향: `mod.rs`·`pdf.rs` 변경에서 누락됐던 Render Diff·Native Skia를 실행합니다.
  `raster.rs`는 Native Skia만, `vector.rs`는 일반 Rust만 유지해 불필요한 Render Diff 실행은 늘리지 않습니다.
- 별도 성능 측정: 적용 대상 아님

## Rollback

기대한 lane이 누락되거나 반대 경로에서 불필요한 Render Diff가 실행되거나 기존 check가 사라지면
merge를 중단합니다. 적용 뒤 문제가 확인되면 integration commit을 revert하는 `devel` 대상 PR로
workflow·classifier·policy·fixture 변경을 함께 되돌립니다.

## 스크린샷

해당 없음 — CI 라우팅·운영 계약 변경이며 렌더링 결과를 변경하지 않습니다.
