### PR TITLE
fix(renderer): 직전 TAC 전진 뒤 문단이 바뀌는 TAC-모순 host 표에 문단 위 간격을 가산한다 (#5809 실측②)

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -9481,6 +9481,39 @@ impl LayoutEngine {
                         if Self::tac_stored_band_is_outer_box(para, t) {
                             y_offset += hwpunit_to_px(t.outer_margin_top as i32, self.dpi);
                         }
+                        // [#5809 실측②] 직전 TAC 의 seg 전진은 줄 간격까지만 담는다.
+                        // **문단이 바뀌는** TAC-모순(treat_as_char + 자리차지) 빈 host
+                        // 표는 자기 문단의 위 간격(sb)을 여기서 받아야 한다 — 건너뛰면
+                        // 표가 저장 사다리보다 sb 만큼 위에 앉는다. 156518601 실측:
+                        // 5쪽 그림 표(sb 20px)가 한글·저장 사다리(간격 28px = ls 8 +
+                        // sb 20) 대비 19.8px 위, 9쪽 연속 host 4개(sb 6.7px)는 표당
+                        // ~sb 씩 계단 누적. 같은 문단 안의 후속 TAC(vpos 델타 전진이
+                        // 간격을 이미 담음)와 구분하기 위해 첫 컨트롤로 한정한다.
+                        if control_index == 0
+                            && !is_column_top
+                            && self.profile.get().hwpx_stored_layout()
+                            && t.common.treat_as_char
+                            && matches!(
+                                t.common.text_wrap,
+                                crate::model::shape::TextWrap::TopAndBottom
+                            )
+                            && !para_has_non_whitespace_text(para)
+                        {
+                            let spacing_before = styles
+                                .para_styles
+                                .get(ps_id)
+                                .map(|ps| ps.spacing_before.max(0.0))
+                                .unwrap_or(0.0);
+                            if spacing_before > 0.0 {
+                                y_offset += spacing_before;
+                                if std::env::var("RHWP_DIAG_TAC").is_ok() {
+                                    eprintln!(
+                                        "DIAG_PAINT_SB pi={} sb={:.1} y={:.1}",
+                                        para_index, spacing_before, y_offset,
+                                    );
+                                }
+                            }
+                        }
                     }
                 } else if !is_current_empty_para_float {
                     if let Some(ps) = styles.para_styles.get(ps_id) {


### PR DESCRIPTION
## 무엇을

#5809 실측 ② — 156518601 5쪽 그림 표 블록이 한글보다 19.7px 위에 그려지는 결함의 렌더러 수정입니다.

## 원인

직전 페이지 아이템이 TAC 표면 렌더 흐름(`layout_table_item` 의 표 위 간격 블록)이
`prev_tac_seg_applied` 분기로 들어가 저장 seg 델타(줄 간격까지만)로만 전진합니다. 이때
**문단이 바뀌는** TAC-모순(treat_as_char + 자리차지) 빈 host 표는 자기 문단의 위 간격(sb)을
받을 자리가 없어, 저장 사다리·한글보다 sb 만큼 위에 앉습니다.

실측(156518601, 한글 2020 COM PDF 오라클):

- 5쪽 그림 표: 한글·저장 사다리의 표간 간격 28px(= 줄간격 8 + sb 20) vs rhwp 9.9px —
  그림 표 위 괘선이 19.7px 위. (표 첫 행이 보이지 않는 1704HU 빈 행이라, 눈에 띄는
  괘선 기준으로는 같은 값이 관측됩니다)
- 9쪽 연속 host 표 4개(sb 6.7px): 표당 ~sb 씩 계단 누적, 쪽말 −16.7pt.

## 수정

`layout.rs` 표 위 간격 블록의 `prev_tac_seg_applied` 분기에서, **첫 컨트롤 + 비단상단 +
HWPX stored-layout 프로필 + TAC-모순 빈 host** 로 한정해 sb 를 가산합니다. 같은 문단 안
후속 TAC(vpos 델타 전진이 경계 간격을 이미 담음)는 `control_index == 0` 으로 배제됩니다.

## 검증

| 지점 | 수정 전 | 수정 후 | 한글 2020 |
| --- | --- | --- | --- |
| 5쪽 그림 표 위 괘선 | 125.0pt | **140.0pt** | 139.8pt |
| 9쪽 괘선 사다리 편차 | −4.7 ~ −16.7pt 계단 | +0.1 ~ +3.3pt | — |
| 10쪽 사다리 편차 | −4.8 ~ −18.2pt | −4.8 ~ +1.8pt | — |
| 쪽수 | 10 | 10 | 10 |
| 1쪽(#6017 축) | 정합 | 정합(무변화) | — |

- 대조군: 156513948(같은 HOSTBOX 계열 31회, 보도자료) 쪽수 32 로 한글과 정합 유지.
- `regression_suite_002/004/012`(issue_5809·issue_5801·issue_5729·issue_2279 오라클 포함)
  124+133+132 = **389 passed, 0 failed**. `cargo fmt --all --check`·`cargo clippy --all-targets` 통과.
- 이 문서 계열 HWP5 프로필은 게이트 밖(무변화)입니다.

## 남는 것

- 9쪽 잔여 +1.6~+3.3pt(표당 ~1pt 과가산)는 별도 미세 축으로 남습니다 — #5809 에 기록 예정.
- 축소 재현체(fixture)는 아직 없습니다. 필요하면 #6017 의 samples/issue5809 방식으로
  5쪽 형상(연속 TAC-모순 host 2개)을 후속 제작하겠습니다.

Closes 없음 — #5809 는 실측 ①(#6017)에 이어 본 PR 로 실측 ② 축이 닫히지만, 이슈 종결
판단은 메인터너에 맡깁니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
