### PR TITLE
fix(ci): #6213 metrics 정책 SHA 조회를 보완한다

### DIFF
--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -155,18 +155,29 @@ jobs:
               ;;
             integration-b|integration-c)
               duration_policy='tests/suites/nextest-target-duration-policy.json'
+              duration_policy_ref='ci-metrics/nextest-target-durations'
               if [[ -n "${{ inputs.duration_policy_sha }}" ]]; then
                 candidate_policy='target/nextest-duration-policy.json'
                 mkdir -p "$(dirname "${candidate_policy}")"
-                if git fetch --depth=1 origin "${{ inputs.duration_policy_sha }}" \
-                  && git show FETCH_HEAD:nextest-target-duration-policy.json > "${candidate_policy}"; then
+                # GitHub does not promise arbitrary SHA fetches. Fetch the advertised
+                # metrics ref instead, then require the PR-pinned SHA to be in its
+                # append-only history before reading the policy blob from that SHA.
+                if git fetch --no-tags origin \
+                  "refs/heads/${duration_policy_ref}:refs/remotes/origin/${duration_policy_ref}" \
+                  && git merge-base --is-ancestor "${{ inputs.duration_policy_sha }}" \
+                    "refs/remotes/origin/${duration_policy_ref}" \
+                  && git show "${{ inputs.duration_policy_sha }}:nextest-target-duration-policy.json" \
+                    > "${candidate_policy}"; then
                   duration_policy="${candidate_policy}"
                   printf 'duration_policy_sha=%s\n' "${{ inputs.duration_policy_sha }}"
+                  printf 'duration_policy_source=metrics-ref\n'
                 else
-                  echo "::warning::Duration policy ${{ inputs.duration_policy_sha }} could not be fetched; using the committed fallback."
+                  echo "::warning::Duration policy ${{ inputs.duration_policy_sha }} is unavailable from ${duration_policy_ref}; using the committed fallback."
+                  printf 'duration_policy_source=fallback:metrics-policy-unavailable\n'
                 fi
               else
                 echo 'duration_policy_sha=fallback:committed'
+                echo 'duration_policy_source=fallback:no-pinned-policy'
               fi
 
               mapfile -t selected_targets < <(

--- a/scripts/tests/test_nextest_archive_workflow.py
+++ b/scripts/tests/test_nextest_archive_workflow.py
@@ -295,6 +295,27 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         self.assertIn("github.ref == 'refs/heads/devel'", self.ci)
         self.assertIn("duration_policy_sha:", self.builder)
         self.assertIn(
+            "duration_policy_ref='ci-metrics/nextest-target-durations'",
+            self.builder,
+        )
+        self.assertIn(
+            'refs/heads/${duration_policy_ref}:refs/remotes/origin/${duration_policy_ref}',
+            self.builder,
+        )
+        self.assertIn(
+            'git merge-base --is-ancestor "${{ inputs.duration_policy_sha }}"',
+            self.builder,
+        )
+        self.assertIn(
+            'git show "${{ inputs.duration_policy_sha }}:nextest-target-duration-policy.json"',
+            self.builder,
+        )
+        self.assertIn("duration_policy_source=metrics-ref", self.builder)
+        self.assertIn(
+            "duration_policy_source=fallback:metrics-policy-unavailable",
+            self.builder,
+        )
+        self.assertNotIn(
             'git fetch --depth=1 origin "${{ inputs.duration_policy_sha }}"',
             self.builder,
         )


### PR DESCRIPTION
## 변경 요약

- B/C archive가 raw SHA를 직접 fetch하지 않고 `ci-metrics/nextest-target-durations` ref를 가져오도록 수정했습니다.
- PR 시작 시 고정한 정책 SHA가 해당 ref의 이력에 포함되는지 검증한 뒤 정확한 정책 blob을 사용합니다.
- 정책 fetch 실패 시 적용 원인을 `duration_policy_source`로 남겨 fallback을 식별할 수 있게 했습니다.

관련 이슈: #6213

## 검증

- `node scripts/rust-test-suite-manifest.mjs --prepare`
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `python3 -m unittest scripts/tests/test_nextest_archive_workflow.py scripts/tests/test_ci_impact_workflow.py`

`Closes` 또는 `Fixes` 키워드를 사용하지 않아 #6213은 자동으로 닫히지 않습니다.