### PR TITLE
perf(ci): nextest archive를 A/B/C/D로 균형 분할

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,7 +7,7 @@ nextest-version = { required = "0.9.91", recommended = "0.9.140" }
 filter = "test(/(^|::)overflow_cell_baseline::/)"
 priority = 100
 
-# B/C archive workers use this profile only to emit a compact JUnit report.
+# B/C/D archive workers use this profile only to emit a compact JUnit report.
 # Successful devel runs retain it for the baseline; same-repository PRs retain a
 # short-lived candidate that a later trusted post-merge verifier may consume.
 [profile.ci-duration-observation.junit]

--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -21,7 +21,7 @@ on:
         required: true
         type: string
       duration_policy_sha:
-        description: Pinned ci-metrics policy commit for integration B/C selection.
+        description: Pinned ci-metrics policy commit for integration B/C/D selection.
         required: false
         type: string
         default: ''
@@ -53,7 +53,7 @@ jobs:
           esac
 
           case "${TARGET_GROUP}" in
-            lib|integration-b|integration-c)
+            lib|integration-b|integration-c|integration-d)
               ;;
             *)
               echo "::error::invalid test archive target group: ${TARGET_GROUP}"
@@ -139,7 +139,7 @@ jobs:
             printf "| cache_save_eligible | \`%s\` |\n" "${CACHE_SAVE_ELIGIBLE}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      # [#5737] lib는 별도 archive로, integration target은 두 archive로 교차 배정해
+      # [#6251] lib는 별도 archive로, integration target은 B/C/D 세 archive에 시간 기준으로 배정해
       # compile/link 임계 경로를 병렬화한다. integration 목록은 파생 suite 준비 뒤
       # metadata에서 구한다.
       - name: Build default-feature test archive
@@ -153,7 +153,7 @@ jobs:
             lib)
               cargo_target_args+=(--lib)
               ;;
-            integration-b|integration-c)
+            integration-b|integration-c|integration-d)
               duration_policy='tests/suites/nextest-target-duration-policy.json'
               duration_policy_ref='ci-metrics/nextest-target-durations'
               if [[ -n "${{ inputs.duration_policy_sha }}" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -811,8 +811,8 @@ jobs:
 
   # [#2393] 기본 테스트 병렬화 — CI impact preflight가 frontend·Rust·Native Skia
   # gate와 worker 조건을 나누는 경계다.
-  # [#5737] archive A는 source-side lib test, B/C는 integration target을 교차 분배해
-  # 각각 compile/link한다. A는 두 hash worker, B/C는 각각 한 worker가 소비한다.
+  # [#6251] archive A는 source-side lib test를 단일 worker가 소비하고, B/C/D는
+  # integration target을 시간 기준으로 분배해 각각 compile/link한다.
   # required check 는 집계 job "Build & Test" 로 불변이다.
   # [#5388] M04-4: tests/cases/prop_*_roundtrip.rs 는 정규 shard 가 archive 에서
   # 자동 실행한다. 전용 싼 job 은 .github/workflows/proptest-roundtrip.yml
@@ -875,6 +875,27 @@ jobs:
       timeout_minutes: ${{ fromJSON(needs.preflight.outputs.test_archive_timeout_minutes || '60') }}
       archive_label: c
       target_group: integration-c
+      duration_policy_sha: ${{ needs.resolve-nextest-duration-policy.outputs.duration_policy_sha }}
+
+
+  build-test-archive-d:
+    uses: ./.github/workflows/build-nextest-archives.yml
+    needs: [preflight, resolve-nextest-duration-policy]
+    if: >-
+      ${{
+        always()
+        && needs.preflight.result == 'success'
+        && needs.preflight.outputs.fast_pass != 'true'
+        && needs.preflight.outputs.rust_required == 'true'
+        && needs.resolve-nextest-duration-policy.result == 'success'
+      }}
+    permissions:
+      contents: read
+    with:
+      cargo_profile: ${{ needs.preflight.outputs.test_profile || 'release' }}
+      timeout_minutes: ${{ fromJSON(needs.preflight.outputs.test_archive_timeout_minutes || '60') }}
+      archive_label: d
+      target_group: integration-d
       duration_policy_sha: ${{ needs.resolve-nextest-duration-policy.outputs.duration_policy_sha }}
 
   lint:
@@ -1382,32 +1403,11 @@ jobs:
     permissions:
       contents: read
     with:
-      label: Archive A shard 1
+      label: Archive A
       count_label: a-1
       archive_label: a
       filterset: "all()"
-      partition: "hash:1/2"
-
-
-  test-archive-a-shard-2:
-    uses: ./.github/workflows/run-nextest-archives.yml
-    needs: [preflight, build-test-archive-a]
-    if: >-
-      ${{
-        always()
-        && needs.preflight.result == 'success'
-        && needs.preflight.outputs.fast_pass != 'true'
-        && needs.preflight.outputs.rust_required == 'true'
-        && needs['build-test-archive-a'].result == 'success'
-      }}
-    permissions:
-      contents: read
-    with:
-      label: Archive A shard 2
-      count_label: a-2
-      archive_label: a
-      filterset: "all()"
-      partition: "hash:2/2"
+      partition: "hash:1/1"
 
 
   test-archive-b-shard-1:
@@ -1452,7 +1452,28 @@ jobs:
       partition: "hash:1/1"
 
 
-  # B/C duration data is refreshed from this devel run, or from the exact green
+  test-archive-d-shard-1:
+    uses: ./.github/workflows/run-nextest-archives.yml
+    needs: [preflight, build-test-archive-d]
+    if: >-
+      ${{
+        always()
+        && needs.preflight.result == 'success'
+        && needs.preflight.outputs.fast_pass != 'true'
+        && needs.preflight.outputs.rust_required == 'true'
+        && needs['build-test-archive-d'].result == 'success'
+      }}
+    permissions:
+      contents: read
+    with:
+      label: Archive D
+      count_label: d-1
+      archive_label: d
+      filterset: "all()"
+      partition: "hash:1/1"
+
+
+  # B/C/D duration data is refreshed from this devel run, or from the exact green
   # same-repository PR run accepted by trusted_postmerge_reuse.
   refresh-nextest-target-duration-data:
     name: Refresh nextest target duration data
@@ -1461,6 +1482,7 @@ jobs:
       - preflight
       - test-archive-b-shard-1
       - test-archive-c-shard-1
+      - test-archive-d-shard-1
     if: >-
       ${{
         always()
@@ -1474,6 +1496,7 @@ jobs:
             && needs.preflight.outputs.fast_pass != 'true'
             && needs.test-archive-b-shard-1.result == 'success'
             && needs.test-archive-c-shard-1.result == 'success'
+            && needs.test-archive-d-shard-1.result == 'success'
           )
           || (
             needs.preflight.outputs.postmerge_reuse == 'true'
@@ -1507,6 +1530,13 @@ jobs:
           name: nextest-target-durations-${{ github.run_id }}-c
           path: duration-c
 
+      - name: Download Archive D duration measurement
+        if: ${{ needs.preflight.outputs.postmerge_reuse != 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nextest-target-durations-${{ github.run_id }}-d
+          path: duration-d
+
       - name: Download trusted PR Archive B duration measurement
         if: ${{ needs.preflight.outputs.postmerge_reuse == 'true' }}
         env:
@@ -1524,6 +1554,15 @@ jobs:
         run: >-
           gh run download "${SOURCE_RUN_ID}" --repo "${GITHUB_REPOSITORY}"
           --name "nextest-target-durations-${SOURCE_RUN_ID}-c" --dir duration-c
+
+      - name: Download trusted PR Archive D duration measurement
+        if: ${{ needs.preflight.outputs.postmerge_reuse == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_RUN_ID: ${{ needs.preflight.outputs.postmerge_source_run_id }}
+        run: >-
+          gh run download "${SOURCE_RUN_ID}" --repo "${GITHUB_REPOSITORY}"
+          --name "nextest-target-durations-${SOURCE_RUN_ID}-d" --dir duration-d
 
       - name: Refresh duration policy data branch
         shell: bash
@@ -1543,6 +1582,7 @@ jobs:
             --policy tests/suites/nextest-target-duration-policy.json \
             --measurement duration-b/target-durations-b.json \
             --measurement duration-c/target-durations-c.json \
+            --measurement duration-d/target-durations-d.json \
             --output "${OUTPUT_POLICY}"
 
           if git ls-remote --exit-code origin "refs/heads/${METRICS_BRANCH}" >/dev/null 2>&1; then
@@ -1576,10 +1616,11 @@ jobs:
       - build-test-archive-a
       - build-test-archive-b
       - build-test-archive-c
+      - build-test-archive-d
       - test-archive-a-shard-1
-      - test-archive-a-shard-2
       - test-archive-b-shard-1
       - test-archive-c-shard-1
+      - test-archive-d-shard-1
       - lint
       - native-skia-tests
       - frontend-unit-gates
@@ -1595,9 +1636,9 @@ jobs:
             needs.preflight.outputs.fast_pass != 'true'
             && needs.preflight.outputs.rust_required == 'true'
             && needs['test-archive-a-shard-1'].result == 'success'
-            && needs['test-archive-a-shard-2'].result == 'success'
             && needs['test-archive-b-shard-1'].result == 'success'
             && needs['test-archive-c-shard-1'].result == 'success'
+            && needs['test-archive-d-shard-1'].result == 'success'
           }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1609,9 +1650,9 @@ jobs:
             needs.preflight.outputs.fast_pass != 'true'
             && needs.preflight.outputs.rust_required == 'true'
             && needs['test-archive-a-shard-1'].result == 'success'
-            && needs['test-archive-a-shard-2'].result == 'success'
             && needs['test-archive-b-shard-1'].result == 'success'
             && needs['test-archive-c-shard-1'].result == 'success'
+            && needs['test-archive-d-shard-1'].result == 'success'
           }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1623,23 +1664,38 @@ jobs:
             needs.preflight.outputs.fast_pass != 'true'
             && needs.preflight.outputs.rust_required == 'true'
             && needs['test-archive-a-shard-1'].result == 'success'
-            && needs['test-archive-a-shard-2'].result == 'success'
             && needs['test-archive-b-shard-1'].result == 'success'
             && needs['test-archive-c-shard-1'].result == 'success'
+            && needs['test-archive-d-shard-1'].result == 'success'
           }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: archive-expected-${{ github.run_id }}-c
           path: archive-expected-c
+
+      - name: Download archive D expected count
+        if: >-
+          ${{
+            needs.preflight.outputs.fast_pass != 'true'
+            && needs.preflight.outputs.rust_required == 'true'
+            && needs['test-archive-a-shard-1'].result == 'success'
+            && needs['test-archive-b-shard-1'].result == 'success'
+            && needs['test-archive-c-shard-1'].result == 'success'
+            && needs['test-archive-d-shard-1'].result == 'success'
+          }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: archive-expected-${{ github.run_id }}-d
+          path: archive-expected-d
       - name: Download shard counts
         if: >-
           ${{
             needs.preflight.outputs.fast_pass != 'true'
             && needs.preflight.outputs.rust_required == 'true'
             && needs['test-archive-a-shard-1'].result == 'success'
-            && needs['test-archive-a-shard-2'].result == 'success'
             && needs['test-archive-b-shard-1'].result == 'success'
             && needs['test-archive-c-shard-1'].result == 'success'
+            && needs['test-archive-d-shard-1'].result == 'success'
           }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1651,24 +1707,25 @@ jobs:
             needs.preflight.outputs.fast_pass != 'true'
             && needs.preflight.outputs.rust_required == 'true'
             && needs['test-archive-a-shard-1'].result == 'success'
-            && needs['test-archive-a-shard-2'].result == 'success'
             && needs['test-archive-b-shard-1'].result == 'success'
             && needs['test-archive-c-shard-1'].result == 'success'
+            && needs['test-archive-d-shard-1'].result == 'success'
           }}
         run: |
           read -r expected_a < archive-expected-a/archive-expected-total.txt
           read -r expected_b < archive-expected-b/archive-expected-total.txt
           read -r expected_c < archive-expected-c/archive-expected-total.txt
+          read -r expected_d < archive-expected-d/archive-expected-total.txt
           read -r a1 < shard-counts/shard-count-a-1/shard-count-a-1.txt
-          read -r a2 < shard-counts/shard-count-a-2/shard-count-a-2.txt
           read -r b1 < shard-counts/shard-count-b-1/shard-count-b-1.txt
           read -r c1 < shard-counts/shard-count-c-1/shard-count-c-1.txt
-          if ! [[ "$expected_a" =~ ^[0-9]+$ && "$expected_b" =~ ^[0-9]+$ && "$expected_c" =~ ^[0-9]+$ && "$a1" =~ ^[0-9]+$ && "$a2" =~ ^[0-9]+$ && "$b1" =~ ^[0-9]+$ && "$c1" =~ ^[0-9]+$ ]]; then
+          read -r d1 < shard-counts/shard-count-d-1/shard-count-d-1.txt
+          if ! [[ "$expected_a" =~ ^[0-9]+$ && "$expected_b" =~ ^[0-9]+$ && "$expected_c" =~ ^[0-9]+$ && "$expected_d" =~ ^[0-9]+$ && "$a1" =~ ^[0-9]+$ && "$b1" =~ ^[0-9]+$ && "$c1" =~ ^[0-9]+$ && "$d1" =~ ^[0-9]+$ ]]; then
             echo "::error::archive expected counts and shard counts must be non-negative integers"
             exit 1
           fi
-          if (( a1 + a2 != expected_a )); then
-            echo "::error::Archive A shard total mismatch: $a1 + $a2 != $expected_a"
+          if (( a1 != expected_a )); then
+            echo "::error::Archive A shard total mismatch: $a1 != $expected_a"
             exit 1
           fi
           if (( b1 != expected_b )); then
@@ -1679,7 +1736,11 @@ jobs:
             echo "::error::Archive C shard total mismatch: $c1 != $expected_c"
             exit 1
           fi
-          printf 'archive_total=%s shard_total=%s\n' "$((expected_a + expected_b + expected_c))" "$((a1 + a2 + b1 + c1))"
+          if (( d1 != expected_d )); then
+            echo "::error::Archive D shard total mismatch: $d1 != $expected_d"
+            exit 1
+          fi
+          printf 'archive_total=%s shard_total=%s\n' "$((expected_a + expected_b + expected_c + expected_d))" "$((a1 + b1 + c1 + d1))"
       - name: Check Build & Test worker results
         env:
           PREFLIGHT_RESULT: ${{ needs.preflight.result }}
@@ -1690,10 +1751,11 @@ jobs:
           BUILD_ARCHIVE_A_RESULT: ${{ needs['build-test-archive-a'].result }}
           BUILD_ARCHIVE_B_RESULT: ${{ needs['build-test-archive-b'].result }}
           BUILD_ARCHIVE_C_RESULT: ${{ needs['build-test-archive-c'].result }}
+          BUILD_ARCHIVE_D_RESULT: ${{ needs['build-test-archive-d'].result }}
           TEST_ARCHIVE_A_1_RESULT: ${{ needs['test-archive-a-shard-1'].result }}
-          TEST_ARCHIVE_A_2_RESULT: ${{ needs['test-archive-a-shard-2'].result }}
           TEST_ARCHIVE_B_1_RESULT: ${{ needs['test-archive-b-shard-1'].result }}
           TEST_ARCHIVE_C_1_RESULT: ${{ needs['test-archive-c-shard-1'].result }}
+          TEST_ARCHIVE_D_1_RESULT: ${{ needs['test-archive-d-shard-1'].result }}
           LINT_RESULT: ${{ needs.lint.result }}
           NATIVE_SKIA_RESULT: ${{ needs['native-skia-tests'].result }}
           FRONTEND_UNIT_RESULT: ${{ needs['frontend-unit-gates'].result }}
@@ -1708,10 +1770,10 @@ jobs:
             exit 0
           fi
           failed=0
-          rust_results="${LINT_RESULT}/${BUILD_ARCHIVE_A_RESULT}/${BUILD_ARCHIVE_B_RESULT}/${BUILD_ARCHIVE_C_RESULT}/${TEST_ARCHIVE_A_1_RESULT}/${TEST_ARCHIVE_A_2_RESULT}/${TEST_ARCHIVE_B_1_RESULT}/${TEST_ARCHIVE_C_1_RESULT}"
+          rust_results="${LINT_RESULT}/${BUILD_ARCHIVE_A_RESULT}/${BUILD_ARCHIVE_B_RESULT}/${BUILD_ARCHIVE_C_RESULT}/${BUILD_ARCHIVE_D_RESULT}/${TEST_ARCHIVE_A_1_RESULT}/${TEST_ARCHIVE_B_1_RESULT}/${TEST_ARCHIVE_C_1_RESULT}/${TEST_ARCHIVE_D_1_RESULT}"
           case "${RUST_REQUIRED}" in
-            true) [[ "$rust_results" == "success/success/success/success/success/success/success/success" ]] || { echo "::error::Rust lane expected success for lint/three builders/four workers, got: $rust_results"; failed=1; } ;;
-            false) [[ "$rust_results" == "skipped/skipped/skipped/skipped/skipped/skipped/skipped/skipped" ]] || { echo "::error::Rust lane expected skipped, got: $rust_results"; failed=1; } ;;
+            true) [[ "$rust_results" == "success/success/success/success/success/success/success/success/success" ]] || { echo "::error::Rust lane expected success for lint/four builders/four workers, got: $rust_results"; failed=1; } ;;
+            false) [[ "$rust_results" == "skipped/skipped/skipped/skipped/skipped/skipped/skipped/skipped/skipped" ]] || { echo "::error::Rust lane expected skipped, got: $rust_results"; failed=1; } ;;
             *) echo "::error::Unknown rust_required: ${RUST_REQUIRED}"; failed=1 ;;
           esac
           case "${NATIVE_SKIA_REQUIRED}" in

--- a/.github/workflows/run-nextest-archives.yml
+++ b/.github/workflows/run-nextest-archives.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       archive_label:
-        description: Stable A/B archive partition label.
+        description: Stable A/B/C/D archive partition label.
         required: true
         type: string
       filterset:
@@ -53,8 +53,8 @@ jobs:
         with:
           name: test-archive-${{ github.run_id }}-${{ inputs.archive_label }}
 
-      # [#5164] 네 worker는 동일 archive에서 서로 배타적인 filter/partition만 실행한다.
-      # 집계 job은 archive runnable 수와 네 Summary run 합계를 대조한다.
+      # [#6251] 각 worker는 자기 archive에서 서로 배타적인 filter/partition만 실행한다.
+      # 집계 job은 archive runnable 수와 worker Summary run 합계를 대조한다.
       - name: Run ${{ inputs.label }}
         env:
           COUNT_LABEL: ${{ inputs.count_label }}
@@ -69,7 +69,7 @@ jobs:
           profile_args=()
           duration_report=""
           case "${{ inputs.archive_label }}" in
-            b|c)
+            b|c|d)
               profile_args=(--profile ci-duration-observation)
               duration_report="target/nextest/ci-duration-observation/junit.xml"
               ;;
@@ -111,8 +111,8 @@ jobs:
       # Same-repository PR artifact is only a short-lived candidate. It cannot
       # update the policy until a trusted post-merge verifier accepts its exact
       # workflow run, merge lineage, and artifact provenance.
-      - name: Upload same-repository PR B/C target durations
-        if: ${{ success() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (inputs.archive_label == 'b' || inputs.archive_label == 'c') }}
+      - name: Upload same-repository PR B/C/D target durations
+        if: ${{ success() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (inputs.archive_label == 'b' || inputs.archive_label == 'c' || inputs.archive_label == 'd') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nextest-target-durations-${{ github.run_id }}-${{ inputs.archive_label }}
@@ -120,10 +120,10 @@ jobs:
           retention-days: 3
           if-no-files-found: error
 
-      # Only successful devel B/C measurements are baseline candidates. They are
+      # Only successful devel B/C/D measurements are baseline candidates. They are
       # retained longer so their provenance can be audited after policy refresh.
-      - name: Upload devel B/C target durations
-        if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/devel' && (inputs.archive_label == 'b' || inputs.archive_label == 'c') }}
+      - name: Upload devel B/C/D target durations
+        if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/devel' && (inputs.archive_label == 'b' || inputs.archive_label == 'c' || inputs.archive_label == 'd') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nextest-target-durations-${{ github.run_id }}-${{ inputs.archive_label }}

--- a/mydocs/working/task_m100_6251_stage1_archive_a_bcd_partition.md
+++ b/mydocs/working/task_m100_6251_stage1_archive_a_bcd_partition.md
@@ -1,0 +1,37 @@
+# #6251 Stage 1 - Archive A 통합과 B/C/D 시간 기반 분할
+
+## 배경
+
+[CI run 33075195320](https://github.com/edwardkim/rhwp/actions/runs/33075195320)에서
+Archive A의 두 worker는 실제 nextest 실행이 각각 20.809초와 15.927초였지만, Archive B와
+C는 각각 10분 19초와 9분 12초가 걸렸다. 전체 CI의 임계 경로는 A가 아니라 B/C
+integration 실행이다.
+
+## 결정
+
+1. `--lib` 전용 Archive A의 `hash:1/2`, `hash:2/2` worker를 하나의 `hash:1/1`
+   worker로 통합한다.
+2. root integration target 전체를 기존 B/C 두 archive 대신 B/C/D 세 archive에
+   시간 기반 LPT 방식으로 결정론적으로 배정한다.
+3. B/C/D는 각각 build job 하나와 test worker 하나를 사용한다. A/B/C/D의 전체
+   worker 수는 네 개로 유지한다.
+4. B/C/D의 JUnit target duration artifact는 같은 PR 또는 `devel` run의 동일
+   provenance를 가진 세 보고서가 모두 있을 때만 metrics data branch에 반영한다.
+5. 집계 job은 A/B/C/D 각각의 archive runnable count와 worker count가 정확히 같은지
+   검증해 누락과 중복을 막는다.
+
+## 기대 효과와 한계
+
+- A의 두 runner가 만드는 setup/download 비용을 없앤다.
+- B/C/D의 integration 실행은 시간 기반으로 약 3분할되어 현재 B의 10분 19초보다 짧은
+  임계 경로를 목표로 한다.
+- D archive도 공통 Rust 의존성을 별도 compile/link하므로 총 runner 사용량은 증가할 수 있다.
+  이 단계의 성공 기준은 총 runner-minutes가 아니라 실제 PR CI의 wall time 단축과 전체 회귀
+  커버리지 유지다.
+
+## 검증 계획
+
+1. selector 단위 테스트로 B/C/D 결정성, 예상 시간, 누락·중복 없는 전체 배정을 확인한다.
+2. metrics refresh 단위 테스트로 동일 provenance의 B/C/D 세 측정값만 허용함을 확인한다.
+3. workflow 계약 테스트로 D builder/worker, A 단일 worker, aggregate count 검증을 확인한다.
+4. PR CI에서 B/C/D 실측 시간과 전체 Build & Test 완료 시간을 run `33075195320`과 비교한다.

--- a/scripts/ci-impact-policy.cjs
+++ b/scripts/ci-impact-policy.cjs
@@ -140,10 +140,11 @@ const CI_RUST_JOBS = [
   'build-test-archive-a',
   'build-test-archive-b',
   'build-test-archive-c',
+  'build-test-archive-d',
   'test-archive-a-shard-1',
-  'test-archive-a-shard-2',
   'test-archive-b-shard-1',
   'test-archive-c-shard-1',
+  'test-archive-d-shard-1',
 ];
 // Reusable workflow calls have two observed REST job names: a skipped call keeps only
 // its caller job id, while an executed call is reported as "caller / called job name".
@@ -162,21 +163,25 @@ const CI_JOB_ALIASES = {
     'build-test-archive-c',
     'build-test-archive-c / Build test archive (c)',
   ],
+  'build-test-archive-d': [
+    'build-test-archive-d',
+    'build-test-archive-d / Build test archive (d)',
+  ],
   'test-archive-a-shard-1': [
     'test-archive-a-shard-1',
-    'test-archive-a-shard-1 / Default-feature tests (Archive A shard 1)',
-  ],
-  'test-archive-a-shard-2': [
-    'test-archive-a-shard-2',
-    'test-archive-a-shard-2 / Default-feature tests (Archive A shard 2)',
+    'test-archive-a-shard-1 / Default-feature tests (Archive A)',
   ],
   'test-archive-b-shard-1': [
     'test-archive-b-shard-1',
-    'test-archive-b-shard-1 / Default-feature tests (Archive B shard 1)',
+    'test-archive-b-shard-1 / Default-feature tests (Archive B)',
   ],
   'test-archive-c-shard-1': [
     'test-archive-c-shard-1',
     'test-archive-c-shard-1 / Default-feature tests (Archive C)',
+  ],
+  'test-archive-d-shard-1': [
+    'test-archive-d-shard-1',
+    'test-archive-d-shard-1 / Default-feature tests (Archive D)',
   ],
 };
 const CI_NATIVE_JOB = 'Native Skia tests';
@@ -188,12 +193,13 @@ const CI_AUDITED_JOB_IDS = {
   'build-test-archive-a': 'build-test-archive-a',
   'build-test-archive-b': 'build-test-archive-b',
   'build-test-archive-c': 'build-test-archive-c',
+  'build-test-archive-d': 'build-test-archive-d',
   'resolve-nextest-duration-policy': 'resolve-nextest-duration-policy',
   'refresh-nextest-target-duration-data': 'refresh-nextest-target-duration-data',
   'test-archive-a-shard-1': 'test-archive-a-shard-1',
-  'test-archive-a-shard-2': 'test-archive-a-shard-2',
   'test-archive-b-shard-1': 'test-archive-b-shard-1',
   'test-archive-c-shard-1': 'test-archive-c-shard-1',
+  'test-archive-d-shard-1': 'test-archive-d-shard-1',
   lint: 'Lint (fmt, clippy, WASM check)',
   'native-skia-tests': CI_NATIVE_JOB,
   'frontend-unit-gates': CI_FRONTEND_JOBS[0],

--- a/scripts/collect-nextest-target-durations.mjs
+++ b/scripts/collect-nextest-target-durations.mjs
@@ -69,11 +69,11 @@ export function collectTargetDurations(junitXml) {
 function main() {
   const options = parseArgs(process.argv.slice(2));
   if (options.help) {
-    process.stdout.write("Usage: node scripts/collect-nextest-target-durations.mjs --archive-label b|c --input junit.xml --output target-durations.json\n");
+    process.stdout.write("Usage: node scripts/collect-nextest-target-durations.mjs --archive-label b|c|d --input junit.xml --output target-durations.json\n");
     return;
   }
-  if (!["b", "c"].includes(options["archive-label"]) || !options.input || !options.output) {
-    fail("--archive-label b|c, --input, and --output are required");
+  if (!["b", "c", "d"].includes(options["archive-label"]) || !options.input || !options.output) {
+    fail("--archive-label b|c|d, --input, and --output are required");
   }
 
   const targets = collectTargetDurations(fs.readFileSync(options.input, "utf8"));

--- a/scripts/refresh-nextest-target-duration-policy.mjs
+++ b/scripts/refresh-nextest-target-duration-policy.mjs
@@ -39,8 +39,8 @@ export function refreshDurationPolicy(policy, measurements) {
   const durations = { ...policy.targets };
   const sourceKeys = new Set();
   for (const measurement of measurements) {
-    if (!measurement || measurement.schema_version !== 1 || !["b", "c"].includes(measurement.archive_label)) {
-      fail("measurement must be a B or C schema_version 1 report");
+    if (!measurement || measurement.schema_version !== 1 || !["b", "c", "d"].includes(measurement.archive_label)) {
+      fail("measurement must be a B, C, or D schema_version 1 report");
     }
     if (!measurement.targets || typeof measurement.targets !== "object" || Array.isArray(measurement.targets)) {
       fail("measurement targets must be an object");
@@ -62,7 +62,7 @@ export function refreshDurationPolicy(policy, measurements) {
     }
   }
   if (sourceKeys.size !== 1) {
-    fail("B and C measurements must have identical run, ref, and sha provenance");
+    fail("B, C, and D measurements must have identical run, ref, and sha provenance");
   }
 
   return {
@@ -82,17 +82,17 @@ export function refreshDurationPolicy(policy, measurements) {
 function main() {
   const options = parseArgs(process.argv.slice(2));
   if (options.help) {
-    process.stdout.write("Usage: node scripts/refresh-nextest-target-duration-policy.mjs --policy policy.json --measurement b.json --measurement c.json --output policy.json\n");
+    process.stdout.write("Usage: node scripts/refresh-nextest-target-duration-policy.mjs --policy policy.json --measurement b.json --measurement c.json --measurement d.json --output policy.json\n");
     return;
   }
-  if (!options.policy || !options.output || options.measurements.length !== 2) {
-    fail("--policy, exactly two --measurement values, and --output are required");
+  if (!options.policy || !options.output || options.measurements.length !== 3) {
+    fail("--policy, exactly three --measurement values, and --output are required");
   }
   const policy = JSON.parse(fs.readFileSync(options.policy, "utf8"));
   const measurements = options.measurements.map((filePath) => JSON.parse(fs.readFileSync(filePath, "utf8")));
   const labels = new Set(measurements.map((measurement) => measurement.archive_label));
-  if (labels.size !== 2 || !labels.has("b") || !labels.has("c")) {
-    fail("measurements must contain exactly one B report and one C report");
+  if (labels.size !== 3 || !labels.has("b") || !labels.has("c") || !labels.has("d")) {
+    fail("measurements must contain exactly one B, C, and D report");
   }
   const refreshed = refreshDurationPolicy(policy, measurements);
   fs.mkdirSync(path.dirname(options.output), { recursive: true });

--- a/scripts/select-nextest-archive-targets.mjs
+++ b/scripts/select-nextest-archive-targets.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
-const GROUPS = new Set(["integration-b", "integration-c"]);
+const GROUPS = ["integration-b", "integration-c", "integration-d"];
 
 function fail(message) {
   throw new Error(`[NextestTargetDuration] ${message}`);
@@ -35,7 +35,7 @@ function usage() {
   return [
     "Usage: cargo metadata --no-deps --format-version 1 |",
     "  node scripts/select-nextest-archive-targets.mjs",
-    "    --group integration-b|integration-c",
+    "    --group integration-b|integration-c|integration-d",
     "    --policy tests/suites/nextest-target-duration-policy.json",
   ].join(" ");
 }
@@ -107,10 +107,9 @@ export function integrationTargetsFromMetadata(metadata, workspaceManifestPath) 
 
 export function assignIntegrationTargets(targets, policy) {
   const parsedPolicy = parseDurationPolicy(policy);
-  const assignments = {
-    "integration-b": { estimatedSeconds: 0, targets: [] },
-    "integration-c": { estimatedSeconds: 0, targets: [] },
-  };
+  const assignments = Object.fromEntries(
+    GROUPS.map((group) => [group, { estimatedSeconds: 0, targets: [] }]),
+  );
 
   const weightedTargets = [...new Set(targets)]
     .map((name) => ({
@@ -120,10 +119,15 @@ export function assignIntegrationTargets(targets, policy) {
     .sort((left, right) => right.seconds - left.seconds || left.name.localeCompare(right.name));
 
   for (const target of weightedTargets) {
-    const destination = assignments["integration-b"].estimatedSeconds
-      <= assignments["integration-c"].estimatedSeconds
-      ? "integration-b"
-      : "integration-c";
+    const destination = GROUPS.reduce((shortest, group) => (
+      assignments[group].estimatedSeconds < assignments[shortest].estimatedSeconds
+      || (
+        assignments[group].estimatedSeconds === assignments[shortest].estimatedSeconds
+        && group.localeCompare(shortest) < 0
+      )
+        ? group
+        : shortest
+    ));
     assignments[destination].targets.push(target.name);
     assignments[destination].estimatedSeconds += target.seconds;
   }
@@ -140,7 +144,7 @@ async function main() {
     process.stdout.write(`${usage()}\n`);
     return;
   }
-  if (!GROUPS.has(options.group) || !options.policy) {
+  if (!GROUPS.includes(options.group) || !options.policy) {
     fail(usage());
   }
 

--- a/scripts/tests/nextest-target-duration-policy.test.mjs
+++ b/scripts/tests/nextest-target-duration-policy.test.mjs
@@ -25,15 +25,21 @@ const policy = {
   },
 };
 
-test("duration-aware assignment is deterministic and balances estimated load", () => {
+test("duration-aware assignment is deterministic and balances three estimated loads", () => {
   const first = assignIntegrationTargets(["fast", "slow", "medium", "new"], policy);
   const second = assignIntegrationTargets(["new", "medium", "fast", "slow"], policy);
 
   assert.deepEqual(first, second);
   assert.deepEqual(first["integration-b"].targets, ["slow"]);
-  assert.deepEqual(first["integration-c"].targets, ["fast", "medium", "new"]);
+  assert.deepEqual(first["integration-c"].targets, ["medium"]);
+  assert.deepEqual(first["integration-d"].targets, ["fast", "new"]);
   assert.equal(first["integration-b"].estimatedSeconds, 9);
-  assert.equal(first["integration-c"].estimatedSeconds, 8);
+  assert.equal(first["integration-c"].estimatedSeconds, 6);
+  assert.equal(first["integration-d"].estimatedSeconds, 2);
+  assert.deepEqual(
+    Object.values(first).flatMap((assignment) => assignment.targets).sort(),
+    ["fast", "medium", "new", "slow"],
+  );
 });
 
 test("empty duration profile preserves stable alternating bootstrap assignment", () => {
@@ -43,8 +49,9 @@ test("empty duration profile preserves stable alternating bootstrap assignment",
     targets: {},
   });
 
-  assert.deepEqual(assignments["integration-b"].targets, ["alpha", "charlie"]);
-  assert.deepEqual(assignments["integration-c"].targets, ["bravo", "delta"]);
+  assert.deepEqual(assignments["integration-b"].targets, ["alpha", "delta"]);
+  assert.deepEqual(assignments["integration-c"].targets, ["bravo"]);
+  assert.deepEqual(assignments["integration-d"].targets, ["charlie"]);
 });
 
 test("metadata selection uses only root integration targets", () => {
@@ -104,7 +111,7 @@ test("JUnit collection aggregates testcase durations per binary and skips setup 
   assert.deepEqual(durations, { issue_1: 2, issue_2: 2 });
 });
 
-test("policy refresh accepts one successful B and C measurement", () => {
+test("policy refresh accepts one successful B, C, and D measurement", () => {
   const refreshed = refreshDurationPolicy({
     schema_version: 1,
     fallback_seconds: 1,
@@ -112,21 +119,24 @@ test("policy refresh accepts one successful B and C measurement", () => {
   }, [
     { schema_version: 1, archive_label: "b", run_id: "10", ref: "refs/heads/devel", sha: "same-sha", targets: { beta: 4 } },
     { schema_version: 1, archive_label: "c", run_id: "10", ref: "refs/heads/devel", sha: "same-sha", targets: { alpha: 2 } },
+    { schema_version: 1, archive_label: "d", run_id: "10", ref: "refs/heads/devel", sha: "same-sha", targets: { delta: 1 } },
   ]);
 
-  assert.deepEqual(refreshed.targets, { alpha: 2, beta: 4, existing: 3 });
+  assert.deepEqual(refreshed.targets, { alpha: 2, beta: 4, delta: 1, existing: 3 });
   assert.deepEqual(refreshed.measurement_sources, {
     b: { run_id: "10", ref: "refs/heads/devel", sha: "same-sha" },
     c: { run_id: "10", ref: "refs/heads/devel", sha: "same-sha" },
+    d: { run_id: "10", ref: "refs/heads/devel", sha: "same-sha" },
   });
 });
 
-test("policy refresh rejects empty or mismatched B/C measurements", () => {
+test("policy refresh rejects empty or mismatched B/C/D measurements", () => {
   const basePolicy = { schema_version: 1, fallback_seconds: 1, targets: {} };
   assert.throws(
     () => refreshDurationPolicy(basePolicy, [
       { schema_version: 1, archive_label: "b", run_id: "10", ref: "refs/heads/devel", sha: "same-sha", targets: {} },
       { schema_version: 1, archive_label: "c", run_id: "10", ref: "refs/heads/devel", sha: "same-sha", targets: { alpha: 2 } },
+      { schema_version: 1, archive_label: "d", run_id: "10", ref: "refs/heads/devel", sha: "same-sha", targets: { delta: 1 } },
     ]),
     /must contain target durations: b/,
   );
@@ -134,6 +144,7 @@ test("policy refresh rejects empty or mismatched B/C measurements", () => {
     () => refreshDurationPolicy(basePolicy, [
       { schema_version: 1, archive_label: "b", run_id: "10", ref: "refs/heads/devel", sha: "first", targets: { beta: 4 } },
       { schema_version: 1, archive_label: "c", run_id: "10", ref: "refs/heads/devel", sha: "second", targets: { alpha: 2 } },
+      { schema_version: 1, archive_label: "d", run_id: "10", ref: "refs/heads/devel", sha: "first", targets: { delta: 1 } },
     ]),
     /identical run, ref, and sha provenance/,
   );

--- a/scripts/tests/test_adapter_diff_workflow.py
+++ b/scripts/tests/test_adapter_diff_workflow.py
@@ -98,14 +98,14 @@ class AdapterDiffWorkflowTests(unittest.TestCase):
         run_at = self.wf.index("run-adapter-diff.mjs --cargo-test")
         self.assertLess(prepare_at, run_at, "prepare 가 실행보다 먼저여야 한다")
 
-    def test_does_not_add_a_fifth_nextest_shard(self) -> None:
-        """A/B/C archive의 worker 네 개 합 = runnable. 다섯 번째 worker는 깨진다."""
+    def test_keeps_nextest_workers_at_four_balanced_archives(self) -> None:
+        """A/B/C/D archive의 worker 네 개 합 = runnable. 다섯 번째 worker는 깨진다."""
         self.assertNotRegex(self.ci, r"(?m)^  adapter-diff:")
         self.assertNotIn("adapter_diff", RUN_ARCHIVE.read_text(encoding="utf-8"))
-        self.assertEqual(1, self.ci.count('partition: "hash:1/2"'))
-        self.assertEqual(1, self.ci.count('partition: "hash:2/2"'))
-        self.assertEqual(2, self.ci.count('partition: "hash:1/1"'))
-        for count_label in ("a-1", "a-2", "b-1", "c-1"):
+        self.assertNotIn('partition: "hash:1/2"', self.ci)
+        self.assertNotIn('partition: "hash:2/2"', self.ci)
+        self.assertEqual(4, self.ci.count('partition: "hash:1/1"'))
+        for count_label in ("a-1", "b-1", "c-1", "d-1"):
             with self.subTest(count_label=count_label):
                 self.assertIn(f"shard-count-{count_label}", self.ci)
 

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -514,10 +514,11 @@ class CiImpactWorkflowTests(unittest.TestCase):
             "BUILD_ARCHIVE_A_RESULT": "skipped",
             "BUILD_ARCHIVE_B_RESULT": "skipped",
             "BUILD_ARCHIVE_C_RESULT": "skipped",
+            "BUILD_ARCHIVE_D_RESULT": "skipped",
             "TEST_ARCHIVE_A_1_RESULT": "skipped",
-            "TEST_ARCHIVE_A_2_RESULT": "skipped",
             "TEST_ARCHIVE_B_1_RESULT": "skipped",
             "TEST_ARCHIVE_C_1_RESULT": "skipped",
+            "TEST_ARCHIVE_D_1_RESULT": "skipped",
             "LINT_RESULT": "skipped",
             "NATIVE_SKIA_RESULT": "skipped",
             "FRONTEND_UNIT_RESULT": "success",
@@ -648,6 +649,11 @@ class CiImpactWorkflowTests(unittest.TestCase):
             (
                 "build-test-archive-c",
                 "integration-c",
+                "needs: [preflight, resolve-nextest-duration-policy]",
+            ),
+            (
+                "build-test-archive-d",
+                "integration-d",
                 "needs: [preflight, resolve-nextest-duration-policy]",
             ),
         ):
@@ -969,10 +975,10 @@ mod support;
 
     def test_rust_workers_wait_only_for_their_archive_partition(self) -> None:
         for archive_label, index, partition in (
-            ("a", 1, "hash:1/2"),
-            ("a", 2, "hash:2/2"),
+            ("a", 1, "hash:1/1"),
             ("b", 1, "hash:1/1"),
             ("c", 1, "hash:1/1"),
+            ("d", 1, "hash:1/1"),
         ):
             job_name = f"test-archive-{archive_label}-shard-{index}"
             with self.subTest(job=job_name):
@@ -1016,6 +1022,7 @@ mod support;
             "Download archive A expected count",
             "Download archive B expected count",
             "Download archive C expected count",
+            "Download archive D expected count",
             "Download shard counts",
             "Verify archive shard totals",
         ):
@@ -1032,10 +1039,11 @@ mod support;
             "BUILD_ARCHIVE_A_RESULT": "success",
             "BUILD_ARCHIVE_B_RESULT": "success",
             "BUILD_ARCHIVE_C_RESULT": "success",
+            "BUILD_ARCHIVE_D_RESULT": "success",
             "TEST_ARCHIVE_A_1_RESULT": "success",
-            "TEST_ARCHIVE_A_2_RESULT": "success",
             "TEST_ARCHIVE_B_1_RESULT": "success",
             "TEST_ARCHIVE_C_1_RESULT": "success",
+            "TEST_ARCHIVE_D_1_RESULT": "success",
         }
         cases = {
             "frontend-only": {},

--- a/scripts/tests/test_nextest_archive_workflow.py
+++ b/scripts/tests/test_nextest_archive_workflow.py
@@ -119,15 +119,15 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
             preflight,
         )
 
-    def test_two_archive_builders_split_lib_and_integration_targets(self):
+    def test_archive_builders_split_lib_and_three_integration_targets(self):
         from pathlib import Path
         root = Path(__file__).resolve().parents[2]
         ci = (root / ".github/workflows/ci.yml").read_text()
         builder = (root / ".github/workflows/build-nextest-archives.yml").read_text()
         runner = (root / ".github/workflows/run-nextest-archives.yml").read_text()
-        self.assertIn("build-test-archive-a:", ci); self.assertIn("build-test-archive-b:", ci); self.assertIn("build-test-archive-c:", ci)
-        self.assertNotIn("test-slow-shard:", ci); self.assertEqual(1, ci.count('partition: "hash:1/2"')); self.assertEqual(1, ci.count('partition: "hash:2/2"')); self.assertEqual(2, ci.count('partition: "hash:1/1"'))
-        self.assertIn("target_group: lib", ci); self.assertIn("target_group: integration-b", ci); self.assertIn("target_group: integration-c", ci)
+        self.assertIn("build-test-archive-a:", ci); self.assertIn("build-test-archive-b:", ci); self.assertIn("build-test-archive-c:", ci); self.assertIn("build-test-archive-d:", ci)
+        self.assertNotIn("test-slow-shard:", ci); self.assertNotIn('partition: "hash:1/2"', ci); self.assertNotIn('partition: "hash:2/2"', ci); self.assertEqual(4, ci.count('partition: "hash:1/1"'))
+        self.assertIn("target_group: lib", ci); self.assertIn("target_group: integration-b", ci); self.assertIn("target_group: integration-c", ci); self.assertIn("target_group: integration-d", ci)
         self.assertIn("cargo metadata --no-deps --format-version 1", builder)
         self.assertIn("scripts/select-nextest-archive-targets.mjs", builder)
         self.assertIn(
@@ -143,7 +143,7 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         self.assertIn("scripts/collect-nextest-target-durations.mjs", runner)
         self.assertIn("nextest-target-durations-${{ github.run_id }}-${{ inputs.archive_label }}", runner)
 
-    def test_duration_policy_collects_devel_and_same_repository_pr_b_and_c_measurements(self):
+    def test_duration_policy_collects_devel_and_same_repository_pr_b_c_d_measurements(self):
         from pathlib import Path
         root = Path(__file__).resolve().parents[2]
         policy = (root / "tests/suites/nextest-target-duration-policy.json").read_text()
@@ -165,12 +165,13 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         )
         self.assertIn("inputs.archive_label == 'b'", runner)
         self.assertIn("inputs.archive_label == 'c'", runner)
+        self.assertIn("inputs.archive_label == 'd'", runner)
         self.assertIn("retention-days: 3", runner)
         self.assertIn("retention-days: 30", runner)
         self.assertIn("estimatedSeconds", selector)
         self.assertIn("<testcase", collector)
         self.assertIn("JUnit report contains no target durations", collector)
-        self.assertIn("exactly one B report and one C report", refresh)
+        self.assertIn("exactly one B, C, and D report", refresh)
         self.assertIn("identical run, ref, and sha provenance", refresh)
 
     def test_native_skia_uses_the_same_test_profile_policy(self) -> None:
@@ -210,9 +211,9 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         ci = (root / ".github/workflows/ci.yml").read_text()
         builder = (root / ".github/workflows/build-nextest-archives.yml").read_text()
         runner = (root / ".github/workflows/run-nextest-archives.yml").read_text()
-        for name in ("test-archive-a-shard-1:", "test-archive-a-shard-2:", "test-archive-b-shard-1:", "test-archive-c-shard-1:"):
+        for name in ("test-archive-a-shard-1:", "test-archive-b-shard-1:", "test-archive-c-shard-1:", "test-archive-d-shard-1:"):
             self.assertIn(name, ci)
-        self.assertIn("Archive A shard total mismatch", ci); self.assertIn("Archive B shard total mismatch", ci); self.assertIn("Archive C shard total mismatch", ci)
+        self.assertIn("Archive A shard total mismatch", ci); self.assertIn("Archive B shard total mismatch", ci); self.assertIn("Archive C shard total mismatch", ci); self.assertIn("Archive D shard total mismatch", ci)
         self.assertIn("name: Build & Test", ci)
 
     def test_reusable_builder_rejects_profile_timeout_mismatches(self) -> None:
@@ -224,6 +225,7 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
             ("release-test", "30", "lib", 0),
             ("release", "60", "integration-b", 0),
             ("release", "60", "integration-c", 0),
+            ("release", "60", "integration-d", 0),
             ("release-test", "60", "lib", 1),
             ("release", "30", "integration-b", 1),
             ("debug", "60", "lib", 1),

--- a/scripts/tests/test_proptest_roundtrip_workflow.py
+++ b/scripts/tests/test_proptest_roundtrip_workflow.py
@@ -91,14 +91,14 @@ class ProptestRoundtripWorkflowTests(unittest.TestCase):
         run_at = self.wf.index("run-prop-roundtrip.mjs --cargo-test")
         self.assertLess(prepare_at, run_at, "prepare 가 실행보다 먼저여야 한다")
 
-    def test_does_not_add_a_fifth_nextest_shard(self) -> None:
-        """A/B/C archive의 worker 네 개 합 = runnable. 다섯 번째 worker는 깨진다."""
+    def test_keeps_nextest_workers_at_four_balanced_archives(self) -> None:
+        """A/B/C/D archive의 worker 네 개 합 = runnable. 다섯 번째 worker는 깨진다."""
         self.assertNotRegex(self.ci, r"(?m)^  proptest-roundtrip:")
         self.assertNotIn("prop_hwpx_roundtrip", RUN_ARCHIVE.read_text(encoding="utf-8"))
-        self.assertEqual(1, self.ci.count('partition: "hash:1/2"'))
-        self.assertEqual(1, self.ci.count('partition: "hash:2/2"'))
-        self.assertEqual(2, self.ci.count('partition: "hash:1/1"'))
-        for count_label in ("a-1", "a-2", "b-1", "c-1"):
+        self.assertNotIn('partition: "hash:1/2"', self.ci)
+        self.assertNotIn('partition: "hash:2/2"', self.ci)
+        self.assertEqual(4, self.ci.count('partition: "hash:1/1"'))
+        for count_label in ("a-1", "b-1", "c-1", "d-1"):
             with self.subTest(count_label=count_label):
                 self.assertIn(f"shard-count-{count_label}", self.ci)
 


### PR DESCRIPTION
## 요약
- Archive A의 두 shard를 단일 실행으로 통합합니다.
- integration target을 B/C/D 세 archive에 시간 기반으로 배정합니다.
- B/C/D JUnit 측정 수집과 전체 target coverage 검증을 갱신합니다.
- CI 영향 정책 감사와 nextest worker 수 계약을 새 archive topology에 맞춥니다.

## 검증
- `node --test scripts/tests/nextest-target-duration-policy.test.mjs`
- `node --test scripts/tests/ci-impact-classifier.test.cjs scripts/tests/ci-impact-policy.test.cjs`
- `python3 -m unittest scripts/tests/test_nextest_archive_workflow.py scripts/tests/test_ci_impact_workflow.py scripts/tests/test_ci_impact_policy_workflow.py scripts/tests/test_workflow_contract_wiring.py`
- `python3 -m unittest scripts/tests/test_adapter_diff_workflow.py scripts/tests/test_proptest_roundtrip_workflow.py scripts/tests/test_nextest_archive_workflow.py scripts/tests/test_workflow_contract_wiring.py`
- `node scripts/rust-test-suite-manifest.mjs --prepare && cargo fmt --all -- --check`

Closes #6251