### PR TITLE
fix(parser): HWP5 개체 번호 범주(attr bits 26-28)를 읽는다 — h2x numberingType 전량 NONE·상호참조 붕괴 해소 (#5864)

### DIFF
--- a/src/parser/control/shape.rs
+++ b/src/parser/control/shape.rs
@@ -356,6 +356,19 @@ pub(crate) fn parse_common_obj_attr(ctrl_data: &[u8]) -> CommonObjAttr {
     common.locked = attr & (1 << 30) != 0;
     common.hwp5_gen_shape_attr_bit26 = attr & (1 << 26) != 0;
     common.hwp5_gen_shape_attr_bit28 = attr & (1 << 28) != 0;
+    // [#5864] 개체 번호 범주(캡션 번호·상호참조 계열) — attr bits 26-28 의 3비트
+    // 열거다. 07276 실측: 표 155/155(0=NONE 23·2=TABLE 126·1=PICTURE 6), 수식
+    // 8/8(=3), gso 분포도 한글 2024 SaveAs HWPX 의 numberingType 과 정합
+    // (PICTURE 28·TABLE 1 정확 일치). 종전엔 안 읽어 h2x 산출이 전량 NONE 이
+    // 됐고, 한글이 상호참조 순번을 전부 1 로 재계산했다(07276 상호참조 153중
+    // 101 오염). bit26/28 개별 보존 플래그(hwp5_gen_shape_attr_bit26/28)는
+    // attr verbatim 왕복용으로 그대로 둔다.
+    common.numbering_type = match (attr >> 26) & 0x7 {
+        1 => crate::model::shape::ObjectNumberingType::Picture,
+        2 => crate::model::shape::ObjectNumberingType::Table,
+        3 => crate::model::shape::ObjectNumberingType::Equation,
+        _ => crate::model::shape::ObjectNumberingType::None,
+    };
     common.vert_rel_to = match (attr >> 3) & 0x03 {
         1 => VertRelTo::Page,
         2 => VertRelTo::Para,

--- a/tests/cases/issue_5864_hwp5_numbering_category.rs
+++ b/tests/cases/issue_5864_hwp5_numbering_category.rs
@@ -1,0 +1,58 @@
+//! [#5864] HWP5 개체 번호 범주(캡션 번호·상호참조 계열)를 파서가 읽는다.
+//!
+//! HWP5 CTRL_HEADER 공통속성 attr bits 26-28 은 3비트 열거다 — 07276 실측
+//! (한글 2024 SaveAs HWPX 정답과 대조): 표 155/155(0=NONE 23·2=TABLE 126·
+//! 1=PICTURE 6), 수식 8/8(=3), gso 분포 정합(PICTURE 28·TABLE 1 정확 일치).
+//! 종전엔 안 읽어 h2x 산출의 `numberingType` 이 전량 NONE 이 됐고, 한글이
+//! 상호참조 순번을 전부 1 로 재계산했다(07276 상호참조 153중 101 오염,
+//! 07378 `<표 24>`→`<표 1>`).
+//!
+//! 왕복 고정: HWPX(numberingType 보유) → HWP5 직렬화(비트 기록) → HWP5 재파싱
+//! (이 수정이 읽음) 에서 범주가 살아남는다. 수정 전에는 재파싱 단계에서 전부
+//! NONE 으로 무너졌다.
+
+use rhwp::model::control::Control;
+use rhwp::model::shape::ObjectNumberingType;
+
+const SAMPLE: &str = "samples/hwpx/143E433F503322BD33.hwpx";
+
+fn numbering_types(doc: &rhwp::model::document::Document) -> Vec<(String, ObjectNumberingType)> {
+    let mut out = Vec::new();
+    for section in &doc.sections {
+        for para in &section.paragraphs {
+            for ctrl in &para.controls {
+                match ctrl {
+                    Control::Table(t) => out.push(("tbl".into(), t.common.numbering_type)),
+                    Control::Picture(p) => out.push(("pic".into(), p.common.numbering_type)),
+                    _ => {}
+                }
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn issue_5864_numbering_category_survives_hwp5_roundtrip() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = std::fs::read(&path).expect("read sample");
+    let original = rhwp::parse_document(&bytes).expect("parse hwpx");
+    let expected = numbering_types(&original);
+    assert!(
+        expected
+            .iter()
+            .any(|(kind, nt)| kind == "tbl" && *nt == ObjectNumberingType::Table),
+        "전제: 표본에 numberingType=TABLE 표가 있어야 한다: {expected:?}"
+    );
+
+    let hwp5 = rhwp::serializer::serialize_document(&original).expect("serialize hwp5");
+    let reparsed = rhwp::parse_document(&hwp5).expect("reparse hwp5");
+    let actual = numbering_types(&reparsed);
+
+    let expected_tables: Vec<_> = expected.iter().filter(|(k, _)| k == "tbl").collect();
+    let actual_tables: Vec<_> = actual.iter().filter(|(k, _)| k == "tbl").collect();
+    assert_eq!(
+        expected_tables, actual_tables,
+        "#5864: 표 번호 범주가 HWP5 왕복에서 살아남아야 한다 — 수정 전엔 재파싱이 전량 NONE"
+    );
+}


### PR DESCRIPTION
# fix(parser): HWP5 개체 번호 범주(attr bits 26-28)를 읽는다 — h2x numberingType 전량 NONE·상호참조 붕괴 해소 (#5864)

## 무엇을 고치나

HWP5 파서가 개체 번호 범주를 읽지 않아(`CommonObjAttr::numbering_type` 주석: "HWP5
파서는 설정하지 않는다") h2x 산출의 `numberingType` 이 전량 `NONE` 으로 나갔고, 한글이
상호참조 순번을 전부 `1` 로 재계산했다 — 07276 상호참조 153중 **101 오염**
(`<표 2-7>`→`<표 2-1>`), 07378 `<표 24>`→`<표 1>`.

## 필드 규명 — 이슈의 비트 가설을 실측으로 교정

이슈는 개별 플래그(bit27=표, bit28=그림)로 추정했는데, 실측 결과 **bits 26-28 의
3비트 열거**다. 07276 원본 CTRL_HEADER 155개를 한글 2024 SaveAs HWPX 정답과 1:1 대조:

| `(attr>>26)&0x7` | 정답 numberingType | 실측 |
|---|---|---|
| 0 | NONE | 표 23/23 |
| 1 | PICTURE | 표 6/6 · gso 28/28 |
| 2 | TABLE | 표 126/126 · gso 1/1 |
| 3 | EQUATION | 수식 8/8 |

기존 코드의 `HWPX_TABLE_NUMBERING_BIT = 0x0800_0000`(#2697) 는 `2<<26` 과 동일 — 즉
역방향(x2h) 기록은 처음부터 이 열거의 TABLE 값을 쓰고 있었고, 읽는 쪽만 비어 있었다.

## 수정 — 한 곳

`parser/control/shape.rs` `parse_common_obj_attr` 에 열거 해석 6줄. attr verbatim 보존
플래그(bit26/28)는 그대로 둔다.

## 검증

**분포 완전 일치** — 07276 h2x 산출의 개체별 numberingType 이 한글 2024 SaveAs 정답과
9개 분류 전부 동일(tbl TABLE 126·NONE 23·PICTURE 6, pic PICTURE 27·NONE 40·TABLE 1,
equation 8, container 3).

**한글 COM 실판정** — rhwp h2x 산출을 한글로 열어 텍스트 추출:

| 문서 | 결과 |
|---|---|
| 07276 (223쪽) | 추출이 원본과 **동일**(비공백) — 구판은 205/101자 차이(상호참조 101회 오염과 정합) |
| 07378 (74쪽) | 추출 **동일**, `<표 24>` 복원 (구판 `<표 1>`) |

**이슈가 요구한 재확인 축** — bit29 캡션 계약(issue_5136)·h2h/x2h 왕복은 release-test
전체 게이트로 판정(아래). 새 왕복 시험도 추가: HWPX→HWP5→재파싱에서 범주 생존
(수정 전엔 재파싱이 전량 NONE — 음성 대조 성립).

**전수 코퍼스 h2x 패스는 로컬에서 수행하지 못했다** — 표본 300 기준 3,465개 개체의
속성이 바뀌는 변경이므로, 필요하면 다음 10k 게이트에 얹어 판정해 주시기 바란다.

## 시험

`tests/cases/issue_5864_hwp5_numbering_category.rs` — HWPX(TABLE 보유 표본)→HWP5
직렬화→재파싱 왕복에서 표 번호 범주 생존.

## 게이트

- rustfmt(변경 파일) · `cargo clippy --lib --bins --tests -- -D warnings` 통과
- focused test 1/1 (release-test)
- `cargo nextest run` 전체 (release-test): **8,200 중 8,199 통과** — 유일 실패
  `wmf_emf_goldens` 는 이 머신 autocrlf `.golden` CRLF 기지 노이즈(내용 동일), CI 통과.
  **h2h/x2h 왕복 게이트·bit29 캡션 계약(issue_5136)·IR sweep 원장 전부 무이동 통과**
- 스코프가 parser 라 Native Skia·WASM 게이트는 표 4.3 기준 비대상

🤖 Generated with [Claude Code](https://claude.com/claude-code)
