### PR TITLE
fix(ci): #6279 review-only tail CI 증적 재사용

### DIFF
--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -143,9 +143,10 @@ jobs:
             const path = require('node:path');
             const { pathToFileURL } = require('node:url');
             const { owner, repo } = context.repo;
+            let classifyReviewOnlyCommit;
             let evaluateTrustedPostMergeReuse;
             try {
-              ({ evaluateTrustedPostMergeReuse } = await import(pathToFileURL(path.join(
+              ({ classifyReviewOnlyCommit, evaluateTrustedPostMergeReuse } = await import(pathToFileURL(path.join(
                 process.env.GITHUB_WORKSPACE,
                 'scripts/verify-trusted-postmerge-ci-reuse.mjs',
               )).href));
@@ -201,12 +202,29 @@ jobs:
                   per_page: 100,
                 }),
               ]);
+              const prCommitHeaders = await github.paginate(
+                github.rest.pulls.listCommits,
+                { owner, repo, pull_number: pr.number, per_page: 100 },
+              );
+              const prCommits = [];
+              for (let index = prCommitHeaders.length - 1; index >= 0; index -= 1) {
+                const commit = (await github.rest.repos.getCommit({
+                  owner,
+                  repo,
+                  ref: prCommitHeaders[index].sha,
+                })).data;
+                prCommits.unshift(commit);
+                if (classifyReviewOnlyCommit(commit).kind !== "review") {
+                  break;
+                }
+              }
               return {
                 mergeCommit,
                 pullRequests,
                 sourceCommit,
                 mergeBaseSha: comparison.merge_base_commit?.sha || '',
                 pullFiles,
+                prCommits,
                 workflowRuns,
               };
             }

--- a/mydocs/working/task_m100_6279_stage1_trusted_review_tail_postmerge_reuse.md
+++ b/mydocs/working/task_m100_6279_stage1_trusted_review_tail_postmerge_reuse.md
@@ -1,0 +1,23 @@
+# Issue #6279 Stage 1: review-only tail Full CI evidence reuse
+
+## 배경
+
+PR #6253과 #6275처럼 코드 변경 커밋에서 Full CI가 성공한 뒤 PR 검토 문서와 추가된 PDF
+증적만 포함한 trailing commit이 추가될 수 있다. trailing commit 자체는 fast-pass를 적용할 수
+있지만, merge 후 `devel` push 정책이 최종 head의 CI run만 찾으면 직전 Full CI와 측정 artifact를
+놓쳐 전체 CI를 다시 실행하게 된다.
+
+## 변경 방향
+
+- 최종 head에서 시작해 허용된 review-only commit을 역추적하고, 선형 이력의 직전 코드 commit을
+  Full CI 증적 후보로 선택한다.
+- 허용 경로는 `mydocs/**`, 새로 추가된 `samples/` 기준 자료, 새로 추가된
+  `pdf/`, `pdf-2020/`, `pdf-large/` PDF로 한정한다.
+- 파일 목록 누락, 300개 이상 파일, 비선형 이력, 허용되지 않은 변경은 재사용하지 않고 기존
+  fail-closed 전체 CI를 실행한다.
+
+## 사전 회귀 방지
+
+- verifier 단위 테스트가 review-only tail에서 직전 코드 commit의 성공 run을 선택하는지 확인한다.
+- parent 연결이 맞지 않으면 재사용을 거부하는지 확인한다.
+- reusable workflow 계약 테스트가 PR commit 상세 조회와 동일한 review-only 분류기를 요구한다.

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -39,6 +39,8 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
         self.assertIn("compareCommits", workflow)
         self.assertIn("listWorkflowRuns", workflow)
         self.assertIn("listFiles", workflow)
+        self.assertIn("listCommits", workflow)
+        self.assertIn("classifyReviewOnlyCommit", workflow)
         self.assertIn("listWorkflowRunArtifacts", workflow)
         self.assertIn("never checks out or executes", workflow)
         self.assertIn("the merged PR head", workflow)

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs
@@ -49,6 +49,11 @@ function input(overrides = {}) {
       created_at: "2026-08-27T10:00:00Z",
     }],
     pullFiles: [{ filename: "src/lib.rs" }],
+    prCommits: [{
+      sha: head,
+      parents: [{ sha: base }],
+      files: [{ filename: "src/lib.rs", status: "modified" }],
+    }],
     workflowRuns: [candidate()],
     ...overrides,
   };

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
@@ -7,6 +7,7 @@ const base = "1".repeat(40);
 const head = "2".repeat(40);
 const merge = "3".repeat(40);
 const tree = "4".repeat(40);
+const code = "5".repeat(40);
 
 function candidate(overrides = {}) {
   return {
@@ -46,6 +47,11 @@ function input(overrides = {}) {
       head: { sha: head, ref: "feature", repo: { full_name: "edwardkim/rhwp" } },
     }],
     pullFiles: [{ filename: "src/renderer/layout.rs" }],
+    prCommits: [{
+      sha: head,
+      parents: [{ sha: base }],
+      files: [{ filename: "src/renderer/layout.rs", status: "modified" }],
+    }],
     workflowRuns: [candidate()],
     ...overrides,
   };
@@ -65,4 +71,50 @@ test("fails closed for direct pushes, stale bases, enforcement changes, and inco
   assert.equal(evaluateTrustedPostMergeReuse(input({ mergeBaseSha: "5".repeat(40) })).reuse, false);
   assert.equal(evaluateTrustedPostMergeReuse(input({ pullFiles: [{ filename: ".github/workflows/ci.yml" }] })).reuse, false);
   assert.equal(evaluateTrustedPostMergeReuse(input({ workflowRuns: [candidate({ status: "in_progress", conclusion: null })] })).reuse, false);
+});
+
+test("reuses the preceding full CI through a linear review-only tail", () => {
+  const result = evaluateTrustedPostMergeReuse(input({
+    prCommits: [
+      {
+        sha: code,
+        parents: [{ sha: base }],
+        files: [{ filename: "src/renderer/layout.rs", status: "modified" }],
+      },
+      {
+        sha: head,
+        parents: [{ sha: code }],
+        files: [
+          { filename: "mydocs/pr/archives/pr_6253_review.md", status: "added" },
+          { filename: "pdf/pr_6253/reference.pdf", status: "added" },
+        ],
+      },
+    ],
+    workflowRuns: [candidate({ id: 456, head_sha: code })],
+  }));
+  assert.deepEqual(result, {
+    reuse: true,
+    reason: "review-tail-green-pr-workflow-reused",
+    sourceRunId: "456",
+    pullNumber: "42",
+  });
+});
+
+test("fails closed when the review-only tail is not linear", () => {
+  const result = evaluateTrustedPostMergeReuse(input({
+    prCommits: [
+      {
+        sha: code,
+        parents: [{ sha: base }],
+        files: [{ filename: "src/renderer/layout.rs", status: "modified" }],
+      },
+      {
+        sha: head,
+        parents: [{ sha: "6".repeat(40) }],
+        files: [{ filename: "mydocs/pr/archives/pr_6253_review.md", status: "added" }],
+      },
+    ],
+  }));
+  assert.equal(result.reuse, false);
+  assert.equal(result.reason, "review-tail-evidence-unavailable");
 });

--- a/scripts/verify-trusted-postmerge-ci-reuse.mjs
+++ b/scripts/verify-trusted-postmerge-ci-reuse.mjs
@@ -33,16 +33,88 @@ function enforcementPathChanged(files) {
   ));
 }
 
-function latestCandidateRun(runs, pullRequest, repository) {
+function allowedReviewOnlyFile(file) {
+  if (!file || typeof file.filename !== "string") {
+    return false;
+  }
+  if (file.filename.startsWith("mydocs/")) {
+    return true;
+  }
+  if (file.status !== "added") {
+    return false;
+  }
+
+  const filename = file.filename;
+  const lowerName = filename.toLowerCase();
+  const sampleReference = filename.startsWith("samples/")
+    && [".hwp", ".hwpx", ".pdf", ".png"].some((extension) => lowerName.endsWith(extension));
+  const pdfReference = ["pdf/", "pdf-2020/", "pdf-large/"]
+    .some((prefix) => filename.startsWith(prefix))
+    && lowerName.endsWith(".pdf");
+  return sampleReference || pdfReference;
+}
+
+export function classifyReviewOnlyCommit(commit) {
+  if (!validSha(commit?.sha) || !Array.isArray(commit?.files)) {
+    return { kind: "invalid" };
+  }
+  if (
+    commit.files.length === 0
+    || commit.files.length >= 300
+    || !Array.isArray(commit.parents)
+  ) {
+    return { kind: "code" };
+  }
+  if (!commit.files.every(allowedReviewOnlyFile)) {
+    return { kind: "code" };
+  }
+  if (commit.parents.length !== 1 || !validSha(commit.parents[0]?.sha)) {
+    return { kind: "code" };
+  }
+  return { kind: "review", parentSha: commit.parents[0].sha };
+}
+
+export function selectTrustedPostMergeCandidate(pullRequest, prCommits) {
+  if (!validSha(pullRequest?.head?.sha) || !Array.isArray(prCommits) || prCommits.length === 0) {
+    return null;
+  }
+
+  let expectedSha = pullRequest.head.sha;
+  let hasReviewOnlyTail = false;
+  for (let index = prCommits.length - 1; index >= 0; index -= 1) {
+    const commit = prCommits[index];
+    if (commit?.sha !== expectedSha) {
+      return null;
+    }
+    const classification = classifyReviewOnlyCommit(commit);
+    if (classification.kind === "invalid") {
+      return null;
+    }
+    if (classification.kind === "code") {
+      return { sha: commit.sha, hasReviewOnlyTail };
+    }
+    hasReviewOnlyTail = true;
+    expectedSha = classification.parentSha;
+  }
+
+  return null;
+}
+
+function latestCandidateRun(runs, pullRequest, repository, candidateSha) {
   const createdAt = timestamp(pullRequest.created_at);
   const mergedAt = timestamp(pullRequest.merged_at);
-  if (!Number.isFinite(createdAt) || !Number.isFinite(mergedAt) || mergedAt < createdAt) {
+  if (
+    !validSha(candidateSha)
+    || !Number.isFinite(createdAt)
+    || !Number.isFinite(mergedAt)
+    || mergedAt < createdAt
+  ) {
     return null;
   }
 
   const matches = (Array.isArray(runs) ? runs : []).filter((run) => (
     run?.event === "pull_request"
-    && run?.head_sha === pullRequest.head?.sha
+    && run?.head_sha === candidateSha
     && run?.head_branch === pullRequest.head?.ref
     && run?.head_repository?.full_name === repository
     && timestamp(run.created_at) >= createdAt
@@ -109,7 +181,16 @@ export function evaluateTrustedPostMergeReuse(input) {
     return denied("pr-changes-ci-enforcement-surface");
   }
 
-  const candidate = latestCandidateRun(input.workflowRuns, pullRequest, input.repository);
+  const candidateSource = selectTrustedPostMergeCandidate(pullRequest, input.prCommits);
+  if (!candidateSource) {
+    return denied("review-tail-evidence-unavailable");
+  }
+  const candidate = latestCandidateRun(
+    input.workflowRuns,
+    pullRequest,
+    input.repository,
+    candidateSource.sha,
+  );
   if (!candidate) {
     return denied("no-current-pr-workflow-candidate");
   }
@@ -121,7 +202,9 @@ export function evaluateTrustedPostMergeReuse(input) {
   }
   return {
     reuse: true,
-    reason: "exact-green-pr-workflow-reused",
+    reason: candidateSource.hasReviewOnlyTail
+      ? "review-tail-green-pr-workflow-reused"
+      : "exact-green-pr-workflow-reused",
     sourceRunId: String(candidate.id),
     pullNumber: String(pullRequest.number),
   };


### PR DESCRIPTION
## 변경 요약

- merge 후 trusted reuse가 최종 PR head의 run만 보던 제한을 보완했습니다.
- 마지막 commit이 허용된 review-only 문서/추가 기준 PDF이고 선형 이력이면, 직전 코드 commit의 성공한 PR CI를 증적으로 선택합니다.
- 파일 목록 누락, 300개 이상 파일, 비선형 이력, 허용 외 변경은 모두 재사용을 거부하고 Full CI로 fail-closed 합니다.
- reusable workflow가 필요한 PR commit 상세만 역순 조회하며, 계약 테스트로 이 동작을 고정했습니다.

## 검증

- `cargo fmt --all && cargo fmt --all -- --check`
- `node --test scripts/tests/ci-impact-classifier.test.cjs scripts/tests/ci-impact-policy.test.cjs scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs` (72 passed)
- `python3 -m unittest discover -s scripts/tests -p 'test_*workflow.py'` (166 passed)

## 운영 영향과 관찰

- 등급: O3 (trusted post-merge reuse의 CI 실행 계약)
- PR 최신 head의 Full CI가 성공해야 합니다.
- merge 후 `devel` push에서 review-only tail의 직전 Full CI run과 duration artifact가 선택되고, worker가 skip되는지 확인합니다.
- 증적 수집 또는 lineage 검증에 실패하면 전체 CI 실행으로 fallback하므로 rollback은 이 커밋 revert입니다.

## 관련 이슈

Ref: #6279
