### PR TITLE
fix(studio): 보호 문서에서 평문 복구본을 만들지 않는다

### DIFF
--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -90,6 +90,8 @@ const documentState = new DocumentDirtyState(eventBus);
 documentState.installBeforeUnload(window);
 const autosaveManager = new AutosaveManager({
   exportBytes: () => wasm.exportHwp(),
+  // exportHwp()는 평문 HWP 바이트를 만든다. 보호 문서에서는 복구본을 남기지 않는다 (#5992).
+  isRecoveryBlocked: () => wasm.requiresPasswordForSave,
   schedule: autosaveScheduleFromUserSettings(),
   onStatus: handleAutosaveStatus,
 });
@@ -390,9 +392,15 @@ function handleAutosaveStatus(status: AutosaveStatus): void {
 
   const restoreTarget = autosavePreviousMessage;
   autosavePreviousMessage = null;
-  const nextMessage = status.state === 'saved'
-    ? `복구용 자동 저장 완료 (${formatBytes(status.byteLength)})`
-    : '복구용 자동 저장 실패';
+  let nextMessage: string;
+  if (status.state === 'saved') {
+    nextMessage = `복구용 자동 저장 완료 (${formatBytes(status.byteLength)})`;
+  } else if (status.state === 'blocked') {
+    // 실패가 아니라 의도된 차단이므로 구분해서 알린다 (#5992).
+    nextMessage = '보호 문서는 복구용 자동 저장을 하지 않습니다';
+  } else {
+    nextMessage = '복구용 자동 저장 실패';
+  }
   message.textContent = nextMessage;
   if (restoreTarget !== null) {
     autosaveStatusRestoreTimer = setTimeout(() => {

--- a/rhwp-studio/src/recovery/autosave-manager.ts
+++ b/rhwp-studio/src/recovery/autosave-manager.ts
@@ -28,10 +28,16 @@ export interface AutosaveScheduleSettings {
 export type AutosaveStatus =
   | { state: 'saving'; reason: string }
   | { state: 'saved'; reason: string; byteLength: number }
+  | { state: 'blocked'; reason: string }
   | { state: 'error'; reason: string; error: unknown };
 
 export interface AutosaveManagerOptions {
   exportBytes: () => Uint8Array;
+  /**
+   * 참이면 복구용 자동 저장을 수행하지 않는다. 보호 문서에서 평문 복구본이 남는 것을
+   * 막기 위한 fail-closed 조건이다 (#5992).
+   */
+  isRecoveryBlocked?: () => boolean;
   debounceMs?: number;
   minSaveIntervalMs?: number;
   schedule?: Partial<AutosaveScheduleSettings>;
@@ -57,6 +63,7 @@ function reasonText(reason: unknown, fallback: string): string {
 
 export class AutosaveManager {
   private readonly exportBytes: () => Uint8Array;
+  private readonly isRecoveryBlocked: () => boolean;
   private readonly now: () => number;
   private readonly idFactory: () => string;
   private readonly store: AutosaveStoreLike;
@@ -75,6 +82,7 @@ export class AutosaveManager {
 
   constructor(options: AutosaveManagerOptions) {
     this.exportBytes = options.exportBytes;
+    this.isRecoveryBlocked = options.isRecoveryBlocked ?? (() => false);
     this.scheduleSettings = normalizeSchedule({
       recoveryEnabled: true,
       recoveryIntervalMs: options.minSaveIntervalMs ?? DEFAULT_RECOVERY_INTERVAL_MS,
@@ -152,6 +160,10 @@ export class AutosaveManager {
 
   schedule(reason = 'document-mutated'): void {
     if (!this.current) return;
+    if (this.isRecoveryBlocked()) {
+      void this.flushNow(reason);
+      return;
+    }
     const settings = this.scheduleSettings;
     if (!settings.recoveryEnabled && !settings.idleEnabled) return;
 
@@ -176,6 +188,14 @@ export class AutosaveManager {
   async flushNow(reason = 'manual'): Promise<void> {
     const current = this.current;
     if (!current) return;
+
+    if (this.isRecoveryBlocked()) {
+      // 보호 문서의 평문 복구본을 만들지 않는다. 보호 상태로 바뀌기 전에 남은 draft가
+      // 있으면 함께 폐기해 복구 후보에서 제외한다 (#5992).
+      await this.discardCurrentDraft('recovery-blocked');
+      this.onStatus?.({ state: 'blocked', reason });
+      return;
+    }
 
     if (this.saving) {
       this.pendingReason = reason;

--- a/rhwp-studio/tests/autosave-manager.test.ts
+++ b/rhwp-studio/tests/autosave-manager.test.ts
@@ -261,3 +261,72 @@ test('AutosaveManager는 대기 중인 저장이 없으면 설정 변경만으�
 
   assert.equal(saved.length, 0);
 });
+
+test('AutosaveManager는 보호 문서에서 평문 draft를 저장하지 않는다', async () => {
+  const { store, saved } = createStore();
+  const statuses: string[] = [];
+  const manager = new AutosaveManager({
+    exportBytes: () => new Uint8Array([1, 2, 3, 4]),
+    isRecoveryBlocked: () => true,
+    debounceMs: 0,
+    minSaveIntervalMs: 0,
+    now: () => 1_000,
+    idFactory: () => 'draft-protected',
+    store,
+    onStatus: (status) => statuses.push(status.state),
+  });
+
+  await manager.beginDocument({ fileName: 'secret.hwp', sourceFormat: 'hwp' });
+  await manager.flushNow('recovery-interval');
+
+  assert.deepEqual(saved, []);
+  assert.ok(statuses.includes('blocked'));
+});
+
+test('AutosaveManager는 보호 상태로 바뀌면 남아 있던 draft를 폐기한다', async () => {
+  const { store, saved, deleted } = createStore();
+  let blocked = false;
+  const manager = new AutosaveManager({
+    exportBytes: () => new Uint8Array([1, 2, 3, 4]),
+    isRecoveryBlocked: () => blocked,
+    debounceMs: 0,
+    minSaveIntervalMs: 0,
+    now: () => 1_000,
+    idFactory: () => 'draft-becomes-protected',
+    store,
+  });
+
+  await manager.beginDocument({ fileName: 'doc.hwp', sourceFormat: 'hwp' });
+  await manager.flushNow('recovery-interval');
+  assert.equal(saved.length, 1);
+
+  // 암호가 설정되어 보호 문서가 된 뒤에는 기존 평문 draft가 남지 않아야 한다.
+  blocked = true;
+  await manager.flushNow('recovery-interval');
+
+  assert.equal(saved.length, 1);
+  assert.ok(deleted.includes('draft-becomes-protected'));
+});
+
+test('AutosaveManager는 보호 해제 후 다시 draft를 저장한다', async () => {
+  const { store, saved } = createStore();
+  let blocked = true;
+  const manager = new AutosaveManager({
+    exportBytes: () => new Uint8Array([9, 9]),
+    isRecoveryBlocked: () => blocked,
+    debounceMs: 0,
+    minSaveIntervalMs: 0,
+    now: () => 2_000,
+    idFactory: () => 'draft-unprotected',
+    store,
+  });
+
+  await manager.beginDocument({ fileName: 'doc.hwp', sourceFormat: 'hwp' });
+  await manager.flushNow('recovery-interval');
+  assert.deepEqual(saved, []);
+
+  blocked = false;
+  await manager.flushNow('recovery-interval');
+  assert.equal(saved.length, 1);
+  assert.equal(saved[0]?.id, 'draft-unprotected');
+});


### PR DESCRIPTION
Refs #5992

## 요약

암호 문서를 편집하는 동안에도 복구용 자동 저장이 `wasm.exportHwp()`로 평문 HWP 바이트를 만들어 IndexedDB에 남겼습니다. 이 복구본은 평문 load 경로로 열리므로, 복구한 문서의 `requiresPasswordForSave`가 `false`가 되고 이어지는 일반 저장이 암호 확인 없이 평문으로 진행될 수 있었습니다.

이 PR은 이슈의 **1단계(평문 복구본 차단)** 에 해당하는 fail-closed 최소 수정입니다. 2단계 암호화 복구 envelope는 포함하지 않습니다.

## 변경 내용

`AutosaveManager`에 선택적 `isRecoveryBlocked: () => boolean` 조건을 추가하고, Studio가 `wasm.requiresPasswordForSave`를 연결합니다.

차단 상태에서는 `flushNow()`가 `exportBytes()`를 **호출하기 전에** 중단하므로 평문 바이트 자체가 만들어지지 않습니다. 또한:

- 보호 상태로 바뀌기 전에 만들어진 draft가 있으면 `discardCurrentDraft()`로 폐기해 복구 후보에서 제외합니다.
- `blocked` 상태를 새로 추가해 사용자에게 "보호 문서는 복구용 자동 저장을 하지 않습니다"로 알립니다. 기존 상태 처리는 `saved`가 아닌 모든 상태를 "복구용 자동 저장 실패"로 표시했기 때문에, 의도된 차단이 실패로 보이지 않도록 분기를 나눴습니다.
- `schedule()`은 차단 상태에서 타이머를 걸지 않고 바로 `flushNow()`로 보내 폐기·알림 경로를 한 곳으로 모읍니다.

보호가 해제되면 이전과 동일하게 다시 저장합니다.

## 검증

| 항목 | 결과 |
| --- | --- |
| `node --test tests/autosave-manager.test.ts` | **12개 통과** (기존 9 + 신규 3) |
| `npx tsc --noEmit` | 변경 전후 오류 **동일 5건** — 모두 `@wasm/rhwp.js` 미빌드로 인한 기존 오류이며, 두 결과를 diff 해 신규 오류가 없음을 확인했습니다 |

신규 회귀 테스트 3건:

1. 보호 문서에서는 draft를 저장하지 않고 `blocked`를 알린다
2. 보호 상태로 바뀌면 남아 있던 draft를 폐기한다
3. 보호가 해제되면 다시 저장한다

Node 22.14에서는 `.ts` 직접 실행에 `--experimental-strip-types`가 필요했습니다.

## 확인하지 못한 부분

- **브라우저에서 실제 암호 문서로 end-to-end 재현을 하지 않았습니다.** WASM 아티팩트 빌드가 필요해 단위 테스트와 코드 경로 확인까지만 했습니다. 이슈의 재현 절차(1~6)를 실제 Studio에서 밟아 확인해 주시면 좋겠습니다.
- **이슈 1단계의 네 번째 항목**(보호 metadata가 없는 **기존** 복구본을 로드해 다음 저장 보호 상태가 `false`가 되는 경로 차단)은 포함하지 않았습니다. 이 PR 이후로는 보호 문서에서 새 평문 draft가 생기지 않지만, 이 변경 이전에 이미 저장된 draft는 그대로 남습니다. 복구본에 보호 metadata를 기록하는 형식 변경이 필요해 보여 별도 작업으로 두는 편이 맞다고 판단했는데, 이 PR에 포함하는 편이 낫다면 알려 주세요.
- `cargo fmt --all -- --check`는 Rust 변경이 없어 실행하지 않았습니다. 이 PR은 `rhwp-studio`의 TypeScript만 수정합니다.

> [!NOTE]
> 사용 모델 — `claude-opus-5`, reasoning effort `high`. 제출 전 모든 줄을 직접 읽고 확인했습니다.
