### PR TITLE
CI stale run 취소 완료 상태를 제한적으로 재확인한다

### DIFF
--- a/.github/workflows/cancel-stale-pr-runs.yml
+++ b/.github/workflows/cancel-stale-pr-runs.yml
@@ -61,6 +61,7 @@ jobs:
             ]);
             const retryableForceCancelStatuses = new Set([502, 503, 504]);
             const forceCancelRetryDelaysMs = [1_000, 2_000, 4_000];
+            const completionPollDelaysMs = [0, 500, 1_000, 2_000];
 
             function sleep(milliseconds) {
               return new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -91,6 +92,24 @@ jobs:
                 }
               }
               throw lastError;
+            }
+
+            async function getWorkflowRun(runId) {
+              const { data } = await github.rest.actions.getWorkflowRun({
+                owner,
+                repo,
+                run_id: runId,
+              });
+              return data;
+            }
+
+            async function waitForCompletedRun(runId) {
+              for (const delay of completionPollDelaysMs) {
+                if (delay > 0) await sleep(delay);
+                const currentRun = await getWorkflowRun(runId);
+                if (currentRun.status === 'completed') return currentRun;
+              }
+              return null;
             }
 
             async function getLivePull() {
@@ -152,17 +171,21 @@ jobs:
               try {
                 await forceCancelWithRetry(run.id);
               } catch (error) {
-                // 대상이 취소되거나 스스로 끝난 뒤 GitHub API가 409뿐 아니라 5xx를
-                // 반환할 수 있다. 응답 코드를 성공으로 간주하지 말고, 대상 run을 다시
-                // 읽어 실제로 completed인 경우만 정상 경과로 취급한다.
-                const { data: currentRun } = await github.rest.actions.getWorkflowRun({
-                  owner,
-                  repo,
-                  run_id: run.id,
-                });
-                if (currentRun.status !== 'completed') throw error;
+                // 대상이 취소되거나 스스로 끝난 뒤 GitHub API가 오류를 반환할 수 있다.
+                // 응답 코드를 성공으로 간주하지 않고, 짧은 bounded polling 안에서 실제
+                // completed를 확인한 경우만 eventual-consistency race로 취급한다.
+                let completedRun;
+                try {
+                  completedRun = await waitForCompletedRun(run.id);
+                } catch (statusError) {
+                  core.warning(
+                    `Failed to poll stale run ${run.id} after force-cancel error ${error.status ?? 'unknown'}: ${statusError.message}`,
+                  );
+                  throw error;
+                }
+                if (!completedRun) throw error;
                 core.info(
-                  `Skip stale run ${run.id} (${run.name}): already completed after force-cancel error ${error.status ?? 'unknown'} (${currentRun.conclusion ?? 'unknown'}).`,
+                  `Skip stale run ${run.id} (${run.name}): already completed after force-cancel error ${error.status ?? 'unknown'} (${completedRun.conclusion ?? 'unknown'}).`,
                 );
                 continue;
               }

--- a/mydocs/orders/20260826.md
+++ b/mydocs/orders/20260826.md
@@ -146,3 +146,18 @@ date: 2026-08-26
   확인한다.
 - [ ] PR #6106을 merge한 뒤 #4967→#4960 sub-issue 연결, W8 checkbox·최종 comment·reopen 조건 정산,
   #4967 close와 branch/worktree 정리를 수행한다.
+
+## Issue #4608 - stale run 취소 완료 상태 polling 회귀 보정
+
+- [x] PR #6116의 유일한 실패가 제품 CI가 아니라 `Cancel stale PR runs`의 force-cancel HTTP 500과
+  완료 상태 반영 사이 race임을 확인했다.
+- [x] 기존 #4608을 regression으로 reopen하고 `postmelee` 담당자와 run 32923641712·stale 대상
+  32923603626 근거를 등록했다.
+- [x] 최신 `upstream/devel@6b5c4f871` 기준 `codex/issue-4608-stale-cancel-poll` 브랜치와 O3 운영 변경
+  수행·구현 계획을 만들었다.
+- [x] 테스트 우선으로 오류 후 `[0, 500, 1_000, 2_000]`ms bounded polling을 구현하고 실제
+  `completed`만 정상 처리하며 active·상태 API 실패는 원래 오류로 보존했다.
+- [x] focused 7건, CI impact Python 42건·Node 65건, 전체 Python workflow 계약 178건과 actionlint,
+  `git diff --check`를 통과했다.
+- [ ] 최종 fmt·diff와 최신 devel 정합성을 확인한 뒤 별도 승인으로 push·PR을 생성한다.
+- [ ] PR 최신 head와 실제 fork synchronize event, 이후 main 배포 경계를 관찰한다.

--- a/mydocs/plans/task_m100_4608.md
+++ b/mydocs/plans/task_m100_4608.md
@@ -1,0 +1,56 @@
+# Task M100 #4608 — stale run 취소 완료 상태 bounded polling 수행 계획
+
+- **Issue**: [#4608](https://github.com/edwardkim/rhwp/issues/4608)
+- **재현 PR**: [#6116](https://github.com/edwardkim/rhwp/pull/6116)
+- **브랜치**: `codex/issue-4608-stale-cancel-poll`
+- **기준**: `upstream/devel@6b5c4f871972380c0866e2a8d27ac2bc67d257e6`
+- **운영 등급**: O3 — `pull_request_target`, Actions write 권한과 stale run 취소 실행 계약
+
+## 배경
+
+#4609는 `force-cancel` 오류 직후 대상 run을 한 번 재조회하고 이미 `completed`이면 정상 경과로
+처리했다. PR #6116에서는 GitHub API가 `500 Failed to cancel workflow run`을 반환한 직후 대상 run이
+여전히 active였지만 약 1초 뒤 `completed/cancelled`가 됐다. 단일 재조회와 실제 상태 반영 사이의
+eventual-consistency window 때문에 cleanup workflow만 실패했고 최신 제품 CI는 모두 통과했다.
+
+## 목표
+
+1. `force-cancel` 오류 뒤 짧고 제한된 polling으로 대상 run의 완료 상태를 확인한다.
+2. 실제 `completed`를 확인한 경우에만 정상 경과로 처리한다.
+3. polling 한도를 넘겨도 active이거나 상태 재조회가 실패하면 원래 취소 오류를 전파한다.
+4. 최신 PR head 보호, fork 저장소·branch 식별과 비신뢰 PR source 비실행 경계를 유지한다.
+
+## 범위
+
+- `.github/workflows/cancel-stale-pr-runs.yml`: 오류 후 완료 상태 bounded polling
+- `scripts/tests/test_cancel_stale_pr_runs_workflow.py`: polling·오류 전파 정적 계약
+- `mydocs/`: 재발 근거, 단계별 결과와 최종 보고
+
+## 범위 밖
+
+- PR #6116의 Studio 제품 코드·테스트 변경
+- required check·branch protection·Actions 권한 변경
+- 일반 `gh run cancel` fallback 추가
+- `pull_request_target`에서 PR source checkout 또는 실행
+- `main` 직접 변경·배포
+
+## 단계와 게이트
+
+1. 재발 증적과 기존 #4608/#4609 계약을 대조하고 계획을 고정한다.
+2. bounded polling을 요구하는 계약 테스트를 먼저 추가해 기존 구현의 실패를 확인한다.
+3. workflow에 polling을 구현하고 focused 계약 테스트를 통과시킨다.
+4. CI impact·workflow wiring·포맷·diff 검증과 최종 보고서를 완료한다.
+5. 별도 승인 뒤 push·PR을 생성하고 실제 fork `synchronize` event를 관찰한다.
+
+## 완료 조건
+
+- #6116의 1초 지연 완료 사례가 polling window 안에서 정상 경과로 분류된다.
+- 완료되지 않은 stale run과 상태 API 실패는 계속 cleanup 실패로 드러난다.
+- 기존 `502/503/504` force-cancel 재시도, 최신 head 재확인과 fork 격리 계약을 보존한다.
+- workflow 계약 테스트와 CI 영향 정책 검사가 통과한다.
+- PR 이후 fork event에서 실행·skip 경로와 최신 head 보호를 확인한다.
+
+## 롤백
+
+polling helper·호출부와 해당 정적 계약만 되돌리면 기존 단일 재조회 동작으로 복귀한다. 권한, trigger,
+required context를 바꾸지 않으므로 별도 저장소 설정 롤백은 필요하지 않다.

--- a/mydocs/plans/task_m100_4608_impl.md
+++ b/mydocs/plans/task_m100_4608_impl.md
@@ -1,0 +1,50 @@
+# Task M100 #4608 — bounded polling 구현 계획
+
+## 변경 파일
+
+### `.github/workflows/cancel-stale-pr-runs.yml`
+
+- 완료 상태 확인 간격을 `[0, 500, 1_000, 2_000]`ms로 제한한다.
+- `getWorkflowRun(runId)` helper로 상태 API 호출을 한 곳에 모은다.
+- `waitForCompletedRun(runId)`은 즉시 1회와 세 번의 지연 조회 중 `completed`를 만나면 해당 run을
+  반환하고, 끝까지 active이면 `null`을 반환한다.
+- `forceCancelWithRetry(run.id)` 오류를 받으면 bounded polling을 수행한다.
+- polling 중 완료 run을 확인한 경우에만 기존 정상 경과 로그를 남긴다.
+- polling이 `null`을 반환하거나 상태 API 자체가 실패하면 원래 force-cancel 오류를 전파한다.
+- 기존 `502/503/504` POST 재시도, 취소 직전 live PR head 재확인과 대상 식별 조건은 그대로 둔다.
+
+### `scripts/tests/test_cancel_stale_pr_runs_workflow.py`
+
+- polling delay가 유한한 네 번의 조회로 고정됐는지 확인한다.
+- 상태 조회가 sleep 뒤 반복되고 `completed`만 성공 반환하는 순서를 확인한다.
+- helper가 한도 뒤 `null`을 반환하며 호출부가 이를 원래 오류로 전파하는지 확인한다.
+- 완료 확인 뒤에만 정상 경과 로그가 나오는 기존 계약을 유지한다.
+
+### 문서
+
+- 단계별 완료 문서에는 실패 run, stale 대상 run, 로컬 검증 결과를 기록한다.
+- 최종 보고서에는 `devel` PR 검증과 별개로 `pull_request_target`이 `main` workflow를 사용한다는 배포
+  경계를 명시한다.
+
+## 검증 명령
+
+```bash
+python3 -m unittest \
+  scripts/tests/test_cancel_stale_pr_runs_workflow.py \
+  scripts/tests/test_workflow_contract_wiring.py
+
+python3 -m unittest \
+  scripts/tests/test_ci_impact_workflow.py \
+  scripts/tests/test_ci_impact_policy_workflow.py
+
+node --test \
+  scripts/tests/ci-impact-classifier.test.cjs \
+  scripts/tests/ci-impact-policy.test.cjs
+
+cargo fmt --all
+cargo fmt --all -- --check
+git diff --check
+```
+
+제품 소스·Rust·Studio·renderer·fixture를 바꾸지 않으므로 Cargo 전체 회귀, WASM build와 시각 검증은
+실행하지 않는다. 실제 권한·event 경계는 PR 최신 head의 Actions와 fork `synchronize` run에서 판정한다.

--- a/mydocs/report/task_m100_4608_report.md
+++ b/mydocs/report/task_m100_4608_report.md
@@ -1,0 +1,65 @@
+# Task M100 #4608 — stale run 취소 완료 상태 polling 최종 보고서
+
+- **Issue**: [#4608](https://github.com/edwardkim/rhwp/issues/4608)
+- **브랜치**: `codex/issue-4608-stale-cancel-poll`
+- **기준**: `upstream/devel@6b5c4f871972380c0866e2a8d27ac2bc67d257e6`
+- **재현 PR**: [#6116](https://github.com/edwardkim/rhwp/pull/6116)
+- **완료일**: 2026-08-26 KST
+
+## 결론
+
+#4609의 오류 직후 단일 상태 재조회는 GitHub가 force-cancel 결과를 약 1초 늦게 노출하는 경우를 흡수하지
+못했다. 오류 뒤 즉시·0.5초·1초·2초에 대상 run을 다시 읽는 bounded polling을 추가했다. 최대 3.5초
+window 안에서 실제 `completed`를 확인한 경우에만 정상 경과로 처리하고, 끝까지 active이거나 상태 API가
+실패하면 원래 force-cancel 오류를 유지한다.
+
+## 재현 사실
+
+| 항목 | 값 |
+| --- | --- |
+| 실패 cleanup | [run 32923641712](https://github.com/edwardkim/rhwp/actions/runs/32923641712) |
+| stale 대상 | [CI run 32923603626](https://github.com/edwardkim/rhwp/actions/runs/32923603626) |
+| stale SHA | `68873f71999e873d9dbdf348ad058ee0aab8a863` |
+| 최신 SHA | `6b0fa6ee9de406c9f9abf13ca8ab19bd277a1321` |
+| 오류 | `POST .../force-cancel` → HTTP 500 |
+| 실제 결과 | 오류 약 1초 뒤 `completed/cancelled` |
+
+동일 cleanup은 앞선 Render Diff·Adapter inter-diff·Proptest·CodeQL 네 run을 정상 취소했다. 최신 SHA의
+required Build & Test, Frontend package, CodeQL, Render Diff, Proptest와 Adapter inter-diff는 모두
+성공했으므로 제품 또는 PR #6116의 기능 실패가 아니라 cleanup 상태 반영 race다.
+
+## 구현
+
+- polling 간격을 `[0, 500, 1_000, 2_000]`ms로 고정해 무한 대기와 과도한 API 호출을 막았다.
+- 상태 조회와 polling helper를 분리하고 `completed`만 성공 반환한다.
+- 상태 조회 오류는 warning을 남기되 원래 force-cancel 오류를 전파한다.
+- 한도 뒤 `null`이면 원래 오류를 전파해 실제 취소 실패를 숨기지 않는다.
+- 기존 `502/503/504` POST 재시도, 최신 head 재확인, fork 저장소·branch 식별을 유지했다.
+- `pull_request_target`에서 PR source checkout·실행을 추가하지 않았다.
+
+## 검증
+
+```text
+focused workflow + wiring: 7 pass
+CI impact Python contracts: 42 pass
+CI impact Node contracts: 65 pass
+전체 Python workflow contracts: 178 pass
+actionlint cancel-stale-pr-runs.yml: pass
+git diff --check: pass
+```
+
+workflow·계약 테스트·문서만 변경했다. 제품 Rust·Studio·renderer·fixture가 없어 Cargo 전체 회귀, WASM과
+시각 검증은 범위 밖이다.
+
+## 남은 운영 게이트
+
+- 별도 승인 뒤 작업 branch를 push하고 `devel` 대상 PR을 생성한다.
+- 최신 PR head의 Full CI와 privileged workflow 경계를 확인한다.
+- 실제 fork `synchronize` event에서 stale run 완료 race가 정상 처리되는지 관찰한다.
+- `pull_request_target`은 기본 브랜치의 workflow를 사용하므로 수정이 정상 release로 `main`에 반영된 뒤
+  fork 경로의 배포 완료를 최종 확인한다.
+
+## 롤백
+
+polling helper와 호출부, 관련 계약 테스트만 되돌리면 #4609의 단일 재조회 동작으로 복귀한다. trigger,
+permission, required check와 저장소 설정은 바꾸지 않았다.

--- a/mydocs/working/task_m100_4608_stage1.md
+++ b/mydocs/working/task_m100_4608_stage1.md
@@ -1,0 +1,46 @@
+# Task M100 #4608 Stage 1 — stale run 완료 상태 bounded polling
+
+- **Issue**: [#4608](https://github.com/edwardkim/rhwp/issues/4608)
+- **기준**: `upstream/devel@6b5c4f871972380c0866e2a8d27ac2bc67d257e6`
+- **재현**: [PR #6116 cleanup run](https://github.com/edwardkim/rhwp/actions/runs/32923641712)
+
+## 변경
+
+- `force-cancel` 오류 뒤 `[0, 500, 1_000, 2_000]`ms 간격으로 최대 네 번 대상 run 상태를 확인한다.
+- `completed`가 확인된 경우에만 eventual-consistency race로 정상 처리한다.
+- 3.5초 window 뒤에도 active이면 원래 force-cancel 오류를 전파한다.
+- 상태 API 자체가 실패해도 원래 force-cancel 오류를 보존한다.
+- 기존 `502/503/504` POST 재시도와 live PR head·fork branch 식별 계약은 변경하지 않았다.
+
+## 테스트 우선 근거
+
+새 bounded polling 계약 테스트를 먼저 작성한 뒤 기존 workflow에서 실행했다. polling 상수와 helper가 없어
+2건이 실패했고, workflow 구현 뒤 같은 묶음 7건이 모두 통과했다.
+
+## 검증
+
+```text
+$ python3 -m unittest \
+    scripts/tests/test_cancel_stale_pr_runs_workflow.py \
+    scripts/tests/test_workflow_contract_wiring.py
+Ran 7 tests — OK
+
+$ python3 -m unittest \
+    scripts/tests/test_ci_impact_workflow.py \
+    scripts/tests/test_ci_impact_policy_workflow.py
+Ran 42 tests — OK
+
+$ node --test \
+    scripts/tests/ci-impact-classifier.test.cjs \
+    scripts/tests/ci-impact-policy.test.cjs
+65 pass, 0 fail
+
+$ git diff --check
+exit 0
+```
+
+## 안전 경계
+
+`pull_request_target`은 계속 PR source를 checkout하거나 실행하지 않고 GitHub API만 사용한다. trigger,
+permission, concurrency group, 최신 head 보호와 stale run 식별식은 그대로다. polling은 취소 오류가 발생한
+stale run의 읽기 전용 상태 조회에만 추가된다.

--- a/scripts/tests/test_cancel_stale_pr_runs_workflow.py
+++ b/scripts/tests/test_cancel_stale_pr_runs_workflow.py
@@ -15,21 +15,55 @@ class CancelStalePrRunsWorkflowTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.workflow = WORKFLOW.read_text(encoding="utf-8")
 
-    def test_force_cancel_error_rechecks_completed_target(self):
-        """500 등 응답 코드가 아니라 대상 run의 실제 완료 상태로 race를 판정한다."""
+    def test_force_cancel_error_polls_bounded_window_for_completed_target(self):
+        """오류 직후 상태 반영이 늦어도 유한 polling 안의 완료만 정상 처리한다."""
         body = self.workflow
         self.assertNotIn("if (error.status !== 409) throw error;", body)
 
-        catch_start = body.index("} catch (error) {")
-        reread = body.index("github.rest.actions.getWorkflowRun", catch_start)
-        active_failure = body.index(
-            "if (currentRun.status !== 'completed') throw error;", reread
+        delays = body.index(
+            "const completionPollDelaysMs = [0, 500, 1_000, 2_000];"
         )
+        status_helper = body.index("async function getWorkflowRun(runId)", delays)
+        poll_helper = body.index("async function waitForCompletedRun(runId)", status_helper)
+        poll_loop = body.index("for (const delay of completionPollDelaysMs)", poll_helper)
+        poll_sleep = body.index("await sleep(delay);", poll_loop)
+        reread = body.index("await getWorkflowRun(runId)", poll_sleep)
+        completed_return = body.index(
+            "if (currentRun.status === 'completed') return currentRun;", reread
+        )
+        exhausted = body.index("return null;", completed_return)
+
+        cancel_call = body.index("await forceCancelWithRetry(run.id);")
+        catch_start = body.index("} catch (error) {", cancel_call)
+        poll_call = body.index("await waitForCompletedRun(run.id)", catch_start)
+        active_failure = body.index("if (!completedRun) throw error;", poll_call)
         completed_notice = body.index("already completed after force-cancel error", active_failure)
 
-        self.assertLess(catch_start, reread)
-        self.assertLess(reread, active_failure)
+        self.assertLess(delays, status_helper)
+        self.assertLess(status_helper, poll_helper)
+        self.assertLess(poll_loop, poll_sleep)
+        self.assertLess(poll_sleep, reread)
+        self.assertLess(reread, completed_return)
+        self.assertLess(completed_return, exhausted)
+        self.assertLess(catch_start, poll_call)
+        self.assertLess(poll_call, active_failure)
         self.assertLess(active_failure, completed_notice)
+
+    def test_status_poll_error_preserves_force_cancel_failure(self):
+        """상태 API 자체가 실패하면 취소 실패를 성공으로 바꾸지 않는다."""
+        body = self.workflow
+        cancel_call = body.index("await forceCancelWithRetry(run.id);")
+        cancel_catch = body.index("} catch (error) {", cancel_call)
+        poll_call = body.index("await waitForCompletedRun(run.id)", cancel_catch)
+        poll_catch = body.index("} catch (statusError) {", poll_call)
+        warning = body.index("Failed to poll stale run", poll_catch)
+        original_error = body.index("throw error;", warning)
+        active_failure = body.index("if (!completedRun) throw error;", original_error)
+
+        self.assertLess(poll_call, poll_catch)
+        self.assertLess(poll_catch, warning)
+        self.assertLess(warning, original_error)
+        self.assertLess(original_error, active_failure)
 
     def test_force_cancel_retries_transient_github_api_errors(self):
         """일시적인 GitHub API 장애는 제한된 backoff 뒤에만 재시도한다."""


### PR DESCRIPTION
## 변경 요약

- stale workflow `force-cancel` 오류 뒤 대상 run의 완료 상태를 즉시·0.5초·1초·2초에 제한적으로 재확인합니다.
- 최대 3.5초 안에서 실제 `completed`를 확인한 경우에만 GitHub eventual-consistency race로 정상 처리합니다.
- polling 뒤에도 대상이 active이거나 상태 API가 실패하면 원래 force-cancel 오류를 그대로 전파합니다.
- 기존 502/503/504 POST 재시도, 최신 PR head 보호, fork repository·branch 식별과 `pull_request_target`의 비신뢰 PR source 비실행 경계를 유지합니다.
- #6116에서 관찰된 1초 지연 완료 회귀를 계약 테스트와 작업 보고서로 고정합니다.

## 관련 이슈

closes #4608

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] 새 integration test 추가 없음
- [x] `src/**`의 `#[cfg(test)]` 변경 없음
- [x] 제품 Rust 코드 변경 없음 — cargo test 비대상
- [x] 제품 Rust 코드 변경 없음 — clippy 비대상
- [x] renderer/sample 변경 없음 — SVG·WASM·시각 검증 비대상
- [x] `python3 -m unittest scripts/tests/test_cancel_stale_pr_runs_workflow.py scripts/tests/test_workflow_contract_wiring.py` — 7 pass
- [x] CI impact Python contracts — 42 pass
- [x] CI impact Node contracts — 65 pass
- [x] `python3 -m unittest discover -s scripts/tests -p 'test_*workflow*.py'` — 178 pass
- [x] `actionlint .github/workflows/cancel-stale-pr-runs.yml`
- [x] `git diff --check`
- [x] 작업 증빙: [#4608 최종 보고서](mydocs/report/task_m100_4608_report.md)
- [x] agent capability 파일 변경 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 정상 취소 성공 경로에는 영향이 없습니다. force-cancel 오류 경로에서만 최대 네 번의 읽기 API와 3.5초의 bounded wait가 추가됩니다.
- 재현·측정: #6116에서는 오류 약 1초 뒤 대상 run이 `completed/cancelled`가 됐습니다. 새 window는 이 사례를 포함하면서 무한 대기와 실제 active 취소 실패 은폐를 막습니다.

## 스크린샷

UI 변경이 아닙니다. 재현 run과 stale 대상 run, 권한·event 경계는 [최종 보고서](mydocs/report/task_m100_4608_report.md)에 기록했습니다.

## 운영 주의

fork PR의 `pull_request_target`은 기본 브랜치 `main`의 workflow를 사용합니다. 이 PR의 `devel` 검증 이후 정상 release로 `main`에 반영돼야 fork cleanup 경로에 실제 배포됩니다.
