### PR TITLE
fix(ci): #6279 최종 head Full CI 증적 재사용

### DIFF
--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -218,7 +218,42 @@ jobs:
                   break;
                 }
               }
-              return {
+              const requireFullLaneEvidence = ["ci.yml", "codeql.yml"]
+                .includes(process.env.WORKFLOW_FILE);
+              const fullLaneRunIds = [];
+              if (requireFullLaneEvidence) {
+                for (const workflowRun of workflowRuns) {
+                  if (workflowRun.status !== "completed" || workflowRun.conclusion !== "success") {
+                    continue;
+                  }
+                  if (process.env.WORKFLOW_FILE === "ci.yml") {
+                    const artifacts = await github.paginate(
+                      github.rest.actions.listWorkflowRunArtifacts,
+                      { owner, repo, run_id: workflowRun.id, per_page: 100 },
+                    );
+                    const expected = new Set(["b", "c", "d"].map((label) => (
+                      `nextest-target-durations-${workflowRun.id}-${label}`
+                    )));
+                    const available = new Set(artifacts.map((artifact) => artifact.name));
+                    if ([...expected].every((name) => available.has(name))) {
+                      fullLaneRunIds.push(String(workflowRun.id));
+                    }
+                    continue;
+                  }
+                  const jobs = await github.paginate(
+                    github.rest.actions.listJobsForWorkflowRun,
+                    { owner, repo, run_id: workflowRun.id, per_page: 100 },
+                  );
+                  if (jobs.some((job) => (
+                    /^Analyze \(.+\)$/.test(job.name || "")
+                    && job.status === "completed"
+                    && job.conclusion === "success"
+                  ))) {
+                    fullLaneRunIds.push(String(workflowRun.id));
+                  }
+                }
+              }
+              const evidence = {
                 mergeCommit,
                 pullRequests,
                 sourceCommit,
@@ -227,6 +262,10 @@ jobs:
                 prCommits,
                 workflowRuns,
               };
+              if (requireFullLaneEvidence) {
+                evidence.fullLaneRunIds = fullLaneRunIds;
+              }
+              return evidence;
             }
 
             let result;
@@ -259,6 +298,7 @@ jobs:
                 const expected = new Set([
                   `nextest-target-durations-${result.sourceRunId}-b`,
                   `nextest-target-durations-${result.sourceRunId}-c`,
+                  `nextest-target-durations-${result.sourceRunId}-d`,
                 ]);
                 const available = new Set(artifacts.map((artifact) => artifact.name));
                 if (![...expected].every((name) => available.has(name))) {

--- a/mydocs/working/task_m100_6279_stage2_final_head_full_lane_reuse.md
+++ b/mydocs/working/task_m100_6279_stage2_final_head_full_lane_reuse.md
@@ -1,0 +1,36 @@
+# Task M100 #6279 Stage 2: PR 최종 head Full CI 재사용
+
+## 배경
+
+PR #6283은 코드 변경과 PR review, 오늘할일, PDF 증적을 같은 PR에 포함했다. 최종
+head `85b8ed2235d20c95fd0ec67d7f0bf99439106f31`의 CI는 Full lane으로 성공했고
+B/C/D nextest duration artifact 및 CodeQL 성공 결과를 남겼다. 그러나 기존 verifier는
+review tail 직전의 코드 commit만 후보로 찾아, 최종 head의 유효한 Full CI를 재사용하지
+못하고 merge 뒤 full lane을 다시 실행했다.
+
+## 목표
+
+다음 두 운영 경로를 모두 fail-closed로 지원한다.
+
+1. 코드, PR review, 오늘할일, PDF 증적을 한 PR에 함께 넣고 최종 head에서 Full CI를
+   통과한 경우: 최종 head run을 우선 재사용한다.
+2. 코드 head의 Full CI 성공 뒤 허용된 review, 오늘할일, PDF tail만 추가한 경우:
+   직전 코드 head run을 fallback으로 재사용한다.
+
+## 신뢰 경계
+
+- 동일 원본 저장소의 `devel` 대상 merged PR, merge 전 완료된 `pull_request` run,
+  PR 최종 tree와 merge tree 일치, CI enforcement surface 무변경을 공통으로 요구한다.
+- CI 후보는 성공 상태만으로 신뢰하지 않고 B/C/D duration artifact가 모두 있을 때만
+  Full lane 증적으로 인정한다.
+- CodeQL 후보는 성공한 `Analyze (...)` job이 최소 하나 있을 때만 실제 분석 증적으로
+  인정한다.
+- 증적이 없는 최종 head는 재사용하지 않고 review-tail 코드 후보를 시도한다. 두 후보가
+  모두 불충분하면 full lane으로 fail-closed 한다.
+
+## 검증 계획
+
+- shared verifier Node 계약 테스트에 최종 head 우선과 증적 부재 거부를 추가한다.
+- shared workflow Python 계약 테스트에 CI artifact 및 CodeQL analysis-job 검증을 추가한다.
+- PR CI 후 코드+문서 동시 포함 사례와 문서 tail 사례가 모두 각각의 증적 run을 선택하는지
+  로그로 확인한다.

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -42,6 +42,10 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
         self.assertIn("listCommits", workflow)
         self.assertIn("classifyReviewOnlyCommit", workflow)
         self.assertIn("listWorkflowRunArtifacts", workflow)
+        self.assertIn("listJobsForWorkflowRun", workflow)
+        self.assertIn("fullLaneRunIds", workflow)
+        self.assertIn('"ci.yml", "codeql.yml"', workflow)
+        self.assertIn('`nextest-target-durations-${workflowRun.id}-${label}`', workflow)
         self.assertIn("never checks out or executes", workflow)
         self.assertIn("the merged PR head", workflow)
 

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
@@ -91,6 +91,7 @@ test("reuses the preceding full CI through a linear review-only tail", () => {
       },
     ],
     workflowRuns: [candidate({ id: 456, head_sha: code })],
+    fullLaneRunIds: ["456"],
   }));
   assert.deepEqual(result, {
     reuse: true,
@@ -98,6 +99,40 @@ test("reuses the preceding full CI through a linear review-only tail", () => {
     sourceRunId: "456",
     pullNumber: "42",
   });
+});
+
+test("prefers the final PR head when code and review evidence passed together", () => {
+  const result = evaluateTrustedPostMergeReuse(input({
+    prCommits: [
+      {
+        sha: code,
+        parents: [{ sha: base }],
+        files: [{ filename: "src/renderer/layout.rs", status: "modified" }],
+      },
+      {
+        sha: head,
+        parents: [{ sha: code }],
+        files: [
+          { filename: "mydocs/pr/archives/pr_6274_review.md", status: "added" },
+          { filename: "pdf/pr_6274/reference.pdf", status: "added" },
+        ],
+      },
+    ],
+    workflowRuns: [candidate({ id: 789, head_sha: head })],
+    fullLaneRunIds: ["789"],
+  }));
+  assert.deepEqual(result, {
+    reuse: true,
+    reason: "review-tail-final-head-green-pr-workflow-reused",
+    sourceRunId: "789",
+    pullNumber: "42",
+  });
+});
+
+test("fails closed when a CI or CodeQL candidate lacks full-lane evidence", () => {
+  const result = evaluateTrustedPostMergeReuse(input({ fullLaneRunIds: [] }));
+  assert.equal(result.reuse, false);
+  assert.equal(result.reason, "candidate-full-lane-evidence-unavailable");
 });
 
 test("fails closed when the review-only tail is not linear", () => {

--- a/scripts/verify-trusted-postmerge-ci-reuse.mjs
+++ b/scripts/verify-trusted-postmerge-ci-reuse.mjs
@@ -130,6 +130,14 @@ function latestCandidateRun(runs, pullRequest, repository, candidateSha) {
   ))[0];
 }
 
+function hasFullLaneEvidence(input, run) {
+  if (!Array.isArray(input?.fullLaneRunIds)) {
+    return true;
+  }
+  const runId = String(run?.id || "");
+  return runId !== "" && input.fullLaneRunIds.some((id) => String(id) === runId);
+}
+
 export function evaluateTrustedPostMergeReuse(input) {
   if (input?.eventName !== "push" || input?.ref !== "refs/heads/devel") {
     return denied("not-a-devel-push");
@@ -185,6 +193,29 @@ export function evaluateTrustedPostMergeReuse(input) {
   if (!candidateSource) {
     return denied("review-tail-evidence-unavailable");
   }
+
+  const finalHeadCandidate = latestCandidateRun(
+    input.workflowRuns,
+    pullRequest,
+    input.repository,
+    pullRequest.head.sha,
+  );
+  if (
+    finalHeadCandidate
+    && finalHeadCandidate.status === "completed"
+    && finalHeadCandidate.conclusion === "success"
+    && hasFullLaneEvidence(input, finalHeadCandidate)
+  ) {
+    return {
+      reuse: true,
+      reason: candidateSource.hasReviewOnlyTail
+        ? "review-tail-final-head-green-pr-workflow-reused"
+        : "exact-green-pr-workflow-reused",
+      sourceRunId: String(finalHeadCandidate.id),
+      pullNumber: String(pullRequest.number),
+    };
+  }
+
   const candidate = latestCandidateRun(
     input.workflowRuns,
     pullRequest,
@@ -193,6 +224,9 @@ export function evaluateTrustedPostMergeReuse(input) {
   );
   if (!candidate) {
     return denied("no-current-pr-workflow-candidate");
+  }
+  if (!hasFullLaneEvidence(input, candidate)) {
+    return denied("candidate-full-lane-evidence-unavailable");
   }
   if (candidate.status !== "completed" || candidate.conclusion !== "success") {
     return denied("latest-pr-workflow-candidate-not-successful");


### PR DESCRIPTION
## 목적

코드와 PR review·오늘할일·PDF 증적을 한 PR에 함께 넣어 최종 head에서 Full CI를 통과한 경우에도, merge 뒤 동일 검증을 다시 실행하지 않고 신뢰 가능한 PR run을 재사용합니다.

Ref: #6279

## 변경

- PR 최종 head의 Full-lane run을 review tail 코드 후보보다 우선 선택합니다.
- CI는 B/C/D nextest duration artifact가 모두 있는 run만 Full-lane 증적으로 인정합니다.
- CodeQL은 성공한 `Analyze (...)` job이 있는 run만 실제 분석 증적으로 인정합니다.
- 최종 head 증적이 없으면 기존 review-only tail 직전 코드 head를 fallback으로 사용합니다.
- 두 후보가 모두 불충분하면 full lane으로 fail-closed 합니다.

## 검증

- `cargo fmt --all -- --check`
- `node --test scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs`
- `python3 -m unittest discover -s scripts/tests -p 'test_*workflow.py'` (`166` tests)
