### PR TITLE
perf(ci): #6205 B/C integration target 시간 기반 배정

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,3 +6,13 @@ nextest-version = { required = "0.9.91", recommended = "0.9.140" }
 [[profile.default.overrides]]
 filter = "test(/(^|::)overflow_cell_baseline::/)"
 priority = 100
+
+# B/C archive workers use this profile only to emit a compact JUnit report. The
+# report is uploaded only from successful devel runs and becomes a reviewed input
+# for the next duration-policy update PR.
+[profile.ci-duration-observation.junit]
+path = "target/nextest/ci-duration-observation/junit.xml"
+report-name = "rhwp-nextest-duration-observation"
+store-success-output = false
+store-failure-output = true
+report-skipped = "none"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,7 +11,7 @@ priority = 100
 # report is uploaded only from successful devel runs and becomes a reviewed input
 # for the next duration-policy update PR.
 [profile.ci-duration-observation.junit]
-path = "target/nextest/ci-duration-observation/junit.xml"
+path = "junit.xml"
 report-name = "rhwp-nextest-duration-observation"
 store-success-output = false
 store-failure-output = true

--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -149,38 +149,12 @@ jobs:
               cargo_target_args+=(--lib)
               ;;
             integration-b|integration-c)
-              mapfile -t integration_targets < <(
-                cargo metadata --no-deps --format-version 1 | node -e '
-                  let source = "";
-                  process.stdin.setEncoding("utf8");
-                  process.stdin.on("data", (chunk) => { source += chunk; });
-                  process.stdin.on("end", () => {
-                    const metadata = JSON.parse(source);
-                    const manifestPath = `${process.cwd()}/Cargo.toml`;
-                    const root = metadata.packages.find((pkg) => pkg.manifest_path === manifestPath);
-                    if (!root) {
-                      throw new Error(`root package not found for ${manifestPath}`);
-                    }
-                    root.targets
-                      .filter((target) => target.kind.length === 1 && target.kind[0] === "test")
-                      .map((target) => target.name)
-                      .sort()
-                      .forEach((name) => console.log(name));
-                  });
-                '
+              mapfile -t selected_targets < <(
+                cargo metadata --no-deps --format-version 1 \
+                  | node scripts/select-nextest-archive-targets.mjs \
+                    --group "${{ inputs.target_group }}" \
+                    --policy tests/suites/nextest-target-duration-policy.json
               )
-              if (( ${#integration_targets[@]} == 0 )); then
-                echo "::error::integration test target discovery returned no targets"
-                exit 1
-              fi
-              selected_targets=()
-              for index in "${!integration_targets[@]}"; do
-                if [[ "${{ inputs.target_group }}" == "integration-b" ]] && (( index % 2 == 0 )); then
-                  selected_targets+=("${integration_targets[index]}")
-                elif [[ "${{ inputs.target_group }}" == "integration-c" ]] && (( index % 2 == 1 )); then
-                  selected_targets+=("${integration_targets[index]}")
-                fi
-              done
               if (( ${#selected_targets[@]} == 0 )); then
                 echo "::error::integration target group selected no targets: ${{ inputs.target_group }}"
                 exit 1
@@ -188,7 +162,7 @@ jobs:
               for target in "${selected_targets[@]}"; do
                 cargo_target_args+=(--test "${target}")
               done
-              printf 'integration_targets=%s selected_targets=%s\n' "${#integration_targets[@]}" "${#selected_targets[@]}"
+              printf 'selected_targets=%s\n' "${#selected_targets[@]}"
               ;;
           esac
 

--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -20,6 +20,11 @@ on:
         description: Cargo test target group assigned to this archive.
         required: true
         type: string
+      duration_policy_sha:
+        description: Pinned ci-metrics policy commit for integration B/C selection.
+        required: false
+        type: string
+        default: ''
 jobs:
   build:
     name: Build test archive (${{ inputs.archive_label }})
@@ -149,11 +154,26 @@ jobs:
               cargo_target_args+=(--lib)
               ;;
             integration-b|integration-c)
+              duration_policy='tests/suites/nextest-target-duration-policy.json'
+              if [[ -n "${{ inputs.duration_policy_sha }}" ]]; then
+                candidate_policy='target/nextest-duration-policy.json'
+                mkdir -p "$(dirname "${candidate_policy}")"
+                if git fetch --depth=1 origin "${{ inputs.duration_policy_sha }}" \
+                  && git show FETCH_HEAD:nextest-target-duration-policy.json > "${candidate_policy}"; then
+                  duration_policy="${candidate_policy}"
+                  printf 'duration_policy_sha=%s\n' "${{ inputs.duration_policy_sha }}"
+                else
+                  echo "::warning::Duration policy ${{ inputs.duration_policy_sha }} could not be fetched; using the committed fallback."
+                fi
+              else
+                echo 'duration_policy_sha=fallback:committed'
+              fi
+
               mapfile -t selected_targets < <(
                 cargo metadata --no-deps --format-version 1 \
                   | node scripts/select-nextest-archive-targets.mjs \
                     --group "${{ inputs.target_group }}" \
-                    --policy tests/suites/nextest-target-duration-policy.json
+                    --policy "${duration_policy}"
               )
               if (( ${#selected_targets[@]} == 0 )); then
                 echo "::error::integration target group selected no targets: ${{ inputs.target_group }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -757,6 +757,45 @@ jobs:
             printf '| reason | %s |\n' "${IMPACT_REASON}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
+  # [#6205] B/C가 같은 측정 정책 commit을 보도록 CI 시작 때 한 번만 SHA를 고정한다.
+  # 데이터 브랜치가 아직 없거나 조회할 수 없으면 committed fallback을 사용한다.
+  resolve-nextest-duration-policy:
+    name: Resolve nextest target duration policy
+    runs-on: ubuntu-latest
+    needs: [preflight]
+    if: >-
+      ${{
+        always()
+        && needs.preflight.result == 'success'
+        && needs.preflight.outputs.fast_pass != 'true'
+        && needs.preflight.outputs.rust_required == 'true'
+      }}
+    permissions:
+      contents: read
+    outputs:
+      duration_policy_sha: ${{ steps.resolve.outputs.duration_policy_sha || '' }}
+    steps:
+      - id: resolve
+        shell: bash
+        env:
+          METRICS_REF: refs/heads/ci-metrics/nextest-target-durations
+        run: |
+          set -euo pipefail
+
+          if policy_sha="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" "${METRICS_REF}" | awk 'NR == 1 { print $1 }')"; then
+            :
+          else
+            policy_sha=''
+          fi
+
+          if [[ -n "${policy_sha}" ]]; then
+            printf 'duration_policy_sha=%s\n' "${policy_sha}" >> "${GITHUB_OUTPUT}"
+            printf 'Using duration policy commit %s.\n' "${policy_sha}" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo 'duration_policy_sha=' >> "${GITHUB_OUTPUT}"
+            echo 'Duration policy data is unavailable; using the committed fallback.' >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
   # [#2393] 기본 테스트 병렬화 — CI impact preflight가 frontend·Rust·Native Skia
   # gate와 worker 조건을 나누는 경계다.
   # [#5737] archive A는 source-side lib test, B/C는 integration target을 교차 분배해
@@ -786,13 +825,14 @@ jobs:
 
   build-test-archive-b:
     uses: ./.github/workflows/build-nextest-archives.yml
-    needs: [preflight]
+    needs: [preflight, resolve-nextest-duration-policy]
     if: >-
       ${{
         always()
         && needs.preflight.result == 'success'
         && needs.preflight.outputs.fast_pass != 'true'
         && needs.preflight.outputs.rust_required == 'true'
+        && needs.resolve-nextest-duration-policy.result == 'success'
       }}
     permissions:
       contents: read
@@ -801,17 +841,19 @@ jobs:
       timeout_minutes: ${{ fromJSON(needs.preflight.outputs.test_archive_timeout_minutes || '60') }}
       archive_label: b
       target_group: integration-b
+      duration_policy_sha: ${{ needs.resolve-nextest-duration-policy.outputs.duration_policy_sha }}
 
 
   build-test-archive-c:
     uses: ./.github/workflows/build-nextest-archives.yml
-    needs: [preflight]
+    needs: [preflight, resolve-nextest-duration-policy]
     if: >-
       ${{
         always()
         && needs.preflight.result == 'success'
         && needs.preflight.outputs.fast_pass != 'true'
         && needs.preflight.outputs.rust_required == 'true'
+        && needs.resolve-nextest-duration-policy.result == 'success'
       }}
     permissions:
       contents: read
@@ -820,6 +862,7 @@ jobs:
       timeout_minutes: ${{ fromJSON(needs.preflight.outputs.test_archive_timeout_minutes || '60') }}
       archive_label: c
       target_group: integration-c
+      duration_policy_sha: ${{ needs.resolve-nextest-duration-policy.outputs.duration_policy_sha }}
 
   lint:
     name: Lint (fmt, clippy, WASM check)
@@ -1394,6 +1437,91 @@ jobs:
       filterset: "all()"
       partition: "hash:1/1"
 
+
+  # [#6205] B/C가 성공한 devel run만 data branch로 기록한다. protected devel에는
+  # 직접 쓰지 않으며, 다음 PR은 이 branch의 고정 SHA를 사용한다.
+  refresh-nextest-target-duration-data:
+    name: Refresh nextest target duration data
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+      - test-archive-b-shard-1
+      - test-archive-c-shard-1
+    if: >-
+      ${{
+        always()
+        && github.event_name == 'push'
+        && github.ref == 'refs/heads/devel'
+        && needs.preflight.result == 'success'
+        && needs.preflight.outputs.fast_pass != 'true'
+        && needs.preflight.outputs.rust_required == 'true'
+        && needs.test-archive-b-shard-1.result == 'success'
+        && needs.test-archive-c-shard-1.result == 'success'
+      }}
+    permissions:
+      actions: read
+      contents: write
+    concurrency:
+      group: nextest-target-duration-data
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Download Archive B duration measurement
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nextest-target-durations-${{ github.run_id }}-b
+          path: duration-b
+
+      - name: Download Archive C duration measurement
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nextest-target-durations-${{ github.run_id }}-c
+          path: duration-c
+
+      - name: Refresh duration policy data branch
+        shell: bash
+        env:
+          METRICS_BRANCH: ci-metrics/nextest-target-durations
+          OUTPUT_POLICY: ${{ runner.temp }}/nextest-target-duration-policy.json
+        run: |
+          set -euo pipefail
+
+          current_devel_sha="$(git ls-remote origin refs/heads/devel | awk 'NR == 1 { print $1 }')"
+          if [[ "${current_devel_sha}" != "${GITHUB_SHA}" ]]; then
+            echo "::notice::A newer devel commit exists; this older measurement is not published."
+            exit 0
+          fi
+
+          node scripts/refresh-nextest-target-duration-policy.mjs \
+            --policy tests/suites/nextest-target-duration-policy.json \
+            --measurement duration-b/target-durations-b.json \
+            --measurement duration-c/target-durations-c.json \
+            --output "${OUTPUT_POLICY}"
+
+          if git ls-remote --exit-code origin "refs/heads/${METRICS_BRANCH}" >/dev/null 2>&1; then
+            git fetch --depth=1 origin \
+              "refs/heads/${METRICS_BRANCH}:refs/remotes/origin/${METRICS_BRANCH}"
+            git switch --detach "refs/remotes/origin/${METRICS_BRANCH}"
+          else
+            git switch --orphan "${METRICS_BRANCH}"
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          cp "${OUTPUT_POLICY}" nextest-target-duration-policy.json
+          git add nextest-target-duration-policy.json
+          if git diff --cached --quiet; then
+            echo 'Duration policy data is unchanged.'
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -m "ci: nextest target duration data ${GITHUB_SHA}"
+          git push origin "HEAD:refs/heads/${METRICS_BRANCH}"
 
   build-and-test:
     name: Build & Test

--- a/.github/workflows/run-nextest-archives.yml
+++ b/.github/workflows/run-nextest-archives.yml
@@ -66,8 +66,17 @@ jobs:
           if [[ -n "${PARTITION}" ]]; then
             partition_args=(--partition "${PARTITION}")
           fi
+          profile_args=()
+          duration_report=""
+          case "${{ inputs.archive_label }}" in
+            b|c)
+              profile_args=(--profile ci-duration-observation)
+              duration_report="target/nextest/ci-duration-observation/junit.xml"
+              ;;
+          esac
           log="nextest-${COUNT_LABEL}.log"
           cargo nextest run \
+            "${profile_args[@]}" \
             --archive-file tests.tar.zst \
             --workspace-remap . \
             --extract-to . \
@@ -84,6 +93,12 @@ jobs:
           echo "worker=${COUNT_LABEL} filter=${FILTERSET} partition=${PARTITION:-none} run=${run}"
           echo "$run" > "shard-count-${COUNT_LABEL}.txt"
           cat "shard-count-${COUNT_LABEL}.txt"
+          if [[ -n "${duration_report}" ]]; then
+            node scripts/collect-nextest-target-durations.mjs \
+              --archive-label "${{ inputs.archive_label }}" \
+              --input "${duration_report}" \
+              --output "target-durations-${{ inputs.archive_label }}.json"
+          fi
 
       - name: Upload ${{ inputs.label }} count
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -91,4 +106,15 @@ jobs:
           name: shard-count-${{ inputs.count_label }}
           path: shard-count-${{ inputs.count_label }}.txt
           retention-days: 1
+          if-no-files-found: error
+
+      # 신뢰 가능한 duration profile은 성공한 devel 실행에서만 수집한다. PR은
+      # 이 artifact를 정책 파일로 자동 반영하지 않으며, 별도 검토 PR이 필요하다.
+      - name: Upload B/C target durations
+        if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/devel' && (inputs.archive_label == 'b' || inputs.archive_label == 'c') }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nextest-target-durations-${{ github.run_id }}-${{ inputs.archive_label }}
+          path: target-durations-${{ inputs.archive_label }}.json
+          retention-days: 30
           if-no-files-found: error

--- a/mydocs/working/task_m100_6205_stage1_duration_aware_archive_assignment.md
+++ b/mydocs/working/task_m100_6205_stage1_duration_aware_archive_assignment.md
@@ -14,31 +14,32 @@
 1. `integration-b`, `integration-c` archive와 실행 shard는 각각 하나만 유지한다.
 2. target은 알려진 실행 시간이 긴 순서로 정렬하고, 동률이면 이름순으로 정렬한다. 각 target은
    현재 추정 시간이 더 짧은 archive에 배정한다.
-3. 실행 시간 정책은 저장소의
-   `tests/suites/nextest-target-duration-policy.json`에 버전 관리한다. 기능 PR은 이 파일을 읽기만
-   하며, 실행 결과로 자동 수정하지 않는다.
+3. 실행 시간 정책의 최신 측정값은
+   `ci-metrics/nextest-target-durations` 데이터 브랜치에 자동 기록한다. 저장소의
+   `tests/suites/nextest-target-duration-policy.json`은 데이터가 없거나 검증에 실패했을 때만 쓰는
+   committed fallback이다.
 4. 새 target 또는 아직 측정되지 않은 target에는 `fallback_seconds: 1`을 적용한다. 빈 정책에서는
    기존 이름순 교차 배정과 같은 결과가 나와 첫 도입에서 임의의 실행 시간 변화가 없다.
 5. B/C 실행은 nextest JUnit 보고서에서 target별 시간을 추출한다. 성공한 `devel` 실행의 B 보고서
-   하나와 C 보고서 하나만 별도 artifact로 보관한다.
-6. 유지보수자는 두 artifact의 run, ref, commit SHA를 검토한 뒤
-   `refresh-nextest-target-duration-policy.mjs`로 정책 후보를 만들고, 별도의 정책 갱신 PR에서
-   반영한다.
+   하나와 C 보고서 하나만 별도 artifact로 30일간 보관한다.
+6. 같은 `devel` run의 B/C artifact는 자동 job이 출처 run, ref, commit SHA와 함께 합친다.
+   최신 `devel` SHA인지 확인한 뒤 데이터 브랜치만 갱신하며, protected `devel`에는 직접
+   push하지 않는다.
 
 ## 이번 단계 범위
 
 - 결정론적인 시간 기반 target 선택 스크립트를 추가한다.
 - nextest JUnit에서 target별 실행 시간을 수집하는 스크립트를 추가한다.
-- B/C 측정 보고서를 정책 파일로 합치는 명시적 유지보수 스크립트를 추가한다.
+- B/C 측정 보고서를 정책 파일로 합치는 자동 갱신 job을 추가한다.
 - 빈 정책 호환성, 결정성, JUnit 파싱, B/C 보고서 조합을 검증하는 테스트를 추가한다.
 - B/C archive build가 정책 선택기를 사용하도록 연결한다.
-- 성공한 `devel`의 B/C 실행에서만 측정 artifact를 30일간 보관한다.
+- 성공한 `devel`의 B/C 실행에서만 측정 artifact를 30일간 보관하고 데이터 브랜치를 갱신한다.
 
 ## 이번 단계에서 하지 않는 일
 
 - B/C 실행 shard를 추가하지 않는다.
 - source-side unit test를 integration test로 일괄 이동하지 않는다.
-- PR 실행 결과로 정책 파일을 자동 생성하거나 자동 커밋하지 않는다.
+- protected `devel` 또는 PR head에는 정책 데이터를 직접 push하지 않는다.
 - 검토·병합된 `devel` 측정값이 없는 상태에서 CI 시간이 줄었다고 주장하지 않는다.
 
 ## 수용 기준
@@ -46,5 +47,7 @@
 1. 빈 정책은 기존 이름순 교차 B/C 분할과 동일한 target 구성을 만든다.
 2. 검토된 시간 프로필이 있으면 B/C의 추정 시간을 결정론적으로 균형화한다.
 3. B/C 측정 artifact는 test binary target 이름과 실행 시간만 포함한다.
-4. 정책 갱신은 성공한 동일 `devel` 실행의 B 보고서와 C 보고서를 각각 하나씩 요구한다.
-5. 갱신된 정책에는 각 측정 보고서의 run, ref, commit SHA 출처가 남는다.
+4. 자동 갱신은 성공한 동일 `devel` 실행의 B 보고서와 C 보고서를 각각 하나씩 요구한다.
+5. 갱신된 데이터에는 각 측정 보고서의 run, ref, commit SHA 출처가 남는다.
+6. 하나의 PR CI에서 B/C는 같은 데이터 브랜치 commit SHA를 사용하며, 조회 실패 시 모두 committed
+   fallback으로 배정한다.

--- a/mydocs/working/task_m100_6205_stage1_duration_aware_archive_assignment.md
+++ b/mydocs/working/task_m100_6205_stage1_duration_aware_archive_assignment.md
@@ -1,0 +1,50 @@
+# #6205 Stage 1 - B/C integration archive 시간 기반 target 배정
+
+## 배경
+
+현재 `integration-b`와 `integration-c`는 root integration target을 이름순 짝수·홀수
+위치로 나눈다. 각 archive와 실행 shard는 하나씩만 유지하므로 worker 수는 작지만, 실행 시간이
+긴 target이 한쪽에 몰리면 해당 쪽이 지속적으로 CI 임계 경로가 된다.
+
+완료된 `devel` CI 로그에는 target별 실행 시간이 보관되어 있지 않다. 따라서 과거 로그만으로
+신뢰할 수 있는 시간 프로필을 만들거나, 임의의 추정값으로 새 배정을 적용해서는 안 된다.
+
+## 결정
+
+1. `integration-b`, `integration-c` archive와 실행 shard는 각각 하나만 유지한다.
+2. target은 알려진 실행 시간이 긴 순서로 정렬하고, 동률이면 이름순으로 정렬한다. 각 target은
+   현재 추정 시간이 더 짧은 archive에 배정한다.
+3. 실행 시간 정책은 저장소의
+   `tests/suites/nextest-target-duration-policy.json`에 버전 관리한다. 기능 PR은 이 파일을 읽기만
+   하며, 실행 결과로 자동 수정하지 않는다.
+4. 새 target 또는 아직 측정되지 않은 target에는 `fallback_seconds: 1`을 적용한다. 빈 정책에서는
+   기존 이름순 교차 배정과 같은 결과가 나와 첫 도입에서 임의의 실행 시간 변화가 없다.
+5. B/C 실행은 nextest JUnit 보고서에서 target별 시간을 추출한다. 성공한 `devel` 실행의 B 보고서
+   하나와 C 보고서 하나만 별도 artifact로 보관한다.
+6. 유지보수자는 두 artifact의 run, ref, commit SHA를 검토한 뒤
+   `refresh-nextest-target-duration-policy.mjs`로 정책 후보를 만들고, 별도의 정책 갱신 PR에서
+   반영한다.
+
+## 이번 단계 범위
+
+- 결정론적인 시간 기반 target 선택 스크립트를 추가한다.
+- nextest JUnit에서 target별 실행 시간을 수집하는 스크립트를 추가한다.
+- B/C 측정 보고서를 정책 파일로 합치는 명시적 유지보수 스크립트를 추가한다.
+- 빈 정책 호환성, 결정성, JUnit 파싱, B/C 보고서 조합을 검증하는 테스트를 추가한다.
+- B/C archive build가 정책 선택기를 사용하도록 연결한다.
+- 성공한 `devel`의 B/C 실행에서만 측정 artifact를 30일간 보관한다.
+
+## 이번 단계에서 하지 않는 일
+
+- B/C 실행 shard를 추가하지 않는다.
+- source-side unit test를 integration test로 일괄 이동하지 않는다.
+- PR 실행 결과로 정책 파일을 자동 생성하거나 자동 커밋하지 않는다.
+- 검토·병합된 `devel` 측정값이 없는 상태에서 CI 시간이 줄었다고 주장하지 않는다.
+
+## 수용 기준
+
+1. 빈 정책은 기존 이름순 교차 B/C 분할과 동일한 target 구성을 만든다.
+2. 검토된 시간 프로필이 있으면 B/C의 추정 시간을 결정론적으로 균형화한다.
+3. B/C 측정 artifact는 test binary target 이름과 실행 시간만 포함한다.
+4. 정책 갱신은 성공한 동일 `devel` 실행의 B 보고서와 C 보고서를 각각 하나씩 요구한다.
+5. 갱신된 정책에는 각 측정 보고서의 run, ref, commit SHA 출처가 남는다.

--- a/scripts/ci-impact-policy.cjs
+++ b/scripts/ci-impact-policy.cjs
@@ -188,6 +188,8 @@ const CI_AUDITED_JOB_IDS = {
   'build-test-archive-a': 'build-test-archive-a',
   'build-test-archive-b': 'build-test-archive-b',
   'build-test-archive-c': 'build-test-archive-c',
+  'resolve-nextest-duration-policy': 'resolve-nextest-duration-policy',
+  'refresh-nextest-target-duration-data': 'refresh-nextest-target-duration-data',
   'test-archive-a-shard-1': 'test-archive-a-shard-1',
   'test-archive-a-shard-2': 'test-archive-a-shard-2',
   'test-archive-b-shard-1': 'test-archive-b-shard-1',

--- a/scripts/collect-nextest-target-durations.mjs
+++ b/scripts/collect-nextest-target-durations.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+function fail(message) {
+  throw new Error(`[NextestTargetDuration] ${message}`);
+}
+
+function parseArgs(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--help") {
+      options.help = true;
+      continue;
+    }
+    if (!["--archive-label", "--input", "--output"].includes(arg)) {
+      fail(`unknown argument: ${arg}`);
+    }
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) {
+      fail(`${arg} requires a value`);
+    }
+    options[arg.slice(2)] = value;
+    index += 1;
+  }
+  return options;
+}
+
+function decodeXml(value) {
+  return value
+    .replaceAll("&quot;", "\"")
+    .replaceAll("&apos;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}
+
+function parseAttributes(raw) {
+  const attributes = new Map();
+  for (const match of raw.matchAll(/([A-Za-z_:][-A-Za-z0-9_.:]*)="([^"]*)"/g)) {
+    attributes.set(match[1], decodeXml(match[2]));
+  }
+  return attributes;
+}
+
+export function collectTargetDurations(junitXml) {
+  const durations = new Map();
+  for (const match of junitXml.matchAll(/<testsuite\b([^>]*)>/g)) {
+    const attributes = parseAttributes(match[1]);
+    const suiteName = attributes.get("name");
+    const seconds = Number(attributes.get("time"));
+    if (!suiteName || suiteName.startsWith("@setup-script:") || !Number.isFinite(seconds) || seconds < 0) {
+      continue;
+    }
+
+    const separator = suiteName.indexOf("::");
+    const target = separator === -1 ? suiteName : suiteName.slice(separator + 2);
+    if (!target) {
+      continue;
+    }
+    durations.set(target, (durations.get(target) ?? 0) + seconds);
+  }
+  return Object.fromEntries([...durations.entries()].sort(([left], [right]) => left.localeCompare(right)));
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write("Usage: node scripts/collect-nextest-target-durations.mjs --archive-label b|c --input junit.xml --output target-durations.json\n");
+    return;
+  }
+  if (!["b", "c"].includes(options["archive-label"]) || !options.input || !options.output) {
+    fail("--archive-label b|c, --input, and --output are required");
+  }
+
+  const targets = collectTargetDurations(fs.readFileSync(options.input, "utf8"));
+  const report = {
+    schema_version: 1,
+    archive_label: options["archive-label"],
+    run_id: process.env.GITHUB_RUN_ID ?? null,
+    ref: process.env.GITHUB_REF ?? null,
+    sha: process.env.GITHUB_SHA ?? null,
+    targets,
+  };
+  fs.mkdirSync(path.dirname(options.output), { recursive: true });
+  fs.writeFileSync(options.output, `${JSON.stringify(report, null, 2)}\n`);
+  process.stderr.write(
+    `[NextestTargetDuration] archive=${report.archive_label} target_durations=${Object.keys(targets).length}\n`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/refresh-nextest-target-duration-policy.mjs
+++ b/scripts/refresh-nextest-target-duration-policy.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { parseDurationPolicy } from "./select-nextest-archive-targets.mjs";
+
+function fail(message) {
+  throw new Error(`[NextestTargetDuration] ${message}`);
+}
+
+function parseArgs(args) {
+  const options = { measurements: [] };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--help") {
+      options.help = true;
+      continue;
+    }
+    if (!["--policy", "--measurement", "--output"].includes(arg)) {
+      fail(`unknown argument: ${arg}`);
+    }
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) {
+      fail(`${arg} requires a value`);
+    }
+    if (arg === "--measurement") {
+      options.measurements.push(value);
+    } else {
+      options[arg.slice(2)] = value;
+    }
+    index += 1;
+  }
+  return options;
+}
+
+export function refreshDurationPolicy(policy, measurements) {
+  parseDurationPolicy(policy);
+  const durations = { ...policy.targets };
+  for (const measurement of measurements) {
+    if (!measurement || measurement.schema_version !== 1 || !["b", "c"].includes(measurement.archive_label)) {
+      fail("measurement must be a B or C schema_version 1 report");
+    }
+    if (!measurement.targets || typeof measurement.targets !== "object" || Array.isArray(measurement.targets)) {
+      fail("measurement targets must be an object");
+    }
+    for (const [target, seconds] of Object.entries(measurement.targets)) {
+      if (!target || !Number.isFinite(seconds) || seconds <= 0) {
+        fail(`measurement target must have a positive duration: ${target}`);
+      }
+      durations[target] = seconds;
+    }
+  }
+
+  return {
+    schema_version: 1,
+    fallback_seconds: policy.fallback_seconds,
+    measurement_sources: Object.fromEntries(measurements
+      .map((measurement) => [measurement.archive_label, {
+        run_id: measurement.run_id ?? null,
+        ref: measurement.ref ?? null,
+        sha: measurement.sha ?? null,
+      }])
+      .sort(([left], [right]) => left.localeCompare(right))),
+    targets: Object.fromEntries(Object.entries(durations).sort(([left], [right]) => left.localeCompare(right))),
+  };
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write("Usage: node scripts/refresh-nextest-target-duration-policy.mjs --policy policy.json --measurement b.json --measurement c.json --output policy.json\n");
+    return;
+  }
+  if (!options.policy || !options.output || options.measurements.length !== 2) {
+    fail("--policy, exactly two --measurement values, and --output are required");
+  }
+  const policy = JSON.parse(fs.readFileSync(options.policy, "utf8"));
+  const measurements = options.measurements.map((filePath) => JSON.parse(fs.readFileSync(filePath, "utf8")));
+  const labels = new Set(measurements.map((measurement) => measurement.archive_label));
+  if (labels.size !== 2 || !labels.has("b") || !labels.has("c")) {
+    fail("measurements must contain exactly one B report and one C report");
+  }
+  const refreshed = refreshDurationPolicy(policy, measurements);
+  fs.mkdirSync(path.dirname(options.output), { recursive: true });
+  fs.writeFileSync(options.output, `${JSON.stringify(refreshed, null, 2)}\n`);
+  process.stderr.write(`[NextestTargetDuration] refreshed_targets=${Object.keys(refreshed.targets).length}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/select-nextest-archive-targets.mjs
+++ b/scripts/select-nextest-archive-targets.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const GROUPS = new Set(["integration-b", "integration-c"]);
+
+function fail(message) {
+  throw new Error(`[NextestTargetDuration] ${message}`);
+}
+
+function parseArgs(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--help") {
+      options.help = true;
+      continue;
+    }
+    if (arg !== "--group" && arg !== "--policy") {
+      fail(`unknown argument: ${arg}`);
+    }
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) {
+      fail(`${arg} requires a value`);
+    }
+    options[arg.slice(2)] = value;
+    index += 1;
+  }
+  return options;
+}
+
+function usage() {
+  return [
+    "Usage: cargo metadata --no-deps --format-version 1 |",
+    "  node scripts/select-nextest-archive-targets.mjs",
+    "    --group integration-b|integration-c",
+    "    --policy tests/suites/nextest-target-duration-policy.json",
+  ].join(" ");
+}
+
+function readJson(filePath, description) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    fail(`${description} cannot be read: ${filePath}: ${error.message}`);
+  }
+}
+
+export function parseDurationPolicy(policy) {
+  if (!policy || policy.schema_version !== 1) {
+    fail("duration policy schema_version must be 1");
+  }
+  if (!Number.isFinite(policy.fallback_seconds) || policy.fallback_seconds <= 0) {
+    fail("duration policy fallback_seconds must be a positive number");
+  }
+  if (!policy.targets || typeof policy.targets !== "object" || Array.isArray(policy.targets)) {
+    fail("duration policy targets must be an object");
+  }
+
+  const durations = new Map();
+  for (const [target, seconds] of Object.entries(policy.targets)) {
+    if (!target || !Number.isFinite(seconds) || seconds <= 0) {
+      fail(`duration policy target must have a positive duration: ${target}`);
+    }
+    durations.set(target, seconds);
+  }
+
+  return {
+    fallbackSeconds: policy.fallback_seconds,
+    durations,
+  };
+}
+
+export function integrationTargetsFromMetadata(metadata, workspaceManifestPath) {
+  if (!metadata || !Array.isArray(metadata.packages)) {
+    fail("cargo metadata packages are missing");
+  }
+  const normalizedManifestPath = path.resolve(workspaceManifestPath);
+  const workspacePackage = metadata.packages.find(
+    (pkg) => path.resolve(pkg.manifest_path) === normalizedManifestPath,
+  );
+  if (!workspacePackage) {
+    fail(`workspace package is missing: ${workspaceManifestPath}`);
+  }
+
+  const targets = workspacePackage.targets
+    .filter((target) => Array.isArray(target.kind) && target.kind.includes("test"))
+    .map((target) => target.name)
+    .sort((left, right) => left.localeCompare(right));
+
+  if (new Set(targets).size !== targets.length) {
+    fail("cargo metadata contains duplicate integration target names");
+  }
+  return targets;
+}
+
+export function assignIntegrationTargets(targets, policy) {
+  const parsedPolicy = parseDurationPolicy(policy);
+  const assignments = {
+    "integration-b": { estimatedSeconds: 0, targets: [] },
+    "integration-c": { estimatedSeconds: 0, targets: [] },
+  };
+
+  const weightedTargets = [...new Set(targets)]
+    .map((name) => ({
+      name,
+      seconds: parsedPolicy.durations.get(name) ?? parsedPolicy.fallbackSeconds,
+    }))
+    .sort((left, right) => right.seconds - left.seconds || left.name.localeCompare(right.name));
+
+  for (const target of weightedTargets) {
+    const destination = assignments["integration-b"].estimatedSeconds
+      <= assignments["integration-c"].estimatedSeconds
+      ? "integration-b"
+      : "integration-c";
+    assignments[destination].targets.push(target.name);
+    assignments[destination].estimatedSeconds += target.seconds;
+  }
+
+  for (const assignment of Object.values(assignments)) {
+    assignment.targets.sort((left, right) => left.localeCompare(right));
+  }
+  return assignments;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+  if (!GROUPS.has(options.group) || !options.policy) {
+    fail(usage());
+  }
+
+  const metadata = JSON.parse(fs.readFileSync(0, "utf8"));
+  const policy = readJson(options.policy, "duration policy");
+  const targets = integrationTargetsFromMetadata(metadata, path.join(process.cwd(), "Cargo.toml"));
+  const assignments = assignIntegrationTargets(targets, policy);
+  const assignment = assignments[options.group];
+
+  process.stderr.write(
+    `[NextestTargetDuration] group=${options.group} integration_targets=${targets.length} `
+      + `selected_targets=${assignment.targets.length} `
+      + `estimated_seconds=${assignment.estimatedSeconds.toFixed(3)}\n`,
+  );
+  process.stdout.write(`${assignment.targets.join("\n")}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/select-nextest-archive-targets.mjs
+++ b/scripts/select-nextest-archive-targets.mjs
@@ -48,6 +48,15 @@ function readJson(filePath, description) {
   }
 }
 
+async function readStandardInput() {
+  let source = "";
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) {
+    source += chunk;
+  }
+  return source;
+}
+
 export function parseDurationPolicy(policy) {
   if (!policy || policy.schema_version !== 1) {
     fail("duration policy schema_version must be 1");
@@ -125,7 +134,7 @@ export function assignIntegrationTargets(targets, policy) {
   return assignments;
 }
 
-function main() {
+async function main() {
   const options = parseArgs(process.argv.slice(2));
   if (options.help) {
     process.stdout.write(`${usage()}\n`);
@@ -135,7 +144,7 @@ function main() {
     fail(usage());
   }
 
-  const metadata = JSON.parse(fs.readFileSync(0, "utf8"));
+  const metadata = JSON.parse(await readStandardInput());
   const policy = readJson(options.policy, "duration policy");
   const targets = integrationTargetsFromMetadata(metadata, path.join(process.cwd(), "Cargo.toml"));
   const assignments = assignIntegrationTargets(targets, policy);
@@ -150,5 +159,8 @@ function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main();
+  main().catch((error) => {
+    process.stderr.write(`${error.stack ?? error.message}\n`);
+    process.exitCode = 1;
+  });
 }

--- a/scripts/tests/ci-impact-policy.test.cjs
+++ b/scripts/tests/ci-impact-policy.test.cjs
@@ -465,6 +465,8 @@ test('every impact-conditioned CI job is covered by the audit allowlist', () => 
     CI_NATIVE_JOB,
     ...CI_FRONTEND_JOBS,
     'Build & Test',
+    'resolve-nextest-duration-policy',
+    'refresh-nextest-target-duration-data',
   ]);
   assert.deepEqual(
     [...new Set(Object.values(CI_AUDITED_JOB_IDS))].sort(),

--- a/scripts/tests/nextest-target-duration-policy.test.mjs
+++ b/scripts/tests/nextest-target-duration-policy.test.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 
 import {
@@ -7,6 +10,10 @@ import {
 } from "../select-nextest-archive-targets.mjs";
 import { collectTargetDurations } from "../collect-nextest-target-durations.mjs";
 import { refreshDurationPolicy } from "../refresh-nextest-target-duration-policy.mjs";
+
+const selectorPath = fileURLToPath(new URL("../select-nextest-archive-targets.mjs", import.meta.url));
+const policyPath = fileURLToPath(new URL("../../tests/suites/nextest-target-duration-policy.json", import.meta.url));
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 
 const policy = {
   schema_version: 1,
@@ -59,6 +66,30 @@ test("metadata selection uses only root integration targets", () => {
   }, "/repo/Cargo.toml");
 
   assert.deepEqual(targets, ["case-a", "case-b"]);
+});
+
+test("CLI consumes streamed cargo metadata without synchronous stdin reads", () => {
+  const result = spawnSync(process.execPath, [
+    selectorPath,
+    "--group", "integration-b",
+    "--policy", policyPath,
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    input: JSON.stringify({
+      packages: [{
+        manifest_path: path.join(repoRoot, "Cargo.toml"),
+        targets: [
+          { name: "case-b", kind: ["test"] },
+          { name: "case-a", kind: ["test"] },
+        ],
+      }],
+    }),
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "case-a\n");
+  assert.match(result.stderr, /integration_targets=2 selected_targets=1/);
 });
 
 test("JUnit collection aggregates one duration per test binary and skips setup suites", () => {

--- a/scripts/tests/nextest-target-duration-policy.test.mjs
+++ b/scripts/tests/nextest-target-duration-policy.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assignIntegrationTargets,
+  integrationTargetsFromMetadata,
+} from "../select-nextest-archive-targets.mjs";
+import { collectTargetDurations } from "../collect-nextest-target-durations.mjs";
+import { refreshDurationPolicy } from "../refresh-nextest-target-duration-policy.mjs";
+
+const policy = {
+  schema_version: 1,
+  fallback_seconds: 1,
+  targets: {
+    slow: 9,
+    medium: 6,
+    fast: 1,
+  },
+};
+
+test("duration-aware assignment is deterministic and balances estimated load", () => {
+  const first = assignIntegrationTargets(["fast", "slow", "medium", "new"], policy);
+  const second = assignIntegrationTargets(["new", "medium", "fast", "slow"], policy);
+
+  assert.deepEqual(first, second);
+  assert.deepEqual(first["integration-b"].targets, ["slow"]);
+  assert.deepEqual(first["integration-c"].targets, ["fast", "medium", "new"]);
+  assert.equal(first["integration-b"].estimatedSeconds, 9);
+  assert.equal(first["integration-c"].estimatedSeconds, 8);
+});
+
+test("empty duration profile preserves stable alternating bootstrap assignment", () => {
+  const assignments = assignIntegrationTargets(["delta", "alpha", "charlie", "bravo"], {
+    schema_version: 1,
+    fallback_seconds: 1,
+    targets: {},
+  });
+
+  assert.deepEqual(assignments["integration-b"].targets, ["alpha", "charlie"]);
+  assert.deepEqual(assignments["integration-c"].targets, ["bravo", "delta"]);
+});
+
+test("metadata selection uses only root integration targets", () => {
+  const targets = integrationTargetsFromMetadata({
+    packages: [
+      {
+        manifest_path: "/repo/Cargo.toml",
+        targets: [
+          { name: "root-lib", kind: ["lib"] },
+          { name: "case-b", kind: ["test"] },
+          { name: "case-a", kind: ["test"] },
+        ],
+      },
+      {
+        manifest_path: "/repo/crates/helper/Cargo.toml",
+        targets: [{ name: "helper-case", kind: ["test"] }],
+      },
+    ],
+  }, "/repo/Cargo.toml");
+
+  assert.deepEqual(targets, ["case-a", "case-b"]);
+});
+
+test("JUnit collection aggregates one duration per test binary and skips setup suites", () => {
+  const durations = collectTargetDurations([
+    '<testsuite name="rhwp::issue_1" time="1.25">',
+    '<testsuite name="@setup-script:seed" time="5.00">',
+    '<testsuite name="rhwp::issue_1" time="0.75">',
+    '<testsuite name="rhwp::issue_2" time="2.00">',
+  ].join("\n"));
+
+  assert.deepEqual(durations, { issue_1: 2, issue_2: 2 });
+});
+
+test("policy refresh accepts one successful B and C measurement", () => {
+  const refreshed = refreshDurationPolicy({
+    schema_version: 1,
+    fallback_seconds: 1,
+    targets: { existing: 3 },
+  }, [
+    { schema_version: 1, archive_label: "b", run_id: "10", ref: "refs/heads/devel", sha: "b-sha", targets: { beta: 4 } },
+    { schema_version: 1, archive_label: "c", run_id: "10", ref: "refs/heads/devel", sha: "c-sha", targets: { alpha: 2 } },
+  ]);
+
+  assert.deepEqual(refreshed.targets, { alpha: 2, beta: 4, existing: 3 });
+  assert.deepEqual(refreshed.measurement_sources, {
+    b: { run_id: "10", ref: "refs/heads/devel", sha: "b-sha" },
+    c: { run_id: "10", ref: "refs/heads/devel", sha: "c-sha" },
+  });
+});

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -638,19 +638,36 @@ class CiImpactWorkflowTests(unittest.TestCase):
         lint = self._job("lint")
         self.assertIn("needs.preflight.outputs.rust_required == 'true'", lint)
 
-        for archive_name, target_group in (
-            ("build-test-archive-a", "lib"),
-            ("build-test-archive-b", "integration-b"),
-            ("build-test-archive-c", "integration-c"),
+        for archive_name, target_group, expected_needs in (
+            ("build-test-archive-a", "lib", "needs: [preflight]"),
+            (
+                "build-test-archive-b",
+                "integration-b",
+                "needs: [preflight, resolve-nextest-duration-policy]",
+            ),
+            (
+                "build-test-archive-c",
+                "integration-c",
+                "needs: [preflight, resolve-nextest-duration-policy]",
+            ),
         ):
             with self.subTest(archive=archive_name):
                 archive = self._job(archive_name)
                 self.assertIn("needs.preflight.outputs.rust_required == 'true'", archive)
-                self.assertIn("needs: [preflight]", archive)
+                self.assertIn(expected_needs, archive)
                 self.assertNotIn("needs.lint.result", archive)
                 self.assertNotIn("frontend-unit-gates", archive)
                 self.assertNotIn("frontend-package-gates", archive)
                 self.assertIn(f"target_group: {target_group}", archive)
+                if archive_name != "build-test-archive-a":
+                    self.assertIn(
+                        "needs.resolve-nextest-duration-policy.result == 'success'",
+                        archive,
+                    )
+                    self.assertIn(
+                        "duration_policy_sha: ${{ needs.resolve-nextest-duration-policy.outputs.duration_policy_sha }}",
+                        archive,
+                    )
 
     def test_lint_prepares_derived_test_targets_before_cargo_commands(self) -> None:
         lint = self._job("lint")

--- a/scripts/tests/test_nextest_archive_workflow.py
+++ b/scripts/tests/test_nextest_archive_workflow.py
@@ -130,7 +130,11 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         self.assertIn("target_group: lib", ci); self.assertIn("target_group: integration-b", ci); self.assertIn("target_group: integration-c", ci)
         self.assertIn("cargo metadata --no-deps --format-version 1", builder)
         self.assertIn("scripts/select-nextest-archive-targets.mjs", builder)
-        self.assertIn("--policy tests/suites/nextest-target-duration-policy.json", builder)
+        self.assertIn(
+            "duration_policy='tests/suites/nextest-target-duration-policy.json'",
+            builder,
+        )
+        self.assertIn('--policy "${duration_policy}"', builder)
         self.assertNotIn("index % 2", builder)
         self.assertIn("cargo_target_args+=(--lib)", builder)
         self.assertIn('cargo_target_args+=(--test "${target}")', builder)
@@ -272,7 +276,7 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         self.assertIn("wasm-pack build --target web --release", self.ci)
 
     def test_duration_policy_is_pinned_for_prs_and_refreshed_only_from_devel(self) -> None:
-        nextest = (root / ".config/nextest.toml").read_text()
+        nextest = (REPO_ROOT / ".config/nextest.toml").read_text()
 
         self.assertIn('[profile.ci-duration-observation.junit]\npath = "junit.xml"', nextest)
         self.assertNotIn('path = "target/nextest/ci-duration-observation/junit.xml"', nextest)

--- a/scripts/tests/test_nextest_archive_workflow.py
+++ b/scripts/tests/test_nextest_archive_workflow.py
@@ -271,6 +271,21 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         )
         self.assertIn("wasm-pack build --target web --release", self.ci)
 
+    def test_duration_policy_is_pinned_for_prs_and_refreshed_only_from_devel(self) -> None:
+        nextest = (root / ".config/nextest.toml").read_text()
+
+        self.assertIn('[profile.ci-duration-observation.junit]\npath = "junit.xml"', nextest)
+        self.assertNotIn('path = "target/nextest/ci-duration-observation/junit.xml"', nextest)
+        self.assertIn("resolve-nextest-duration-policy:", self.ci)
+        self.assertIn("refresh-nextest-target-duration-data:", self.ci)
+        self.assertIn("ci-metrics/nextest-target-durations", self.ci)
+        self.assertIn("github.ref == 'refs/heads/devel'", self.ci)
+        self.assertIn("duration_policy_sha:", self.builder)
+        self.assertIn(
+            'git fetch --depth=1 origin "${{ inputs.duration_policy_sha }}"',
+            self.builder,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_nextest_archive_workflow.py
+++ b/scripts/tests/test_nextest_archive_workflow.py
@@ -129,9 +129,36 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         self.assertNotIn("test-slow-shard:", ci); self.assertEqual(1, ci.count('partition: "hash:1/2"')); self.assertEqual(1, ci.count('partition: "hash:2/2"')); self.assertEqual(2, ci.count('partition: "hash:1/1"'))
         self.assertIn("target_group: lib", ci); self.assertIn("target_group: integration-b", ci); self.assertIn("target_group: integration-c", ci)
         self.assertIn("cargo metadata --no-deps --format-version 1", builder)
+        self.assertIn("scripts/select-nextest-archive-targets.mjs", builder)
+        self.assertIn("--policy tests/suites/nextest-target-duration-policy.json", builder)
+        self.assertNotIn("index % 2", builder)
         self.assertIn("cargo_target_args+=(--lib)", builder)
         self.assertIn('cargo_target_args+=(--test "${target}")', builder)
         self.assertNotIn("--tests", builder)
+        self.assertIn("--profile ci-duration-observation", runner)
+        self.assertIn("scripts/collect-nextest-target-durations.mjs", runner)
+        self.assertIn("nextest-target-durations-${{ github.run_id }}-${{ inputs.archive_label }}", runner)
+
+    def test_duration_policy_collects_only_successful_devel_b_and_c_measurements(self):
+        from pathlib import Path
+        root = Path(__file__).resolve().parents[2]
+        policy = (root / "tests/suites/nextest-target-duration-policy.json").read_text()
+        config = (root / ".config/nextest.toml").read_text()
+        runner = (root / ".github/workflows/run-nextest-archives.yml").read_text()
+        selector = (root / "scripts/select-nextest-archive-targets.mjs").read_text()
+        collector = (root / "scripts/collect-nextest-target-durations.mjs").read_text()
+        refresh = (root / "scripts/refresh-nextest-target-duration-policy.mjs").read_text()
+
+        self.assertIn('"schema_version": 1', policy)
+        self.assertIn('"fallback_seconds": 1', policy)
+        self.assertIn("[profile.ci-duration-observation.junit]", config)
+        self.assertIn("github.event_name == 'push'", runner)
+        self.assertIn("github.ref == 'refs/heads/devel'", runner)
+        self.assertIn("inputs.archive_label == 'b'", runner)
+        self.assertIn("inputs.archive_label == 'c'", runner)
+        self.assertIn("estimatedSeconds", selector)
+        self.assertIn("<testsuite", collector)
+        self.assertIn("exactly one B report and one C report", refresh)
 
     def test_native_skia_uses_the_same_test_profile_policy(self) -> None:
         native = job_body(self.ci, "native-skia-tests")

--- a/tests/suites/nextest-target-duration-policy.json
+++ b/tests/suites/nextest-target-duration-policy.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": 1,
+  "fallback_seconds": 1,
+  "targets": {}
+}


### PR DESCRIPTION
## 요약

- integration B/C archive target을 실행 시간 정책으로 결정론적으로 배정합니다.
- nextest JUnit 경로를 profile 상대 경로로 고정해 B/C 측정 수집이 archive 실행에서도 동작하도록 보정합니다.
- 성공한 devel B/C 실행의 같은 run artifact 쌍을 합쳐 ci-metrics/nextest-target-durations 데이터 브랜치를 자동 갱신합니다.
- 각 PR은 시작 시 데이터 브랜치 commit SHA를 한 번 고정하고, B/C 모두 같은 정책을 사용합니다. 데이터가 없거나 검증 또는 fetch에 실패하면 committed fallback으로 결정적으로 배정합니다.

Closes #6205

## 검증 상태

- cargo fmt --all
- cargo fmt --all -- --check
- 자동 갱신과 JUnit 경로 보정을 포함한 CI는 commit e2c192699에서 새로 실행됩니다.

## 운영 영향

B/C archive와 실행 shard 수는 각각 하나로 유지합니다. 갱신 job은 devel에 직접 push하지 않고 데이터 전용 브랜치만 갱신하며, 더 최신 devel SHA가 있으면 오래된 run의 측정값은 게시하지 않습니다.
