### PR TITLE
수정(studio): 한양 legacy face 를 설치 face 이름으로 먼저 해석한다 (#6263)

### DIFF
--- a/rhwp-studio/src/core/font-loader.ts
+++ b/rhwp-studio/src/core/font-loader.ts
@@ -11,6 +11,7 @@ import {
   getProjectedWebFontRuleIds,
   isCanvasKitSfntPlanned,
   normalizeProjectedFontFamily,
+  projectedSubstituteTargets,
   resolveProjectedCanvasKitFontPlan,
   type ProjectedWebFontEntry,
 } from './font-rule-runtime.ts';
@@ -265,7 +266,13 @@ export async function loadWebFonts(
   // 이미 등록한 face가 있으면 브라우저가 그 face를 시스템 글꼴처럼 보고할 수 있으므로
   // 해당 이름은 재감지하지 않는다.
   const targetNames = [...(docFonts ?? []), ...CRITICAL_FONTS];
-  detectOSFonts(targetNames);
+  // legacy 이름(`한양중고딕`)은 stand-in 웹폰트로만 공급되므로 치환 대상(`HY중고딕`)까지
+  // 감지 후보에 넣어야 설치 face를 표시 체인 앞에 둘 수 있다.
+  const detectionNames = [
+    ...targetNames,
+    ...targetNames.flatMap(name => projectedSubstituteTargets(name).map(target => target.face)),
+  ];
+  detectOSFonts(detectionNames);
   const systemFontNames = [...new Set(targetNames.filter(isDetectedOSFont))];
   if (systemFontNames.length > 0) {
     console.debug(`[FontLoader][debug] 시스템 글꼴 사용: ${systemFontNames.join(', ')}`);

--- a/rhwp-studio/src/core/font-rule-runtime.ts
+++ b/rhwp-studio/src/core/font-rule-runtime.ts
@@ -121,6 +121,70 @@ export const FONT_RULE_SUBSTITUTION_TABLES: readonly (readonly ProjectedSubstitu
       }),
   )));
 
+export interface ProjectedSubstituteTarget {
+  /** 치환 대상 face 이름. 설치 face 이름인 경우가 많다(`한양중고딕` → `HY중고딕`). */
+  face: string;
+  altType: number;
+  ruleId: string;
+}
+
+function substitutionKey(face: string, altType: number): string {
+  return `${face}\u0000${altType}`;
+}
+
+const substitutionIndexes: (Map<string, ProjectedSubstituteTarget> | null)[] =
+  Array.from({ length: 7 }, () => null);
+
+function substitutionIndex(languageSlot: number): Map<string, ProjectedSubstituteTarget> {
+  const cached = substitutionIndexes[languageSlot];
+  if (cached) return cached;
+  const index = new Map<string, ProjectedSubstituteTarget>();
+  for (const [sourceFace, sourceAltType, targetFace, targetAltType, ruleId]
+    of FONT_RULE_SUBSTITUTION_TABLES[languageSlot]) {
+    const key = substitutionKey(sourceFace, sourceAltType);
+    if (!index.has(key)) index.set(key, { face: targetFace, altType: targetAltType, ruleId });
+  }
+  substitutionIndexes[languageSlot] = index;
+  return index;
+}
+
+/**
+ * 등록 웹폰트 여부와 무관하게 paint 치환 대상 체인을 그대로 돌려준다.
+ *
+ * `resolveFont`는 요청 이름이 이미 등록 웹폰트면 체인을 타지 않는다. 그러나 legacy 이름의
+ * 웹폰트 공급이 번들 stand-in(예: `한양중고딕` → `NotoSansKR-Regular.woff2`)뿐이면 호스트에
+ * 설치된 실제 face(`HY중고딕`)를 찾기 위해 치환 대상 자체가 필요하다.
+ */
+export function projectedSubstituteTargets(
+  fontName: string,
+  altType = 0,
+  langId = 0,
+): ProjectedSubstituteTarget[] {
+  if (!fontName) return [];
+  const index = substitutionIndex(langId >= 0 && langId <= 6 ? langId : 0);
+  let name = fontName;
+  let type = altType || 0;
+  if (type === 0) {
+    if (index.has(substitutionKey(name, 1))) type = 1;
+    else if (index.has(substitutionKey(name, 2))) type = 2;
+    else return [];
+  }
+
+  const targets: ProjectedSubstituteTarget[] = [];
+  const visited = new Set<string>();
+  for (let step = 0; step < 15; step += 1) {
+    const key = substitutionKey(name, type);
+    if (visited.has(key)) break;
+    visited.add(key);
+    const target = index.get(key);
+    if (!target) break;
+    targets.push(target);
+    name = target.face;
+    type = target.altType;
+  }
+  return targets;
+}
+
 export interface ProjectedGovernmentSuccessor {
   sourceFace: string;
   targetFace: string;

--- a/rhwp-studio/src/core/font-substitution.ts
+++ b/rhwp-studio/src/core/font-substitution.ts
@@ -10,13 +10,14 @@
  *   3. 최종 fallback → generic serif/sans-serif
  */
 
-import { REGISTERED_FONTS } from './font-loader.ts';
+import { getDetectedOSFonts, REGISTERED_FONTS } from './font-loader.ts';
 import { resolveLocalFont } from './local-fonts.ts';
 
 import {
   FONT_RULE_DISPLAY_CHAIN_POLICY_IDS,
   FONT_RULE_GOVERNMENT_SUCCESSORS,
   FONT_RULE_SUBSTITUTION_TABLES,
+  projectedSubstituteTargets,
 } from './font-rule-runtime.ts';
 
 interface SubstitutionTarget {
@@ -160,6 +161,63 @@ function resolveGovernmentFontSuccessorWithRule(
     }
   }
   return { fontName: null, ruleId: null };
+}
+
+let detectedOSFontIndexCache: Map<string, string> | null = null;
+let detectedOSFontIndexSize = -1;
+
+/** 감지 결과가 늘어날 때만 다시 색인해 paint 경로의 문자열 정규화를 줄인다. */
+function detectedOSFontIndex(): ReadonlyMap<string, string> {
+  const detected = getDetectedOSFonts();
+  if (detectedOSFontIndexCache !== null && detectedOSFontIndexSize === detected.size) {
+    return detectedOSFontIndexCache;
+  }
+  const index = new Map<string, string>();
+  for (const name of detected) index.set(normalizedFamilyKey(name), name);
+  detectedOSFontIndexCache = index;
+  detectedOSFontIndexSize = detected.size;
+  return index;
+}
+
+/**
+ * 이 호스트에 실제 face가 있는 이름인지 판정하고 CSS에 쓸 canonical 이름을 돌려준다.
+ *
+ * 번들 stand-in 웹폰트 등록(`REGISTERED_FONTS`)은 실제 face 보유로 보지 않는다.
+ * legacy 이름은 stand-in만 있고 실제 face는 다른 이름으로 설치돼 있기 때문이다.
+ */
+function installedFaceName(
+  fontName: string,
+  confirmedLocalFonts: readonly string[] | undefined,
+): string | null {
+  if (!fontName) return null;
+  if (confirmedLocalFonts === undefined) {
+    const record = resolveLocalFont(fontName);
+    if (record) return localRecordCssFamily(fontName, record);
+  } else {
+    const confirmed = confirmedFontName([fontName], confirmedLocalFonts);
+    if (confirmed) return confirmed;
+  }
+  return detectedOSFontIndex().get(normalizedFamilyKey(fontName)) ?? null;
+}
+
+/**
+ * legacy 이름의 공급이 stand-in 웹폰트뿐일 때, 이 호스트에 설치된 치환 대상 face를 찾는다.
+ *
+ * `한양중고딕`은 studio 공급 카탈로그에 있으므로 `resolveFont`가 체인을 타지 않고
+ * 그대로 돌려준다. 그 공급은 번들 `NotoSansKR-Regular.woff2` stand-in이라 실제로
+ * 설치된 `HY중고딕`이 있어도 산세리프로 그려진다. 설치 face를 체인 앞에 둬 이를 막는다.
+ */
+function installedSubstituteFace(
+  fontName: string,
+  altType: number,
+  langId: number,
+  confirmedLocalFonts: readonly string[] | undefined,
+): { fontName: string; ruleId: string } | null {
+  for (const target of projectedSubstituteTargets(fontName, altType, langId)) {
+    const installed = installedFaceName(target.face, confirmedLocalFonts);
+    if (installed) return { fontName: installed, ruleId: target.ruleId };
+  }
+  return null;
 }
 
 function quoteCssFontFamily(fontName: string): string {
@@ -329,6 +387,17 @@ export function fontFamilyCandidatesForDisplayWithRules(
     options.includeUnconfirmedOriginal === true ||
     REGISTERED_FONTS.has(fontName) ||
     confirmedLocalFontSet.has(fontName.toLocaleLowerCase('en-US'));
+
+  if (!localRecord) {
+    const substitute = installedFaceName(fontName, options.confirmedLocalFonts) === null
+      ? installedSubstituteFace(fontName, altType, langId, options.confirmedLocalFonts)
+      : null;
+    if (substitute) {
+      pushUniqueFontFamily(families, substitute.fontName);
+      ruleIds.push(substitute.ruleId);
+      ruleIds.push(FONT_RULE_DISPLAY_CHAIN_POLICY_IDS['paint-substitute']);
+    }
+  }
 
   if (localRecord) {
     pushUniqueFontFamily(families, localRecordCssFamily(fontName, localRecord));

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -92,6 +92,7 @@ import {
 } from './glyph-outline-payload-status';
 import { parseStaticSvgPathLayers, type StaticSvgPathLayer } from './static-svg-path-layers';
 import { loadLocalFontBytesFor, localFontFaceKey, resolveLocalFont, type LocalFontRecord } from '@/core/local-fonts';
+import { projectedSubstituteTargets } from '@/core/font-rule-runtime';
 import type { CanvasKitBundledFontSource } from '@/core/font-loader';
 import type { FontDecisionTraceRecordV1 } from '@/core/font-decision-trace';
 import { readBoundedResponseArrayBuffer } from './canvaskit/bounded-response';
@@ -550,7 +551,12 @@ export class CanvasKitLayerRenderer {
     if (this.disposed || !fontNames?.length) return 0;
     const generation = this.documentGeneration;
     const pendingRecords = new Map<string, LocalFontRecord>();
-    for (const fontName of fontNames) {
+    // legacy 이름(`한양중고딕`)은 설치 face 이름이 아니므로 치환 대상(`HY중고딕`)까지 함께 본다.
+    const candidateNames = [
+      ...fontNames,
+      ...fontNames.flatMap(name => projectedSubstituteTargets(name).map(target => target.face)),
+    ];
+    for (const fontName of candidateNames) {
       const record = resolveLocalFont(fontName);
       const faceKey = record ? localFontFaceKey(record) : '';
       if (!record || !faceKey || this.localTypefaces.has(faceKey)

--- a/rhwp-studio/tests/font-rule-runtime.test.ts
+++ b/rhwp-studio/tests/font-rule-runtime.test.ts
@@ -8,6 +8,7 @@ import {
   FONT_RULE_WEBFONT_ENTRIES,
   generatedCanvas2dPaintRuleCount,
   generatedCanvasKitRuleCount,
+  projectedSubstituteTargets,
 } from '../src/core/font-rule-runtime.ts';
 
 test('Studio runtime은 W7 generated projection의 승인 분모를 전부 소비한다', () => {
@@ -34,4 +35,14 @@ test('legacy SUBST_TABLES와 FONT_LIST literal은 production owner에서 제거�
   assert.match(substitutionSource, /FONT_RULE_SUBSTITUTION_TABLES/);
   assert.match(loaderSource, /FONT_RULE_WEBFONT_ENTRIES/);
   assert.match(loaderSource, /resolveProjectedCanvasKitFontPlan/);
+});
+
+test('projectedSubstituteTargets는 등록 웹폰트 이름도 치환 대상 체인을 돌려준다', () => {
+  const targets = projectedSubstituteTargets('한양중고딕', 0, 0);
+
+  assert.equal(targets.length > 0, true);
+  assert.equal(targets[0].face, 'HY중고딕');
+  assert.match(targets[0].ruleId, /^rule\./);
+  assert.deepEqual(projectedSubstituteTargets('없는글꼴', 0, 0), []);
+  assert.deepEqual(projectedSubstituteTargets('', 0, 0), []);
 });

--- a/rhwp-studio/tests/font-substitution.test.ts
+++ b/rhwp-studio/tests/font-substitution.test.ts
@@ -105,3 +105,32 @@ test('ROKG successor는 정부상징 legacy 이름에만 적용한다', () => {
 
   assert.doesNotMatch(chain, /ROKG/u);
 });
+
+test('stand-in 웹폰트만 있는 legacy 이름은 설치된 치환 대상 face를 앞에 둔다', () => {
+  // `한양중고딕`은 studio 공급 카탈로그에 있어 resolveFont가 그대로 돌려준다.
+  // 그 공급은 번들 Noto Sans KR stand-in이므로 설치 face `HY중고딕`이 먼저 와야 한다.
+  const installed = fontFamilyChainForDisplay('한양중고딕', 0, 0, {
+    confirmedLocalFonts: ['HY중고딕'],
+  });
+  assert.match(installed, /^"HY중고딕", "한양중고딕", "Malgun Gothic"/u);
+  assert.match(installed, /sans-serif$/u);
+});
+
+test('치환 대상이 설치돼 있지 않으면 legacy 이름의 기존 체인을 유지한다', () => {
+  const chain = fontFamilyChainForDisplay('한양중고딕', 0, 0, {
+    confirmedLocalFonts: [],
+  });
+
+  assert.equal(
+    chain,
+    '"한양중고딕", "Malgun Gothic", "Apple SD Gothic Neo", "Noto Sans KR", "Pretendard", sans-serif',
+  );
+});
+
+test('요청 이름 자체가 설치돼 있으면 치환 대상을 앞에 두지 않는다', () => {
+  const chain = fontFamilyChainForDisplay('굴림', 0, 0, {
+    confirmedLocalFonts: ['굴림', '새굴림'],
+  });
+
+  assert.match(chain, /^"굴림"/u);
+});


### PR DESCRIPTION
## 증상

studio(브라우저)에서 한양 계열 글꼴로 지정된 괄호(`【 】`, `「 」`)가 가는 대체 글꼴로 그려져 괄호 뒤에 눈에 띄는 공백이 생긴다. 같은 문서를 `export-pdf`/`export-svg` 로 내보내면 한글과 일치한다 — 어긋나는 것은 studio 뿐이다.

## 근인 — 이슈 추정과 다르다

이슈 #6263 은 「치환 규칙의 `supply: null` 때문에 legacy 이름으로 FontFace 를 만들어 로드 실패」로 봤다. 실측해 보니 **`한양중고딕` 에 stand-in 공급이 있다는 것 자체가 원인**이다.

- `assets/font-rules/font_rule_registry_v2.json` 의 `rule.studio-supply.856cdf2bb6bf547fb7da.canvas2d` 가 `한양중고딕 → fonts/NotoSansKR-Regular.woff2` **stand-in** 공급을 선언한다(생성물: `rhwp-studio/src/core/generated/font-rule-projections/webfont-supply.ts:497-517`).
- 그래서 `한양중고딕` 이 `REGISTERED_FONTS`(`font-loader.ts:63`)에 들어가고, `font-substitution.ts:216` `resolveFontWithRules` 의 첫 줄

  ```ts
  if (... REGISTERED_FONTS.has(fontName)) return { fontName ... }
  ```

  에서 **단락**돼 paint 치환(`한양중고딕 → HY중고딕`)이 끝내 적용되지 않는다. 이어서 `originalAllowed`(`font-substitution.ts:373`)도 참이 돼 CSS 체인 첫 자리를 stand-in 이름이 차지한다.

노드 단위 실행으로 확정:

| 요청 face | 수정 전 체인 | 비고 |
| --- | --- | --- |
| `한양중고딕` | `"한양중고딕", "Malgun Gothic", …` | `HY중고딕` 을 설치 face 로 확인시켜도 체인에 등장하지 않음 |
| `한양신명조` (카탈로그 없음) | `"HY신명조", …` | 정상 치환 |

즉 `document.fonts` 의 `status: "error"` 는 2차 증상이고, 로드가 성공했어도 그려지는 것은 Noto Sans KR(가는 산세리프)이라 신고 증상과 일치한다. CanvasKit 표면도 같은 뿌리로, `prepareLocalFonts` 가 `resolveLocalFont('한양중고딕') → null` 이라 설치 face 를 등록하지 못하고 bundled alias 로 떨어진다.

렌더러(Rust) 쪽 체인은 정상이다(`src/renderer/mod.rs` `installed_render_font_aliases`) — 그래서 SVG/PDF 만 맞게 나왔다.

## 수정

요청 이름의 실제 face 가 호스트에 없고 **치환 대상이 설치돼 있으면**, 그 설치 face 를 체인 맨 앞에 둔다. 설치돼 있지 않으면 기존 체인 그대로다.

- `font-rule-runtime.ts` — 등록 웹폰트 여부와 무관하게 치환 대상 체인을 주는 `projectedSubstituteTargets()` 추가
- `font-substitution.ts` — 위 규칙으로 설치 face 를 체인 앞에 삽입
- `font-loader.ts` — 치환 대상 이름도 OS 글꼴 감지 후보에 포함(설치돼 있으면 stand-in `@font-face` 를 등록하지 않음)
- `canvaskit-renderer.ts` — `prepareLocalFonts` 가 치환 대상 face 도 후보로 본다

생성물(`generated/`)과 레지스트리는 손대지 않았다. 규칙 데이터는 이미 옳고, **그 규칙을 건너뛰던 소비 로직**이 문제였다.

## 테스트

`rhwp-studio/tests/` 에 4건 추가 — 설치 시 `"HY중고딕", "한양중고딕", …` 순서 / 미설치 시 기존 체인 완전 동일 / 요청 이름 자체가 설치된 `굴림` 은 순서 불변 / `projectedSubstituteTargets` 계약.

| 게이트 | 결과 |
| --- | --- |
| `tsc --noEmit` | 신규 오류 0 (기존 `@wasm/rhwp.js` 미빌드 오류 5건만 잔존) |
| `npm test` | 1226 tests / 1225 pass / 0 fail / 1 skip(기존) |

Rust·CSS 미변경이라 cargo 게이트와 CSS 규약은 해당 없다.

## 검증 한계

리눅스 작업 환경에 `HY중고딕`(`H2GTRM.TTF`)이 없고 이슈 문서도 로컬에 없어 **브라우저 픽셀 실측 재현은 하지 못했다.** 논리는 `confirmedLocalFonts` 를 주입한 단위 테스트로 고정했다. 최종 확인은 Windows + 한양 글꼴 설치 호스트에서 이슈의 headless probe 로 `document.fonts` 와 괄호 폭을 대조해야 한다.

## 남긴 것

설치 face 가 없는 호스트에서는 동작이 전혀 바뀌지 않는다 — 등록된 `한양중고딕` stand-in 이 먼저 잡히는 것은 유지된다. stand-in 자체를 걷어내는 판단은 `굴림`·`바탕` 등 12개 이름의 렌더 베이스라인을 흔들 수 있어 별건으로 남겼다.

Closes #6263
