### PR TITLE
fix(ci): 기준선 병합 뒤 문서 tail fast-pass 재사용

### DIFF
--- a/.github/workflows/adapter-diff.yml
+++ b/.github/workflows/adapter-diff.yml
@@ -30,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     outputs:
-      adapter_required: ${{ steps.classify.outputs.adapter_required || 'true' }}
-      reason: ${{ steps.classify.outputs.reason || 'preflight-unavailable' }}
+      adapter_required: ${{ steps.finalize.outputs.adapter_required || 'true' }}
+      reason: ${{ steps.finalize.outputs.reason || 'preflight-unavailable' }}
     steps:
       # 문서 전용 PR 또는 검증된 코드 후보 뒤의 review-only tail에서는 stable check
       # 이름을 유지하고 worker만 skip한다. API·계보·후보 run 판정은 fail-closed다.
@@ -45,6 +45,18 @@ jobs:
               core.setOutput('adapter_required', required ? 'true' : 'false');
               core.setOutput('reason', reason);
               core.info(`adapter_required=${required} reason=${reason}`);
+            }
+
+            function setPendingBaseMergeResult(reason, candidateSha, mergeSha, sourceParentSha) {
+              core.setOutput('adapter_required', 'pending-base-merge-tree');
+              core.setOutput('reason', reason);
+              core.setOutput('candidate_sha', candidateSha);
+              core.setOutput('base_merge_sha', mergeSha);
+              core.setOutput('source_parent_sha', sourceParentSha);
+              core.info(
+                `adapter_required=pending-base-merge-tree reason=${reason} candidate_sha=${candidateSha} `
+                + `base_merge_sha=${mergeSha} source_parent_sha=${sourceParentSha}`,
+              );
             }
 
             const pr = context.payload.pull_request;
@@ -80,6 +92,20 @@ jobs:
               );
             }
 
+            function isCurrentBaseUpdateMerge(commit, baseSha) {
+              const parents = commit.parents || [];
+              return parents.length === 2
+                && parents.filter((parent) => parent.sha === baseSha).length === 1;
+            }
+
+            function isAdapterExecutionPath(filename) {
+              return filename === '.github/workflows/adapter-diff.yml'
+                || filename === 'scripts/run-adapter-diff.mjs'
+                || filename === 'scripts/tests/run-adapter-diff.test.mjs'
+                || filename === 'scripts/rust-test-suite-manifest.mjs'
+                || filename.startsWith('tools/adapter_diff/');
+            }
+
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -88,6 +114,13 @@ jobs:
             });
             if (files.length > 0 && files.every((file) => isAllowedReviewPath(file))) {
               setResult(false, 'skip-review-only-pr');
+              return;
+            }
+            if (files.some((file) => (
+              isAdapterExecutionPath(file.filename)
+              || isAdapterExecutionPath(file.previous_filename || '')
+            ))) {
+              setResult(true, 'adapter-execution-surface-change');
               return;
             }
 
@@ -100,8 +133,32 @@ jobs:
             const reviewOnlyCandidates = [];
             let codeCandidateSha = '';
             let newerTailCommit = null;
+            let baseMergeBridge = null;
             for (let index = commits.length - 1; index >= 0; index -= 1) {
               const commit = commits[index];
+              const parents = commit.parents || [];
+              if (isCurrentBaseUpdateMerge(commit, pr.base.sha)) {
+                if (newerTailCommit && newerTailCommit.parents[0].sha !== commit.sha) {
+                  setResult(true, 'full-code-or-non-mydocs-change');
+                  return;
+                }
+                if (baseMergeBridge) {
+                  setResult(true, `multiple-current-base-update-merges:${commit.sha}`);
+                  return;
+                }
+                const sourceParent = parents.find((parent) => parent.sha !== pr.base.sha);
+                if (!sourceParent) {
+                  setResult(true, 'current-base-source-parent-unavailable');
+                  return;
+                }
+                baseMergeBridge = {
+                  mergeSha: commit.sha,
+                  sourceParentSha: sourceParent.sha,
+                };
+                newerTailCommit = { parents: [{ sha: sourceParent.sha }] };
+                core.info(`including current-base update merge bridge ${commit.sha}`);
+                continue;
+              }
               const detail = await github.rest.repos.getCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -116,7 +173,6 @@ jobs:
                 codeCandidateSha = commit.sha;
                 break;
               }
-              const parents = commit.parents || [];
               if (parents.length !== 1
                 || (newerTailCommit && newerTailCommit.parents[0].sha !== commit.sha)) {
                 setResult(true, 'full-code-or-non-mydocs-change');
@@ -129,12 +185,17 @@ jobs:
               }
               newerTailCommit = commit;
             }
-            if (reviewOnlyCandidates.length === 0 || !codeCandidateSha
-              || newerTailCommit.parents[0].sha !== codeCandidateSha) {
+            if (reviewOnlyCandidates.length === 0 && !codeCandidateSha) {
               setResult(true, 'full-code-or-non-mydocs-change');
               return;
             }
-            reviewOnlyCandidates.push(codeCandidateSha);
+            if (codeCandidateSha) {
+              if (!newerTailCommit || newerTailCommit.parents[0].sha !== codeCandidateSha) {
+                setResult(true, 'full-code-or-non-mydocs-change');
+                return;
+              }
+              reviewOnlyCandidates.push(codeCandidateSha);
+            }
 
             const candidateRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
               owner: context.repo.owner,
@@ -165,11 +226,111 @@ jobs:
                 setResult(true, 'review-tail-candidate-run-unavailable');
                 return;
               }
+              if (baseMergeBridge) {
+                setPendingBaseMergeResult(
+                  `adapter-run-green:${latestCandidateRun.conclusion}`,
+                  candidateSha,
+                  baseMergeBridge.mergeSha,
+                  baseMergeBridge.sourceParentSha,
+                );
+                return;
+              }
               setResult(false, `skip-trusted-mydocs-tail:${candidateSha}`);
               return;
             }
 
             setResult(true, 'review-tail-candidate-run-unavailable');
+
+      # 기준선 병합을 fast-pass bridge로 쓸 때는 untrusted source를 실행하지 않는다.
+      # 자동 3-way merge tree가 같거나, 충돌 해소가 mydocs로 한정될 때만 재사용한다.
+      - name: Check out current-base merge tree inputs
+        id: checkout-base-merge-tree
+        if: ${{ steps.classify.outputs.adapter_required == 'pending-base-merge-tree' }}
+        continue-on-error: true
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          fetch-depth: 0
+          lfs: false
+          persist-credentials: false
+
+      - name: Verify current-base merge tree
+        id: verify-base-merge-tree
+        if: ${{ always() && steps.classify.outputs.adapter_required == 'pending-base-merge-tree' }}
+        shell: bash
+        env:
+          BASE_MERGE_SHA: ${{ steps.classify.outputs.base_merge_sha }}
+          SOURCE_PARENT_SHA: ${{ steps.classify.outputs.source_parent_sha }}
+          CURRENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          fail() {
+            printf 'verified=false\nreason=%s\n' "$1" >> "$GITHUB_OUTPUT"
+          }
+
+          if ! git cat-file -e "${BASE_MERGE_SHA}^{commit}" \
+            || ! git cat-file -e "${SOURCE_PARENT_SHA}^{commit}" \
+            || ! git cat-file -e "${CURRENT_BASE_SHA}^{commit}"; then
+            fail 'current-base-merge-input-unavailable'
+            exit 0
+          fi
+
+          if ! expected_tree="$(git merge-tree --write-tree "${SOURCE_PARENT_SHA}" "${CURRENT_BASE_SHA}" 2>/dev/null)"; then
+            resolution_check="$(mktemp)"
+            trap 'rm -f "${resolution_check}"' EXIT
+            if ! git show "${CURRENT_BASE_SHA}:scripts/verify_review_only_merge_resolution.py" \
+              > "${resolution_check}"; then
+              fail 'current-base-merge-resolution-check-unavailable'
+            elif resolution_reason="$(python3 "${resolution_check}" \
+              --repository . --base-sha "${CURRENT_BASE_SHA}" "${BASE_MERGE_SHA}")"; then
+              printf 'verified=true\nreason=%s\n' "${resolution_reason}" >> "$GITHUB_OUTPUT"
+            else
+              fail 'current-base-merge-resolution-not-mydocs'
+            fi
+            exit 0
+          fi
+          expected_tree="${expected_tree%%$'\n'*}"
+          actual_tree="$(git show -s --format=%T "${BASE_MERGE_SHA}")"
+          if [[ "${expected_tree}" != "${actual_tree}" ]]; then
+            fail 'current-base-merge-tree-mismatch'
+            exit 0
+          fi
+
+          printf 'verified=true\nreason=current-base-merge-tree-match\n' >> "$GITHUB_OUTPUT"
+
+      - name: Finalize adapter impact
+        id: finalize
+        if: ${{ always() }}
+        shell: bash
+        env:
+          DETECTED_REQUIRED: ${{ steps.classify.outputs.adapter_required || 'true' }}
+          DETECTED_REASON: ${{ steps.classify.outputs.reason || 'preflight-unavailable' }}
+          MERGE_TREE_VERIFIED: ${{ steps.verify-base-merge-tree.outputs.verified || 'false' }}
+          MERGE_TREE_REASON: ${{ steps.verify-base-merge-tree.outputs.reason || 'not-required' }}
+        run: |
+          set -euo pipefail
+          adapter_required='true'
+          reason="${DETECTED_REASON}"
+          case "${DETECTED_REQUIRED}" in
+            false)
+              adapter_required='false'
+              ;;
+            pending-base-merge-tree)
+              if [[ "${MERGE_TREE_VERIFIED}" == 'true' ]]; then
+                adapter_required='false'
+                if [[ "${MERGE_TREE_REASON}" == 'current-base-merge-resolution-mydocs-only' ]]; then
+                  reason='current-base-update-merge-resolution-mydocs-only-green'
+                else
+                  reason='current-base-update-merge-tree-green'
+                fi
+              else
+                reason="${MERGE_TREE_REASON}"
+              fi
+              ;;
+          esac
+          printf 'adapter_required=%s\nreason=%s\n' \
+            "${adapter_required}" "${reason}" >> "$GITHUB_OUTPUT"
 
   adapter-diff:
     name: adapter inter-diff

--- a/.github/workflows/proptest-roundtrip.yml
+++ b/.github/workflows/proptest-roundtrip.yml
@@ -50,6 +50,18 @@ jobs:
               core.info(`fast_pass=${fastPass} reason=${reason}`);
             }
 
+            function setPendingBaseMergeResult(reason, candidateSha, mergeSha, sourceParentSha) {
+              core.setOutput('fast_pass', 'pending-base-merge-tree');
+              core.setOutput('reason', reason);
+              core.setOutput('candidate_sha', candidateSha);
+              core.setOutput('base_merge_sha', mergeSha);
+              core.setOutput('source_parent_sha', sourceParentSha);
+              core.info(
+                `fast_pass=pending-base-merge-tree reason=${reason} candidate_sha=${candidateSha} `
+                + `base_merge_sha=${mergeSha} source_parent_sha=${sourceParentSha}`,
+              );
+            }
+
             if (context.eventName !== 'pull_request') {
               setResult(false, `non-pull-request:${context.eventName}`);
               return;
@@ -87,6 +99,20 @@ jobs:
               );
             }
 
+            function isCurrentBaseUpdateMerge(commit, baseSha) {
+              const parents = commit.parents || [];
+              return parents.length === 2
+                && parents.filter((parent) => parent.sha === baseSha).length === 1;
+            }
+
+            function isProptestExecutionPath(filename) {
+              return filename === '.github/workflows/proptest-roundtrip.yml'
+                || filename === 'scripts/run-prop-roundtrip.mjs'
+                || filename === 'scripts/tests/run-prop-roundtrip.test.mjs'
+                || filename === 'scripts/rust-test-suite-manifest.mjs'
+                || filename.startsWith('tools/proptest_roundtrip/');
+            }
+
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -95,6 +121,13 @@ jobs:
             });
             if (files.length > 0 && files.every((file) => isAllowedReviewPath(file))) {
               setResult(true, 'review-only-devel-pr');
+              return;
+            }
+            if (files.some((file) => (
+              isProptestExecutionPath(file.filename)
+              || isProptestExecutionPath(file.previous_filename || '')
+            ))) {
+              setResult(false, 'proptest-execution-surface-change');
               return;
             }
 
@@ -107,8 +140,32 @@ jobs:
             const reviewOnlyCandidates = [];
             let codeCandidateSha = '';
             let newerTailCommit = null;
+            let baseMergeBridge = null;
             for (let index = commits.length - 1; index >= 0; index -= 1) {
               const commit = commits[index];
+              const parents = commit.parents || [];
+              if (isCurrentBaseUpdateMerge(commit, pr.base.sha)) {
+                if (newerTailCommit && newerTailCommit.parents[0].sha !== commit.sha) {
+                  setResult(false, 'code-or-non-mydocs-change');
+                  return;
+                }
+                if (baseMergeBridge) {
+                  setResult(false, `multiple-current-base-update-merges:${commit.sha}`);
+                  return;
+                }
+                const sourceParent = parents.find((parent) => parent.sha !== pr.base.sha);
+                if (!sourceParent) {
+                  setResult(false, 'current-base-source-parent-unavailable');
+                  return;
+                }
+                baseMergeBridge = {
+                  mergeSha: commit.sha,
+                  sourceParentSha: sourceParent.sha,
+                };
+                newerTailCommit = { parents: [{ sha: sourceParent.sha }] };
+                core.info(`including current-base update merge bridge ${commit.sha}`);
+                continue;
+              }
               const detail = await github.rest.repos.getCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -123,7 +180,6 @@ jobs:
                 codeCandidateSha = commit.sha;
                 break;
               }
-              const parents = commit.parents || [];
               if (parents.length !== 1
                 || (newerTailCommit && newerTailCommit.parents[0].sha !== commit.sha)) {
                 setResult(false, 'code-or-non-mydocs-change');
@@ -136,12 +192,17 @@ jobs:
               }
               newerTailCommit = commit;
             }
-            if (reviewOnlyCandidates.length === 0 || !codeCandidateSha
-              || newerTailCommit.parents[0].sha !== codeCandidateSha) {
+            if (reviewOnlyCandidates.length === 0 && !codeCandidateSha) {
               setResult(false, 'code-or-non-mydocs-change');
               return;
             }
-            reviewOnlyCandidates.push(codeCandidateSha);
+            if (codeCandidateSha) {
+              if (!newerTailCommit || newerTailCommit.parents[0].sha !== codeCandidateSha) {
+                setResult(false, 'code-or-non-mydocs-change');
+                return;
+              }
+              reviewOnlyCandidates.push(codeCandidateSha);
+            }
 
             const candidateRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
               owner: context.repo.owner,
@@ -172,28 +233,109 @@ jobs:
                 setResult(false, 'review-tail-candidate-run-unavailable');
                 return;
               }
+              if (baseMergeBridge) {
+                setPendingBaseMergeResult(
+                  `proptest-run-green:${latestCandidateRun.conclusion}`,
+                  candidateSha,
+                  baseMergeBridge.mergeSha,
+                  baseMergeBridge.sourceParentSha,
+                );
+                return;
+              }
               setResult(true, `trusted-mydocs-tail:${candidateSha}`);
               return;
             }
 
             setResult(false, 'review-tail-candidate-run-unavailable');
 
+      # 기준선 병합을 fast-pass bridge로 쓸 때는 untrusted source를 실행하지 않는다.
+      # 자동 3-way merge tree가 같거나, 충돌 해소가 mydocs로 한정될 때만 재사용한다.
+      - name: Check out current-base merge tree inputs
+        id: checkout-base-merge-tree
+        if: ${{ steps.detect.outputs.fast_pass == 'pending-base-merge-tree' }}
+        continue-on-error: true
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          fetch-depth: 0
+          lfs: false
+          persist-credentials: false
+
+      - name: Verify current-base merge tree
+        id: verify-base-merge-tree
+        if: ${{ always() && steps.detect.outputs.fast_pass == 'pending-base-merge-tree' }}
+        shell: bash
+        env:
+          BASE_MERGE_SHA: ${{ steps.detect.outputs.base_merge_sha }}
+          SOURCE_PARENT_SHA: ${{ steps.detect.outputs.source_parent_sha }}
+          CURRENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          fail() {
+            printf 'verified=false\nreason=%s\n' "$1" >> "$GITHUB_OUTPUT"
+          }
+
+          if ! git cat-file -e "${BASE_MERGE_SHA}^{commit}" \
+            || ! git cat-file -e "${SOURCE_PARENT_SHA}^{commit}" \
+            || ! git cat-file -e "${CURRENT_BASE_SHA}^{commit}"; then
+            fail 'current-base-merge-input-unavailable'
+            exit 0
+          fi
+
+          if ! expected_tree="$(git merge-tree --write-tree "${SOURCE_PARENT_SHA}" "${CURRENT_BASE_SHA}" 2>/dev/null)"; then
+            resolution_check="$(mktemp)"
+            trap 'rm -f "${resolution_check}"' EXIT
+            if ! git show "${CURRENT_BASE_SHA}:scripts/verify_review_only_merge_resolution.py" \
+              > "${resolution_check}"; then
+              fail 'current-base-merge-resolution-check-unavailable'
+            elif resolution_reason="$(python3 "${resolution_check}" \
+              --repository . --base-sha "${CURRENT_BASE_SHA}" "${BASE_MERGE_SHA}")"; then
+              printf 'verified=true\nreason=%s\n' "${resolution_reason}" >> "$GITHUB_OUTPUT"
+            else
+              fail 'current-base-merge-resolution-not-mydocs'
+            fi
+            exit 0
+          fi
+          expected_tree="${expected_tree%%$'\n'*}"
+          actual_tree="$(git show -s --format=%T "${BASE_MERGE_SHA}")"
+          if [[ "${expected_tree}" != "${actual_tree}" ]]; then
+            fail 'current-base-merge-tree-mismatch'
+            exit 0
+          fi
+
+          printf 'verified=true\nreason=current-base-merge-tree-match\n' >> "$GITHUB_OUTPUT"
+
       - name: Finalize fast pass
         id: finalize
         if: ${{ always() }}
+        shell: bash
         env:
           DETECTED_FAST_PASS: ${{ steps.detect.outputs.fast_pass || 'false' }}
           DETECTED_REASON: ${{ steps.detect.outputs.reason || 'preflight-unavailable' }}
+          MERGE_TREE_VERIFIED: ${{ steps.verify-base-merge-tree.outputs.verified || 'false' }}
+          MERGE_TREE_REASON: ${{ steps.verify-base-merge-tree.outputs.reason || 'not-required' }}
         run: |
           set -euo pipefail
           fast_pass='false'
-          reason='preflight-unavailable'
-          if [[ "${DETECTED_FAST_PASS}" == 'true' ]]; then
-            fast_pass='true'
-            reason="${DETECTED_REASON}"
-          elif [[ "${DETECTED_REASON}" != 'preflight-unavailable' ]]; then
-            reason="${DETECTED_REASON}"
-          fi
+          reason="${DETECTED_REASON}"
+          case "${DETECTED_FAST_PASS}" in
+            true)
+              fast_pass='true'
+              ;;
+            pending-base-merge-tree)
+              if [[ "${MERGE_TREE_VERIFIED}" == 'true' ]]; then
+                fast_pass='true'
+                if [[ "${MERGE_TREE_REASON}" == 'current-base-merge-resolution-mydocs-only' ]]; then
+                  reason='current-base-update-merge-resolution-mydocs-only-green'
+                else
+                  reason='current-base-update-merge-tree-green'
+                fi
+              else
+                reason="${MERGE_TREE_REASON}"
+              fi
+              ;;
+          esac
           printf 'fast_pass=%s\nreason=%s\n' "${fast_pass}" "${reason}" >> "$GITHUB_OUTPUT"
 
   proptest-roundtrip:

--- a/mydocs/working/task_m100_6197_stage1_review_tail_base_merge_bridge.md
+++ b/mydocs/working/task_m100_6197_stage1_review_tail_base_merge_bridge.md
@@ -1,0 +1,52 @@
+---
+kind: working
+status: active
+issue: 6197
+stage: 1
+---
+
+# #6197 Stage 1 - 보조 CI의 기준선 병합 문서 tail 재사용
+
+## 문제
+
+PR #6188은 이미 성공한 코드 후보 뒤에 문서 기록을 추가하고 최신 `devel`을 병합했다. CI 본체는
+source parent의 녹색 `Build & Test`와 현재 기준선 병합 tree를 확인해 fast-pass했지만,
+`adapter-diff.yml`과 `proptest-roundtrip.yml`은 병합 commit을 코드 변경으로 분류해 worker를 다시 실행했다.
+
+## 변경
+
+- 두 workflow가 현재 PR base를 부모로 갖는 2-parent merge를 한 개의 기준선 bridge로만 인식한다.
+- source 계보의 기존 성공 workflow run을 재사용 후보로 확인하면 preflight는 즉시 skip하지 않고
+  `pending-base-merge-tree` 상태를 낸다.
+- checkout 뒤 `git merge-tree --write-tree`가 일치하거나, 충돌 해소가
+  `scripts/verify_review_only_merge_resolution.py`로 `mydocs/` 한정임을 검증한 경우에만 worker를 skip한다.
+- workflow와 runner, suite prepare, adapter/proptest harness 변경은 execution surface로 분류해
+  fast-pass를 허용하지 않는다.
+- 모의 preflight 회귀 테스트는 #6188과 같은 source candidate + current-base merge 계보가
+  `pending-base-merge-tree`가 되는지 고정한다.
+
+## 로컬 검증
+
+2026-08-27에 아래 명령을 순차 실행했다.
+
+```bash
+node scripts/rust-test-suite-manifest.mjs --prepare
+cargo fmt --all
+cargo fmt --all -- --check
+python3 -m unittest \
+  scripts/tests/test_adapter_diff_workflow.py \
+  scripts/tests/test_proptest_roundtrip_workflow.py \
+  scripts/tests/test_review_only_fast_pass_workflows.py
+git diff --check
+```
+
+- 결과: Python workflow 계약 테스트 38건 통과.
+- `cargo fmt --all -- --check` 및 `git diff --check` 통과.
+- 제품 Rust, WASM, Studio 회귀는 workflow 정책 변경의 직접 검증 범위가 아니므로 실행하지 않았다.
+
+## 후속 확인
+
+PR의 최신 head GitHub Actions에서 `adapter inter-diff`와 `prop roundtrip`이
+`current-base-update-merge-tree-green` 또는 `current-base-update-merge-resolution-mydocs-only-green`으로
+skip되는지 확인한다. 계보, 후보 run, merge tree, 실행 경로 중 하나라도 검증하지 못하면 full worker가
+실행되어야 한다.

--- a/scripts/tests/test_adapter_diff_workflow.py
+++ b/scripts/tests/test_adapter_diff_workflow.py
@@ -63,7 +63,7 @@ class AdapterDiffWorkflowTests(unittest.TestCase):
 
     def test_review_only_preflight_script_parses(self) -> None:
         script = self.wf.split("script: |\n", maxsplit=1)[1].split(
-            "\n\n  adapter-diff:", maxsplit=1
+            "\n\n      # 기준선 병합을 fast-pass bridge로", maxsplit=1
         )[0]
         script = "\n".join(
             line.removeprefix("            ") for line in script.splitlines()

--- a/scripts/tests/test_proptest_roundtrip_workflow.py
+++ b/scripts/tests/test_proptest_roundtrip_workflow.py
@@ -57,7 +57,7 @@ class ProptestRoundtripWorkflowTests(unittest.TestCase):
 
     def test_review_only_preflight_script_parses(self) -> None:
         script = self.wf.split("script: |\n", maxsplit=1)[1].split(
-            "\n\n      - name: Finalize fast pass", maxsplit=1
+            "\n\n      # 기준선 병합을 fast-pass bridge로", maxsplit=1
         )[0]
         script = "\n".join(
             line.removeprefix("            ") for line in script.splitlines()

--- a/scripts/tests/test_review_only_fast_pass_workflows.py
+++ b/scripts/tests/test_review_only_fast_pass_workflows.py
@@ -18,14 +18,14 @@ WORKFLOWS = {
 WORKER_PREFLIGHTS = {
     "proptest": (
         ROOT / ".github/workflows/proptest-roundtrip.yml",
-        "\n\n      - name: Finalize fast pass",
+        "\n\n      # 기준선 병합을 fast-pass bridge로",
         "fast_pass",
         "true",
         "false",
     ),
     "adapter": (
         ROOT / ".github/workflows/adapter-diff.yml",
-        "\n\n  adapter-diff:",
+        "\n\n      # 기준선 병합을 fast-pass bridge로",
         "adapter_required",
         "false",
         "true",
@@ -238,6 +238,59 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
                 )
                 self.assertEqual(output[output_name], skip_value)
 
+    def test_worker_preflights_require_a_verified_base_merge_bridge(self) -> None:
+        base_sha = "b" * 40
+        code_candidate = "c" * 40
+        merge_sha = "m" * 40
+        files = [
+            {"filename": "src/renderer/layout.rs", "status": "modified"},
+            {"filename": "mydocs/orders/20260827.md", "status": "modified"},
+        ]
+        commits = [
+            {
+                "sha": code_candidate,
+                "parents": [{"sha": "d" * 40}],
+                "files": [{"filename": "src/renderer/layout.rs", "status": "modified"}],
+            },
+            {
+                "sha": merge_sha,
+                "parents": [{"sha": code_candidate}, {"sha": base_sha}],
+                "files": files,
+            },
+        ]
+        runs = [
+            {
+                "event": "pull_request",
+                "head_sha": code_candidate,
+                "head_branch": "fix/bughunt-batch-r3",
+                "head_repository": {"id": 7},
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": "2026-08-20T12:00:00Z",
+            }
+        ]
+        for name, (_, _, output_name, _, _) in WORKER_PREFLIGHTS.items():
+            with self.subTest(workflow=name):
+                output = self._run_worker_preflight(
+                    name, files=files, commits=commits, runs=runs, base_sha=base_sha
+                )
+                self.assertEqual(output[output_name], "pending-base-merge-tree")
+                self.assertEqual(output["base_merge_sha"], merge_sha)
+                self.assertEqual(output["source_parent_sha"], code_candidate)
+
+    def test_worker_base_merge_fast_passes_fail_closed_for_execution_changes(self) -> None:
+        for name, (workflow_path, _, _, _, _) in WORKER_PREFLIGHTS.items():
+            with self.subTest(workflow=name):
+                workflow = workflow_path.read_text(encoding="utf-8")
+                self.assertIn("isCurrentBaseUpdateMerge", workflow)
+                self.assertIn("pending-base-merge-tree", workflow)
+                self.assertIn("multiple-current-base-update-merges", workflow)
+                self.assertIn("git merge-tree --write-tree", workflow)
+                self.assertIn("verify_review_only_merge_resolution.py", workflow)
+                self.assertIn("current-base-merge-resolution-not-mydocs", workflow)
+                self.assertIn("persist-credentials: false", workflow)
+                self.assertIn("ExecutionPath(file.filename)", workflow)
+
     def test_worker_preflights_reuse_a_green_review_only_candidate_head(
         self,
     ) -> None:
@@ -415,6 +468,7 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
         files: list[dict[str, object]],
         commits: list[dict[str, object]] | None = None,
         runs: list[dict[str, object]] | None = None,
+        base_sha: str = "b" * 40,
     ) -> dict[str, str]:
         workflow_path, end_marker, _, _, _ = WORKER_PREFLIGHTS[name]
         workflow = workflow_path.read_text(encoding="utf-8")
@@ -439,7 +493,7 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
               rest: {
                 pulls: { listFiles, listCommits },
                 repos: {
-                  getCommit: async ({ ref }) => ({ data: { files: commits.get(ref).files } }),
+                  getCommit: async ({ ref }) => ({ data: commits.get(ref) }),
                 },
                 actions: { listWorkflowRuns },
               },
@@ -457,7 +511,7 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
                 pull_request: {
                   number: 5772,
                   created_at: '2026-08-20T00:00:00Z',
-                  base: { ref: 'devel' },
+                  base: { ref: 'devel', sha: %(base_sha)s },
                   head: { ref: 'fix/bughunt-batch-r3', repo: { id: 7 } },
                 },
               },
@@ -473,7 +527,11 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
               (error) => { process.stderr.write(String(error.stack || error)); process.exitCode = 1; },
             );
             """
-        ) % {"fixture": json.dumps(fixture), "script": textwrap.indent(script, "  ")}
+        ) % {
+            "fixture": json.dumps(fixture),
+            "script": textwrap.indent(script, "  "),
+            "base_sha": json.dumps(base_sha),
+        }
         completed = subprocess.run(
             ["node"],
             input=harness,


### PR DESCRIPTION
## 변경 요약

- `adapter-diff`와 `proptest-roundtrip`이 검증된 source candidate 뒤의 현재 `devel` 병합 bridge를 인식합니다.
- merge tree가 같거나 충돌 해소가 `mydocs/`에 한정됨을 확인한 뒤에만 worker를 skip합니다.
- worker 실행 경로 변경, 후보 run 부재·실패, 계보 불일치는 full validation으로 fail-closed 처리합니다.

## 관련 이슈

closes #6197

## 테스트

- [x] `node scripts/rust-test-suite-manifest.mjs --prepare`
- [x] `cargo fmt --all -- --check`
- [x] `python3 -m unittest scripts/tests/test_adapter_diff_workflow.py scripts/tests/test_proptest_roundtrip_workflow.py scripts/tests/test_review_only_fast_pass_workflows.py`
- [x] `git diff --check`
- [ ] 제품 Rust/WASM 회귀: workflow 정책 변경의 직접 검증 범위가 아니므로 실행하지 않음

## CI 관찰

PR 최신 head에서 `adapter inter-diff`와 `prop roundtrip`이 검증된 current-base merge tree에 대해 skip되고, 검증 불가 경로에서는 기존처럼 worker가 실행되는지 확인합니다.
