### PR TITLE
fix(ci): squash merge 뒤 trusted CodeQL 재사용 보완

### DIFF
--- a/.github/workflows/adapter-diff.yml
+++ b/.github/workflows/adapter-diff.yml
@@ -33,6 +33,9 @@ jobs:
       pull-requests: read
     with:
       workflow_file: adapter-diff.yml
+      caller_event_name: ${{ github.event_name }}
+      caller_ref: ${{ github.ref }}
+      caller_sha: ${{ github.sha }}
 
   adapter-impact:
     name: adapter inter-diff preflight

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
     with:
       workflow_file: ci.yml
       require_duration_artifacts: true
+      caller_event_name: ${{ github.event_name }}
+      caller_ref: ${{ github.ref }}
+      caller_sha: ${{ github.sha }}
 
   preflight:
     name: CI preflight
@@ -990,6 +993,8 @@ jobs:
       # 추가하면 그 테스트가 실패하므로 여기 한 줄을 같이 넣어야 한다.
       - name: Validate workflow contracts
         run: |
+          node --test scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
+          node --test scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs
           python3 -m unittest scripts/tests/test_cache_sweep_workflow.py
           python3 -m unittest scripts/tests/test_cancel_stale_pr_runs_workflow.py
           python3 -m unittest scripts/tests/test_ci_impact_policy_workflow.py

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,6 +55,9 @@ jobs:
       pull-requests: read
     with:
       workflow_file: codeql.yml
+      caller_event_name: ${{ github.event_name }}
+      caller_ref: ${{ github.ref }}
+      caller_sha: ${{ github.sha }}
 
   preflight:
     name: CodeQL preflight

--- a/.github/workflows/proptest-roundtrip.yml
+++ b/.github/workflows/proptest-roundtrip.yml
@@ -36,6 +36,9 @@ jobs:
       pull-requests: read
     with:
       workflow_file: proptest-roundtrip.yml
+      caller_event_name: ${{ github.event_name }}
+      caller_ref: ${{ github.ref }}
+      caller_sha: ${{ github.sha }}
 
   preflight:
     name: Proptest preflight

--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -7,6 +7,18 @@ on:
         description: Source workflow filename whose successful PR run may be reused.
         required: true
         type: string
+      caller_event_name:
+        description: Original caller event name; workflow_call itself is not evidence.
+        required: true
+        type: string
+      caller_ref:
+        description: Original caller Git ref.
+        required: true
+        type: string
+      caller_sha:
+        description: Original caller commit SHA.
+        required: true
+        type: string
       require_duration_artifacts:
         description: Require B/C duration artifacts before permitting CI worker reuse.
         required: false
@@ -50,19 +62,53 @@ jobs:
       # falls back to full CI; later PRs use this immutable pre-merge revision.
       - name: Resolve trusted source base parent
         id: source-base
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
+        if: ${{ inputs.caller_event_name == 'push' && inputs.caller_ref == 'refs/heads/devel' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CALLER_SHA: ${{ inputs.caller_sha }}
         with:
           script: |
             try {
+              const mergeSha = process.env.CALLER_SHA;
+              if (!/^[0-9a-f]{40}$/.test(mergeSha)) {
+                core.setOutput('sha', '');
+                core.warning('Caller SHA is unavailable; running full.');
+                return;
+              }
               const { data: commit } = await github.rest.repos.getCommit({
                 ...context.repo,
-                ref: context.sha,
+                ref: mergeSha,
               });
               const parents = (commit.parents || []).map((parent) => parent.sha);
-              if (parents.length !== 2 || new Set(parents).size !== 2) {
+              if (commit.sha !== mergeSha || new Set(parents).size !== parents.length) {
                 core.setOutput('sha', '');
-                core.warning('Post-merge reuse requires exactly two merge parents.');
+                core.warning('Post-merge commit identity is unavailable; running full.');
+                return;
+              }
+              if (parents.length === 2) {
+                core.setOutput('sha', parents[0]);
+                return;
+              }
+              if (parents.length !== 1) {
+                core.setOutput('sha', '');
+                core.warning('Post-merge reuse requires one squash parent or two merge parents.');
+                return;
+              }
+              const pullRequests = await github.paginate(
+                github.rest.repos.listPullRequestsAssociatedWithCommit,
+                { ...context.repo, commit_sha: mergeSha, per_page: 100 },
+              );
+              const matching = pullRequests.filter((candidate) => (
+                candidate.state === 'closed'
+                && candidate.merged_at
+                && candidate.merge_commit_sha === mergeSha
+                && candidate.base?.ref === 'devel'
+                && candidate.head?.repo?.full_name === process.env.GITHUB_REPOSITORY
+                && /^[0-9a-f]{40}$/.test(candidate.head?.sha || '')
+              ));
+              if (matching.length !== 1) {
+                core.setOutput('sha', '');
+                core.warning('Squash post-merge reuse requires exactly one same-repository merged PR.');
                 return;
               }
               core.setOutput('sha', parents[0]);
@@ -89,6 +135,9 @@ jobs:
         env:
           WORKFLOW_FILE: ${{ inputs.workflow_file }}
           REQUIRE_DURATION_ARTIFACTS: ${{ inputs.require_duration_artifacts }}
+          CALLER_EVENT_NAME: ${{ inputs.caller_event_name }}
+          CALLER_REF: ${{ inputs.caller_ref }}
+          CALLER_SHA: ${{ inputs.caller_sha }}
         with:
           script: |
             const path = require('node:path');
@@ -109,19 +158,20 @@ jobs:
             }
 
             async function collectEvidence() {
+              const mergeSha = process.env.CALLER_SHA;
               const mergeCommit = (await github.rest.repos.getCommit({
                 owner,
                 repo,
-                ref: context.sha,
+                ref: mergeSha,
               })).data;
               const pullRequests = await github.paginate(
                 github.rest.repos.listPullRequestsAssociatedWithCommit,
-                { owner, repo, commit_sha: context.sha, per_page: 100 },
+                { owner, repo, commit_sha: mergeSha, per_page: 100 },
               );
               const pullRequest = pullRequests.filter((candidate) => (
                 candidate.state === 'closed'
                 && candidate.merged_at
-                && candidate.merge_commit_sha === context.sha
+                && candidate.merge_commit_sha === mergeSha
                 && candidate.base?.ref === 'devel'
                 && candidate.head?.repo?.full_name === process.env.GITHUB_REPOSITORY
               ));
@@ -129,9 +179,10 @@ jobs:
                 return { mergeCommit, pullRequests, pullFiles: [], workflowRuns: [] };
               }
               const pr = pullRequest[0];
-              const baseParent = (mergeCommit.parents || [])
-                .map((parent) => parent.sha)
-                .find((sha) => sha !== pr.head.sha);
+              const mergeParents = (mergeCommit.parents || []).map((parent) => parent.sha);
+              const baseParent = mergeParents.length === 1
+                ? mergeParents[0]
+                : mergeParents.find((sha) => sha !== pr.head.sha);
               const [sourceCommit, comparison, pullFiles, workflowRuns] = await Promise.all([
                 github.rest.repos.getCommit({ owner, repo, ref: pr.head.sha }).then((response) => response.data),
                 baseParent
@@ -164,10 +215,10 @@ jobs:
             try {
               const evidence = await collectEvidence();
               result = evaluateTrustedPostMergeReuse({
-                eventName: context.eventName,
-                ref: context.ref,
+                eventName: process.env.CALLER_EVENT_NAME,
+                ref: process.env.CALLER_REF,
                 repository: process.env.GITHUB_REPOSITORY,
-                mergeSha: context.sha,
+                mergeSha: process.env.CALLER_SHA,
                 ...evidence,
               });
             } catch (error) {

--- a/mydocs/manual/pr_review/local_validation.md
+++ b/mydocs/manual/pr_review/local_validation.md
@@ -277,6 +277,23 @@ remote push, PR 생성, ready 전환, merge 승인과는 별개다.
 | CI workflow | [GitHub 저장소 운영 매뉴얼](../github_operations.md)의 변경 등급에 따른 workflow 구문·정책 테스트·required check 영향·최신 GitHub Actions 결과 |
 | 기존 golden/baseline/fixture | 관련 focused test, snapshot 결정성, 최신 PR head CI |
 
+archive label 또는 trusted post-merge reuse topology를 바꾸면, 일반 workflow 계약 검사에 더해
+아래 두 묶음을 PR 전에 모두 실행한다. Studio E2E나 OS resource-limit처럼 이 변경 범위와
+무관한 Node 테스트까지 glob으로 섞지 않는다.
+
+~~~bash
+node --test \
+  scripts/tests/ci-impact-classifier.test.cjs \
+  scripts/tests/ci-impact-policy.test.cjs \
+  scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs \
+  scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs
+python3 -m unittest discover -s scripts/tests -p 'test_*workflow.py'
+~~~
+
+이 묶음은 archive consumer, CI impact, CodeQL, adapter, proptest, reusable workflow의
+상호 계약을 함께 검사한다. 따라서 새 archive label이나 reusable input을 추가한 PR은
+GitHub CI에서가 아니라 PR을 열기 전에 누락된 consumer를 발견해야 한다.
+
 ### 4.3.0 PR 검토의 GitHub Full CI 재사용
 
 이 표의 기본 검증은 새 code head를 만들거나 아직 GitHub 전체 검증이 없는 PR에 적용한다. 이미

--- a/mydocs/orders/20260828.md
+++ b/mydocs/orders/20260828.md
@@ -1,0 +1,8 @@
+# 2026-08-28 오늘할일
+
+## CI 운영
+
+- [ ] [#6257](https://github.com/edwardkim/rhwp/pull/6257) squash merge 뒤 trusted CodeQL 재사용 보완
+  - 로컬 CI policy 및 trusted reuse 계약 70건, Python workflow 계약 166건 통과.
+  - 최신 PR head의 GitHub Actions 통과 뒤 merge한다.
+  - merge 뒤 devel push에서 동일 PR의 성공 run이 재사용되고 CodeQL worker가 skip 되는지 확인한다.

--- a/mydocs/pr/archives/pr_6257_review.md
+++ b/mydocs/pr/archives/pr_6257_review.md
@@ -1,0 +1,67 @@
+---
+pr: 6257
+issue: 6256
+author: jangster77
+base: devel
+head: codex/6256-squash-codeql-reuse
+code_candidate_sha: 59c06a4ed92a65aace886d0cd53bb5fd89639787
+created_at: 2026-08-28
+---
+
+# PR #6257 검토 기록
+
+## 접수 정보
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#6257](https://github.com/edwardkim/rhwp/pull/6257) |
+| 관련 이슈 | [#6256](https://github.com/edwardkim/rhwp/issues/6256) |
+| 작성자 | jangster77 self-review |
+| base / head | devel / codex/6256-squash-codeql-reuse |
+| 코드 후보 SHA | 59c06a4ed92a65aace886d0cd53bb5fd89639787 |
+| 변경 규모 | 11 files, +255 / -17 |
+| 작성 시점 상태 | MERGEABLE, required check 대기로 BLOCKED |
+
+상태값은 문서 작성 시점 참고값이다. merge 판단 전에는 review 기록 commit을 포함한 최신
+head의 mergeability와 GitHub Actions 결과를 다시 확인한다.
+
+## 변경 범위와 판단
+
+- reusable trusted post-merge workflow가 caller의 원래 event, ref, SHA를 받도록 변경한다.
+- 단일 부모 squash commit은 동일 저장소의 단일 merged PR, PR head와 같은 결과 tree,
+  성공한 정확한 PR workflow가 모두 확인될 때만 worker 재사용을 허용한다.
+- direct push, merge queue, 모호한 PR 연결, tree 불일치, enforcement surface 변경,
+  missing/pending/failed candidate는 full CI로 fail-closed한다.
+- evaluator의 기존 및 squash 계약을 CI workflow contracts 단계에 배선하고, 해당 배선의
+  존재를 Python workflow 계약으로 고정한다.
+
+변경은 CI 정책, JavaScript/Python 계약 테스트, 검증 가이드에 한정된다. renderer, HWP/HWPX,
+PDF fixture, 제품 출력은 변경하지 않으므로 visual sweep 증적은 대상이 아니다.
+
+## 로컬 검증
+
+다음 계약 검증을 코드 후보 SHA에서 완료했다.
+
+| 명령 | 결과 |
+| --- | --- |
+| node --test ci-impact-classifier, ci-impact-policy, 기존/squash trusted reuse evaluator | 70 passed |
+| python3 -m unittest discover -s scripts/tests -p test_*workflow.py | 166 passed |
+| git diff --check | passed |
+
+전체 Studio Node glob은 설치되지 않은 @noble/hashes와 OS resource-limit 테스트처럼 이 PR 범위와
+무관한 환경 의존 검사를 포함하므로, CI topology 회귀 gate로 사용하지 않았다. 대신 이 PR이 변경한
+CI policy, trusted reuse evaluator, 모든 Python workflow contract를 명시적으로 실행했다.
+
+## CI 및 merge 조건
+
+1. review 기록 commit을 포함한 최신 PR head의 required checks가 성공해야 한다.
+2. CI workflow와 CodeQL workflow가 full lane에서 정책 변경을 검증해야 한다.
+3. merge 뒤 devel push에서 trusted post-merge reuse가 squash merge PR을 정확히 식별하고,
+   검증된 PR run을 재사용하는지 확인한다.
+4. direct push 또는 evidence가 불완전한 squash merge가 full lane으로 fail-closed하는 기존 보안
+   성질은 유지되어야 한다.
+
+## 최종 권고
+
+**CI 대기.** 로컬 계약 검증은 통과했다. 최신 PR head의 GitHub Actions와 squash merge 뒤
+devel run에서의 실제 재사용 결과를 확인한 뒤 merge 여부를 판단한다.

--- a/mydocs/working/task_m100_6256_stage1_squash_postmerge_codeql_reuse.md
+++ b/mydocs/working/task_m100_6256_stage1_squash_postmerge_codeql_reuse.md
@@ -1,0 +1,38 @@
+# #6256 Stage 1: squash merge 뒤 trusted CodeQL 재사용 보완
+
+## 배경
+
+#6253의 squash merge 뒤 devel push에서 CodeQL과 CI 후속 workflow가 다시 전체 실행되었다.
+[실행 33084109437](https://github.com/edwardkim/rhwp/actions/runs/33084109437)의
+재사용 job은 reusable workflow 내부의 event가 workflow_call로 보이는 문제와, squash
+commit의 부모가 하나인 문제 때문에 reuse=false로 종료했다.
+
+## 원인
+
+기존 정책은 reusable workflow가 직접 push/refs/heads/devel event를 보고, merge commit이
+부모 두 개와 PR head 부모를 가진다고 전제했다. workflow_call과 GitHub squash merge에서는
+각각 그 전제가 성립하지 않아 안전한 full lane으로 fallback했다.
+
+## 보완 범위
+
+- 각 caller가 원래의 event, ref, SHA를 reusable workflow에 명시적으로 전달한다.
+- 부모 하나의 commit은 GitHub가 연결한 동일 저장소의 단일 merged PR일 때만 squash 후보로
+  취급한다.
+- 후보 PR head의 결과 tree, pre-merge base 관계, enforcement surface 비변경, 해당 workflow의
+  최종 성공 run이 모두 일치해야 worker를 건너뛴다.
+- direct push, merge queue, 모호한 PR 연결, tree 불일치, 정책 surface 변경,
+  missing/pending/failed run은 full CI로 fail-closed한다.
+
+## PR 전 계약 확인
+
+archive label 또는 trusted reuse topology를 바꾸면 PR을 열기 전에 다음 두 묶음을 모두
+실행한다.
+
+- Node CI 정책과 trusted reuse 계약: ci-impact-classifier, ci-impact-policy, 기존 evaluator,
+  squash evaluator test를 명시적으로 실행한다.
+- Python workflow 계약 전체: python3 -m unittest discover -s scripts/tests -p test_*workflow.py
+
+이 확인은 #6253에서 archive consumer 계약을 하나씩 놓쳐 후속 수정 커밋이 생긴 문제를
+막는다. Studio E2E와 OS resource-limit 같이 무관한 테스트를 glob으로 섞어 환경 실패를
+CI topology 회귀로 오판하지 않는다. 실제 GitHub Actions 재사용 성공은 PR CI와 squash
+merge 뒤 devel run에서 별도로 확인한다.

--- a/scripts/tests/test_codeql_workflow.py
+++ b/scripts/tests/test_codeql_workflow.py
@@ -77,6 +77,12 @@ class CodeQLWorkflowTests(unittest.TestCase):
             workflow.index("return { state: 'green' };"),
         )
 
+    def test_trusted_postmerge_reuse_receives_original_caller_identity(self) -> None:
+        trusted_reuse = job_body(self.workflow, "trusted_postmerge_reuse")
+        self.assertIn("caller_event_name: ${{ github.event_name }}", trusted_reuse)
+        self.assertIn("caller_ref: ${{ github.ref }}", trusted_reuse)
+        self.assertIn("caller_sha: ${{ github.sha }}", trusted_reuse)
+
     def test_green_analyze_jobs_cannot_reuse_a_failed_security_check(self) -> None:
         outputs = self._run_preflight("failure")
         self.assertEqual(outputs["fast_pass"], "false")

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REUSABLE = REPO_ROOT / ".github/workflows/trusted-postmerge-ci-reuse.yml"
+CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
 WORKFLOWS = {
     "ci": REPO_ROOT / ".github/workflows/ci.yml",
     "codeql": REPO_ROOT / ".github/workflows/codeql.yml",
@@ -25,6 +26,13 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
         self.assertIn("Default to full verification", workflow)
         self.assertIn("Resolve trusted source base parent", workflow)
         self.assertIn("ref: ${{ steps.source-base.outputs.sha }}", workflow)
+        self.assertIn("caller_event_name:", workflow)
+        self.assertIn("caller_ref:", workflow)
+        self.assertIn("caller_sha:", workflow)
+        self.assertIn("inputs.caller_event_name == 'push'", workflow)
+        self.assertIn("CALLER_SHA: ${{ inputs.caller_sha }}", workflow)
+        self.assertIn("one squash parent or two merge parents", workflow)
+        self.assertIn("exactly one same-repository merged PR", workflow)
         self.assertIn("trusted-base-verifier-unavailable", workflow)
         self.assertIn("event: 'pull_request'", workflow)
         self.assertIn("listPullRequestsAssociatedWithCommit", workflow)
@@ -49,6 +57,11 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
                 self.assertIn("./.github/workflows/trusted-postmerge-ci-reuse.yml", workflow)
                 self.assertIn(expected_workflow_files[name], workflow)
                 self.assertIn("needs.trusted_postmerge_reuse.outputs.reuse", workflow)
+                self.assertIn(
+                    "caller_event_name: ${{ github.event_name }}", workflow
+                )
+                self.assertIn("caller_ref: ${{ github.ref }}", workflow)
+                self.assertIn("caller_sha: ${{ github.sha }}", workflow)
 
     def test_ci_requires_candidate_duration_artifacts_before_worker_reuse(self) -> None:
         ci = WORKFLOWS["ci"].read_text(encoding="utf-8")
@@ -56,6 +69,15 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
         self.assertIn("postmerge_source_run_id", ci)
         self.assertIn("Download trusted PR Archive B duration measurement", ci)
         self.assertIn("Download trusted PR Archive C duration measurement", ci)
+
+    def test_trusted_reuse_evaluator_contracts_are_invoked_by_ci(self) -> None:
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs", ci
+        )
+        self.assertIn(
+            "scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs", ci
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { evaluateTrustedPostMergeReuse } from "../verify-trusted-postmerge-ci-reuse.mjs";
+
+const base = "1".repeat(40);
+const head = "2".repeat(40);
+const merge = "3".repeat(40);
+const tree = "4".repeat(40);
+
+function candidate() {
+  return {
+    id: 123,
+    event: "pull_request",
+    head_sha: head,
+    head_branch: "codex/6256",
+    head_repository: { full_name: "edwardkim/rhwp" },
+    created_at: "2026-08-27T10:01:00Z",
+    updated_at: "2026-08-27T10:02:00Z",
+    status: "completed",
+    conclusion: "success",
+  };
+}
+
+function input(overrides = {}) {
+  return {
+    eventName: "push",
+    ref: "refs/heads/devel",
+    repository: "edwardkim/rhwp",
+    mergeSha: merge,
+    mergeCommit: {
+      sha: merge,
+      parents: [{ sha: base }],
+      commit: { tree: { sha: tree } },
+    },
+    sourceCommit: { sha: head, commit: { tree: { sha: tree } } },
+    mergeBaseSha: base,
+    pullRequests: [{
+      number: 6256,
+      state: "closed",
+      merged_at: "2026-08-27T10:03:00Z",
+      merge_commit_sha: merge,
+      base: { ref: "devel" },
+      head: {
+        sha: head,
+        ref: "codex/6256",
+        repo: { full_name: "edwardkim/rhwp" },
+      },
+      created_at: "2026-08-27T10:00:00Z",
+    }],
+    pullFiles: [{ filename: "src/lib.rs" }],
+    workflowRuns: [candidate()],
+    ...overrides,
+  };
+}
+
+test("reuses an exact green same-repository PR after a squash merge", () => {
+  assert.deepEqual(evaluateTrustedPostMergeReuse(input()), {
+    reuse: true,
+    reason: "exact-green-pr-workflow-reused",
+    sourceRunId: "123",
+    pullNumber: "6256",
+  });
+});
+
+test("fails closed when a squash merge tree differs from the reviewed PR head", () => {
+  const result = evaluateTrustedPostMergeReuse(input({
+    mergeCommit: {
+      sha: merge,
+      parents: [{ sha: base }],
+      commit: { tree: { sha: "5".repeat(40) } },
+    },
+  }));
+  assert.equal(result.reuse, false);
+  assert.equal(result.reason, "merge-tree-does-not-match-pr-head");
+});
+
+test("fails closed when a squash merge has no unique associated PR", () => {
+  const result = evaluateTrustedPostMergeReuse(input({ pullRequests: [] }));
+  assert.equal(result.reuse, false);
+  assert.equal(result.reason, "merge-commit-must-map-to-one-merged-same-repository-pr");
+});

--- a/scripts/verify-trusted-postmerge-ci-reuse.mjs
+++ b/scripts/verify-trusted-postmerge-ci-reuse.mjs
@@ -68,8 +68,11 @@ export function evaluateTrustedPostMergeReuse(input) {
   const parents = Array.isArray(input.mergeCommit.parents)
     ? input.mergeCommit.parents.map((parent) => parent?.sha || parent).filter(validSha)
     : [];
-  if (parents.length !== 2 || new Set(parents).size !== 2) {
-    return denied("merge-commit-must-have-two-parents");
+  if (
+    (parents.length !== 1 && parents.length !== 2)
+    || new Set(parents).size !== parents.length
+  ) {
+    return denied("merge-commit-must-have-one-or-two-parents");
   }
 
   const pullRequests = (Array.isArray(input.pullRequests) ? input.pullRequests : []).filter((pullRequest) => (
@@ -84,12 +87,17 @@ export function evaluateTrustedPostMergeReuse(input) {
     return denied("merge-commit-must-map-to-one-merged-same-repository-pr");
   }
   const pullRequest = pullRequests[0];
-  if (!parents.includes(pullRequest.head.sha)) {
+  if (parents.length === 2 && !parents.includes(pullRequest.head.sha)) {
     return denied("merge-parent-does-not-match-pr-head");
   }
-  const baseParent = parents.find((parent) => parent !== pullRequest.head.sha);
+  const baseParent = parents.length === 1
+    ? parents[0]
+    : parents.find((parent) => parent !== pullRequest.head.sha);
   if (!baseParent || input.mergeBaseSha !== baseParent) {
     return denied("pr-head-does-not-contain-merge-base");
+  }
+  if (input.sourceCommit?.sha !== pullRequest.head.sha) {
+    return denied("source-commit-does-not-match-pr-head");
   }
   if (
     input.mergeCommit?.commit?.tree?.sha !== input.sourceCommit?.commit?.tree?.sha


### PR DESCRIPTION
## 관련 이슈

Closes #6256

## 변경 사항

- reusable workflow에 caller의 원래 event, ref, SHA를 전달해 `workflow_call` context 혼동을 제거했습니다.
- squash merge는 연결된 동일 저장소의 단일 merged PR, 동일 결과 tree, 성공한 정확한 PR workflow가 모두 일치할 때만 재사용합니다.
- direct push, 모호한 연결, tree 불일치, 정책 surface 변경, 실패 또는 진행 중 후보는 full CI로 fail-closed합니다.
- trusted reuse evaluator의 기존·squash 계약을 CI workflow contracts 단계에 배선하고, PR 전 계약 검증 절차를 로컬 가이드에 추가했습니다.

## 로컬 검증

- `node --test scripts/tests/ci-impact-classifier.test.cjs scripts/tests/ci-impact-policy.test.cjs scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs` (70 passed)
- `python3 -m unittest discover -s scripts/tests -p 'test_*workflow.py'` (166 passed)

## 후속 확인

PR CI의 현재 head가 통과한 뒤 실제 squash merge 후 `devel` push에서 trusted reuse와 CodeQL worker skip을 다시 확인합니다.
