### PR TITLE
수정: 투명선 표시 시 병합된 셀 내부에 남은 옛 경계 안내선 제거

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@
 6. 개발·문서·Git 작업은 `mydocs/manual/codex/docs_and_git_workflow.md`
 7. PR 검토·merge·후속 처리는 `mydocs/manual/pr_review_workflow.md`를 먼저 읽고,
    `mydocs/manual/pr_review/README.md`의 선택표가 지정한 기본·보조 자식 문서를 작업 전에 모두 읽는다.
+   rhwp 첫 외부 contributor PR이면
+   `mydocs/manual/pr_review/first_time_contributor.md`를 추가로 읽는다.
 8. 로컬 빌드·WASM 검증은 `mydocs/manual/dev_environment_guide.md`,
    변경 범위별 검증 게이트는 `mydocs/manual/pr_review/local_validation.md`의 4.3
 9. CLI 작업은 `mydocs/manual/cli_commands.md`

--- a/mydocs/README.md
+++ b/mydocs/README.md
@@ -58,6 +58,7 @@ front matter는 `mydocs/manual`, `mydocs/tech`, `mydocs/troubleshootings`의 모
 | [Claude memory dump 색인](manual/memory/MEMORY.md) | memory | historical | `manual/codex/docs_and_git_workflow.md` | 2026-07-17 |
 | [PR 리뷰·통합 워크플로](manual/pr_review_workflow.md) | canonical | active | `manual/pr_review_workflow.md` | 2026-08-07 |
 | [PR review 조건별 가이드](manual/pr_review/README.md) | guide | active | `manual/pr_review_workflow.md` | 2026-07-25 |
+| [첫 기여자 외부 PR 처리](manual/pr_review/first_time_contributor.md) | guide | active | `manual/pr_review_workflow.md` | 2026-08-28 |
 | [에이전트 capability 카탈로그](manual/agent_capability_registry.md) | canonical | active | `manual/agent_capability_registry.md` | 2026-07-26 |
 | [개발 환경 가이드](manual/dev_environment_guide.md) | guide | active | `manual/dev_environment_guide.md` | 2026-08-11 |
 | [온보딩 가이드](manual/onboarding_guide.md) | guide | active | `manual/README.md` | 2026-07-17 |

--- a/mydocs/manual/README.md
+++ b/mydocs/manual/README.md
@@ -19,6 +19,7 @@ last_verified: 2026-08-24
 | Codex 저장소 부트스트랩 | [Codex 문서 지도](codex/README.md) | [프로젝트 메모리 덤프](codex/MEMORY.md), [문서와 Git 워크플로우](codex/docs_and_git_workflow.md) |
 | Claude·Codex 재사용 capability 등록·중복 판단 | [에이전트 capability 카탈로그](agent_capability_registry.md) | 각 capability의 권위 playbook |
 | 외부 PR 검토, collaborator 처리, merge 후속 | [PR 리뷰·통합 워크플로우](pr_review_workflow.md) | [조건별 PR review 가이드](pr_review/README.md), [개발 환경 가이드](dev_environment_guide.md) |
+| rhwp 첫 외부 contributor PR | [PR 리뷰·통합 워크플로우](pr_review_workflow.md) | [첫 기여자 외부 PR 처리](pr_review/first_time_contributor.md), [조건별 PR review 가이드](pr_review/README.md) |
 | 로컬 빌드, 테스트, WASM 검증 | [개발 환경 가이드](dev_environment_guide.md) | [CLI 명령어 매뉴얼](cli_commands.md) |
 | 문서 이동·정보구조의 링크 검사 | [문서 링크와 메타데이터 로컬 검사](markdown_link_check_guide.md) | [문서와 Git 워크플로우](codex/docs_and_git_workflow.md) |
 | 신규 기여자 시작 | [온보딩 가이드](onboarding_guide.md) | [문서와 Git 워크플로우](codex/docs_and_git_workflow.md) |

--- a/mydocs/manual/pr_review/README.md
+++ b/mydocs/manual/pr_review/README.md
@@ -23,6 +23,7 @@ last_verified: 2026-07-25
 | [maintainer_general.md](maintainer_general.md) | maintainer가 외부 PR을 일반 경로로 처리 |
 | [collaborator_self_merge.md](collaborator_self_merge.md) | collaborator 자신의 PR을 준비·merge |
 | [collaborator_external_pr.md](collaborator_external_pr.md) | collaborator가 contributor PR head를 보정하거나 기록을 더함 |
+| [first_time_contributor.md](first_time_contributor.md) | rhwp 첫 외부 contributor PR의 환영, base 위험, maintainer 보정, merge 후속 처리 |
 | [local_validation.md](local_validation.md) | local fetch, simulation, Cargo/npm/fixture 검증 |
 | [visual_fixture_evidence.md](visual_fixture_evidence.md) | renderer 또는 HWP/HWPX/PDF fixture·페이지·시각 검증. 문서 비교 절차는 [Visual Sweep 가이드](../verification/visual_sweep_guide.md#github-merge-comment)를 정본으로 사용 |
 | [multi_pr_update_branch.md](multi_pr_update_branch.md) | 대량 유입, 다수 PR 누적 검토, update branch, stale CI |
@@ -39,6 +40,7 @@ last_verified: 2026-07-25
 | 한 기여자의 여러 PR을 체리픽 누적 검토 | maintainer_general | intake_and_review, local_validation, multi_pr_update_branch, 필요 시 visual_fixture_evidence, post_merge |
 | collaborator 본인 PR | collaborator_self_merge | intake_and_review, local_validation, 필요 시 visual_fixture_evidence |
 | collaborator가 contributor PR에 보정 commit을 추가 | collaborator_external_pr | intake_and_review, local_validation, 필요 시 visual_fixture_evidence와 multi_pr_update_branch, post_merge |
+| rhwp 첫 외부 contributor PR | collaborator_external_pr | first_time_contributor, intake_and_review, local_validation, 필요 시 visual_fixture_evidence, post_merge |
 | collaborator가 contributor code를 local 검증한 뒤 review·오늘할일만 source head에 추가 | collaborator_external_pr | intake_and_review, local_validation, review_only_fast_pass, post_merge |
 | 완료된 원 PR의 review·asset만 별도 PR로 반영 | collaborator_self_merge | intake_and_review, review_only_fast_pass, post_merge |
 | base가 잘못되었거나 재작업 요청 | 해당 기본 경로 | intake_and_review, rework_and_exceptions |

--- a/mydocs/manual/pr_review/first_time_contributor.md
+++ b/mydocs/manual/pr_review/first_time_contributor.md
@@ -1,0 +1,88 @@
+---
+kind: guide
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-28
+---
+
+# 첫 기여자 외부 PR 처리
+
+이 문서는 rhwp에 처음 기여하는 외부 contributor의 PR을 검토·보정·merge할 때 적용하는
+공식 절차다. 일반 외부 PR 절차의 기준 문서는
+[PR 검토 workflow](../pr_review_workflow.md)와
+[외부 contributor PR](collaborator_external_pr.md)다.
+
+## 적용 범위
+
+다음 조건을 모두 만족하면 이 절차를 적용한다.
+
+- PR 작성자가 rhwp에 처음 기여한다.
+- PR head가 contributor fork에 있고 maintainer가 보정 또는 merge를 진행한다.
+- 변경은 코드, 테스트, 문서 또는 이들의 조합일 수 있다.
+
+첫 기여자라는 이유로 검증 기준을 낮추거나 branch protection을 우회하지 않는다. 환영과
+안전성은 함께 지킨다.
+
+## merge 전 검토
+
+1. PR head, fork remote branch, 검토 branch의 시작 SHA가 일치하는지 확인한다.
+2. fork base와 최신 `upstream/devel`의 차이를 확인한다. base가 뒤처져 사실상 revert 또는
+   충돌 위험이 있으면 즉시 merge하지 않고 rebase 또는 분리 PR을 안내한다.
+3. PR 목적에 맞는 focused 검증을 수행하고, 실행하지 않은 PDF·시각·전체 회귀 검증을
+   실행한 것처럼 기록하지 않는다.
+4. source head에 review-only tail이 추가된 경우에도 code candidate와 trailing head의 CI를
+   각각 최신 SHA 기준으로 확인한다.
+
+## maintainer 보정
+
+원 기여 구현이 수용 가능하지만 테스트, 문서 또는 최소한의 안전장치가 부족할 수 있다.
+이 경우 다음을 지킨다.
+
+1. contributor의 원래 변경과 maintainer 보정의 diff·commit을 분리한다.
+2. 보정은 원 PR head 위에만 올린다. 관련 없는 `devel` 이력이나 다른 PR 변경을 fork branch에
+   섞지 않는다.
+3. 보정 사유, 보정 범위, 검증 결과와 검증하지 못한 범위를 review 문서와 PR comment에
+   명시한다.
+4. 사용자 또는 maintainer가 실제 동작을 확인한 경우에는 그 사실과 확인 주체를 기록하되,
+   자동화 검증 결과로 바꾸어 표현하지 않는다.
+
+## review·오늘할일 trailing commit
+
+코드 후보의 최신 required CI가 성공한 뒤에만 다음 문서를 같은 source branch의 trailing
+commit으로 추가한다.
+
+- `mydocs/pr/archives/pr_N_review.md`
+- `mydocs/orders/YYYYMMDD.md`
+
+검토 정책을 함께 보완해야 하면 `mydocs/manual/pr_review_workflow.md`와 이 문서를 같은
+trailing commit에 포함할 수 있다. trailing commit은 review, 오늘할일, 절차 문서만 포함해야
+하며 source, test, fixture, workflow, baseline 변경을 섞지 않는다. push 전에는 LFS 대상 여부와
+remote dry-run을 확인한다.
+
+trailing head가 생성한 CI에서 fast pass가 허용되는지 preflight 결과로 확인한다. 허용되지 않으면
+전체 CI를 정상적으로 완료해야 하며, 문서 변경이라는 이유로 required check를 우회하지 않는다.
+
+## merge 및 후속 처리
+
+1. trailing head의 최신 CI, `MERGEABLE`, `CLEAN` 상태를 확인한 뒤 merge한다.
+2. merge SHA를 확인하고 `devel`을 `upstream/devel`에 fast-forward한다.
+3. issue의 자동 close 여부를 확인하고, 필요한 경우 실제 merge·검증 결과를 담은 maintainer
+   comment를 게시한다.
+4. 원 PR에는 따뜻한 감사와 rhwp 첫 기여 환영을 명시한다. contributor의 기여 내용과 maintainer
+   보정 사유를 구분하고, 실제 CI·로컬 검증·시각 검증 결과만 적는다.
+5. contributor fork branch는 삭제하지 않는다. 이번 처리에서 만든 clean local branch, worktree,
+   검토 전용 산출물만 [merge 후속 처리](post_merge.md)의 정리 절차로 정리한다.
+
+## 기록 예시
+
+```markdown
+rhwp 첫 기여를 보내주셔서 감사합니다. 검토와 merge를 완료했습니다.
+
+- 기여 구현: <원 기여 범위>
+- maintainer 보정: <보정이 필요한 이유와 최소 범위>
+- CI: <실제로 성공한 최신 head check>
+- 로컬 검증: <실제로 실행한 focused 검증>
+- 동작 확인: <사용자 또는 maintainer가 확인한 범위, 해당하는 경우>
+
+contributor fork branch는 유지했습니다. 다음 기여도 환영합니다.
+```

--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -74,6 +74,7 @@ current head: <작성 시점 참고 SHA 또는 재확인 필요>
 | --- | --- | --- |
 | 접수·리뷰 기록 | 모든 정식 PR review | [PR 접수와 리뷰 기록](pr_review/intake_and_review.md) |
 | 로컬 검증 | fetch, merge simulation, Cargo, npm, fixture 검증을 수행 | [로컬 검증](pr_review/local_validation.md) |
+| 첫 기여자 외부 PR | rhwp에 처음 기여하는 외부 contributor PR | [첫 기여자 외부 PR 처리](pr_review/first_time_contributor.md) |
 | 시각·fixture 증적 | renderer/layout/paint, HWP/HWPX/PDF sample, 기준 PDF, 페이지·표·wrap·clipping 주장 | [시각·fixture 증적](pr_review/visual_fixture_evidence.md) |
 | 다수 PR·update branch | 대량 유입, 누적 cherry-pick, stale SHA CI 취소, update branch 발생 | [다수 PR과 update branch](pr_review/multi_pr_update_branch.md) |
 | review-only fast-pass | code PR 뒤 review 기록만 추가하거나 PR 전체가 문서·허용된 신규 기준 자료뿐임 | [review-only fast-pass](pr_review/review_only_fast_pass.md) |

--- a/mydocs/orders/20260828.md
+++ b/mydocs/orders/20260828.md
@@ -6,6 +6,17 @@ date: 2026-08-28
 
 # 오늘 할일 - 2026년 8월 28일
 
+## PR #6302 - 투명선 병합 경계 안내선
+
+- [x] [#6302](https://github.com/edwardkim/rhwp/pull/6302) `@t2c-lab`의 rhwp 첫 기여를 검토했다.
+- [x] 원 기여 구현을 수용하고, maintainer가 가로·세로 span 내부 안내선 제거와 실제 `none`
+  테두리 안내선 유지의 회귀 범위를 테스트만으로 보완했다.
+- [x] 코드 후보 `9c1bb890a890af45057c958a6a3294697ab2c3a8`의 최신 required CI가 성공했고,
+  작업지시자가 실제 동작을 확인했다.
+- [ ] review·오늘할일·첫 기여자 공식 절차 trailing head의 문서 CI와 merge 가능 상태를 확인한 뒤 merge한다.
+- [ ] merge 뒤 [#6301](https://github.com/edwardkim/rhwp/issues/6301) 상태, 첫 기여자 감사 comment,
+  `devel` 동기화와 이번 처리 worktree 정리를 후속 처리한다.
+
 ## CI 운영
 
 - [ ] [#6257](https://github.com/edwardkim/rhwp/pull/6257) squash merge 뒤 trusted CodeQL 재사용 보완

--- a/mydocs/pr/archives/pr_6302_review.md
+++ b/mydocs/pr/archives/pr_6302_review.md
@@ -1,0 +1,47 @@
+---
+kind: review
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-28
+---
+
+# PR #6302 검토 - 투명선 병합 경계 안내선
+
+- PR: [#6302](https://github.com/edwardkim/rhwp/pull/6302)
+- 이슈: [#6301](https://github.com/edwardkim/rhwp/issues/6301)
+- 작성자: `@t2c-lab` (rhwp 첫 기여)
+- 코드 후보 head: `9c1bb890a890af45057c958a6a3294697ab2c3a8`
+
+## 변경 검토
+
+기여 구현은 병합된 셀 내부에 남아 있던 투명 테두리 안내선을 제거하도록 table border 렌더링과
+span 내부 커버 범위를 조정한다. 변경 경로는 `src/renderer/layout/border_rendering.rs`,
+`table_cell_content.rs`, `table_layout.rs`, `table_partial.rs` 및 이슈 회귀 테스트다.
+
+원 기여 구현은 수용한다. maintainer는 제품 코드를 바꾸지 않고
+`tests/cases/issue_6301_transparent_border_merge_guide.rs`만 보완했다.
+
+## maintainer 보정 사유
+
+원 테스트는 가로 병합 셀의 안내선 제거만 확인했다. 이슈의 병합 경계 처리를 안전하게 유지하려면
+세로 span 내부도 안내선 없이 처리되는지와, 실제 `none` 테두리는 편집 안내선이 계속 표시되는지의
+역방향 경우도 함께 보호해야 한다.
+
+- 보정 commit: `9c1bb890a890af45057c958a6a3294697ab2c3a8`
+- 추가 범위: 가로·세로 span 내부의 안내선 제거, 실제 `none` 테두리의 안내선 유지
+- 제품 코드 변경: 없음
+
+## 검증
+
+- GitHub Actions: 코드 후보 최신 head에서 CI, CodeQL, Render Diff, Adapter inter-diff,
+  Proptest roundtrip, Native Skia를 포함한 required check가 성공했다.
+- 로컬 focused 회귀: `issue_6301_transparent_border_merge_guide` 2건 통과.
+- 로컬 형식·계약: `cargo fmt --all -- --check`, Rust test suite manifest prepare/check 통과.
+- 동작 검증: 작업지시자가 실제 동작을 확인했다.
+- PDF·visual sweep: 원본 HWP/HWPX와 기준 PDF가 제공되지 않아 이번 merge 판단 근거로 실행하지 않았다.
+
+## 결론과 후속 처리
+
+PR #6302는 수용 가능하다. 이 trailing commit은 첫 기여자 외부 PR 공식 절차, review 기록과
+오늘할일을 함께 보존한다. 최신 trailing head의 문서 CI가 성공하고 merge 가능 상태를 재확인한 뒤
+merge 후속 처리와 첫 기여자 감사 comment를 진행한다.

--- a/mydocs/working/issue_6301_transparent_border_merge_guide.md
+++ b/mydocs/working/issue_6301_transparent_border_merge_guide.md
@@ -1,0 +1,89 @@
+# #6301 투명선 표시 시 병합된 셀 내부에 남은 옛 경계 안내선 제거
+
+## 무엇을
+
+"보기 > 투명선"(편집 전용 안내선, `show_transparent_borders`)이 켜진 상태에서 표를 셀
+합치기·삭제·라인 숨김 등으로 편집하면, 편집된 형태를 반영하지 않고 원본 그리드가 그대로
+점선 안내선으로 표시됐다. 특히 셀 병합 시 이제는 존재하지 않는 옛 내부 경계 위치에도
+안내선이 남아 사용자에게 "편집이 반영되지 않은 것처럼" 보였다.
+
+## 왜 (원인)
+
+`render_transparent_borders()`(`src/renderer/layout/border_rendering.rs`)는
+`h_edges`/`v_edges: Vec<Vec<Option<BorderLine>>>` 그리드에서 `None`인 슬롯에 점선 안내선을
+그린다. 이 그리드는 `collect_cell_borders()`가 **각 셀 자신의 span 경계**에만 값을 채우는
+방식으로 만들어지는데, 셀이 병합되면 병합 이전에 존재했던 내부 경계 위치는 병합 후 어느
+셀도 다시 방문하지 않아 계속 `None`으로 남는다.
+
+`render_transparent_borders()`는 이 `None`이 다음 두 경우 중 어느 쪽인지 구분하지 못했다.
+
+1. 실제로 테두리가 없는 자리(사용자가 "테두리 없음"으로 지정) — 안내선을 그려야 함.
+2. 병합으로 셀 내부가 되어 사라진 옛 경계 — 안내선을 그리면 안 됨.
+
+두 경우 모두 그리드 값이 동일하게 `None`이라 (1)만 그려야 할 안내선이 (2)에도 그려졌다.
+표 레이아웃은 일반(`table_layout.rs`)·페이지 분할 조각(`table_partial.rs`)·셀 콘텐츠
+(`table_cell_content.rs`) 세 경로로 나뉘어 있고 세 경로 모두 동일한 `h_edges`/`v_edges`
+수집·렌더링 패턴을 공유하므로 동일하게 영향을 받는다.
+
+## 어떻게 (변경)
+
+`mark_cell_span_interior_covered()`(`border_rendering.rs`)를 새로 추가했다. 셀 레이아웃 시
+`collect_cell_borders()` 호출 지점마다 함께 호출해, 병합 셀의 `col_span`/`row_span` 내부
+(자기 자신의 경계를 뺀 나머지) 위치를 별도의 커버리지 그리드
+(`h_span_covered`/`v_span_covered: Vec<Vec<bool>>`)에 표시한다.
+
+`render_transparent_borders()`는 `h_covered`/`v_covered` 파라미터를 추가로 받아
+`edge_opt.is_none() && !is_covered(..)` 조건으로 안내선 그리기를 건너뛴다 — 그리드 값이
+`None`이면서 **커버리지 표시가 없는** 위치(= 실제로 테두리 없음)에만 그린다.
+
+세 표 레이아웃 경로 모두 동일하게 적용했다:
+
+- `src/renderer/layout/table_layout.rs` — `layout_table_cells()` 시그니처에
+  `h_span_covered`/`v_span_covered` 추가, 셀 루프에서 `collect_cell_borders()` 뒤
+  (`independent_col_row_y.is_none()` 조건) 커버리지 기록.
+- `src/renderer/layout/table_cell_content.rs` — 동일 패턴, 조건 없이 무조건 기록.
+- `src/renderer/layout/table_partial.rs` — 세로쓰기/가로쓰기 두 셀 루프 모두, 조각
+  가시 행 범위(`fri`/`lri`)를 `border_style` 조건 **이전**에 계산해 `border_style`이
+  `None`이어도(=병합 등으로 테두리 스타일 자체가 없는 셀도) 커버리지는 기록되도록
+  구조를 바꿨다.
+- `src/renderer/layout/border_rendering.rs` — `render_transparent_borders()` 시그니처에
+  `h_covered`/`v_covered` 파라미터 추가, 수평/수직 엣지 루프 조건에 커버리지 확인 추가.
+
+## 검증
+
+### 회귀 테스트
+
+`tests/cases/issue_6301_transparent_border_merge_guide.rs` — 빈 문서에 1×3 표(기본 실선
+테두리)를 만들고, `show_transparent_borders`를 켠 상태에서 (0,0)~(0,1) 셀을 병합한다.
+`build_page_render_tree()`로 얻은 렌더 트리에서 편집 전용(`editor_only`) `Line` 노드 개수를
+병합 전후로 비교한다.
+
+- 병합 전: 0개 (기본 실선 표라 전제 조건 확인용 기준선).
+- 병합 후(수정 후): 0개.
+- 병합 후(수정 전 코드로 일시 되돌린 상태): 1개 — `assertion left == right failed: left: 1,
+  right: 0` 로 실패 확인. 확인 후 조건을 원복하고 재통과를 재확인했다.
+
+### 실제 렌더링 비교 (수동, HWPX 표 편집 시나리오)
+
+셀 병합·라인 숨김이 포함된 실제 HWPX 표 샘플로 SVG→PNG 렌더링 전후를 캡처해 비교했다.
+편집된 영역(병합 셀 내부, 라인 숨김 위치)에서 수정 전에는 점선 안내선이 남아있었고
+수정 후에는 사라졌다. 편집되지 않은 영역의 실선 테두리·기존 투명선 동작은 변화 없음을
+확인했다.
+
+- 수정 전: `~/Downloads/투명선_병합셀_수정전.png`
+- 수정 후: `~/Downloads/투명선_병합셀_수정후.png`
+- 전후 비교(diff 강조): `~/Downloads/투명선_병합셀_전후비교.png`
+
+### 로컬 검증 게이트
+
+- `cargo fmt --check` — 통과 (본 변경 4개 파일 기준; 저장소의 `tests/generated/*.rs`는
+  review-worktree/CI에서만 생성되는 파생물이라 신선한 checkout에는 없음 — 무관한 사전
+  조건이며 본 PR 범위 밖).
+- `cargo clippy --lib -- -D warnings` — 경고 없음.
+- `cargo test --test regression_suite_018 issue_6301` (로컬 review-worktree 전용
+  `node scripts/rust-test-suite-manifest.mjs --prepare` + `run-rust-test.mjs`로 배정 확인
+  후 실행) — 통과.
+
+렌더러/레이아웃 변경의 전체 공식 회귀 범위(`release-test` 전체 `cargo nextest run`, Native
+Skia 3종, `wasm-pack build`)는 로컬 환경에 `cargo-nextest`/Docker WASM 경로가 없어 이번
+PR에서는 수행하지 못했다 — 리뷰 시 CI에서 확인 필요.

--- a/src/renderer/layout/border_rendering.rs
+++ b/src/renderer/layout/border_rendering.rs
@@ -62,6 +62,52 @@ fn merge_border(a: &BorderLine, b: &BorderLine) -> BorderLine {
     }
 }
 
+/// 병합/숨김 등으로 편집된 셀의 span 내부 위치를 "이미 처리됨"으로 표시한다.
+/// h_edges/v_edges 그리드는 각 셀의 자기 span 경계에만 채워지므로, 병합된 셀 내부의
+/// 미기록 슬롯(`None`)은 "실제로 선이 없음"과 "병합으로 사라진 경계"를 구분하지 못한다.
+/// 투명선 가이드가 후자에도 그려지는 것을 막기 위해 별도 커버리지 그리드에 기록한다.
+pub(crate) fn mark_cell_span_interior_covered(
+    h_covered: &mut [Vec<bool>],
+    v_covered: &mut [Vec<bool>],
+    col: usize,
+    row: usize,
+    col_span: usize,
+    row_span: usize,
+) {
+    let h_rows = h_covered.len();
+    let v_cols = v_covered.len();
+    let col_count = if h_rows > 0 {
+        h_covered[0].len()
+    } else {
+        return;
+    };
+    let row_count = if v_cols > 0 {
+        v_covered[0].len()
+    } else {
+        return;
+    };
+    let end_col = (col + col_span).min(col_count);
+    let end_row = (row + row_span).min(row_count);
+    if row_span > 1 {
+        for r in (row + 1)..end_row {
+            if r < h_rows {
+                for c in col..end_col {
+                    h_covered[r][c] = true;
+                }
+            }
+        }
+    }
+    if col_span > 1 {
+        for c in (col + 1)..end_col {
+            if c < v_cols {
+                for r in row..end_row {
+                    v_covered[c][r] = true;
+                }
+            }
+        }
+    }
+}
+
 /// 엣지 그리드 슬롯에 테두리를 병합 저장
 fn merge_edge_slot(slot: &mut Option<BorderLine>, border: &BorderLine) {
     if border.line_type == BorderLineType::None {
@@ -610,6 +656,8 @@ pub(crate) fn render_transparent_borders(
     tree: &mut PageLayoutContext,
     h_edges: &[Vec<Option<BorderLine>>],
     v_edges: &[Vec<Option<BorderLine>>],
+    h_covered: &[Vec<bool>],
+    v_covered: &[Vec<bool>],
     row_col_x: &[Vec<f64>],
     row_y: &[f64],
     table_x: f64,
@@ -620,6 +668,18 @@ pub(crate) fn render_transparent_borders(
     let width = 0.4_f64;
     let dash = StrokeDash::Dot;
     let row_count = if row_y.len() > 1 { row_y.len() - 1 } else { 0 };
+    let is_h_covered = |ri: usize, ci: usize| -> bool {
+        h_covered
+            .get(ri)
+            .and_then(|row| row.get(ci).copied())
+            .unwrap_or(false)
+    };
+    let is_v_covered = |ci: usize, ri: usize| -> bool {
+        v_covered
+            .get(ci)
+            .and_then(|col| col.get(ri).copied())
+            .unwrap_or(false)
+    };
 
     // 수평 투명 엣지
     for (ri, h_row) in h_edges.iter().enumerate() {
@@ -629,7 +689,7 @@ pub(crate) fn render_transparent_borders(
         let mut seg_start: Option<usize> = None;
 
         for (ci, edge_opt) in h_row.iter().enumerate() {
-            if edge_opt.is_none() {
+            if edge_opt.is_none() && !is_h_covered(ri, ci) {
                 if seg_start.is_none() {
                     seg_start = Some(ci);
                 }
@@ -662,7 +722,7 @@ pub(crate) fn render_transparent_borders(
                     .get(ri)
                     .and_then(|rx| rx.get(ci).copied())
                     .unwrap_or(0.0);
-            if edge_opt.is_none() {
+            if edge_opt.is_none() && !is_v_covered(ci, ri) {
                 if seg_start.is_none() {
                     seg_start = Some(ri);
                     seg_x = x;

--- a/src/renderer/layout/table_cell_content.rs
+++ b/src/renderer/layout/table_cell_content.rs
@@ -6,7 +6,8 @@ use super::super::render_tree::*;
 use super::super::style_resolver::ResolvedStyleSet;
 use super::super::{hwpunit_to_px, ShapeStyle, TextStyle};
 use super::border_rendering::{
-    build_row_col_x, collect_cell_borders, render_edge_borders, render_transparent_borders,
+    build_row_col_x, collect_cell_borders, mark_cell_span_interior_covered, render_edge_borders,
+    render_transparent_borders,
 };
 use super::text_measurement::{
     is_cjk_char, is_vertical_rotate_char, resolved_to_text_style, vertical_substitute_char,
@@ -583,6 +584,10 @@ impl LayoutEngine {
         use crate::model::style::BorderLine;
         let mut h_edges: Vec<Vec<Option<BorderLine>>> = vec![vec![None; col_count]; row_count + 1];
         let mut v_edges: Vec<Vec<Option<BorderLine>>> = vec![vec![None; row_count]; col_count + 1];
+        // 병합 등으로 편집되어 h_edges/v_edges에 기록되지 않는 span 내부 위치를
+        // 투명선 가이드에서 제외하기 위한 커버리지 그리드 (§투명선/셀 편집 정합성).
+        let mut h_span_covered: Vec<Vec<bool>> = vec![vec![false; col_count]; row_count + 1];
+        let mut v_span_covered: Vec<Vec<bool>> = vec![vec![false; row_count]; col_count + 1];
 
         // 표 노드 생성
         // [#4334] TAC(text-as-char) 중첩 표는 자기 자신의 (section, para, control) 을
@@ -714,6 +719,14 @@ impl LayoutEngine {
                     &bs.borders,
                 );
             }
+            mark_cell_span_interior_covered(
+                &mut h_span_covered,
+                &mut v_span_covered,
+                c,
+                r,
+                cell.col_span as usize,
+                cell.row_span as usize,
+            );
 
             // 셀 패딩 (apply_inner_margin 고려)
             let (mut pad_left, mut pad_right, pad_top, pad_bottom) =
@@ -976,7 +989,15 @@ impl LayoutEngine {
         ));
         if self.show_transparent_borders.get() {
             table_node.children.extend(render_transparent_borders(
-                tree, &h_edges, &v_edges, &row_col_x, &row_y, table_x, table_y,
+                tree,
+                &h_edges,
+                &v_edges,
+                &h_span_covered,
+                &v_span_covered,
+                &row_col_x,
+                &row_y,
+                table_x,
+                table_y,
             ));
         }
 

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -165,8 +165,9 @@ fn stored_layout_relocated_empty_rowbreak_picture_resets_offset(
 use super::super::composer::effective_text_for_metrics;
 use super::super::{hwpunit_to_px, ShapeStyle};
 use super::border_rendering::{
-    build_row_col_x, collect_cell_borders, create_border_line_nodes, render_cell_diagonal,
-    render_edge_borders, render_transparent_borders,
+    build_row_col_x, collect_cell_borders, create_border_line_nodes,
+    mark_cell_span_interior_covered, render_cell_diagonal, render_edge_borders,
+    render_transparent_borders,
 };
 use super::text_measurement::{estimate_text_width, resolved_to_text_style};
 use super::utils::find_bin_data_bytes;
@@ -2966,6 +2967,10 @@ impl LayoutEngine {
         // ── 5. 셀 레이아웃 ──
         let mut h_edges: Vec<Vec<Option<BorderLine>>> = vec![vec![None; col_count]; row_count + 1];
         let mut v_edges: Vec<Vec<Option<BorderLine>>> = vec![vec![None; row_count]; col_count + 1];
+        // 병합 등으로 편집되어 h_edges/v_edges에 기록되지 않는 span 내부 위치를
+        // 투명선 가이드에서 제외하기 위한 커버리지 그리드 (§투명선/셀 편집 정합성).
+        let mut h_span_covered: Vec<Vec<bool>> = vec![vec![false; col_count]; row_count + 1];
+        let mut v_span_covered: Vec<Vec<bool>> = vec![vec![false; row_count]; col_count + 1];
 
         self.layout_table_cells(
             tree,
@@ -2989,6 +2994,8 @@ impl LayoutEngine {
             table_y,
             &mut h_edges,
             &mut v_edges,
+            &mut h_span_covered,
+            &mut v_span_covered,
             split_row_range,
             row_y_shift,
             split_y_offset,
@@ -3120,7 +3127,15 @@ impl LayoutEngine {
             ));
             if self.show_transparent_borders.get() {
                 table_node.children.extend(render_transparent_borders(
-                    tree, &h_edges, &v_edges, &row_col_x, &row_y, table_x, table_y,
+                    tree,
+                    &h_edges,
+                    &v_edges,
+                    &h_span_covered,
+                    &v_span_covered,
+                    &row_col_x,
+                    &row_y,
+                    table_x,
+                    table_y,
                 ));
             }
         }
@@ -6600,6 +6615,8 @@ impl LayoutEngine {
         table_y: f64,
         h_edges: &mut Vec<Vec<Option<BorderLine>>>,
         v_edges: &mut Vec<Vec<Option<BorderLine>>>,
+        h_span_covered: &mut [Vec<bool>],
+        v_span_covered: &mut [Vec<bool>],
         row_filter: Option<(usize, usize)>,
         row_y_shift: f64,
         split_y_offset: f64,
@@ -7270,6 +7287,16 @@ impl LayoutEngine {
                         &bs.borders,
                     );
                 }
+            }
+            if independent_col_row_y.is_none() {
+                mark_cell_span_interior_covered(
+                    h_span_covered,
+                    v_span_covered,
+                    c,
+                    r,
+                    cell.col_span as usize,
+                    cell.row_span as usize,
+                );
             }
 
             table_node.children.push(cell_node);

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -8,7 +8,8 @@ use super::super::render_tree::*;
 use super::super::style_resolver::ResolvedStyleSet;
 use super::super::{hwpunit_to_px, px_to_hwpunit, ShapeStyle};
 use super::border_rendering::{
-    build_row_col_x, collect_cell_borders, render_edge_borders, render_transparent_borders,
+    build_row_col_x, collect_cell_borders, mark_cell_span_interior_covered, render_edge_borders,
+    render_transparent_borders,
 };
 use super::table_layout::{
     calc_nested_split_rows, effective_margin_left_line, extend_completed_nested_table_border_clips,
@@ -747,6 +748,8 @@ impl LayoutEngine {
         render_row_y: &[f64],
         h_edges: &mut Vec<Vec<Option<BorderLine>>>,
         v_edges: &mut Vec<Vec<Option<BorderLine>>>,
+        h_span_covered: &mut [Vec<bool>],
+        v_span_covered: &mut [Vec<bool>],
         measured_table: Option<&MeasuredTable>,
         enclosing_cell_ctx: Option<&CellContext>,
         clamp_header_negative_para_offset: bool,
@@ -1310,7 +1313,7 @@ impl LayoutEngine {
                     enclosing_cell_ctx.cloned(),
                 );
                 // 세로쓰기 셀도 테두리를 엣지 그리드에 수집
-                if let Some(bs) = border_style {
+                {
                     let cell_end_row_idx = cell_row + cell.row_span as usize;
                     let first_ri = render_rows.iter().position(|&r| r == cell_row).or_else(|| {
                         render_rows
@@ -1321,14 +1324,24 @@ impl LayoutEngine {
                         .iter()
                         .rposition(|&r| r >= cell_row && r < cell_end_row_idx);
                     if let (Some(fri), Some(lri)) = (first_ri, last_ri) {
-                        collect_cell_borders(
-                            &mut *h_edges,
-                            &mut *v_edges,
+                        if let Some(bs) = border_style {
+                            collect_cell_borders(
+                                &mut *h_edges,
+                                &mut *v_edges,
+                                cell_col,
+                                fri,
+                                cell.col_span as usize,
+                                lri + 1 - fri,
+                                &bs.borders,
+                            );
+                        }
+                        mark_cell_span_interior_covered(
+                            &mut *h_span_covered,
+                            &mut *v_span_covered,
                             cell_col,
                             fri,
                             cell.col_span as usize,
                             lri + 1 - fri,
-                            &bs.borders,
                         );
                     }
                 }
@@ -2841,7 +2854,7 @@ impl LayoutEngine {
             );
 
             // 셀 테두리를 엣지 그리드에 수집 (인접 셀 중복 제거)
-            if let Some(bs) = border_style {
+            {
                 let cell_end_row_idx = cell_row + cell.row_span as usize;
                 let first_ri = render_rows.iter().position(|&r| r == cell_row).or_else(|| {
                     render_rows
@@ -2852,14 +2865,24 @@ impl LayoutEngine {
                     .iter()
                     .rposition(|&r| r >= cell_row && r < cell_end_row_idx);
                 if let (Some(fri), Some(lri)) = (first_ri, last_ri) {
-                    collect_cell_borders(
-                        &mut *h_edges,
-                        &mut *v_edges,
+                    if let Some(bs) = border_style {
+                        collect_cell_borders(
+                            &mut *h_edges,
+                            &mut *v_edges,
+                            cell_col,
+                            fri,
+                            cell.col_span as usize,
+                            lri + 1 - fri,
+                            &bs.borders,
+                        );
+                    }
+                    mark_cell_span_interior_covered(
+                        &mut *h_span_covered,
+                        &mut *v_span_covered,
                         cell_col,
                         fri,
                         cell.col_span as usize,
                         lri + 1 - fri,
-                        &bs.borders,
                     );
                 }
             }
@@ -3534,6 +3557,10 @@ impl LayoutEngine {
             vec![vec![None; col_count]; render_row_count + 1];
         let mut v_edges: Vec<Vec<Option<BorderLine>>> =
             vec![vec![None; render_row_count]; col_count + 1];
+        // 병합 등으로 편집되어 h_edges/v_edges에 기록되지 않는 span 내부 위치를
+        // 투명선 가이드에서 제외하기 위한 커버리지 그리드 (§투명선/셀 편집 정합성).
+        let mut h_span_covered: Vec<Vec<bool>> = vec![vec![false; col_count]; render_row_count + 1];
+        let mut v_span_covered: Vec<Vec<bool>> = vec![vec![false; render_row_count]; col_count + 1];
         let mut grid_row_y = render_row_y.clone();
         grid_row_y.push(partial_table_height);
 
@@ -3665,6 +3692,8 @@ impl LayoutEngine {
             &render_row_y,
             &mut h_edges,
             &mut v_edges,
+            &mut h_span_covered,
+            &mut v_span_covered,
             measured_table,
             enclosing_cell_ctx,
             clamp_header_negative_para_offset,
@@ -3715,6 +3744,8 @@ impl LayoutEngine {
                 tree,
                 &h_edges,
                 &v_edges,
+                &h_span_covered,
+                &v_span_covered,
                 &fragment_row_col_x,
                 &grid_row_y,
                 table_x,

--- a/tests/cases/issue_6301_transparent_border_merge_guide.rs
+++ b/tests/cases/issue_6301_transparent_border_merge_guide.rs
@@ -37,41 +37,69 @@ fn count_editor_only_lines(node: &RenderNode) -> usize {
     n
 }
 
-#[test]
-fn issue_6301_merged_cell_interior_has_no_transparent_border_guide() {
-    let mut doc = HwpDocument::create_empty();
+fn create_table(doc: &mut HwpDocument, rows: u32, cols: u32) -> (u32, u32) {
+    let create_json = doc.create_table(0, 0, 0, rows, cols).expect("표 생성");
+    let value: serde_json::Value = serde_json::from_str(&create_json).expect("표 생성 JSON 파싱");
+    (
+        value["paraIdx"].as_u64().expect("paraIdx") as u32,
+        value["controlIdx"].as_u64().expect("controlIdx") as u32,
+    )
+}
 
-    let create_json = doc.create_table(0, 0, 0, 1, 3).expect("1x3 표 생성");
-    let v: serde_json::Value = serde_json::from_str(&create_json).expect("표 생성 JSON 파싱");
-    let para_idx = v["paraIdx"].as_u64().expect("paraIdx") as u32;
-    let ctrl_idx = v["controlIdx"].as_u64().expect("controlIdx") as u32;
+fn editor_only_line_count(doc: &HwpDocument, para_idx: u32) -> usize {
+    let tree = doc.build_page_render_tree(0).expect("페이지 렌더 트리");
+    let table = table_for_paragraph(&tree.root, para_idx as usize).expect("표 노드");
+    count_editor_only_lines(table)
+}
+
+#[test]
+fn issue_6301_merged_cell_span_interiors_have_no_transparent_border_guides() {
+    let mut doc = HwpDocument::create_empty();
+    let (para_idx, ctrl_idx) = create_table(&mut doc, 2, 3);
 
     doc.set_show_transparent_borders(true);
 
     // 병합 전: 기본 실선 테두리 표라 편집 전용 안내선이 없어야 한다 (기준선).
-    let before_tree = doc
-        .build_page_render_tree(0)
-        .expect("병합 전 페이지 렌더 트리");
-    let before_table =
-        table_for_paragraph(&before_tree.root, para_idx as usize).expect("표 노드(병합 전)");
-    let before_count = count_editor_only_lines(before_table);
     assert_eq!(
-        before_count, 0,
+        editor_only_line_count(&doc, para_idx),
+        0,
         "병합 전 기본 실선 표에 편집 전용 안내선이 있으면 테스트 전제가 틀림"
     );
 
-    // (0,0)~(0,1) 셀 병합: 옛 col0/col1 경계가 병합 셀 내부로 사라진다.
+    // 가로·세로 병합 모두 각 방향의 옛 내부 경계를 제거한다.
     doc.merge_table_cells(0, para_idx, ctrl_idx, 0, 0, 0, 1)
-        .expect("셀 병합");
-
-    let after_tree = doc
-        .build_page_render_tree(0)
-        .expect("병합 후 페이지 렌더 트리");
-    let after_table =
-        table_for_paragraph(&after_tree.root, para_idx as usize).expect("표 노드(병합 후)");
-    let after_count = count_editor_only_lines(after_table);
+        .expect("가로 셀 병합");
+    doc.merge_table_cells(0, para_idx, ctrl_idx, 0, 2, 1, 2)
+        .expect("세로 셀 병합");
     assert_eq!(
-        after_count, 0,
-        "병합으로 사라진 셀 내부 경계에 투명선 안내선이 남아있음 (회귀)"
+        editor_only_line_count(&doc, para_idx),
+        0,
+        "병합으로 사라진 셀 span 내부 경계에 투명선 안내선이 남아있음 (회귀)"
+    );
+}
+
+#[test]
+fn issue_6301_real_none_border_keeps_transparent_border_guide() {
+    let mut doc = HwpDocument::create_empty();
+    let (para_idx, ctrl_idx) = create_table(&mut doc, 1, 2);
+
+    doc.set_show_transparent_borders(true);
+    doc.set_cell_properties(
+        0,
+        para_idx,
+        ctrl_idx,
+        0,
+        r##"{
+            "borderLeft":{"type":1,"width":1,"color":"#000000"},
+            "borderRight":{"type":0,"width":0,"color":"#000000"},
+            "borderTop":{"type":1,"width":1,"color":"#000000"},
+            "borderBottom":{"type":1,"width":1,"color":"#000000"}
+        }"##,
+    )
+    .expect("셀 오른쪽 테두리를 없음으로 설정");
+
+    assert!(
+        editor_only_line_count(&doc, para_idx) > 0,
+        "실제 테두리 없음 경계에도 투명선 안내선이 유지되어야 함"
     );
 }

--- a/tests/cases/issue_6301_transparent_border_merge_guide.rs
+++ b/tests/cases/issue_6301_transparent_border_merge_guide.rs
@@ -1,0 +1,77 @@
+//! 회귀 검증: 보기 > 투명선 켠 상태에서 셀 병합으로 사라진 내부 경계에
+//! 더 이상 존재하지 않는 안내선이 남아있으면 안 된다.
+//!
+//! `render_transparent_borders`는 `h_edges`/`v_edges` 그리드에서 `None`인 위치에
+//! 점선 안내선을 그린다. 병합된 셀 내부의 옛 경계 위치도 `collect_cell_borders`가
+//! 다시 방문하지 않으므로 `None`으로 남는데, 이는 "테두리 없음으로 편집됨"과
+//! 구분되지 않아 병합 후에도 안내선이 그려졌다. `mark_cell_span_interior_covered`가
+//! 이 두 경우를 구분해 병합된 span 내부를 커버리지로 표시한다.
+
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+use rhwp::wasm_api::HwpDocument;
+
+fn table_for_paragraph(node: &RenderNode, para_index: usize) -> Option<&RenderNode> {
+    if matches!(
+        &node.node_type,
+        RenderNodeType::Table(table) if table.para_index == Some(para_index)
+    ) {
+        return Some(node);
+    }
+    node.children
+        .iter()
+        .find_map(|child| table_for_paragraph(child, para_index))
+}
+
+/// 편집 전용(투명선 안내선 등)으로 표시된 Line 노드 개수.
+fn count_editor_only_lines(node: &RenderNode) -> usize {
+    let mut n = if node.editor_only && matches!(node.node_type, RenderNodeType::Line(_)) {
+        1
+    } else {
+        0
+    };
+    n += node
+        .children
+        .iter()
+        .map(count_editor_only_lines)
+        .sum::<usize>();
+    n
+}
+
+#[test]
+fn issue_6301_merged_cell_interior_has_no_transparent_border_guide() {
+    let mut doc = HwpDocument::create_empty();
+
+    let create_json = doc.create_table(0, 0, 0, 1, 3).expect("1x3 표 생성");
+    let v: serde_json::Value = serde_json::from_str(&create_json).expect("표 생성 JSON 파싱");
+    let para_idx = v["paraIdx"].as_u64().expect("paraIdx") as u32;
+    let ctrl_idx = v["controlIdx"].as_u64().expect("controlIdx") as u32;
+
+    doc.set_show_transparent_borders(true);
+
+    // 병합 전: 기본 실선 테두리 표라 편집 전용 안내선이 없어야 한다 (기준선).
+    let before_tree = doc
+        .build_page_render_tree(0)
+        .expect("병합 전 페이지 렌더 트리");
+    let before_table =
+        table_for_paragraph(&before_tree.root, para_idx as usize).expect("표 노드(병합 전)");
+    let before_count = count_editor_only_lines(before_table);
+    assert_eq!(
+        before_count, 0,
+        "병합 전 기본 실선 표에 편집 전용 안내선이 있으면 테스트 전제가 틀림"
+    );
+
+    // (0,0)~(0,1) 셀 병합: 옛 col0/col1 경계가 병합 셀 내부로 사라진다.
+    doc.merge_table_cells(0, para_idx, ctrl_idx, 0, 0, 0, 1)
+        .expect("셀 병합");
+
+    let after_tree = doc
+        .build_page_render_tree(0)
+        .expect("병합 후 페이지 렌더 트리");
+    let after_table =
+        table_for_paragraph(&after_tree.root, para_idx as usize).expect("표 노드(병합 후)");
+    let after_count = count_editor_only_lines(after_table);
+    assert_eq!(
+        after_count, 0,
+        "병합으로 사라진 셀 내부 경계에 투명선 안내선이 남아있음 (회귀)"
+    );
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

"보기 > 투명선" 표시가 켜진 상태에서 표를 셀 합치기·삭제·라인 숨김 등으로 편집하면, 편집된
형태를 반영하지 않고 원본 그리드가 그대로 점선 안내선으로 표시되던 문제를 수정한다.

`render_transparent_borders()`는 `h_edges`/`v_edges` 그리드에서 `None`인 슬롯에 안내선을
그리는데, `collect_cell_borders()`가 각 셀 자신의 span 경계에만 값을 채우므로 병합된 셀
내부의 옛 경계 위치도 계속 `None`으로 남아 "실제로 테두리 없음"과 구분되지 않았다.

`mark_cell_span_interior_covered()`를 추가해 병합 셀의 span 내부 위치를 별도 커버리지
그리드에 표시하고, `render_transparent_borders()`가 이를 함께 확인해 병합으로 사라진 경계에는
안내선을 건너뛰도록 했다. 표 레이아웃 세 경로(`table_layout.rs`/`table_partial.rs`/
`table_cell_content.rs`) 모두 동일하게 적용했다.

상세 원인·변경·검증 기록: [`mydocs/working/issue_6301_transparent_border_merge_guide.md`](../mydocs/working/issue_6301_transparent_border_merge_guide.md)

## 관련 이슈

closes #6301

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`,
      `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음
- [ ] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과
      — 해당 없음(`#[cfg(test)]` 변경 없음)
- [x] `cargo test` 통과 — 신규 테스트를 로컬 review-worktree 전용 절차(`--prepare` +
      `run-rust-test.mjs`)로 배정 확인 후 `regression_suite_018` 대상 실행. 수정 전 코드로
      일시 되돌려 테스트가 실제로 실패함(1 != 0)을 확인한 뒤 복원.
- [x] `cargo clippy -- -D warnings` 통과
- [x] 관련 샘플 파일로 SVG 내보내기 확인 — 병합·라인 숨김 포함 HWPX 표 샘플로 SVG→PNG 전후
      비교 (문서에 캡처 경로 기록)
- [ ] 웹(WASM) 렌더링 확인 — 로컬에 `wasm-pack`/Docker WASM 경로 없어 미수행, CI 확인 필요
- [ ] rhwp-studio 편집·UI 변경 시 — 해당 없음 (렌더러 코어만 변경)
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — 코드 수정 작업이라 문서 편집용
      `rhwp replay --capsule` 캡슐 대신 처리 결과 문서로 검증 근거를 남김
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 — 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 (표 셀 루프당 O(span) 커버리지 기록 1회 추가, 기존 `collect_cell_borders`
  와 같은 자리에서 호출)
- 재현·측정: 미측정 (렌더링 경로에 조건 분기 1개 추가 수준)

## 스크린샷

수정 전/후 및 diff 비교 이미지를 로컬 검증 시 캡처했다 (PR에는 미첨부, 처리 결과 문서에
로컬 경로 기록). 요청 시 첨부 가능.
