### PR TITLE
perf(ci): #6213 green PR 검증을 merge 뒤 재사용한다

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,9 +7,9 @@ nextest-version = { required = "0.9.91", recommended = "0.9.140" }
 filter = "test(/(^|::)overflow_cell_baseline::/)"
 priority = 100
 
-# B/C archive workers use this profile only to emit a compact JUnit report. The
-# report is uploaded only from successful devel runs and becomes a reviewed input
-# for the next duration-policy update PR.
+# B/C archive workers use this profile only to emit a compact JUnit report.
+# Successful devel runs retain it for the baseline; same-repository PRs retain a
+# short-lived candidate that a later trusted post-merge verifier may consume.
 [profile.ci-duration-observation.junit]
 path = "junit.xml"
 report-name = "rhwp-nextest-duration-observation"

--- a/.github/workflows/adapter-diff.yml
+++ b/.github/workflows/adapter-diff.yml
@@ -25,13 +25,23 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  trusted_postmerge_reuse:
+    uses: ./.github/workflows/trusted-postmerge-ci-reuse.yml
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    with:
+      workflow_file: adapter-diff.yml
+
   adapter-impact:
     name: adapter inter-diff preflight
     runs-on: ubuntu-latest
+    needs: [trusted_postmerge_reuse]
     timeout-minutes: 3
     outputs:
-      adapter_required: ${{ steps.finalize.outputs.adapter_required || 'true' }}
-      reason: ${{ steps.finalize.outputs.reason || 'preflight-unavailable' }}
+      adapter_required: ${{ needs.trusted_postmerge_reuse.outputs.reuse == 'true' && 'false' || steps.finalize.outputs.adapter_required || 'true' }}
+      reason: ${{ needs.trusted_postmerge_reuse.outputs.reuse == 'true' && needs.trusted_postmerge_reuse.outputs.reason || steps.finalize.outputs.reason || 'preflight-unavailable' }}
     steps:
       # 문서 전용 PR 또는 검증된 코드 후보 뒤의 review-only tail에서는 stable check
       # 이름을 유지하고 worker만 skip한다. API·계보·후보 run 판정은 fail-closed다.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -979,6 +979,7 @@ jobs:
           python3 -m unittest scripts/tests/test_gym_release_gate_workflow.py
           python3 -m unittest scripts/tests/test_proptest_roundtrip_workflow.py
           python3 -m unittest scripts/tests/test_adapter_diff_workflow.py
+          python3 -m unittest scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
           python3 -m unittest scripts/tests/test_llm_verifier_workflow.py
           python3 -m unittest scripts/tests/test_undo_depth_e2e_workflow.py
           python3 -m unittest scripts/tests/test_workflow_contract_wiring.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,20 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  trusted_postmerge_reuse:
+    uses: ./.github/workflows/trusted-postmerge-ci-reuse.yml
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    with:
+      workflow_file: ci.yml
+      require_duration_artifacts: true
+
   preflight:
     name: CI preflight
     runs-on: ubuntu-latest
+    needs: [trusted_postmerge_reuse]
     # [#3284] 러너 hang 을 실패로 드러내는 상한 (성능 목표 아님) — 실험 종료 후에도 유지
     timeout-minutes: 10
     permissions:
@@ -74,9 +85,11 @@ jobs:
       pull-requests: read
       statuses: read
     outputs:
-      fast_pass: ${{ steps.finalize.outputs.fast_pass || 'false' }}
-      reason: ${{ steps.finalize.outputs.reason || 'preflight-unavailable' }}
+      fast_pass: ${{ needs.trusted_postmerge_reuse.outputs.reuse == 'true' && 'true' || steps.finalize.outputs.fast_pass || 'false' }}
+      reason: ${{ needs.trusted_postmerge_reuse.outputs.reuse == 'true' && needs.trusted_postmerge_reuse.outputs.reason || steps.finalize.outputs.reason || 'preflight-unavailable' }}
       candidate_sha: ${{ steps.finalize.outputs.candidate_sha || '' }}
+      postmerge_reuse: ${{ needs.trusted_postmerge_reuse.outputs.reuse || 'false' }}
+      postmerge_source_run_id: ${{ needs.trusted_postmerge_reuse.outputs.source_run_id || '' }}
       # [#3790 Stage 4·5B] frontend_mode·render_required·rust_required·
       # native_skia_required는 이 workflow의 worker 조건에 사용한다. codeql_languages는
       # codeql.yml이 같은 trusted-base 판정으로 소비한다. 모든 기본값은 full lane이다.
@@ -1438,8 +1451,8 @@ jobs:
       partition: "hash:1/1"
 
 
-  # [#6205] B/C가 성공한 devel run만 data branch로 기록한다. protected devel에는
-  # 직접 쓰지 않으며, 다음 PR은 이 branch의 고정 SHA를 사용한다.
+  # B/C duration data is refreshed from this devel run, or from the exact green
+  # same-repository PR run accepted by trusted_postmerge_reuse.
   refresh-nextest-target-duration-data:
     name: Refresh nextest target duration data
     runs-on: ubuntu-latest
@@ -1453,10 +1466,19 @@ jobs:
         && github.event_name == 'push'
         && github.ref == 'refs/heads/devel'
         && needs.preflight.result == 'success'
-        && needs.preflight.outputs.fast_pass != 'true'
         && needs.preflight.outputs.rust_required == 'true'
-        && needs.test-archive-b-shard-1.result == 'success'
-        && needs.test-archive-c-shard-1.result == 'success'
+        && (
+          (
+            needs.preflight.outputs.postmerge_reuse != 'true'
+            && needs.preflight.outputs.fast_pass != 'true'
+            && needs.test-archive-b-shard-1.result == 'success'
+            && needs.test-archive-c-shard-1.result == 'success'
+          )
+          || (
+            needs.preflight.outputs.postmerge_reuse == 'true'
+            && needs.preflight.outputs.postmerge_source_run_id != ''
+          )
+        )
       }}
     permissions:
       actions: read
@@ -1471,16 +1493,36 @@ jobs:
           fetch-depth: 1
 
       - name: Download Archive B duration measurement
+        if: ${{ needs.preflight.outputs.postmerge_reuse != 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextest-target-durations-${{ github.run_id }}-b
           path: duration-b
 
       - name: Download Archive C duration measurement
+        if: ${{ needs.preflight.outputs.postmerge_reuse != 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextest-target-durations-${{ github.run_id }}-c
           path: duration-c
+
+      - name: Download trusted PR Archive B duration measurement
+        if: ${{ needs.preflight.outputs.postmerge_reuse == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_RUN_ID: ${{ needs.preflight.outputs.postmerge_source_run_id }}
+        run: >-
+          gh run download "${SOURCE_RUN_ID}" --repo "${GITHUB_REPOSITORY}"
+          --name "nextest-target-durations-${SOURCE_RUN_ID}-b" --dir duration-b
+
+      - name: Download trusted PR Archive C duration measurement
+        if: ${{ needs.preflight.outputs.postmerge_reuse == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_RUN_ID: ${{ needs.preflight.outputs.postmerge_source_run_id }}
+        run: >-
+          gh run download "${SOURCE_RUN_ID}" --repo "${GITHUB_REPOSITORY}"
+          --name "nextest-target-durations-${SOURCE_RUN_ID}-c" --dir duration-c
 
       - name: Refresh duration policy data branch
         shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,9 +47,19 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  trusted_postmerge_reuse:
+    uses: ./.github/workflows/trusted-postmerge-ci-reuse.yml
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    with:
+      workflow_file: codeql.yml
+
   preflight:
     name: CodeQL preflight
     runs-on: ubuntu-latest
+    needs: [trusted_postmerge_reuse]
     timeout-minutes: 10
     permissions:
       actions: read
@@ -58,8 +68,8 @@ jobs:
       pull-requests: read
       statuses: read
     outputs:
-      fast_pass: ${{ steps.finalize.outputs.fast_pass || 'false' }}
-      reason: ${{ steps.finalize.outputs.reason || 'preflight-unavailable' }}
+      fast_pass: ${{ needs.trusted_postmerge_reuse.outputs.reuse == 'true' && 'true' || steps.finalize.outputs.fast_pass || 'false' }}
+      reason: ${{ needs.trusted_postmerge_reuse.outputs.reuse == 'true' && needs.trusted_postmerge_reuse.outputs.reason || steps.finalize.outputs.reason || 'preflight-unavailable' }}
       candidate_sha: ${{ steps.finalize.outputs.candidate_sha || '' }}
       codeql_languages: ${{ steps.languages.outputs.codeql_languages || 'javascript-typescript,python,rust' }}
       classification_status: ${{ steps.languages.outputs.classification_status || 'full' }}

--- a/.github/workflows/proptest-roundtrip.yml
+++ b/.github/workflows/proptest-roundtrip.yml
@@ -28,12 +28,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  trusted_postmerge_reuse:
+    uses: ./.github/workflows/trusted-postmerge-ci-reuse.yml
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    with:
+      workflow_file: proptest-roundtrip.yml
+
   preflight:
     name: Proptest preflight
     runs-on: ubuntu-latest
+    needs: [trusted_postmerge_reuse]
     outputs:
-      fast_pass: ${{ steps.finalize.outputs.fast_pass || 'false' }}
-      reason: ${{ steps.finalize.outputs.reason || 'preflight-unavailable' }}
+      fast_pass: ${{ needs.trusted_postmerge_reuse.outputs.reuse == 'true' && 'true' || steps.finalize.outputs.fast_pass || 'false' }}
+      reason: ${{ needs.trusted_postmerge_reuse.outputs.reuse == 'true' && needs.trusted_postmerge_reuse.outputs.reason || steps.finalize.outputs.reason || 'preflight-unavailable' }}
     steps:
       # 문서 전용 devel PR과 검증된 코드 후보 뒤의 review-only tail도 `prop roundtrip`
       # check 이름은 남겨야 한다. workflow-level paths-ignore를 쓰면 required check가

--- a/.github/workflows/run-nextest-archives.yml
+++ b/.github/workflows/run-nextest-archives.yml
@@ -108,9 +108,21 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-      # 신뢰 가능한 duration profile은 성공한 devel 실행에서만 수집한다. PR은
-      # 이 artifact를 정책 파일로 자동 반영하지 않으며, 별도 검토 PR이 필요하다.
-      - name: Upload B/C target durations
+      # Same-repository PR artifact is only a short-lived candidate. It cannot
+      # update the policy until a trusted post-merge verifier accepts its exact
+      # workflow run, merge lineage, and artifact provenance.
+      - name: Upload same-repository PR B/C target durations
+        if: ${{ success() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (inputs.archive_label == 'b' || inputs.archive_label == 'c') }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nextest-target-durations-${{ github.run_id }}-${{ inputs.archive_label }}
+          path: target-durations-${{ inputs.archive_label }}.json
+          retention-days: 3
+          if-no-files-found: error
+
+      # Only successful devel B/C measurements are baseline candidates. They are
+      # retained longer so their provenance can be audited after policy refresh.
+      - name: Upload devel B/C target durations
         if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/devel' && (inputs.archive_label == 'b' || inputs.archive_label == 'c') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -1,0 +1,216 @@
+name: Trusted post-merge CI reuse
+
+on:
+  workflow_call:
+    inputs:
+      workflow_file:
+        description: Source workflow filename whose successful PR run may be reused.
+        required: true
+        type: string
+      require_duration_artifacts:
+        description: Require B/C duration artifacts before permitting CI worker reuse.
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      reuse:
+        description: Whether the caller may skip its workers.
+        value: ${{ jobs.verify.outputs.reuse }}
+      reason:
+        description: Fail-closed verification result.
+        value: ${{ jobs.verify.outputs.reason }}
+      source_run_id:
+        description: Exact successful PR workflow run used as evidence.
+        value: ${{ jobs.verify.outputs.source_run_id }}
+
+permissions: {}
+
+jobs:
+  verify:
+    name: Verify trusted post-merge reuse
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    outputs:
+      reuse: ${{ steps.evaluate.outputs.reuse || steps.defaults.outputs.reuse }}
+      reason: ${{ steps.evaluate.outputs.reason || steps.defaults.outputs.reason }}
+      source_run_id: ${{ steps.evaluate.outputs.source_run_id || '' }}
+    steps:
+      - name: Default to full verification
+        id: defaults
+        shell: bash
+        run: |
+          printf 'reuse=false\nreason=not-a-devel-push\n' >> "$GITHUB_OUTPUT"
+
+      # Resolve the merge's pre-PR source parent before any local verifier code
+      # is checked out. An initial rollout has no base verifier and therefore
+      # falls back to full CI; later PRs use this immutable pre-merge revision.
+      - name: Resolve trusted source base parent
+        id: source-base
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            try {
+              const { data: commit } = await github.rest.repos.getCommit({
+                ...context.repo,
+                ref: context.sha,
+              });
+              const parents = (commit.parents || []).map((parent) => parent.sha);
+              if (parents.length !== 2 || new Set(parents).size !== 2) {
+                core.setOutput('sha', '');
+                core.warning('Post-merge reuse requires exactly two merge parents.');
+                return;
+              }
+              core.setOutput('sha', parents[0]);
+            } catch (error) {
+              core.setOutput('sha', '');
+              core.warning(`Could not resolve merge base; running full. ${error.message}`);
+            }
+
+      # This checkout is the pre-PR devel parent. It never checks out or executes
+      # the merged PR head, including a verifier changed by that PR.
+      - name: Checkout trusted verifier
+        if: ${{ steps.source-base.outputs.sha != '' }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ steps.source-base.outputs.sha }}
+          sparse-checkout: |
+            scripts/verify-trusted-postmerge-ci-reuse.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Evaluate exact PR workflow evidence
+        id: evaluate
+        if: ${{ steps.source-base.outputs.sha != '' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          WORKFLOW_FILE: ${{ inputs.workflow_file }}
+          REQUIRE_DURATION_ARTIFACTS: ${{ inputs.require_duration_artifacts }}
+        with:
+          script: |
+            const path = require('node:path');
+            const { pathToFileURL } = require('node:url');
+            const { owner, repo } = context.repo;
+            let evaluateTrustedPostMergeReuse;
+            try {
+              ({ evaluateTrustedPostMergeReuse } = await import(pathToFileURL(path.join(
+                process.env.GITHUB_WORKSPACE,
+                'scripts/verify-trusted-postmerge-ci-reuse.mjs',
+              )).href));
+            } catch (error) {
+              core.warning(`Trusted base has no compatible verifier; running full. ${error.message}`);
+              core.setOutput('reuse', 'false');
+              core.setOutput('reason', 'trusted-base-verifier-unavailable');
+              core.setOutput('source_run_id', '');
+              return;
+            }
+
+            async function collectEvidence() {
+              const mergeCommit = (await github.rest.repos.getCommit({
+                owner,
+                repo,
+                ref: context.sha,
+              })).data;
+              const pullRequests = await github.paginate(
+                github.rest.repos.listPullRequestsAssociatedWithCommit,
+                { owner, repo, commit_sha: context.sha, per_page: 100 },
+              );
+              const pullRequest = pullRequests.filter((candidate) => (
+                candidate.state === 'closed'
+                && candidate.merged_at
+                && candidate.merge_commit_sha === context.sha
+                && candidate.base?.ref === 'devel'
+                && candidate.head?.repo?.full_name === process.env.GITHUB_REPOSITORY
+              ));
+              if (pullRequest.length !== 1) {
+                return { mergeCommit, pullRequests, pullFiles: [], workflowRuns: [] };
+              }
+              const pr = pullRequest[0];
+              const baseParent = (mergeCommit.parents || [])
+                .map((parent) => parent.sha)
+                .find((sha) => sha !== pr.head.sha);
+              const [sourceCommit, comparison, pullFiles, workflowRuns] = await Promise.all([
+                github.rest.repos.getCommit({ owner, repo, ref: pr.head.sha }).then((response) => response.data),
+                baseParent
+                  ? github.rest.repos.compareCommits({ owner, repo, base: baseParent, head: pr.head.sha })
+                    .then((response) => response.data)
+                  : Promise.resolve({ merge_base_commit: { sha: '' } }),
+                github.paginate(github.rest.pulls.listFiles, {
+                  owner, repo, pull_number: pr.number, per_page: 100,
+                }),
+                github.paginate(github.rest.actions.listWorkflowRuns, {
+                  owner,
+                  repo,
+                  workflow_id: process.env.WORKFLOW_FILE,
+                  event: 'pull_request',
+                  branch: pr.head.ref,
+                  per_page: 100,
+                }),
+              ]);
+              return {
+                mergeCommit,
+                pullRequests,
+                sourceCommit,
+                mergeBaseSha: comparison.merge_base_commit?.sha || '',
+                pullFiles,
+                workflowRuns,
+              };
+            }
+
+            let result;
+            try {
+              const evidence = await collectEvidence();
+              result = evaluateTrustedPostMergeReuse({
+                eventName: context.eventName,
+                ref: context.ref,
+                repository: process.env.GITHUB_REPOSITORY,
+                mergeSha: context.sha,
+                ...evidence,
+              });
+            } catch (error) {
+              core.warning(`Trusted post-merge reuse is unavailable; running full. ${error.message}`);
+              result = {
+                reuse: false,
+                reason: 'evidence-collection-error',
+                sourceRunId: '',
+                pullNumber: '',
+              };
+            }
+            if (result.reuse && process.env.REQUIRE_DURATION_ARTIFACTS === 'true') {
+              try {
+                const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                  owner,
+                  repo,
+                  run_id: Number(result.sourceRunId),
+                  per_page: 100,
+                });
+                const expected = new Set([
+                  `nextest-target-durations-${result.sourceRunId}-b`,
+                  `nextest-target-durations-${result.sourceRunId}-c`,
+                ]);
+                const available = new Set(artifacts.map((artifact) => artifact.name));
+                if (![...expected].every((name) => available.has(name))) {
+                  result = {
+                    reuse: false,
+                    reason: 'candidate-duration-artifacts-unavailable',
+                    sourceRunId: '',
+                    pullNumber: '',
+                  };
+                }
+              } catch (error) {
+                core.warning(`Could not inspect candidate duration artifacts; running full. ${error.message}`);
+                result = {
+                  reuse: false,
+                  reason: 'candidate-duration-artifact-check-error',
+                  sourceRunId: '',
+                  pullNumber: '',
+                };
+              }
+            }
+            core.setOutput('reuse', result.reuse ? 'true' : 'false');
+            core.setOutput('reason', result.reason);
+            core.setOutput('source_run_id', result.sourceRunId || '');
+            core.info(`reuse=${result.reuse} reason=${result.reason} source_run_id=${result.sourceRunId || 'none'}`);

--- a/mydocs/orders/20260827.md
+++ b/mydocs/orders/20260827.md
@@ -37,6 +37,6 @@
 
 ## CI 운영 개선
 
-- [x] [#6216](https://github.com/edwardkim/rhwp/pull/6216)에서 #6213의 trusted post-merge CI 재사용과 nextest duration 측정 무결성 보강을 구현하고, workflow 계약 검증 92건을 통과시켰다.
+- [x] [#6216](https://github.com/edwardkim/rhwp/pull/6216)에서 #6213의 trusted post-merge CI 재사용과 nextest duration 측정 무결성 보강을 구현하고, Node 9건과 Python workflow 계약 86건을 통과시켰다. CI가 발견한 새 계약 테스트 배선 누락도 보정했다.
 - [ ] #6216 최신 head CI가 성공하고 첫 배포가 full fallback으로 안전하게 끝나는지 확인한 뒤 merge한다.
 - [ ] merge 뒤 첫 적격 PR의 post-merge 실행에서 source PR green 결과와 B/C duration artifact가 정확히 재사용되는지 확인한다.

--- a/mydocs/orders/20260827.md
+++ b/mydocs/orders/20260827.md
@@ -34,3 +34,9 @@
   native-skia, WASM, Studio unit/build/#6053 e2e/responsive e2e 통과.
 - [x] 원 PR별 review 문서와 통합 review 문서, 시각 증적 SHA/검증 요약 asset을 준비했다.
 - [ ] 통합 PR 생성 전 사전 승인을 받는다.
+
+## CI 운영 개선
+
+- [x] [#6216](https://github.com/edwardkim/rhwp/pull/6216)에서 #6213의 trusted post-merge CI 재사용과 nextest duration 측정 무결성 보강을 구현하고, workflow 계약 검증 92건을 통과시켰다.
+- [ ] #6216 최신 head CI가 성공하고 첫 배포가 full fallback으로 안전하게 끝나는지 확인한 뒤 merge한다.
+- [ ] merge 뒤 첫 적격 PR의 post-merge 실행에서 source PR green 결과와 B/C duration artifact가 정확히 재사용되는지 확인한다.

--- a/mydocs/pr/archives/pr_6216_review.md
+++ b/mydocs/pr/archives/pr_6216_review.md
@@ -30,10 +30,17 @@
 - `node scripts/rust-test-suite-manifest.mjs --check`
 - `git diff --check`
 
+## CI 발견 보정
+
+- 최초 head CI의 `Validate workflow contracts`가 새
+  `test_trusted_postmerge_ci_reuse_workflow.py` 호출 누락을 fail-closed로 발견했다.
+- 같은 단계의 호출 목록에 테스트를 추가했고, workflow 관련 Python 계약 86건과
+  `git diff --check`를 다시 통과했다.
+
 ## 시각 증적
 
 이 PR은 GitHub Actions workflow, CI 정책 스크립트와 계약 테스트만 변경한다. 문서 렌더링 또는 Studio 화면 동작을 변경하지 않으므로 visual sweep 대상이 아니다.
 
 ## 결론
 
-로컬 계약 검증은 통과했다. 최신 head의 필수 CI가 성공하고, 첫 배포가 기대대로 전체 CI fallback으로 완료되는 것을 확인한 뒤 merge한다.
+로컬 계약 검증은 통과했다. 보정된 최신 head의 필수 CI가 성공하고, 첫 배포가 기대대로 전체 CI fallback으로 완료되는 것을 확인한 뒤 merge한다.

--- a/mydocs/pr/archives/pr_6216_review.md
+++ b/mydocs/pr/archives/pr_6216_review.md
@@ -1,0 +1,39 @@
+# PR #6216 검토 기록
+
+## 대상
+
+- PR: [#6216](https://github.com/edwardkim/rhwp/pull/6216)
+- 제목: `perf(ci): #6213 green PR 검증을 merge 뒤 재사용한다`
+- 기준 브랜치: `devel`
+- head: `task_m100_6213_trusted_postmerge_reuse`
+- 관련 이슈: [#6213](https://github.com/edwardkim/rhwp/issues/6213)
+
+## 검토 범위
+
+- `devel` merge commit이 정확히 하나의 green PR 검증 결과를 재사용할 수 있는지 판정하는 공통 workflow를 추가했다.
+- CI, CodeQL, adapter diff, proptest-roundtrip에 동일한 fail-closed 판정을 연결했다.
+- nextest B/C JUnit 측정에서 testcase 기준 target 시간을 수집하고, 빈 값과 서로 다른 provenance의 정책 반영을 거부한다.
+
+## 안전성 판단
+
+- 재사용은 `devel`의 2-parent merge, 정확히 일치하는 merged PR, source head와 merge tree, base 계보, 최신 successful PR workflow run, enforcement 경로 무변경을 모두 만족할 때만 허용한다.
+- direct push, stale base, merge-queue 형태, pending/failed/missing source run, workflow 또는 CI 계약 변경은 모두 전체 CI로 폴백한다.
+- CI duration 정책은 B/C artifact가 같은 `run_id`, `ref`, `sha`를 가지며 target map이 비어 있지 않을 때만 승격한다.
+- 첫 배포 PR은 기준 `devel`에 verifier helper가 아직 없으므로 의도적으로 전체 CI를 실행한다. helper를 PR head에서 실행하지 않아 self-approval 경로를 만들지 않는다.
+
+## 로컬 검증
+
+- `cargo fmt --all`
+- `cargo fmt --all -- --check`
+- `node --test scripts/tests/nextest-target-duration-policy.test.mjs scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs` (9 passed)
+- `python3 -m unittest scripts/tests/test_nextest_archive_workflow.py scripts/tests/test_ci_impact_workflow.py scripts/tests/test_codeql_workflow.py scripts/tests/test_adapter_diff_workflow.py scripts/tests/test_proptest_roundtrip_workflow.py scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py` (83 passed)
+- `node scripts/rust-test-suite-manifest.mjs --check`
+- `git diff --check`
+
+## 시각 증적
+
+이 PR은 GitHub Actions workflow, CI 정책 스크립트와 계약 테스트만 변경한다. 문서 렌더링 또는 Studio 화면 동작을 변경하지 않으므로 visual sweep 대상이 아니다.
+
+## 결론
+
+로컬 계약 검증은 통과했다. 최신 head의 필수 CI가 성공하고, 첫 배포가 기대대로 전체 CI fallback으로 완료되는 것을 확인한 뒤 merge한다.

--- a/mydocs/pr/archives/pr_6216_review_impl.md
+++ b/mydocs/pr/archives/pr_6216_review_impl.md
@@ -1,0 +1,25 @@
+# PR #6216 구현 검토 기록
+
+## 구현 단계
+
+1. `trusted-postmerge-ci-reuse.yml`은 merge commit의 pre-PR `devel` parent만 checkout한다.
+2. base parent에 존재하는 verifier가 merge SHA, parent 관계, PR 연관성, tree, changed paths, source workflow run을 판정한다.
+3. 판정 결과가 `reuse=true`일 때만 각 workflow가 source PR의 green 결과를 재사용한다.
+4. CI duration 갱신은 source PR의 B/C artifact와 provenance가 모두 유효할 때만 수행한다.
+
+## 불변 조건
+
+- PR head의 verifier 또는 workflow를 checkout하거나 실행하지 않는다.
+- 검증 정보가 누락되거나 모순되면 성공으로 추정하지 않고 전체 CI를 수행한다.
+- B/C target-duration 측정은 빈 map, 서로 다른 run, ref, SHA를 허용하지 않는다.
+
+## 롤백 경로
+
+- 재사용 판정에 결함이 확인되면 네 호출 workflow에서 `trusted_postmerge_reuse` 의존성과 fast-pass 연결을 제거하면 이전의 post-merge 전체 CI 동작으로 되돌아간다.
+- duration 수집 또는 승격 결함은 새 collector/refresh 검증을 제거하거나 정책 파일 갱신을 중단해 기존 고정 정책으로 복귀할 수 있다.
+
+## 배포 관찰 항목
+
+- #6216 자체는 verifier helper가 base에 없으므로 전체 CI fallback이어야 한다.
+- merge 뒤 다음 적격 PR의 `devel` post-merge 실행에서 source run ID가 기록되고, 변경 경로가 안전할 때만 재사용되어야 한다.
+- 재사용 불가 조건에서는 workflow가 성공을 위장하지 않고 정상 전체 검증 경로를 실행해야 한다.

--- a/mydocs/pr/archives/pr_6216_review_impl.md
+++ b/mydocs/pr/archives/pr_6216_review_impl.md
@@ -12,6 +12,7 @@
 - PR head의 verifier 또는 workflow를 checkout하거나 실행하지 않는다.
 - 검증 정보가 누락되거나 모순되면 성공으로 추정하지 않고 전체 CI를 수행한다.
 - B/C target-duration 측정은 빈 map, 서로 다른 run, ref, SHA를 허용하지 않는다.
+- 새 workflow 계약 테스트는 `ci.yml`의 `Validate workflow contracts` 단계에 명시적으로 배선한다.
 
 ## 롤백 경로
 

--- a/mydocs/working/task_m100_6213_stage1_trusted_postmerge_ci_reuse.md
+++ b/mydocs/working/task_m100_6213_stage1_trusted_postmerge_ci_reuse.md
@@ -18,8 +18,9 @@ data branch의 target map이 모두 비어 있었다. 따라서 green job 결론
 - 저장소의 기본 브랜치는 `main`이다. 새 `workflow_run` 또는
   `workflow_dispatch` workflow를 `devel`에만 추가해 post-merge worker를 분리하면
   GitHub가 실행하지 않는다.
-- write 권한 경로는 trusted `devel` 코드만 실행하며, PR head의 코드나 script를
-  checkout 또는 실행하면 안 된다.
+- verifier는 merge의 pre-PR `devel` source parent에서만 실행한다. 첫 배포는 base에
+  verifier가 없으므로 full CI로 fallback하며, PR head의 코드나 script를 checkout 또는
+  실행하면 안 된다.
 
 ## 설계 결정
 
@@ -29,8 +30,10 @@ data branch의 target map이 모두 비어 있었다. 따라서 green job 결론
 3. 다음 조건이 모두 충족될 때만 해당 workflow worker를 재사용한다.
    - 현재 `devel` tip이 merge commit이다.
    - merge commit의 source parent, PR head, 대상 `devel` base 계보가 일치한다.
+   - PR head가 merge의 base parent를 조상으로 포함하고, merge tree가 PR head tree와 같다.
    - 같은 PR head의 해당 workflow 최종 candidate가 완료·성공했다.
-   - 후보가 stale, fork, direct push, 재실행 중, 누락 또는 실패가 아니다.
+   - PR이 workflow·action·duration 정책 등 CI enforcement surface를 바꾸지 않았고,
+     후보가 stale, fork, direct push, 재실행 중, 누락 또는 실패가 아니다.
 4. 어느 하나라도 불명확하면 worker를 skip하지 않고 기존 전체 CI로 fail-closed 한다.
 5. CI의 duration 갱신은 재사용한 PR run ID의 B/C artifact만 읽는다. 두 artifact는
    같은 run/head 출처여야 하며, B/C target map이 비어 있거나 현재 integration

--- a/mydocs/working/task_m100_6213_stage1_trusted_postmerge_ci_reuse.md
+++ b/mydocs/working/task_m100_6213_stage1_trusted_postmerge_ci_reuse.md
@@ -1,0 +1,52 @@
+# #6213 Stage 1: green PR 검증의 안전한 post-merge 재사용
+
+## 배경
+
+PR #6207은 B/C target 실행시간을 수집하기 위해 `devel` CI가 성공한 뒤
+측정 정책을 갱신하도록 구현했다. 그러나 이 방식은 PR에서 이미 통과한 CI,
+CodeQL, adapter, proptest worker를 merge 뒤 다시 실행한다.
+
+`devel` run `33064128254`는 refresh job까지 성공했지만 B/C 측정 artifact와
+data branch의 target map이 모두 비어 있었다. 따라서 green job 결론만으로
+측정 정책의 기능적 성공을 판단할 수 없다.
+
+## 확인한 운영 제약
+
+- `devel` push에서 CI, CodeQL, Adapter inter-diff, Proptest roundtrip이 실행된다.
+- `devel` 직접 push, 후보 누락, stale head, 실패 또는 pending 후보는 전체 검증을
+  유지해야 한다.
+- 저장소의 기본 브랜치는 `main`이다. 새 `workflow_run` 또는
+  `workflow_dispatch` workflow를 `devel`에만 추가해 post-merge worker를 분리하면
+  GitHub가 실행하지 않는다.
+- write 권한 경로는 trusted `devel` 코드만 실행하며, PR head의 코드나 script를
+  checkout 또는 실행하면 안 된다.
+
+## 설계 결정
+
+1. 기존 `devel` push trigger와 required check 이름은 유지한다.
+2. CI, CodeQL, Adapter inter-diff, Proptest preflight가 공통 검증기로 merge commit을
+   해석한다.
+3. 다음 조건이 모두 충족될 때만 해당 workflow worker를 재사용한다.
+   - 현재 `devel` tip이 merge commit이다.
+   - merge commit의 source parent, PR head, 대상 `devel` base 계보가 일치한다.
+   - 같은 PR head의 해당 workflow 최종 candidate가 완료·성공했다.
+   - 후보가 stale, fork, direct push, 재실행 중, 누락 또는 실패가 아니다.
+4. 어느 하나라도 불명확하면 worker를 skip하지 않고 기존 전체 CI로 fail-closed 한다.
+5. CI의 duration 갱신은 재사용한 PR run ID의 B/C artifact만 읽는다. 두 artifact는
+   같은 run/head 출처여야 하며, B/C target map이 비어 있거나 현재 integration
+   target 집합과 일치하지 않으면 publish를 거부한다.
+
+## 완료 기준
+
+- 공통 검증기 unit test가 exact candidate, stale candidate, base/head 불일치, direct
+  push, fork, pending 또는 failed 후보를 구분한다.
+- 네 workflow 계약 test가 post-merge 재사용 및 full fallback 조건을 고정한다.
+- PR CI는 workflow 변경으로 full 검증한다.
+- merge 뒤 `devel`에서는 exact green PR만 worker가 재사용되고, duration data에는
+  비어 있지 않은 target 시간이 기록된다.
+
+## 제외
+
+- `devel` 직접 push의 전체 검증 제거
+- required check 이름 변경
+- B/C shard 수 변경

--- a/mydocs/working/task_m100_6213_stage2_duration_measurement_integrity.md
+++ b/mydocs/working/task_m100_6213_stage2_duration_measurement_integrity.md
@@ -1,0 +1,41 @@
+# #6213 Stage 2: B/C 실행시간 측정의 출처와 완전성 고정
+
+## 목표
+
+Stage 1의 post-merge 재사용은 B/C artifact가 실제 선택 target의 실행시간을 담는다는
+전제가 있어야 한다. PR #6207의 `devel` run `33064128254`는 성공했지만 수집 결과가
+0 target이었다. 이 단계를 먼저 고쳐 다음 단계가 빈 측정값을 신뢰하지 못하게 한다.
+
+## 원인
+
+nextest JUnit은 test binary를 `testsuite`로, 개별 test 실행시간을 `testcase`로 기록한다.
+기존 수집기는 `testsuite`의 `time`만 읽었으므로, suite-level 시간이 없는 실제 JUnit에서
+모든 target을 누락했다.
+
+## 구현
+
+1. `testcase.classname`에서 test binary 이름을 읽고 `time`을 binary별로 합산한다.
+2. 수집 결과가 빈 target map이면 artifact를 쓰지 않고 worker를 실패시킨다.
+3. refresh는 B/C 각각이 비어 있지 않고 같은 `run_id`, `ref`, `sha` 출처임을 요구한다.
+4. 성공한 `devel` B/C artifact는 30일, 같은 저장소 PR B/C artifact는 trusted
+   post-merge 후보 소비를 위해 3일 보관한다. fork PR artifact는 만들지 않는다.
+
+## 보안 및 운영 경계
+
+- PR artifact는 이 단계에서 duration policy를 갱신하지 않는다.
+- 다음 단계의 trusted verifier가 same-repository PR, exact merge lineage, 성공한
+  workflow run을 모두 확인할 때만 PR artifact를 읽을 수 있다.
+- direct `devel` push와 후보 누락 또는 출처 불일치는 기존 전체 검증과 `devel` 측정
+  경로로 fail-closed 한다.
+- 같은 Stage의 shared verifier는 PR head가 merge base를 포함하고 merge tree와 같은지를
+  검증한다. 따라서 stale PR의 source-head green 결과로 merge 결과를 대체하지 않는다.
+- CI worker 재사용은 source PR run의 B/C artifact 이름·존재까지 검사한 뒤에만 허용한다.
+  artifact가 없는 기존 PR, fork, 검증 오류는 full `devel` worker로 fallback한다.
+- verifier 스크립트는 merge commit이 아니라 pre-PR source parent에서 checkout한다. 이
+  bootstrap PR은 base에 verifier가 없어 full CI를 실행하고, 이후 PR부터 재사용한다.
+
+## 완료 기준
+
+- suite-level `time`이 없는 JUnit fixture에서 B/C target별 합계가 생성된다.
+- 빈 map 및 B/C 출처 불일치가 policy refresh 전에 거부된다.
+- workflow 계약 test가 `devel` 30일, same-repository PR 3일 artifact 경계를 고정한다.

--- a/scripts/collect-nextest-target-durations.mjs
+++ b/scripts/collect-nextest-target-durations.mjs
@@ -48,9 +48,9 @@ function parseAttributes(raw) {
 
 export function collectTargetDurations(junitXml) {
   const durations = new Map();
-  for (const match of junitXml.matchAll(/<testsuite\b([^>]*)>/g)) {
+  for (const match of junitXml.matchAll(/<testcase\b([^>]*)>/g)) {
     const attributes = parseAttributes(match[1]);
-    const suiteName = attributes.get("name");
+    const suiteName = attributes.get("classname");
     const seconds = Number(attributes.get("time"));
     if (!suiteName || suiteName.startsWith("@setup-script:") || !Number.isFinite(seconds) || seconds < 0) {
       continue;
@@ -77,6 +77,9 @@ function main() {
   }
 
   const targets = collectTargetDurations(fs.readFileSync(options.input, "utf8"));
+  if (Object.keys(targets).length === 0) {
+    fail("JUnit report contains no target durations");
+  }
   const report = {
     schema_version: 1,
     archive_label: options["archive-label"],

--- a/scripts/refresh-nextest-target-duration-policy.mjs
+++ b/scripts/refresh-nextest-target-duration-policy.mjs
@@ -37,6 +37,7 @@ function parseArgs(args) {
 export function refreshDurationPolicy(policy, measurements) {
   parseDurationPolicy(policy);
   const durations = { ...policy.targets };
+  const sourceKeys = new Set();
   for (const measurement of measurements) {
     if (!measurement || measurement.schema_version !== 1 || !["b", "c"].includes(measurement.archive_label)) {
       fail("measurement must be a B or C schema_version 1 report");
@@ -44,12 +45,24 @@ export function refreshDurationPolicy(policy, measurements) {
     if (!measurement.targets || typeof measurement.targets !== "object" || Array.isArray(measurement.targets)) {
       fail("measurement targets must be an object");
     }
-    for (const [target, seconds] of Object.entries(measurement.targets)) {
+    const entries = Object.entries(measurement.targets);
+    if (entries.length === 0) {
+      fail(`measurement must contain target durations: ${measurement.archive_label}`);
+    }
+    const source = [measurement.run_id, measurement.ref, measurement.sha];
+    if (!source.every((value) => typeof value === "string" && value.length > 0)) {
+      fail(`measurement must identify its run, ref, and sha: ${measurement.archive_label}`);
+    }
+    sourceKeys.add(JSON.stringify(source));
+    for (const [target, seconds] of entries) {
       if (!target || !Number.isFinite(seconds) || seconds <= 0) {
         fail(`measurement target must have a positive duration: ${target}`);
       }
       durations[target] = seconds;
     }
+  }
+  if (sourceKeys.size !== 1) {
+    fail("B and C measurements must have identical run, ref, and sha provenance");
   }
 
   return {

--- a/scripts/tests/nextest-target-duration-policy.test.mjs
+++ b/scripts/tests/nextest-target-duration-policy.test.mjs
@@ -92,12 +92,13 @@ test("CLI consumes streamed cargo metadata without synchronous stdin reads", () 
   assert.match(result.stderr, /integration_targets=2 selected_targets=1/);
 });
 
-test("JUnit collection aggregates one duration per test binary and skips setup suites", () => {
+test("JUnit collection aggregates testcase durations per binary and skips setup suites", () => {
   const durations = collectTargetDurations([
-    '<testsuite name="rhwp::issue_1" time="1.25">',
-    '<testsuite name="@setup-script:seed" time="5.00">',
-    '<testsuite name="rhwp::issue_1" time="0.75">',
-    '<testsuite name="rhwp::issue_2" time="2.00">',
+    '<testsuite name="rhwp::issue_1">',
+    '<testcase name="first" classname="rhwp::issue_1" time="1.25" />',
+    '<testcase name="setup" classname="@setup-script:seed" time="5.00" />',
+    '<testcase name="second" classname="rhwp::issue_1" time="0.75" />',
+    '<testcase name="third" classname="rhwp::issue_2" time="2.00" />',
   ].join("\n"));
 
   assert.deepEqual(durations, { issue_1: 2, issue_2: 2 });
@@ -109,13 +110,31 @@ test("policy refresh accepts one successful B and C measurement", () => {
     fallback_seconds: 1,
     targets: { existing: 3 },
   }, [
-    { schema_version: 1, archive_label: "b", run_id: "10", ref: "refs/heads/devel", sha: "b-sha", targets: { beta: 4 } },
-    { schema_version: 1, archive_label: "c", run_id: "10", ref: "refs/heads/devel", sha: "c-sha", targets: { alpha: 2 } },
+    { schema_version: 1, archive_label: "b", run_id: "10", ref: "refs/heads/devel", sha: "same-sha", targets: { beta: 4 } },
+    { schema_version: 1, archive_label: "c", run_id: "10", ref: "refs/heads/devel", sha: "same-sha", targets: { alpha: 2 } },
   ]);
 
   assert.deepEqual(refreshed.targets, { alpha: 2, beta: 4, existing: 3 });
   assert.deepEqual(refreshed.measurement_sources, {
-    b: { run_id: "10", ref: "refs/heads/devel", sha: "b-sha" },
-    c: { run_id: "10", ref: "refs/heads/devel", sha: "c-sha" },
+    b: { run_id: "10", ref: "refs/heads/devel", sha: "same-sha" },
+    c: { run_id: "10", ref: "refs/heads/devel", sha: "same-sha" },
   });
+});
+
+test("policy refresh rejects empty or mismatched B/C measurements", () => {
+  const basePolicy = { schema_version: 1, fallback_seconds: 1, targets: {} };
+  assert.throws(
+    () => refreshDurationPolicy(basePolicy, [
+      { schema_version: 1, archive_label: "b", run_id: "10", ref: "refs/heads/devel", sha: "same-sha", targets: {} },
+      { schema_version: 1, archive_label: "c", run_id: "10", ref: "refs/heads/devel", sha: "same-sha", targets: { alpha: 2 } },
+    ]),
+    /must contain target durations: b/,
+  );
+  assert.throws(
+    () => refreshDurationPolicy(basePolicy, [
+      { schema_version: 1, archive_label: "b", run_id: "10", ref: "refs/heads/devel", sha: "first", targets: { beta: 4 } },
+      { schema_version: 1, archive_label: "c", run_id: "10", ref: "refs/heads/devel", sha: "second", targets: { alpha: 2 } },
+    ]),
+    /identical run, ref, and sha provenance/,
+  );
 });

--- a/scripts/tests/test_nextest_archive_workflow.py
+++ b/scripts/tests/test_nextest_archive_workflow.py
@@ -143,7 +143,7 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         self.assertIn("scripts/collect-nextest-target-durations.mjs", runner)
         self.assertIn("nextest-target-durations-${{ github.run_id }}-${{ inputs.archive_label }}", runner)
 
-    def test_duration_policy_collects_only_successful_devel_b_and_c_measurements(self):
+    def test_duration_policy_collects_devel_and_same_repository_pr_b_and_c_measurements(self):
         from pathlib import Path
         root = Path(__file__).resolve().parents[2]
         policy = (root / "tests/suites/nextest-target-duration-policy.json").read_text()
@@ -158,11 +158,20 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         self.assertIn("[profile.ci-duration-observation.junit]", config)
         self.assertIn("github.event_name == 'push'", runner)
         self.assertIn("github.ref == 'refs/heads/devel'", runner)
+        self.assertIn("github.event_name == 'pull_request'", runner)
+        self.assertIn(
+            "github.event.pull_request.head.repo.full_name == github.repository",
+            runner,
+        )
         self.assertIn("inputs.archive_label == 'b'", runner)
         self.assertIn("inputs.archive_label == 'c'", runner)
+        self.assertIn("retention-days: 3", runner)
+        self.assertIn("retention-days: 30", runner)
         self.assertIn("estimatedSeconds", selector)
-        self.assertIn("<testsuite", collector)
+        self.assertIn("<testcase", collector)
+        self.assertIn("JUnit report contains no target durations", collector)
         self.assertIn("exactly one B report and one C report", refresh)
+        self.assertIn("identical run, ref, and sha provenance", refresh)
 
     def test_native_skia_uses_the_same_test_profile_policy(self) -> None:
         native = job_body(self.ci, "native-skia-tests")

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -1,0 +1,62 @@
+"""Trusted post-merge worker-reuse workflow contracts."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REUSABLE = REPO_ROOT / ".github/workflows/trusted-postmerge-ci-reuse.yml"
+WORKFLOWS = {
+    "ci": REPO_ROOT / ".github/workflows/ci.yml",
+    "codeql": REPO_ROOT / ".github/workflows/codeql.yml",
+    "adapter": REPO_ROOT / ".github/workflows/adapter-diff.yml",
+    "proptest": REPO_ROOT / ".github/workflows/proptest-roundtrip.yml",
+}
+
+
+class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
+    def test_reusable_verifier_is_read_only_and_fail_closed(self) -> None:
+        workflow = REUSABLE.read_text(encoding="utf-8")
+        self.assertIn("actions: read", workflow)
+        self.assertIn("contents: read", workflow)
+        self.assertIn("pull-requests: read", workflow)
+        self.assertIn("Default to full verification", workflow)
+        self.assertIn("Resolve trusted source base parent", workflow)
+        self.assertIn("ref: ${{ steps.source-base.outputs.sha }}", workflow)
+        self.assertIn("trusted-base-verifier-unavailable", workflow)
+        self.assertIn("event: 'pull_request'", workflow)
+        self.assertIn("listPullRequestsAssociatedWithCommit", workflow)
+        self.assertIn("compareCommits", workflow)
+        self.assertIn("listWorkflowRuns", workflow)
+        self.assertIn("listFiles", workflow)
+        self.assertIn("listWorkflowRunArtifacts", workflow)
+        self.assertIn("never checks out or executes", workflow)
+        self.assertIn("the merged PR head", workflow)
+
+    def test_all_duplicate_postmerge_workflows_call_the_shared_verifier(self) -> None:
+        expected_workflow_files = {
+            "ci": "workflow_file: ci.yml",
+            "codeql": "workflow_file: codeql.yml",
+            "adapter": "workflow_file: adapter-diff.yml",
+            "proptest": "workflow_file: proptest-roundtrip.yml",
+        }
+        for name, workflow_path in WORKFLOWS.items():
+            with self.subTest(workflow=name):
+                workflow = workflow_path.read_text(encoding="utf-8")
+                self.assertIn("trusted_postmerge_reuse:", workflow)
+                self.assertIn("./.github/workflows/trusted-postmerge-ci-reuse.yml", workflow)
+                self.assertIn(expected_workflow_files[name], workflow)
+                self.assertIn("needs.trusted_postmerge_reuse.outputs.reuse", workflow)
+
+    def test_ci_requires_candidate_duration_artifacts_before_worker_reuse(self) -> None:
+        ci = WORKFLOWS["ci"].read_text(encoding="utf-8")
+        self.assertIn("require_duration_artifacts: true", ci)
+        self.assertIn("postmerge_source_run_id", ci)
+        self.assertIn("Download trusted PR Archive B duration measurement", ci)
+        self.assertIn("Download trusted PR Archive C duration measurement", ci)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { evaluateTrustedPostMergeReuse } from "../verify-trusted-postmerge-ci-reuse.mjs";
+
+const base = "1".repeat(40);
+const head = "2".repeat(40);
+const merge = "3".repeat(40);
+const tree = "4".repeat(40);
+
+function candidate(overrides = {}) {
+  return {
+    id: 123,
+    event: "pull_request",
+    status: "completed",
+    conclusion: "success",
+    head_sha: head,
+    head_branch: "feature",
+    head_repository: { full_name: "edwardkim/rhwp" },
+    created_at: "2026-08-27T10:01:00Z",
+    updated_at: "2026-08-27T10:02:00Z",
+    ...overrides,
+  };
+}
+
+function input(overrides = {}) {
+  return {
+    eventName: "push",
+    ref: "refs/heads/devel",
+    repository: "edwardkim/rhwp",
+    mergeSha: merge,
+    mergeCommit: {
+      sha: merge,
+      parents: [{ sha: base }, { sha: head }],
+      commit: { tree: { sha: tree } },
+    },
+    sourceCommit: { sha: head, commit: { tree: { sha: tree } } },
+    mergeBaseSha: base,
+    pullRequests: [{
+      number: 42,
+      state: "closed",
+      merged_at: "2026-08-27T10:03:00Z",
+      merge_commit_sha: merge,
+      created_at: "2026-08-27T10:00:00Z",
+      base: { ref: "devel" },
+      head: { sha: head, ref: "feature", repo: { full_name: "edwardkim/rhwp" } },
+    }],
+    pullFiles: [{ filename: "src/renderer/layout.rs" }],
+    workflowRuns: [candidate()],
+    ...overrides,
+  };
+}
+
+test("reuses only the latest exact green PR workflow run", () => {
+  assert.deepEqual(evaluateTrustedPostMergeReuse(input()), {
+    reuse: true,
+    reason: "exact-green-pr-workflow-reused",
+    sourceRunId: "123",
+    pullNumber: "42",
+  });
+});
+
+test("fails closed for direct pushes, stale bases, enforcement changes, and incomplete candidates", () => {
+  assert.equal(evaluateTrustedPostMergeReuse(input({ eventName: "workflow_dispatch" })).reuse, false);
+  assert.equal(evaluateTrustedPostMergeReuse(input({ mergeBaseSha: "5".repeat(40) })).reuse, false);
+  assert.equal(evaluateTrustedPostMergeReuse(input({ pullFiles: [{ filename: ".github/workflows/ci.yml" }] })).reuse, false);
+  assert.equal(evaluateTrustedPostMergeReuse(input({ workflowRuns: [candidate({ status: "in_progress", conclusion: null })] })).reuse, false);
+});

--- a/scripts/verify-trusted-postmerge-ci-reuse.mjs
+++ b/scripts/verify-trusted-postmerge-ci-reuse.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+const SHA = /^[0-9a-f]{40}$/;
+
+function denied(reason) {
+  return { reuse: false, reason, sourceRunId: "", pullNumber: "" };
+}
+
+function validSha(value) {
+  return typeof value === "string" && SHA.test(value);
+}
+
+function timestamp(value) {
+  const parsed = Date.parse(value || "");
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+}
+
+function enforcementPathChanged(files) {
+  const paths = (Array.isArray(files) ? files : [])
+    .flatMap((file) => [file?.filename, file?.previous_filename])
+    .filter((path) => typeof path === "string" && path.length > 0);
+  return paths.some((path) => (
+    path.startsWith(".github/workflows/")
+    || path.startsWith(".github/actions/")
+    || path === ".config/nextest.toml"
+    || path === "scripts/ci-impact-classifier.cjs"
+    || path === "scripts/ci-impact-policy.cjs"
+    || path === "scripts/select-nextest-archive-targets.mjs"
+    || path === "scripts/collect-nextest-target-durations.mjs"
+    || path === "scripts/refresh-nextest-target-duration-policy.mjs"
+    || path === "scripts/verify-trusted-postmerge-ci-reuse.mjs"
+    || path === "tests/suites/nextest-target-duration-policy.json"
+  ));
+}
+
+function latestCandidateRun(runs, pullRequest, repository) {
+  const createdAt = timestamp(pullRequest.created_at);
+  const mergedAt = timestamp(pullRequest.merged_at);
+  if (!Number.isFinite(createdAt) || !Number.isFinite(mergedAt) || mergedAt < createdAt) {
+    return null;
+  }
+
+  const matches = (Array.isArray(runs) ? runs : []).filter((run) => (
+    run?.event === "pull_request"
+    && run?.head_sha === pullRequest.head?.sha
+    && run?.head_branch === pullRequest.head?.ref
+    && run?.head_repository?.full_name === repository
+    && timestamp(run.created_at) >= createdAt
+    && timestamp(run.updated_at) <= mergedAt
+  ));
+  if (matches.length === 0) {
+    return null;
+  }
+  return matches.sort((left, right) => (
+    timestamp(right.updated_at) - timestamp(left.updated_at)
+    || Number(right.run_attempt || 0) - Number(left.run_attempt || 0)
+    || Number(right.id || 0) - Number(left.id || 0)
+  ))[0];
+}
+
+export function evaluateTrustedPostMergeReuse(input) {
+  if (input?.eventName !== "push" || input?.ref !== "refs/heads/devel") {
+    return denied("not-a-devel-push");
+  }
+  if (!validSha(input?.mergeSha) || input.mergeCommit?.sha !== input.mergeSha) {
+    return denied("merge-commit-unavailable");
+  }
+  const parents = Array.isArray(input.mergeCommit.parents)
+    ? input.mergeCommit.parents.map((parent) => parent?.sha || parent).filter(validSha)
+    : [];
+  if (parents.length !== 2 || new Set(parents).size !== 2) {
+    return denied("merge-commit-must-have-two-parents");
+  }
+
+  const pullRequests = (Array.isArray(input.pullRequests) ? input.pullRequests : []).filter((pullRequest) => (
+    pullRequest?.state === "closed"
+    && typeof pullRequest.merged_at === "string"
+    && pullRequest.merge_commit_sha === input.mergeSha
+    && pullRequest.base?.ref === "devel"
+    && pullRequest.head?.repo?.full_name === input.repository
+    && validSha(pullRequest.head?.sha)
+  ));
+  if (pullRequests.length !== 1) {
+    return denied("merge-commit-must-map-to-one-merged-same-repository-pr");
+  }
+  const pullRequest = pullRequests[0];
+  if (!parents.includes(pullRequest.head.sha)) {
+    return denied("merge-parent-does-not-match-pr-head");
+  }
+  const baseParent = parents.find((parent) => parent !== pullRequest.head.sha);
+  if (!baseParent || input.mergeBaseSha !== baseParent) {
+    return denied("pr-head-does-not-contain-merge-base");
+  }
+  if (
+    input.mergeCommit?.commit?.tree?.sha !== input.sourceCommit?.commit?.tree?.sha
+    || !input.mergeCommit?.commit?.tree?.sha
+  ) {
+    return denied("merge-tree-does-not-match-pr-head");
+  }
+  if (enforcementPathChanged(input.pullFiles)) {
+    return denied("pr-changes-ci-enforcement-surface");
+  }
+
+  const candidate = latestCandidateRun(input.workflowRuns, pullRequest, input.repository);
+  if (!candidate) {
+    return denied("no-current-pr-workflow-candidate");
+  }
+  if (candidate.status !== "completed" || candidate.conclusion !== "success") {
+    return denied("latest-pr-workflow-candidate-not-successful");
+  }
+  if (!Number.isInteger(candidate.id) && !/^[1-9][0-9]*$/.test(String(candidate.id || ""))) {
+    return denied("candidate-run-id-unavailable");
+  }
+  return {
+    reuse: true,
+    reason: "exact-green-pr-workflow-reused",
+    sourceRunId: String(candidate.id),
+    pullNumber: String(pullRequest.number),
+  };
+}


### PR DESCRIPTION
## 관련 이슈
Closes #6213

## 변경 사항
- devel merge commit을 기준으로 정확히 일치하는 green PR CI만 post-merge에서 재사용하는 공통 검증 workflow를 추가했습니다.
- merge SHA, 두 parent, PR head/base 계보, merge tree, enforcement 경로, 최신 성공 PR run을 모두 확인하고 하나라도 다르면 전체 CI로 폴백합니다.
- CI, CodeQL, adapter diff, proptest workflow를 공통 검증에 연결했습니다.
- nextest B/C JUnit testcase 측정값의 target 매핑과 run/ref/SHA provenance를 검증해 빈·혼합 측정값의 정책 반영을 차단했습니다.

## 안전성
- 첫 배포 시점에는 기준 devel에 검증 helper가 없으므로 재사용하지 않고 전체 CI를 실행합니다.
- direct push, stale base, merge-queue 형태, workflow/CI 계약 변경, pending·실패·누락 source run, B/C artifact 누락은 모두 fail-closed로 전체 CI를 수행합니다.

## CI 발견 보정
- 초기 CI가 새 workflow 계약 테스트의 CI 호출 누락을 fail-closed로 감지했습니다.
- Validate workflow contracts 단계에 test_trusted_postmerge_ci_reuse_workflow.py를 추가했고, 관련 Python workflow 계약 86건을 재검증했습니다.

## 로컬 검증
- cargo fmt --all
- cargo fmt --all -- --check
- node --test scripts/tests/nextest-target-duration-policy.test.mjs scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
- python3 -m unittest scripts/tests/test_workflow_contract_wiring.py scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py scripts/tests/test_nextest_archive_workflow.py scripts/tests/test_ci_impact_workflow.py scripts/tests/test_codeql_workflow.py scripts/tests/test_adapter_diff_workflow.py scripts/tests/test_proptest_roundtrip_workflow.py
- node scripts/rust-test-suite-manifest.mjs --check
- git diff --check