### PR TITLE
fix: visual_sweep 한글 라벨 폰트 fallback 보완

### DIFF
--- a/mydocs/manual/pr_review/visual_fixture_evidence.md
+++ b/mydocs/manual/pr_review/visual_fixture_evidence.md
@@ -25,6 +25,16 @@ visual sweep을 실제 검토 근거로 쓰면 review 문서에 다음을 모두
 - pixel match, visual_accuracy_proxy_percent
 - 사람이 확인한 결과와 PR 주장과의 관계
 
+대표 review PNG는 파일 경로와 수치만 확인하지 않는다. PR comment나 archive 증적으로 쓰기 전에 실제
+이미지를 열어 다음을 확인한다.
+
+- HWP/PDF 본문 렌더와 visual_sweep이 덧그린 도구 라벨을 구분해 본다.
+- 도구 라벨의 한글 glyph, metric 수치, overlay legend가 tofu·`??`·잘림 없이 판독 가능한지 본다.
+- 낮은 `visual_accuracy_proxy_percent`를 “전체 fidelity 통과”처럼 쓰지 않고, PR 주장과 직접 연결되는
+  blocker 해소 근거인지 별도 residual인지 분리해 적는다.
+- 증적 생성 도구의 폰트·라벨 문제처럼 제품 렌더와 무관한 결함은 별도 issue로 등록하고, 해당 PR
+  comment에는 그 한계를 함께 쓴다.
+
 Codex 또는 Claude가 이미지를 확인했더라도 작업지시자 승인 전에는 시각 판정을 최종 통과라고 단정하지 않는다.
 원본 HWP/HWPX, 기준 PDF, visual sweep 결과의 출처·역할·SHA-256을 구분해 보존한다.
 

--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -289,8 +289,10 @@ review 문서 경로, review_impl 작성 조건, 사전 판단 report의 범위�
 [PR 접수와 리뷰 기록](pr_review/intake_and_review.md)을 따른다. 시각 검증을 실제 판단 근거로 사용하면
 문서 비교 절차의 정본으로 [PDF/SVG visual sweep 가이드](verification/visual_sweep_guide.md#github-merge-comment)를
 사용한다. 임시 output 경로만 남기지 말고, 대표 review PNG를 mydocs/pr/assets 아래 안정 경로에 보존한 뒤
-그 경로를 review 문서와 실제 GitHub comment에 사용한다. merge 후 comment에는 Visual Sweep 정본 link와
-review 문서의 실제 수치·결론을 함께 남기며, PNG는 merge commit SHA 고정 raw URL로 표시한다.
+그 경로를 review 문서와 실제 GitHub comment에 사용한다. 이때 대표 review PNG 자체를 열어 도구 라벨,
+한글 glyph, 수치 표기, overlay legend가 판독 가능한지 확인하고, 깨진 라벨이나 판정 오해 소지가 있으면
+merge 전 보정하거나 별도 issue로 분리해 review 문서에 적는다. merge 후 comment에는 Visual Sweep 정본
+link와 review 문서의 실제 수치·결론을 함께 남기며, PNG는 merge commit SHA 고정 raw URL로 표시한다.
 
 ## 5. 기존 절 번호 대응
 

--- a/mydocs/orders/20260824.md
+++ b/mydocs/orders/20260824.md
@@ -188,3 +188,18 @@ date: 2026-08-24
 - [ ] 통합 PR 생성 뒤 최신 GitHub CI, mergeability, review 문서·증적 포함 여부를 확인한다.
 - [ ] 통합 PR merge 승인 뒤 원 PR comment/close, merge SHA의 `upstream/devel` 포함 확인,
   branch/worktree 정리를 `post_merge.md`에 따라 처리한다.
+
+## PR #6018 - visual_sweep 한글 라벨 폰트 fallback 보완
+
+- [x] #6016에서 `mydocs/pr/assets/pr_6014_issue5712_p1_review.png`의 한글 metric 라벨이 tofu로 보이는
+  현상을 제품 renderer가 아니라 visual sweep 도구 라벨 폰트 선택 문제로 분리했다.
+- [x] `RHWP_VISUAL_SWEEP_LABEL_FONT`, fontconfig `fc-match`, Linux/macOS/Windows CJK 폰트 경로 후보를
+  순서대로 적용하고, 모든 TrueType 후보가 실패할 때만 Pillow 기본 폰트로 fallback하도록 보완했다.
+- [x] PR review workflow와 visual fixture evidence 문서에 대표 review PNG의 한글 glyph·metric text·overlay
+  legend 판독성을 직접 확인하는 gate를 추가했다.
+- [x] `python3 -m unittest scripts.tests.test_visual_sweep` 43 tests OK, `py_compile`, Markdown 링크 검사,
+  `cargo fmt --all -- --check`, `git diff --check`를 통과했다.
+- [x] self-review 문서 `mydocs/pr/archives/pr_6018_review.md`를 준비했다.
+- [ ] trailing commit push 뒤 최신 head의 GitHub CI와 `MERGEABLE/CLEAN`을 확인한다.
+- [ ] 자동 merge 승인에 따라 #6018을 merge하고 #6016 close 확인, PR/issue comment, merge SHA의
+  `upstream/devel` 포함 및 branch/worktree 정리를 `post_merge.md`에 따라 수행한다.

--- a/mydocs/orders/20260825.md
+++ b/mydocs/orders/20260825.md
@@ -1,0 +1,22 @@
+---
+kind: daily-order
+status: active
+date: 2026-08-25
+---
+
+# 2026-08-25 오늘할 일
+
+## PR #6018 - visual_sweep 한글 라벨 폰트 fallback 보완
+
+- [x] #6016에서 `mydocs/pr/assets/pr_6014_issue5712_p1_review.png`의 한글 metric 라벨이 tofu로 보이는
+  현상을 제품 renderer가 아니라 visual sweep 도구 라벨 폰트 선택 문제로 분리했다.
+- [x] `RHWP_VISUAL_SWEEP_LABEL_FONT`, fontconfig `fc-match`, Linux/macOS/Windows CJK 폰트 경로 후보를
+  순서대로 적용하고, 모든 TrueType 후보가 실패할 때만 Pillow 기본 폰트로 fallback하도록 보완했다.
+- [x] PR review workflow와 visual fixture evidence 문서에 대표 review PNG의 한글 glyph·metric text·overlay
+  legend 판독성을 직접 확인하는 gate를 추가했다.
+- [x] `python3 -m unittest scripts.tests.test_visual_sweep` 43 tests OK, `py_compile`, Markdown 링크 검사,
+  `cargo fmt --all -- --check`, `git diff --check`를 통과했다.
+- [x] self-review 문서 `mydocs/pr/archives/pr_6018_review.md`와 오늘할일 trailing commit을 준비했다.
+- [ ] 최신 head의 GitHub CI와 `MERGEABLE/CLEAN`을 확인한다.
+- [ ] 자동 merge 승인에 따라 #6018을 merge하고 #6016 close 확인, PR/issue comment, merge SHA의
+  `upstream/devel` 포함 및 branch/worktree 정리를 `post_merge.md`에 따라 수행한다.

--- a/mydocs/pr/archives/pr_6018_review.md
+++ b/mydocs/pr/archives/pr_6018_review.md
@@ -1,0 +1,77 @@
+---
+kind: pr-review
+status: accepted-pending-ci
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-24
+---
+
+# PR #6018 review - visual_sweep 한글 라벨 폰트 fallback 보완 (#6016)
+
+## 접수 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#6018](https://github.com/edwardkim/rhwp/pull/6018) |
+| Issue | [#6016](https://github.com/edwardkim/rhwp/issues/6016) |
+| 작성자 | [@jangster77](https://github.com/jangster77) |
+| base | `devel` |
+| head | `task_m100_6016_visual_sweep_cjk_label_font` |
+| 검토 head | `9f69dafd6f37c3019e400ae96f368f5d33c7103b` |
+| GitHub 상태 | `MERGEABLE`, GitHub CI 진행 중 |
+| 판정 | **수용 권고 / 최신 CI 대기** |
+
+## 변경 검토
+
+PR #6015 후속 처리 과정에서 `mydocs/pr/assets/pr_6014_issue5712_p1_review.png`의 visual sweep
+도구 라벨 중 한글 설명이 tofu 네모 박스로 표시됐다. 같은 증적의 문서 본문 한글과 기준 PDF 한글은
+깨지지 않았으므로, 제품 renderer 회귀가 아니라 `scripts/visual_sweep.py`가 review/contact sheet PNG 위에
+그리는 도구 라벨 폰트 선택 문제로 분리했다.
+
+기존 `label_font()`는 macOS Arial 계열 경로만 확인하고 Linux에서는 Pillow 기본 폰트로 fallback했다.
+현재 Ubuntu 서버에는 `Noto Sans CJK KR`와 `NanumGothic`이 설치되어 있었으나, fontconfig와 Linux CJK
+폰트 경로를 조회하지 않아 사용할 수 없었다.
+
+이번 보정은 다음 순서로 라벨 폰트 후보를 고른다.
+
+- `RHWP_VISUAL_SWEEP_LABEL_FONT` 환경변수에 지정한 경로를 최우선으로 사용한다.
+- `fc-match`가 있으면 `Noto Sans CJK KR`, `NanumGothic`, `UnDotum`, `Malgun Gothic`,
+  `Apple SD Gothic Neo` family 후보를 조회한다.
+- `platform.system()` 기준 현재 OS의 알려진 CJK 폰트 경로를 먼저 확인하고, 이후 다른 OS 후보를
+  fallback으로 평가한다.
+- 모든 TrueType 후보가 실패할 때만 `ImageFont.load_default()`로 fallback한다.
+
+제품 renderer, HWP/PDF 변환, layout 알고리즘은 변경하지 않는다. 변경 범위는 visual sweep 증적 PNG의
+도구 라벨 폰트 선택과, 같은 누락을 반복하지 않기 위한 PR review workflow 문서 보강에 한정된다.
+
+## 절차 보강
+
+누락 원인은 visual sweep 대표 PNG를 GitHub comment에 첨부하고 수치만 기록했지만, 증적 생성 도구가
+덧그린 한글 라벨 자체의 판독성까지 별도 gate로 확인하는 절차가 부족했던 것이다. 따라서
+`mydocs/manual/pr_review_workflow.md`와 `mydocs/manual/pr_review/visual_fixture_evidence.md`에 다음을
+명시했다.
+
+- 대표 review PNG를 실제로 열어 도구 라벨, 한글 glyph, metric text, overlay legend를 확인한다.
+- 문서 본문 렌더 회귀와 visual sweep 도구 라벨 회귀를 분리해 판단한다.
+- 도구 라벨 문제는 원 PR의 제품 fidelity 결함으로 오인하지 않고 별도 issue/후속 PR로 추적한다.
+- `visual_accuracy_proxy_percent`는 자동 보조값이며, 사람이 읽는 시각 판정의 완전한 대체값으로 쓰지
+  않는다.
+
+## 로컬 검증
+
+- `python3 -m unittest scripts.tests.test_visual_sweep`: 43 tests OK
+- `python3 -m py_compile scripts/visual_sweep.py scripts/tests/test_visual_sweep.py`: 통과
+- `python3 scripts/check_markdown_links.py mydocs/working/task_m100_6016_stage1.md mydocs/manual/pr_review_workflow.md mydocs/manual/pr_review/visual_fixture_evidence.md`: 3개 문서 링크 검사 통과
+- `cargo fmt --all -- --check`: 통과
+- `git diff --check`: 통과
+- Ubuntu 서버에서 `configured_label_font_paths()`의 첫 기존 후보가
+  `/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc`이고, `label_font()`가 `FreeTypeFont`로
+  로드됨을 확인했다.
+
+macOS와 Windows는 현재 로컬에서 실제 visual sweep 실행을 하지 않았고, OS별 후보 우선순위와 path
+separator/env/fontconfig 계약을 mock 단위 테스트로 고정했다. 실제 host에서 다른 폰트 경로를 쓰는 경우에는
+`RHWP_VISUAL_SWEEP_LABEL_FONT`로 명시할 수 있다.
+
+## 권고
+
+증적 생성 도구의 한글 라벨 판독성 문제를 제품 renderer 변경 없이 좁게 보정했고, 누락을 막는 workflow
+문서 gate도 함께 강화했다. 최신 GitHub CI가 통과하면 merge 가능하다.

--- a/mydocs/working/task_m100_6016_stage1.md
+++ b/mydocs/working/task_m100_6016_stage1.md
@@ -1,0 +1,51 @@
+---
+kind: working
+status: done
+issue: 6016
+---
+
+# task_m100_6016 stage1 - visual_sweep Linux 한글 라벨 폰트 분석
+
+## 배경
+
+PR #6015 검토 증적 `mydocs/pr/assets/pr_6014_issue5712_p1_review.png`에서 오른쪽 overlay/contact
+sheet 하단의 metric 설명 라벨이 한글 glyph 대신 네모 박스(tofu)로 표시됐다. 문서 본문 렌더와 기준 PDF의
+한글은 깨지지 않았고, `visual_sweep.py`가 PNG 위에 그리는 설명 라벨만 깨졌다.
+
+## 원인
+
+`scripts/visual_sweep.py`의 `label_font()`는 macOS Arial 계열 경로 두 개만 확인하고, Linux에서는
+`ImageFont.load_default()`로 fallback했다. Ubuntu 개발 서버에는 `Noto Sans CJK KR`와 `NanumGothic`이
+설치되어 있었지만, 기존 구현이 fontconfig나 Linux CJK 폰트 경로를 조회하지 않아 사용할 수 없었다.
+
+확인한 현재 서버 fontconfig 결과:
+
+```text
+NotoSansCJK-Regular.ttc: "Noto Sans CJK KR" "Regular"
+NanumGothic.ttf: "NanumGothic" "Regular"
+```
+
+따라서 설치 폰트 부족이 아니라 증적 생성 도구의 라벨 폰트 선택 경로 누락이다.
+
+## 보정 방향
+
+`label_font()`를 다음 순서로 변경한다.
+
+1. `RHWP_VISUAL_SWEEP_LABEL_FONT` 환경변수로 명시한 폰트가 있으면 우선 사용한다.
+2. `fc-match`로 `Noto Sans CJK KR`, `NanumGothic`, `UnDotum`, Windows/macOS CJK 계열 후보를 찾는다.
+3. Linux/macOS/Windows의 알려진 CJK 폰트 경로를 직접 확인한다.
+4. 위 후보가 모두 실패할 때만 기존처럼 `ImageFont.load_default()`를 사용한다.
+
+## 회귀 테스트
+
+시스템 폰트 설치 상태에 직접 의존하지 않도록 `scripts/tests/test_visual_sweep.py`에서 다음 계약을 mock으로
+검증한다.
+
+- `fc-match`가 반환한 기존 파일 경로를 `fontconfig_label_font_path()`가 선택한다.
+- 환경변수 지정 폰트가 fontconfig 결과보다 앞선다.
+- `label_font()`는 후보 TrueType 폰트를 먼저 로드하고, 성공하면 Pillow 기본 폰트로 fallback하지 않는다.
+
+## 영향 범위
+
+제품 렌더러나 HWP/PDF 변환 결과는 변경하지 않는다. 변경 범위는 visual sweep 증적 PNG의 라벨 폰트 선택과
+해당 Python 단위 테스트에 한정된다.

--- a/mydocs/working/task_m100_6016_stage1.md
+++ b/mydocs/working/task_m100_6016_stage1.md
@@ -29,11 +29,14 @@ NanumGothic.ttf: "NanumGothic" "Regular"
 
 ## 보정 방향
 
-`label_font()`를 다음 순서로 변경한다.
+`label_font()`를 Linux/macOS/Windows 공통으로 다음 순서로 변경한다.
 
-1. `RHWP_VISUAL_SWEEP_LABEL_FONT` 환경변수로 명시한 폰트가 있으면 우선 사용한다.
-2. `fc-match`로 `Noto Sans CJK KR`, `NanumGothic`, `UnDotum`, Windows/macOS CJK 계열 후보를 찾는다.
-3. Linux/macOS/Windows의 알려진 CJK 폰트 경로를 직접 확인한다.
+1. `RHWP_VISUAL_SWEEP_LABEL_FONT` 환경변수로 명시한 폰트가 있으면 우선 사용한다. 값은 실행 OS의
+   `os.pathsep`으로 여러 후보를 나열할 수 있다.
+2. `fc-match`가 있는 환경에서는 `Noto Sans CJK KR`, `NanumGothic`, `UnDotum`, Windows/macOS CJK 계열
+   family 후보를 찾는다.
+3. `platform.system()` 기준 현재 OS의 알려진 CJK 폰트 경로를 먼저 확인하고, 그 뒤 다른 OS 후보도
+   fallback으로 확인한다.
 4. 위 후보가 모두 실패할 때만 기존처럼 `ImageFont.load_default()`를 사용한다.
 
 ## 회귀 테스트
@@ -42,7 +45,9 @@ NanumGothic.ttf: "NanumGothic" "Regular"
 검증한다.
 
 - `fc-match`가 반환한 기존 파일 경로를 `fontconfig_label_font_path()`가 선택한다.
-- 환경변수 지정 폰트가 fontconfig 결과보다 앞선다.
+- 환경변수 지정 폰트가 fontconfig 결과보다 앞서며, OS별 path separator로 여러 후보를 받을 수 있다.
+- 현재 OS의 알려진 font path 후보가 다른 OS 후보보다 먼저 평가된다.
+- 환경변수·fontconfig·고정 경로가 같은 파일을 가리키면 중복 후보를 제거한다.
 - `label_font()`는 후보 TrueType 폰트를 먼저 로드하고, 성공하면 Pillow 기본 폰트로 fallback하지 않는다.
 
 ## 영향 범위

--- a/scripts/tests/test_visual_sweep.py
+++ b/scripts/tests/test_visual_sweep.py
@@ -50,9 +50,42 @@ class LabelFontTests(unittest.TestCase):
             with (
                 patch.dict(os.environ, {SWEEP.LABEL_FONT_ENV: str(env_font)}),
                 patch.object(SWEEP, "fontconfig_label_font_path", return_value=fc_font),
-                patch.object(SWEEP, "LABEL_FONT_PATHS", ()),
+                patch.object(SWEEP, "known_label_font_paths", return_value=[]),
             ):
                 self.assertEqual(SWEEP.configured_label_font_paths(), [env_font, fc_font])
+
+    def test_env_label_font_paths_accepts_platform_path_separator(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            first = Path(temp_dir) / "first.ttf"
+            second = Path(temp_dir) / "second.ttf"
+            value = os.pathsep.join([str(first), str(second)])
+            with patch.dict(os.environ, {SWEEP.LABEL_FONT_ENV: value}):
+                self.assertEqual(SWEEP.env_label_font_paths(), [first, second])
+
+    def test_known_label_font_paths_prioritizes_current_platform(self) -> None:
+        paths_by_platform = {
+            "Linux": ("linux-font.ttf",),
+            "Darwin": ("mac-font.ttf",),
+            "Windows": ("windows-font.ttf",),
+        }
+        with (
+            patch.object(SWEEP.platform, "system", return_value="Windows"),
+            patch.object(SWEEP, "LABEL_FONT_PATHS_BY_PLATFORM", paths_by_platform),
+        ):
+            self.assertEqual(
+                SWEEP.known_label_font_paths(),
+                [Path("windows-font.ttf"), Path("linux-font.ttf"), Path("mac-font.ttf")],
+            )
+
+    def test_configured_label_font_paths_dedupes_repeated_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            font_path = Path(temp_dir) / "same.ttf"
+            with (
+                patch.dict(os.environ, {SWEEP.LABEL_FONT_ENV: str(font_path)}),
+                patch.object(SWEEP, "fontconfig_label_font_path", return_value=font_path),
+                patch.object(SWEEP, "known_label_font_paths", return_value=[font_path]),
+            ):
+                self.assertEqual(SWEEP.configured_label_font_paths(), [font_path])
 
     def test_label_font_loads_truetype_before_default_font(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/tests/test_visual_sweep.py
+++ b/scripts/tests/test_visual_sweep.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
+import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from PIL import Image, ImageDraw
 
@@ -17,6 +20,53 @@ if SPEC is None or SPEC.loader is None:
 SWEEP = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = SWEEP
 SPEC.loader.exec_module(SWEEP)
+
+
+class LabelFontTests(unittest.TestCase):
+    def setUp(self) -> None:
+        SWEEP.label_font.cache_clear()
+
+    def tearDown(self) -> None:
+        SWEEP.label_font.cache_clear()
+
+    def test_fontconfig_label_font_path_uses_existing_match(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            font_path = Path(temp_dir) / "NotoSansCJK-Regular.ttc"
+            font_path.write_bytes(b"fake font")
+
+            def fake_run(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+                return subprocess.CompletedProcess(cmd, 0, stdout=f"{font_path}\n", stderr="")
+
+            with (
+                patch.object(SWEEP.shutil, "which", return_value="/usr/bin/fc-match"),
+                patch.object(SWEEP.subprocess, "run", side_effect=fake_run),
+            ):
+                self.assertEqual(SWEEP.fontconfig_label_font_path(), font_path)
+
+    def test_configured_label_font_paths_puts_env_before_fontconfig(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_font = Path(temp_dir) / "review-label.ttf"
+            fc_font = Path(temp_dir) / "NotoSansCJK-Regular.ttc"
+            with (
+                patch.dict(os.environ, {SWEEP.LABEL_FONT_ENV: str(env_font)}),
+                patch.object(SWEEP, "fontconfig_label_font_path", return_value=fc_font),
+                patch.object(SWEEP, "LABEL_FONT_PATHS", ()),
+            ):
+                self.assertEqual(SWEEP.configured_label_font_paths(), [env_font, fc_font])
+
+    def test_label_font_loads_truetype_before_default_font(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            font_path = Path(temp_dir) / "NanumGothic.ttf"
+            font_path.write_bytes(b"fake font")
+            sentinel = object()
+            with (
+                patch.object(SWEEP, "configured_label_font_paths", return_value=[font_path]),
+                patch.object(SWEEP.ImageFont, "truetype", return_value=sentinel) as truetype,
+                patch.object(SWEEP.ImageFont, "load_default") as load_default,
+            ):
+                self.assertIs(SWEEP.label_font(), sentinel)
+                truetype.assert_called_once_with(str(font_path), 18)
+                load_default.assert_not_called()
 
 
 class SelectedRasterTests(unittest.TestCase):

--- a/scripts/visual_sweep.py
+++ b/scripts/visual_sweep.py
@@ -21,6 +21,25 @@ from pathlib import Path
 from PIL import Image, ImageDraw, ImageFont
 
 
+LABEL_FONT_ENV = "RHWP_VISUAL_SWEEP_LABEL_FONT"
+LABEL_FONTCONFIG_FAMILIES = (
+    "Noto Sans CJK KR:lang=ko",
+    "NanumGothic:lang=ko",
+    "UnDotum:lang=ko",
+    "Malgun Gothic:lang=ko",
+    "Apple SD Gothic Neo:lang=ko",
+)
+LABEL_FONT_PATHS = (
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/truetype/nanum/NanumGothic.ttf",
+    "/usr/share/fonts/truetype/nanum/NanumGothicCoding.ttf",
+    "/usr/share/fonts/truetype/unfonts-core/UnDotum.ttf",
+    "/System/Library/Fonts/Supplemental/Arial Unicode.ttf",
+    "/System/Library/Fonts/Supplemental/Arial.ttf",
+    "/System/Library/Fonts/AppleSDGothicNeo.ttc",
+    "C:/Windows/Fonts/malgun.ttf",
+)
+
 FRAME_OVERFLOW_PIXEL_LIMIT = 20
 FRAME_OVERFLOW_EXTRA_PIXEL_LIMIT = 12
 FRAME_OVERFLOW_TOLERATED_BLEED_PX = 12
@@ -4270,13 +4289,43 @@ def analyze_pages(
     return {"summary": summary, "flagged_pages": flagged_pages}
 
 
+def fontconfig_label_font_path() -> Path | None:
+    fc_match = shutil.which("fc-match")
+    if not fc_match:
+        return None
+    for family in LABEL_FONTCONFIG_FAMILIES:
+        proc = subprocess.run(
+            [fc_match, "-f", "%{file}\n", family],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            continue
+        font_path = Path(proc.stdout.splitlines()[0].strip()) if proc.stdout.strip() else None
+        if font_path and font_path.exists():
+            return font_path
+    return None
+
+
+def configured_label_font_paths() -> list[Path]:
+    env_path = os.environ.get(LABEL_FONT_ENV)
+    paths = [Path(env_path)] if env_path else []
+    fc_path = fontconfig_label_font_path()
+    if fc_path:
+        paths.append(fc_path)
+    paths.extend(Path(font_path) for font_path in LABEL_FONT_PATHS)
+    return paths
+
+
+@lru_cache(maxsize=1)
 def label_font() -> ImageFont.ImageFont:
-    for font_path in (
-        "/System/Library/Fonts/Supplemental/Arial Unicode.ttf",
-        "/System/Library/Fonts/Supplemental/Arial.ttf",
-    ):
-        if Path(font_path).exists():
-            return ImageFont.truetype(font_path, 18)
+    for font_path in configured_label_font_paths():
+        if font_path.exists():
+            try:
+                return ImageFont.truetype(str(font_path), 18)
+            except OSError:
+                continue
     return ImageFont.load_default()
 
 

--- a/scripts/visual_sweep.py
+++ b/scripts/visual_sweep.py
@@ -9,6 +9,7 @@ import html as html_lib
 import importlib.util
 import json
 import os
+import platform
 import re
 import shutil
 import subprocess
@@ -29,16 +30,27 @@ LABEL_FONTCONFIG_FAMILIES = (
     "Malgun Gothic:lang=ko",
     "Apple SD Gothic Neo:lang=ko",
 )
-LABEL_FONT_PATHS = (
-    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
-    "/usr/share/fonts/truetype/nanum/NanumGothic.ttf",
-    "/usr/share/fonts/truetype/nanum/NanumGothicCoding.ttf",
-    "/usr/share/fonts/truetype/unfonts-core/UnDotum.ttf",
-    "/System/Library/Fonts/Supplemental/Arial Unicode.ttf",
-    "/System/Library/Fonts/Supplemental/Arial.ttf",
-    "/System/Library/Fonts/AppleSDGothicNeo.ttc",
-    "C:/Windows/Fonts/malgun.ttf",
-)
+LABEL_FONT_PATHS_BY_PLATFORM = {
+    "Linux": (
+        "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/truetype/nanum/NanumGothic.ttf",
+        "/usr/share/fonts/truetype/nanum/NanumGothicCoding.ttf",
+        "/usr/share/fonts/truetype/unfonts-core/UnDotum.ttf",
+    ),
+    "Darwin": (
+        "/System/Library/Fonts/AppleSDGothicNeo.ttc",
+        "/System/Library/Fonts/Supplemental/AppleGothic.ttf",
+        "/System/Library/Fonts/Supplemental/Arial Unicode.ttf",
+        "/System/Library/Fonts/Supplemental/Arial.ttf",
+        "/Library/Fonts/Arial Unicode.ttf",
+    ),
+    "Windows": (
+        "C:/Windows/Fonts/malgun.ttf",
+        "C:/Windows/Fonts/malgunbd.ttf",
+        "C:/Windows/Fonts/gulim.ttc",
+        "C:/Windows/Fonts/batang.ttc",
+    ),
+}
 
 FRAME_OVERFLOW_PIXEL_LIMIT = 20
 FRAME_OVERFLOW_EXTRA_PIXEL_LIMIT = 12
@@ -4308,14 +4320,46 @@ def fontconfig_label_font_path() -> Path | None:
     return None
 
 
+def env_label_font_paths() -> list[Path]:
+    env_value = os.environ.get(LABEL_FONT_ENV)
+    if not env_value:
+        return []
+    return [
+        Path(os.path.expandvars(os.path.expanduser(item)))
+        for item in env_value.split(os.pathsep)
+        if item.strip()
+    ]
+
+
+def known_label_font_paths() -> list[Path]:
+    current = platform.system()
+    platform_order = [current, *(name for name in LABEL_FONT_PATHS_BY_PLATFORM if name != current)]
+    return [
+        Path(font_path)
+        for platform_name in platform_order
+        for font_path in LABEL_FONT_PATHS_BY_PLATFORM.get(platform_name, ())
+    ]
+
+
+def dedupe_paths(paths: list[Path]) -> list[Path]:
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(path)
+    return deduped
+
+
 def configured_label_font_paths() -> list[Path]:
-    env_path = os.environ.get(LABEL_FONT_ENV)
-    paths = [Path(env_path)] if env_path else []
+    paths = env_label_font_paths()
     fc_path = fontconfig_label_font_path()
     if fc_path:
         paths.append(fc_path)
-    paths.extend(Path(font_path) for font_path in LABEL_FONT_PATHS)
-    return paths
+    paths.extend(known_label_font_paths())
+    return dedupe_paths(paths)
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
## 요약

Closes #6016.

`visual_sweep.py`가 review/contact sheet PNG에 한글 라벨을 그릴 때 Linux에서 Pillow 기본 폰트로 fallback되어 tofu 네모 박스가 표시되는 문제를 고쳤습니다. 문서 본문 렌더링이 아니라 증적 생성 도구의 라벨 폰트 선택 문제입니다.

## 변경

- `RHWP_VISUAL_SWEEP_LABEL_FONT` 환경변수로 라벨 폰트를 명시할 수 있게 했습니다.
- `fc-match`가 있는 환경에서는 `Noto Sans CJK KR`, `NanumGothic`, `UnDotum`, `Malgun Gothic`, `Apple SD Gothic Neo` family 후보를 조회합니다.
- fontconfig가 없거나 실패하면 Linux/macOS/Windows의 알려진 CJK 폰트 경로를 현재 OS 우선으로 확인합니다.
- 모든 TrueType 후보가 실패할 때만 기존처럼 `ImageFont.load_default()`로 fallback합니다.
- `scripts/tests/test_visual_sweep.py`에 env/fontconfig/OS별 후보 순서/truetype fallback 계약 테스트를 추가했습니다.
- 원인 분석 문서 `mydocs/working/task_m100_6016_stage1.md`를 추가했습니다.
- PR review workflow 계열 문서에 대표 review PNG의 라벨·glyph·수치 판독성을 직접 확인하도록 강화했습니다.
- self-review 기록 `mydocs/pr/archives/pr_6018_review.md`와 오늘할일 항목을 trailing commit으로 보존했습니다.

## 검증

- `python3 -m unittest scripts.tests.test_visual_sweep`: 43 tests OK
- `python3 -m py_compile scripts/visual_sweep.py scripts/tests/test_visual_sweep.py`: 통과
- `python3 scripts/check_markdown_links.py mydocs/working/task_m100_6016_stage1.md mydocs/manual/pr_review_workflow.md mydocs/manual/pr_review/visual_fixture_evidence.md mydocs/pr/archives/pr_6018_review.md mydocs/orders/20260824.md`: 내부 Markdown 상대 링크 이상 없음
- `cargo fmt --all -- --check`: 통과
- `git diff --check`: 통과
- 현재 Ubuntu 서버에서 `configured_label_font_paths()`의 첫 기존 폰트가 `/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc`이고, `label_font()`가 `FreeTypeFont`로 로드됨을 확인했습니다.

## 범위

제품 렌더러, HWP/PDF 변환, layout 알고리즘은 변경하지 않습니다. visual sweep 증적 PNG의 도구 라벨 폰트 선택과 관련 절차 문서만 보정합니다.
