### PR TITLE
docs: 렌더링 PR 시각 검증 필수 조건 명확화

### DIFF
--- a/mydocs/manual/pr_review/intake_and_review.md
+++ b/mydocs/manual/pr_review/intake_and_review.md
@@ -65,6 +65,26 @@ Cargo 성공은 시각 검증 판정을 대체하지 않는다. 다음 중 하�
 - PR이 기준 PDF, 한컴 출력, 페이지 수, render-diff, visual regression 해결을 주장한다.
 - HWP/HWPX sample, 기준 PDF, golden, visual fixture를 추가·갱신한다.
 
+다음 조합은 "필요 여부 검토"가 아니라 **merge/수용 판정 전 직접 증적 필수**다.
+
+- renderer/layout/typeset/paint/page-visible 경로가 바뀌고, PR 또는 관련 issue에 HWP/HWPX/PDF fixture가
+  첨부·추가되어 있다.
+- PR 설명이 특정 문서의 페이지, 표, 줄바꿈, clipping, 겹침, 여백, z-order, 그림·도형 배치 개선을
+  주장한다.
+
+이 경우 review 문서의 최종 권고를 `merge` 또는 `수용`으로 쓰기 전에 다음 중 하나를 완료해야 한다.
+
+- `rhwp info --json`으로 원본 HWP/HWPX의 저장 버전을 확인하고, 버전에 맞는 MCP 기준 PDF를 만든 뒤,
+  visual sweep 대표 PNG와 요약 지표를 실제로 열어 확인한다.
+- 이미 PR branch에 포함된 기준 PDF/PNG를 쓰는 경우에도, 그 파일을 직접 열어 PR 주장의 페이지·영역이
+  해결됐는지 확인하고, 원본·기준·검토 asset의 경로와 SHA-256을 review 문서에 적는다.
+- 직접 시각 검증을 수행하지 못하면 최종 권고는 `보류` 또는 `조건부 보류`로 적고, "원 PR 제공
+  before/after만 확인했고 maintainer visual sweep은 미실행"처럼 누락 범위를 명시한다.
+
+원 PR이 before/after 이미지나 수치를 제공했더라도 maintainer가 직접 확인한 visual sweep 또는 동등한
+시각 판정 없이 이를 "시각 검증 통과"로 승격하지 않는다. 특히 통합 cherry-pick PR에서는 source PR의
+증적을 참고 자료로만 기록하고, 통합 head의 실제 산출물로 다시 확인했는지 별도 항목으로 적는다.
+
 개체 geometry 무회귀의 재실증은 다음 명령을 사용할 수 있다. 추적 개체가 없는 0→0 행은 근거로 삼지 않는다.
 
 ~~~bash

--- a/mydocs/manual/pr_review/visual_fixture_evidence.md
+++ b/mydocs/manual/pr_review/visual_fixture_evidence.md
@@ -2,7 +2,7 @@
 kind: guide
 status: active
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-08-24
+last_verified: 2026-08-26
 ---
 
 # 시각·fixture 증적
@@ -15,6 +15,19 @@ renderer, layout, typeset, paint, WASM 출력, HWP/HWPX/PDF fixture, 페이지 �
 최종 판단은 PR이 약속한 사용자-visible 변경 범위다. renderer/layout/paint 개선은 기준 PDF와의 시각 차이가
 blocker가 될 수 있지만, parser·serializer 구조 보존 PR은 visual 차이를 참고 자료로 기록하고 그 차이만으로
 merge를 보류하지 않는다.
+
+renderer/layout/typeset/paint 등 사용자-visible 렌더링 경로가 바뀌고 HWP/HWPX/PDF fixture가 함께 있으면,
+reviewer는 source PR이 첨부한 before/after나 수치만으로 "시각 검증 완료"라고 쓰지 않는다. 통합 head에서
+직접 만든 기준 PDF·visual sweep 또는 reviewer가 직접 연 기준 PDF/PNG 판정이 있어야 수용 근거가 된다.
+
+직접 visual sweep 또는 동등한 판정을 수행하지 못한 경우 review 문서의 최종 권고는 다음처럼 제한한다.
+
+- `보류`: PR 주장이 시각 결과 자체이고 기준 산출물을 확인하지 못했다.
+- `조건부 보류`: 코드·회귀 테스트는 통과했지만 시각 asset 확인이 남았다.
+- `수용 아님`: 원 PR 증적만 확인했고 maintainer 검증이 없는 상태다.
+
+이 상태에서는 "원 PR 증적 확인", "numeric/contract test 통과", "IR sweep baseline 통과" 같은 표현을
+"visual sweep 통과"와 섞지 않는다.
 
 visual sweep을 실제 검토 근거로 쓰면 review 문서에 다음을 모두 기록한다.
 

--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -294,6 +294,12 @@ review 문서 경로, review_impl 작성 조건, 사전 판단 report의 범위�
 merge 전 보정하거나 별도 issue로 분리해 review 문서에 적는다. merge 후 comment에는 Visual Sweep 정본
 link와 review 문서의 실제 수치·결론을 함께 남기며, PNG는 merge commit SHA 고정 raw URL로 표시한다.
 
+renderer/layout/typeset/paint 등 사용자-visible 렌더링 변경에 HWP/HWPX/PDF fixture가 붙어 있으면
+"시각 검증을 판단 근거로 사용한 경우"가 아니라 **시각 검증 필요 후보**로 먼저 분류한다. 이때 원 PR의
+before/after 이미지나 한컴 수치만 확인하고 maintainer의 직접 visual sweep 또는 동등한 판정 없이
+`수용`·`merge 권고`로 결론 내리지 않는다. 직접 수행하지 못했으면 review 문서와 PR comment에
+`visual sweep 미실행`, `원 PR 증적만 확인`, `보류/조건부 보류` 중 하나를 명시한다.
+
 ## 5. 기존 절 번호 대응
 
 기존 링크 경로인 이 파일은 유지한다. 과거 review 문서와 보고서에 남은 절 번호를 해석할 때는 아래 표를


### PR DESCRIPTION
## 요약

렌더링 변경 PR에 HWP/HWPX/PDF fixture가 붙어 있을 때, maintainer가 직접 visual sweep 또는 동등한 시각 판정을 하지 않고 수용 판정을 내리지 않도록 PR review 문서를 보강했습니다.

## 변경 내용

- 렌더링 변경 + HWP/HWPX/PDF fixture 조합은 merge/수용 전 직접 시각 증적 필수로 명시
- 원 PR의 before/after 이미지나 수치만으로 시각 검증 완료라고 쓰지 않도록 제한
- 직접 시각 검증을 못 했으면 보류/조건부 보류, visual sweep 미실행, 원 PR 증적만 확인을 명시하도록 상위 workflow에 반영

## 검증

- git diff --check

문서-only 변경이라 전체 Rust/npm 회귀 테스트는 실행하지 않았습니다.
