### PR TITLE
perf(codeql): PR Rust sparse checkout으로 전송 범위를 맞춘다

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -783,9 +783,11 @@ jobs:
             .
             .cargo
             .github/codeql
+            bindings
             crates
             rhwp-desk
             src
+            tools
 
       # devel push, schedule, and manual runs deliberately retain whole-repository
       # Rust analysis. They do not consume the PR-only rust-pr.yml scope.
@@ -822,6 +824,10 @@ jobs:
       - name: Install Rust toolchain
         if: ${{ matrix.language == 'rust' && contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) }}
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
+
+      - name: Validate Rust CodeQL sparse workspace
+        if: ${{ matrix.language == 'rust' && contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) }}
+        run: cargo metadata --locked --offline --no-deps --format-version=1 > /dev/null
 
       # [#5187] Rust는 명시적 none 모드로 분석한다. 동일 SHA 비교에서 현재 기본 경로와
       # 추출 파일·SARIF 지표가 같았고, none 모드가 더 짧아 Rust 자동 빌드 의존을 제거한다.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -778,6 +778,9 @@ jobs:
       - name: Checkout Rust PR CodeQL sources
         if: ${{ matrix.language == 'rust' && contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) && github.event_name == 'pull_request' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        # Cargo.toml이 명시 등록한 integration target의 source도 workspace
+        # 모델에 필요하다. 빠지면 Rust extractor가 proc-macro를 빌드하지 못해
+        # src 분석 결과가 대량 오류로 떨어진다.
         with:
           sparse-checkout: |
             .
@@ -787,6 +790,7 @@ jobs:
             crates
             rhwp-desk
             src
+            tests
             tools
 
       # devel push, schedule, and manual runs deliberately retain whole-repository

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -767,8 +767,31 @@ jobs:
         run: |
           printf 'Skipping unselected CodeQL language: %s\n' '${{ matrix.language }}'
 
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: ${{ contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) }}
+      - name: Checkout selected non-Rust language
+        if: ${{ matrix.language != 'rust' && contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Rust PR analysis already limits the CodeQL database to production paths in
+      # rust-pr.yml. Match the worktree to that scope so the shallow fetch does not
+      # transfer unrelated generated assets, fixtures, or tests. Cone mode retains
+      # root manifests, Cargo.lock, build.rs, and rust-toolchain.toml.
+      - name: Checkout Rust PR CodeQL sources
+        if: ${{ matrix.language == 'rust' && contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) && github.event_name == 'pull_request' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: |
+            .
+            .cargo
+            .github/codeql
+            crates
+            rhwp-desk
+            src
+
+      # devel push, schedule, and manual runs deliberately retain whole-repository
+      # Rust analysis. They do not consume the PR-only rust-pr.yml scope.
+      - name: Checkout Rust full-scan sources
+        if: ${{ matrix.language == 'rust' && contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) && github.event_name != 'pull_request' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # [#3290] 호스티드 16GB VM 은 CodeQL 자동 감지 값이 적정하다. self-hosted 로
       # 되돌릴 경우 ram/threads 캡 필수 — #3289 사고(무캡 JVM 40~55GB×2 로 호스트

--- a/mydocs/working/task_m100_3790_stage5c_rust_codeql_sparse_checkout.md
+++ b/mydocs/working/task_m100_3790_stage5c_rust_codeql_sparse_checkout.md
@@ -1,0 +1,43 @@
+# 작업 기록 — task_m100_3790 Stage 5C
+
+- **이슈**: [#3790](https://github.com/edwardkim/rhwp/issues/3790)
+- **브랜치**: `task_m100_3790_stage5c_codeql_sparse_checkout`
+- **기준**: `upstream/devel` `385e93b2c317d1f50d874fd655e88cf4b2a1ba07`
+- **상태**: 구현 및 focused 검증 진행 중
+
+## 배경
+
+PR #5455는 PR Rust CodeQL 데이터베이스를 `src/**`, `crates/**`,
+`rhwp-desk/src/**`, `build.rs`로 한정했다. 그러나 2026-08-24 PR #6017의
+`Analyze (rust)` job은 shallow fetch만 3분 33초를 사용해 저장소 전체를 받은 뒤
+861개 Rust 파일을 추출했다. checkout의 실제 파일 전개는 약 10초였으므로 병목은
+worktree 전개가 아니라 분석에 필요 없는 blob 전송이다.
+
+같은 job의 Rust 분석은 추출 및 데이터베이스 생성에 5분 35초, 기본 쿼리 평가에
+7분 37초를 사용했다. 따라서 Cargo cache, `build-mode`, 또는 query suite를 바꾸지
+않고 PR checkout 입력부터 분석 범위와 맞춘다.
+
+## 설계
+
+- 선택된 JavaScript/TypeScript와 Python lane은 기존 full checkout을 유지한다.
+- 선택된 Rust PR lane만 cone sparse checkout으로 루트 파일, `.cargo`,
+  `.github/codeql`, `crates`, `rhwp-desk`, `src`를 받는다.
+- cone sparse checkout의 루트 파일에는 `Cargo.toml`, `Cargo.lock`, `build.rs`,
+  `rust-toolchain.toml`이 남아 Rust workspace와 CodeQL 설정을 보존한다.
+- `devel` push, schedule, workflow_dispatch의 Rust lane은 PR config를 쓰지 않으므로
+  별도 full checkout을 유지한다.
+- partial clone `filter`는 sparse checkout 입력을 덮어쓰므로 사용하지 않는다.
+
+## 수용 기준
+
+1. PR Rust lane에만 정확한 sparse checkout 경로가 선언된다.
+2. non-PR Rust lane은 sparse checkout 없이 전체 분석을 유지한다.
+3. CodeQL workflow 계약 테스트와 YAML/actionlint 검증이 통과한다.
+4. PR CI에서 Rust checkout, 추출 성공·오류 파일 수, SARIF/CodeQL 결과, 전체 Rust job 시간을
+   #6017 기준선과 비교한다. extraction 오류 증가 또는 결과 범위 이상이 보이면 merge하지 않는다.
+
+## 비범위
+
+- Rust `build-mode: none` 재변경, 기본 CodeQL query suite 축소, larger runner 도입
+- trusted classifier의 fail-closed 언어 선택 정책 변경
+- nextest archive B/C 구조 변경. 이는 독립 측정 PR에서 다룬다.

--- a/scripts/tests/test_codeql_workflow.py
+++ b/scripts/tests/test_codeql_workflow.py
@@ -173,7 +173,7 @@ class CodeQLWorkflowTests(unittest.TestCase):
         self.assertIn("name: Analyze (${{ matrix.language }})", analyze)
         self.assertIn("name: Skip unselected language", analyze)
         self.assertIn(f"if: ${{{{ !{selected} }}}}", analyze)
-        self.assertEqual(analyze.count(f"if: ${{{{ {selected} }}}}"), 2)
+        self.assertEqual(analyze.count(f"if: ${{{{ {selected} }}}}"), 1)
         self.assertIn(
             "if: ${{ matrix.language != 'rust' && " + selected + " }}",
             analyze,
@@ -194,6 +194,38 @@ class CodeQLWorkflowTests(unittest.TestCase):
             line.strip() for line in analyze.splitlines() if line.strip().startswith("if:")
         )
         self.assertNotIn("codeql_languages", job_if)
+
+    def test_rust_pr_checkout_matches_the_pr_analysis_scope(self) -> None:
+        analyze = job_body(self.workflow, "analyze")
+        selected = (
+            "contains(format(',{0},', env.SELECTED_LANGUAGES), "
+            "format(',{0},', matrix.language))"
+        )
+        pr_checkout = analyze.split(
+            "      - name: Checkout Rust PR CodeQL sources\n", 1
+        )[1].split("\n      - name:", 1)[0]
+        self.assertIn(
+            "if: ${{ matrix.language == 'rust' && "
+            + selected
+            + " && github.event_name == 'pull_request' }}",
+            pr_checkout,
+        )
+        self.assertIn("uses: actions/checkout@", pr_checkout)
+        self.assertIn("sparse-checkout: |", pr_checkout)
+        for path in (".", ".cargo", ".github/codeql", "crates", "rhwp-desk", "src"):
+            self.assertIn(f"          {path}\n", pr_checkout)
+
+        full_checkout = analyze.split(
+            "      - name: Checkout Rust full-scan sources\n", 1
+        )[1].split("\n      - name:", 1)[0]
+        self.assertIn(
+            "if: ${{ matrix.language == 'rust' && "
+            + selected
+            + " && github.event_name != 'pull_request' }}",
+            full_checkout,
+        )
+        self.assertIn("uses: actions/checkout@", full_checkout)
+        self.assertNotIn("sparse-checkout:", full_checkout)
 
     def test_fast_pass_summary_marks_language_classification_not_applicable(
         self,


### PR DESCRIPTION
## 목적

Related #3790.

PR Rust CodeQL의 데이터베이스 범위는 이미 제품 Rust 경로로 제한돼 있지만, checkout은 저장소 전체를 shallow fetch하고 있었습니다. PR Rust lane의 worktree도 분석 범위에 맞춰 불필요한 blob 전송 시간을 줄입니다.

## 변경

- 선택된 Rust `pull_request` lane만 cone sparse checkout을 사용합니다.
- root manifest, `.cargo`, `.github/codeql`, `crates`, `rhwp-desk`, `src`를 포함해 Cargo workspace와 CodeQL 설정을 보존합니다.
- `devel` push, schedule, workflow_dispatch Rust lane은 full checkout과 전체 Rust scan을 유지합니다.
- workflow 계약 테스트가 PR sparse path와 non-PR full checkout을 각각 고정합니다.

## 기준선과 CI 판정

PR #6017의 Rust CodeQL job은 전체 17분 28초였고 shallow fetch만 3분 33초를 사용했습니다. Rust 추출 및 DB 생성은 5분 35초, 기본 쿼리 평가는 7분 37초였습니다.

CI에서 다음을 #6017과 비교합니다.

- Rust checkout 시간
- 추출 성공·오류 파일 수
- CodeQL/SARIF 결과와 annotation
- Rust job 전체 시간

추출 오류 증가 또는 결과 범위 이상이 확인되면 merge하지 않습니다.

## 로컬 검증

- `python3 -m unittest scripts/tests/test_codeql_workflow.py` — 16 passed
- `actionlint .github/workflows/codeql.yml`
- Ruby YAML parse: CodeQL workflow/config
- `cargo fmt --all -- --check`
- `git diff --check`