### PR TITLE
검증(renderer/font): 한양견고딕·한양견명조 별칭 사슬을 회귀 테스트로 잠근다 (#6171)

### DIFF
--- a/tests/cases/issue_6171_hanyang_gyeongothic_alias.rs
+++ b/tests/cases/issue_6171_hanyang_gyeongothic_alias.rs
@@ -1,0 +1,98 @@
+//! [#6171] 한양견고딕/한양견명조가 설치 face 를 건너뛰고 generic 으로 떨어지지 않게 잡는다.
+//!
+//! 3146683 1쪽 `『별표 7』` 의 `별표` 획이 한글 2020 출력보다 가늘었던 원인은 조판이
+//! 아니라 face 선택이었다. SVG `font-family` 사슬을 실제로 만드는 것은
+//! `renderer::render_font_family_chain`(내부 `installed_render_font_aliases`)이며,
+//! 견고딕/견명조 arm 이 없으면 사슬이 `'한양견고딕'` 하나 뒤에 곧바로 generic
+//! (고딕 계열의 첫 항목이 `Malgun Gothic`)으로 떨어져, `HY견고딕` 이 설치된 호스트에서도
+//! Malgun Regular 로 그려졌다.
+//!
+//! `svg.rs` 의 `font_local_aliases`/`known_font_filenames` 는 그 모듈의 단위 테스트가
+//! 지키고, SVG golden 두 건(issue-617/issue-677)은 사슬 문자열 전체를 통째로 고정한다.
+//! 여기서는 golden 문서와 무관하게 (1) 사슬 앞머리와 (2) 배치 폭을 정하는 메트릭 별칭이
+//! 같은 face 계열로 이어지는지를 직접 고정한다.
+
+use rhwp::renderer::font_metrics_data::find_metric;
+use rhwp::renderer::{render_font_family_chain, render_font_family_chain_for_weight};
+
+/// 원 face 바로 뒤에 설치 face 이름이 순서대로 와야 한다.
+///
+/// generic 폴백은 계열마다 다르므로(고딕=`Malgun Gothic`…, 명조=`Batang`…) 사슬 전체가
+/// 아니라 앞머리만 계약으로 잡는다 — 설치 face 가 어떤 generic 보다도 앞선다는 뜻이다.
+fn assert_chain_head(chain: &str, expected: &[&str]) {
+    let head: String = expected
+        .iter()
+        .map(|face| format!("'{face}'"))
+        .collect::<Vec<_>>()
+        .join(",");
+    assert!(
+        chain.starts_with(&format!("{head},")),
+        "사슬 앞머리가 `{head}` 여야 한다: {chain}"
+    );
+}
+
+#[test]
+fn hanyang_gyeongothic_chain_reaches_installed_hy_face() {
+    assert_chain_head(
+        &render_font_family_chain("한양견고딕"),
+        &["한양견고딕", "HY견고딕", "HYGothic-Extra"],
+    );
+}
+
+#[test]
+fn hanyang_gyeonmyeongjo_chain_reaches_installed_hy_face() {
+    assert_chain_head(
+        &render_font_family_chain("한양견명조"),
+        &["한양견명조", "HY견명조", "HYMyeongJo-Extra"],
+    );
+}
+
+#[test]
+fn bold_chain_keeps_gyeongothic_alias() {
+    // bold 경로는 ExtraLight 를 걸러내는 별도 함수라 별칭 삽입이 빠질 수 있다.
+    assert_chain_head(
+        &render_font_family_chain_for_weight("한양견고딕", true),
+        &["한양견고딕", "HY견고딕", "HYGothic-Extra"],
+    );
+}
+
+#[test]
+fn gyeongothic_metric_alias_stays_paired_with_render_face() {
+    // 사슬만 고치고 메트릭 별칭을 두면 화면 face 와 배치 폭이 어긋난다.
+    // legacy 한양* 이름은 [#2430] 한글 COM 실측 ASCII 를 덧씌운 overlay 를 쓰고,
+    // 한글 음절 폭은 설치 face(HY*)의 메트릭을 그대로 공유한다. 두 축이 갈라지면
+    // 이 테스트가 먼저 깨진다.
+    let pairs = [
+        (
+            "한양견고딕",
+            "HanyangKyunGothic",
+            "HY견고딕",
+            "HYGothic-Extra",
+        ),
+        (
+            "한양견명조",
+            "HanyangKyunMyeongJo",
+            "HY견명조",
+            "HYMyeongJo-Extra",
+        ),
+    ];
+    for (legacy_name, legacy_metric, installed_name, installed_metric) in pairs {
+        let legacy = find_metric(legacy_name, false, false)
+            .unwrap_or_else(|| panic!("`{legacy_name}` 메트릭 별칭이 해소되지 않는다"));
+        assert_eq!(legacy.metric.name, legacy_metric);
+        let installed = find_metric(installed_name, false, false)
+            .unwrap_or_else(|| panic!("`{installed_name}` 메트릭 별칭이 해소되지 않는다"));
+        assert_eq!(installed.metric.name, installed_metric);
+        assert_eq!(
+            legacy.metric.em_size, installed.metric.em_size,
+            "`{legacy_name}` overlay 와 `{installed_name}` 의 em 이 달라지면 폭이 갈라진다"
+        );
+        for ch in ['별', '표', '가', '힣'] {
+            assert_eq!(
+                legacy.metric.get_width(ch),
+                installed.metric.get_width(ch),
+                "`{legacy_name}` 의 한글 폭은 `{installed_metric}` 과 같아야 한다 ({ch})"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 요지 — 이슈 #6171 의 코드 수정은 이미 devel 에 있다. 비어 있던 것은 회귀 테스트다.

#6171 은 `한양견고딕` 이 `Malgun Gothic` 으로 떨어지는 문제를 (①) 별칭 부재와 (②) 임베드 파일명 오기로 지목했다. 확인해 보니 **두 원인의 수정은 이미 base(`devel` 5645e1f5b)에 들어와 있었다.** PR #6195 는 CLOSED 지만 그 내용이 cherry-pick(`dcd11dede` + golden 갱신 `99069609c`)으로 통합됐다.

| 위치 | 현재 상태 |
| --- | --- |
| `src/renderer/mod.rs::installed_render_font_aliases` | `한양견고딕`→`HY견고딕`,`HYGothic-Extra` / `한양견명조`→`HY견명조`,`HYMyeongJo-Extra` 있음 |
| `src/renderer/svg.rs::font_local_aliases` | 견고딕·견명조 4개 arm 있음 |
| `src/renderer/svg.rs::known_font_filenames` | `H2GTRE.TTF`/`H2MJRE.TTF` 우선, 구 `HYGTRE`/`HYMJRE` 는 뒤 후보 |

이슈가 지목한 `font_local_aliases` 는 실제로는 `@font-face src` 만 만들고, SVG `font-family` 사슬을 만드는 **결정적 경로는 `mod.rs::installed_render_font_aliases`** 다(원 PR 본문도 같은 결론).

**메트릭 별칭 동기화도 누락 없음.** `font_rule_projections/layout_metric.rs` 에 `한양견고딕→HanyangKyunGothic`, `HY견고딕→HYGothic-Extra`(견명조 동일)가 이미 있다. `HanyangKyun*` 은 #2430 한글 COM 실측 ASCII 를 덧씌운 overlay 로 한글 음절 폭·em 은 `HY*` 와 공유한다 — 설계상 의도된 분리이며 불일치가 아니다.

## 그래서 이 PR 은 소스 변경 0줄이다

비어 있던 자리는 **결정적 경로를 직접 잠그는 테스트**였다. 기존에는 SVG golden 2건이 사슬을 간접적으로만 고정하고 있어, `installed_render_font_aliases` 의 arm 이 사라져도 golden 을 재생성하면 조용히 통과한다.

`tests/cases/issue_6171_hanyang_gyeongothic_alias.rs` 에 4건 추가 —

1. 사슬 앞머리 고정: 견고딕 / 견명조 / bold 경로
2. 메트릭 별칭 짝 고정: legacy overlay ↔ 설치 face 의 em·한글 폭 일치

**RED 확인**: `installed_render_font_aliases` 의 두 arm 을 임시로 지우니 사슬이 이슈 보고와 동일하게 `'한양견고딕','Malgun Gothic','맑은 고딕',…` 로 떨어지며 3건이 실패했고, 복구하니 green 이 됐다. 실산출 근거로 golden `tests/golden_svg/issue-617/exam-kor-page5.svg` 의 실제 `font-family` 는 `'한양견고딕','HY견고딕','HYGothic-Extra','Malgun Gothic',…` 다.

## 게이트

| 게이트 | 결과 |
| --- | --- |
| `rust-test-suite-manifest.mjs --generate` | OK (generated·manifest 는 커밋하지 않음, `Cargo.toml` 불변) |
| `rust-unit-test-tiers.mjs --check` | OK |
| `cargo fmt --all -- --check` | OK |
| `cargo clippy --all-targets -- -D warnings` | 경고 0 |
| `cargo test` 전체 | lib 전체 + 통합 33 타깃, 본 변경 관련 실패 0 (`regression_suite_028` EXIT=0) |

전체 실행 중 실패 2건은 이 변경과 무관한 부하 민감 flake 이며 각각 단독 실행으로 통과를 확인했다 — `issue_4126…builds_few_page_trees`(프로세스 전역 `PAGE_TREE_BUILDS` 카운터가 같은 suite 바이너리의 병렬 테스트와 경합, 관측 10/상한 8), `issue_2833…does_not_slow_down_parsing`(500ms 벽시계 예산, 단독 0.21s). 별도 이슈로 올렸다.

## 이슈를 닫지 않는다

#6171 의 **원인 ③**(`『` 폴백이 `Malgun Gothic` 보다 바탕/함초롬바탕을 먼저 잡아야 한다)은 여전히 열려 있다. 원 PR 이 의도적으로 보류했고(별개 런 `한양중고딕` 문제 + generic 사슬 순서 변경은 모든 고딕 문서에 파급), 이번에도 손대지 않았다. 실측상 `『`→`별` 간격 13.5px→12.0px, 오라클은 4.25~4.75px 다.

따라서 이 PR 은 #6171 의 ①②를 **회귀로 잠그기만** 하고 이슈는 ③ 범위로 남겨 둔다.

Refs #6171
