### PR TITLE
수정(렌더러): 본문 clip 이 세로 테두리 획의 왼쪽 절반을 자르지 않게 한다 (#6269)

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -3395,6 +3395,38 @@ impl LayoutEngine {
                         | RenderNodeType::RawSvg(_)
                 )
             }
+            // [#6269] clip 확장에 쓰는 노드의 **가로로 칠해지는** 범위.
+            //
+            // 선 노드의 bbox 는 `create_single_line` 계열이 `(x2-x1).abs().max(width)` 로
+            // 잡아, 세로선이면 `x .. x+width` 처럼 획을 오른쪽으로만 세운다. 그런데 실제
+            // 획은 경로 중심 기준이라 `x-width/2 .. x+width/2` 를 덮는다. body clip 은 이
+            // bbox 합집합으로 정해지므로 본문 좌단(`body_area.x`)에 붙은 세로선은 획의
+            // 왼쪽 절반이 clip 밖에 놓여 잘렸다. clip 을 적용하지 않는 직접 PDF 출력만
+            // 온전했고 clip 을 지키는 studio(CanvasKit)·SVG·Canvas 는 잉크가 절반이 됐다
+            // (156739836 2·3쪽: studio 51 vs PDF 94).
+            //
+            // 세로축(위/아래)은 건드리지 않는다. 본문 **상단**의 같은 잘림은 #3820 이
+            // 이미 테두리 paint 를 안쪽으로 미는 방식으로 고쳤고 그 계약이 body clip 의
+            // y 를 기준으로 못박혀 있다. 여기서 y 까지 넓히면 그 보정과 이중으로 겹친다.
+            //
+            // 회전 변환이 걸린 선까지 안전하도록 선분 좌표를 다시 풀지 않고 bbox 를 획
+            // 두께의 절반만큼 좌우로 부풀린다. clip 은 상한일 뿐이고 여유분이 선 자신의
+            // 획 두께를 넘지 않으므로 다른 콘텐츠를 더 보이게 하지는 않는다.
+            fn clip_paint_extent(node: &RenderNode) -> BoundingBox {
+                let RenderNodeType::Line(line) = &node.node_type else {
+                    return node.bbox;
+                };
+                let half = line.style.width / 2.0;
+                if !half.is_finite() || half <= 0.0 {
+                    return node.bbox;
+                }
+                BoundingBox {
+                    x: node.bbox.x - half,
+                    y: node.bbox.y,
+                    width: node.bbox.width + half * 2.0,
+                    height: node.bbox.height,
+                }
+            }
             // clip 을 **가시** 자식 bbox 로 확장. `float_subtree` 가 참이면 그 서브트리는
             // 부동 그림으로 취급해 상한 적용 대상 clip 만 넓힌다.
             //
@@ -3408,7 +3440,7 @@ impl LayoutEngine {
                 node: &RenderNode,
                 float_subtree: bool,
             ) {
-                let cb = &node.bbox;
+                let cb = clip_paint_extent(node);
                 let is_float = float_subtree || is_floating_object(node);
                 let target: &mut BoundingBox = if is_float { &mut *float } else { &mut *flow };
                 let child_bottom = cb.y + cb.height;

--- a/tests/cases/issue_6269_body_clip_left_border_stroke.rs
+++ b/tests/cases/issue_6269_body_clip_left_border_stroke.rs
@@ -1,0 +1,153 @@
+//! Issue #6269: 본문 좌단에 붙은 세로 테두리선의 획 절반이 body clip 에 잘리던 회귀 가드.
+//!
+//! 세로선 render 노드의 bbox 는 `x .. x+width` 로 잡히지만 실제 획은 경로 중심 기준이라
+//! `x-width/2 .. x+width/2` 를 덮는다. body clip 을 bbox 합집합으로만 잡으면 본문 좌단
+//! (`body_area.x`)에 놓인 세로선은 왼쪽 절반이 clip 밖으로 나가 잘린다. PDF 직접 출력은
+//! clip 을 적용하지 않아 온전했고 clip 을 지키는 studio(CanvasKit)·SVG 만 잉크가 절반이
+//! 됐다(156739836 2·3쪽: studio 잉크 51 vs PDF 94).
+//!
+//! 여기서는 body clipRect 아래의 모든 line op 에 대해 **획 왼쪽 끝**이 clip 안에 있는지
+//! 본다. 오른쪽·아래는 부동 개체 상한(#5855)이 따로 걸려 있어 왼쪽 경계만 판정한다.
+
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+const TOLERANCE: f64 = 1e-6;
+const MAX_PAGES: u32 = 3;
+
+/// 획 왼쪽 끝이 body clip 왼쪽 경계보다 얼마나 밖으로 나갔는지(px). 양수면 잘린다.
+struct Scan {
+    worst_deficit: f64,
+    worst_label: String,
+    lines_checked: usize,
+}
+
+fn walk(node: &Value, body_left: Option<f64>, page: u32, scan: &mut Scan) {
+    match node.get("kind").and_then(Value::as_str) {
+        Some("clipRect") => {
+            let clip_kind = node.get("clipKind").and_then(Value::as_str).unwrap_or("");
+            // 셀 clip 안의 자손은 body clip 확장 대상이 아니다(#42065 RowBreak 중첩 표).
+            if clip_kind == "tableCell" {
+                return;
+            }
+            let next = if clip_kind == "body" {
+                node.get("clip")
+                    .and_then(|clip| clip.get("x"))
+                    .and_then(Value::as_f64)
+            } else {
+                body_left
+            };
+            if let Some(child) = node.get("child") {
+                walk(child, next, page, scan);
+            }
+        }
+        Some("group") => {
+            for child in node
+                .get("children")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                walk(child, body_left, page, scan);
+            }
+        }
+        Some("leaf") => {
+            let Some(left) = body_left else {
+                return;
+            };
+            for op in node
+                .get("ops")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                if op.get("type").and_then(Value::as_str) != Some("line") {
+                    continue;
+                }
+                let x1 = op.get("x1").and_then(Value::as_f64).unwrap_or(0.0);
+                let x2 = op.get("x2").and_then(Value::as_f64).unwrap_or(0.0);
+                let width = op
+                    .get("style")
+                    .and_then(|style| style.get("width"))
+                    .and_then(Value::as_f64)
+                    .unwrap_or(0.0);
+                if !width.is_finite() || width <= 0.0 {
+                    continue;
+                }
+                scan.lines_checked += 1;
+                let stroke_left = x1.min(x2) - width / 2.0;
+                let deficit = left - stroke_left;
+                if deficit > scan.worst_deficit {
+                    scan.worst_deficit = deficit;
+                    scan.worst_label = format!(
+                        "page {page}: line x={:.2} width={:.2} 획 왼쪽 {stroke_left:.2} < clip {left:.2}",
+                        x1.min(x2),
+                        width
+                    );
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn scan_sample(relative: &str) -> Scan {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(relative);
+    let bytes = fs::read(&path).unwrap_or_else(|err| panic!("read {relative}: {err}"));
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|err| panic!("parse {relative}: {err:?}"));
+    let mut scan = Scan {
+        worst_deficit: 0.0,
+        worst_label: String::new(),
+        lines_checked: 0,
+    };
+    for page in 0..doc.page_count().min(MAX_PAGES) {
+        let json = doc
+            .get_page_layer_tree_native(page)
+            .unwrap_or_else(|err| panic!("{relative} page {page} layer tree: {err:?}"));
+        let value: Value = serde_json::from_str(&json)
+            .unwrap_or_else(|err| panic!("{relative} page {page} layer tree json: {err}"));
+        if let Some(root) = value.get("root") {
+            walk(root, None, page, &mut scan);
+        }
+    }
+    scan
+}
+
+fn assert_left_stroke_inside_body_clip(relative: &str) {
+    let scan = scan_sample(relative);
+    assert!(
+        scan.lines_checked > 0,
+        "{relative}: body clip 아래에서 검사한 line op 가 없다 — 가드가 비어 있다"
+    );
+    assert!(
+        scan.worst_deficit <= TOLERANCE,
+        "{relative}: 세로선 획 왼쪽 {:.3}px 이 body clip 밖이다 ({})",
+        scan.worst_deficit,
+        scan.worst_label
+    );
+}
+
+#[test]
+fn issue_6269_multi_column_doc_keeps_left_border_stroke_inside_body_clip() {
+    // 1.5px 세로 테두리선 — 이슈 원문(156739836)과 같은 굵기.
+    assert_left_stroke_inside_body_clip("samples/hwp-multi-001.hwp");
+}
+
+#[test]
+fn issue_6269_thin_border_keeps_left_stroke_inside_body_clip() {
+    // 0.5px 얇은 선도 절반이 잘리면 화면에서 사라진다.
+    assert_left_stroke_inside_body_clip("samples/basic/BlogForm_Recipe.hwp");
+}
+
+#[test]
+fn issue_6269_thick_border_keeps_left_stroke_inside_body_clip() {
+    // 굵은 선(5.7px)은 잘림 폭이 커 육안으로도 드러났다.
+    assert_left_stroke_inside_body_clip("samples/pr-1674.hwp");
+}
+
+#[test]
+fn issue_6269_table_border_keeps_left_stroke_inside_body_clip() {
+    assert_left_stroke_inside_body_clip("samples/issue_1133.hwp");
+}

--- a/tests/golden_svg/form-002/page-0.svg
+++ b/tests/golden_svg/form-002/page-0.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="793.7066666666667" height="1122.48" viewBox="0 0 793.7066666666667 1122.48">
 <defs>
-<clipPath id="body-clip-3"><rect x="75.58666666666667" y="94.48" width="858.4733333333332" height="933.52"/></clipPath>
+<clipPath id="body-clip-3"><rect x="75.33666666666667" y="94.48" width="858.7233333333332" height="933.52"/></clipPath>
 <clipPath id="cell-clip-305"><rect x="75.58666666666667" y="581.2" width="635.64" height="429.3333333333335"/></clipPath>
 <clipPath id="cell-clip-339"><rect x="92.34666666666666" y="826.1866666666668" width="610.1466666666666" height="27.306666666666615"/></clipPath>
 </defs>

--- a/tests/golden_svg/issue-157/page-1.svg
+++ b/tests/golden_svg/issue-157/page-1.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="793.7066666666667" height="1122.5066666666667" viewBox="0 0 793.7066666666667 1122.5066666666667">
 <defs>
-<clipPath id="body-clip-3"><rect x="60.00000000000001" y="60.00000000000001" width="1030" height="1033.3333333333335"/></clipPath>
+<clipPath id="body-clip-3"><rect x="59.75000000000001" y="60.00000000000001" width="1030.25" height="1033.3333333333335"/></clipPath>
 <clipPath id="cell-clip-25"><rect x="60.00000000000001" y="224.60000000000002" width="679.0933333333332" height="25.906666666666695"/></clipPath>
 <clipPath id="cell-clip-29"><rect x="60.00000000000001" y="250.50666666666672" width="135.81333333333333" height="25.906666666666638"/></clipPath>
 <clipPath id="cell-clip-32"><rect x="195.81333333333333" y="250.50666666666672" width="196.18666666666667" height="25.906666666666638"/></clipPath>

--- a/tests/golden_svg/issue-267/ktx-toc-page.svg
+++ b/tests/golden_svg/issue-267/ktx-toc-page.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="793.7066666666667" height="1122.5066666666667" viewBox="0 0 793.7066666666667 1122.5066666666667">
 <defs>
-<clipPath id="body-clip-3"><rect x="75.58666666666667" y="94.46666666666667" width="646.0466666666666" height="956.8199999999999"/></clipPath>
+<clipPath id="body-clip-3"><rect x="75.58666666666667" y="94.46666666666667" width="646.5966666666667" height="956.8199999999999"/></clipPath>
 <clipPath id="cell-clip-6"><rect x="77.46666666666667" y="96.34666666666666" width="147.54666666666665" height="16.02666666666667"/></clipPath>
 <clipPath id="cell-clip-9"><rect x="225.01333333333332" y="96.34666666666666" width="351.76" height="66.18666666666667"/></clipPath>
 <clipPath id="textbox-clip-25"><rect x="314.78000000000003" y="102.55333333333333" width="173.10666666666668" height="29.386666666666667"/></clipPath>

--- a/tests/golden_svg/issue-617/exam-kor-page5.svg
+++ b/tests/golden_svg/issue-617/exam-kor-page5.svg
@@ -4,7 +4,7 @@
 <clipPath id="cell-clip-8"><rect x="413.24" y="132.28" width="296.0666666666666" height="64.26666666666668"/></clipPath>
 <clipPath id="cell-clip-12"><rect x="709.3066666666666" y="132.28" width="296.08000000000004" height="64.26666666666668"/></clipPath>
 <clipPath id="textbox-clip-16"><rect x="924.2" y="134.84" width="79.30666666666667" height="39.666666666666664"/></clipPath>
-<clipPath id="body-clip-23"><rect x="117.17333333333335" y="211.65333333333334" width="888.6600000000001" height="1211.28"/></clipPath>
+<clipPath id="body-clip-23"><rect x="116.92333333333335" y="211.65333333333334" width="889.1600000000001" height="1211.28"/></clipPath>
 <clipPath id="cell-clip-35"><rect x="132.24" y="273.73333333333335" width="173.8" height="8.666666666666686"/></clipPath>
 <clipPath id="cell-clip-38"><rect x="306.04" y="273.73333333333335" width="60.599999999999966" height="17.333333333333314"/></clipPath>
 <clipPath id="cell-clip-41"><rect x="366.64" y="273.73333333333335" width="173.80000000000007" height="8.666666666666686"/></clipPath>

--- a/tests/golden_svg/table-text/page-0.svg
+++ b/tests/golden_svg/table-text/page-0.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="793.7066666666667" height="1122.48" viewBox="0 0 793.7066666666667 1122.48">
 <defs>
-<clipPath id="body-clip-3"><rect x="113.38666666666667" y="132.26666666666668" width="614.8733333333333" height="876.8266666666667"/></clipPath>
+<clipPath id="body-clip-3"><rect x="113.38666666666667" y="132.26666666666668" width="615.8233333333333" height="876.8266666666667"/></clipPath>
 <clipPath id="cell-clip-6"><rect x="115.26666666666667" y="134.14666666666668" width="305.5466666666667" height="31.439999999999998"/></clipPath>
 <clipPath id="cell-clip-10"><rect x="420.81333333333333" y="134.14666666666668" width="305.5466666666667" height="31.439999999999998"/></clipPath>
 <clipPath id="cell-clip-14"><rect x="115.26666666666667" y="165.58666666666667" width="76.38666666666667" height="36.49333333333334"/></clipPath>


### PR DESCRIPTION
## 증상

studio(브라우저)에서 본문 좌단에 붙은 세로 테두리선이 거의 보이지 않는다. 같은 문서를 `export-pdf` 로 내보내면 보인다(156739836 2·3쪽, 사용자 신고 「2쪽 목차, 3쪽 일러두기 — 테두리선 안 보임」). 이슈 실측으로 잉크가 **studio 51 vs PDF 94** 로 절반이었다.

## 근인 — 선 bbox 가 획을 오른쪽으로만 세운다

`src/renderer/layout.rs` 의 body clip 확정 블록(`expand_clip`).

- 선 노드의 bbox 는 `layout/border_rendering.rs` 의 `create_single_line`(918-940)·`create_parallel_lines`(880-900)가 `(x2-x1).abs().max(width)` 로 잡는다. 세로선이면 bbox 는 `x .. x+width` — 즉 **획을 오른쪽으로만** 세운다.
- 그런데 실제 획은 경로 중심 기준이라 `x-width/2 .. x+width/2` 를 덮는다.
- body clip 은 이 bbox 들의 합집합이므로, 본문 좌단(`body_area.x` = 75.6px = 20mm@96dpi)에 놓인 세로선은 **획의 왼쪽 절반이 clip 밖**이 된다.

그래서 표면별로 갈렸다 — ClipRect 를 검증만 하고 적용하지 않는 직접 PDF 출력(`src/renderer/pdf.rs`)만 온전했고, clip 을 지키는 studio(CanvasKit `canvaskit-renderer.ts:1207` `canvas.clipRect`)·SVG(`svg.rs:904`)·Canvas 는 모두 잉크가 절반이다. 이슈의 「clip 경계에 걸려 획 절반이 잘린다」 추정이 정확했고 스냅·반픽셀·DPR 은 무관하다.

## 재현 — 저장소 샘플에 같은 형상이 있다

이슈 문서는 로컬에 없지만 동일 형상을 저장소 샘플에서 확인했다.

| 샘플 | 선 | 결손 |
| --- | --- | --- |
| `samples/issue_1133.hwp` p2 | `x=75.59 width=1.50` → 획 좌단 74.84 < clip 75.59 | 0.75px (이슈 원문 `x=75.60 w=1.50` 과 동일) |
| `samples/pr-1674.hwp` | width 5.7px | 2.85px |
| `samples/BlogForm_Recipe.hwp` | width 0.5px | 0.25px |

## 수정

`expand_clip` 이 쓰는 노드 범위를 `clip_paint_extent(node)` 로 바꿔, Line 노드만 bbox 를 획 두께의 절반만큼 **좌우로만** 부풀린다. 회전 변환이 걸린 선까지 안전하도록 선분 좌표를 다시 풀지 않고 bbox 를 팽창시킨다.

**세로축은 의도적으로 제외했다.** 본문 상단의 같은 잘림은 #3820 이 이미 테두리 paint 를 안쪽으로 미는 방식(`inset_horizontal_border_group_at_top_clip`)으로 고쳤고 그 계약 테스트가 clip 의 y 를 기준으로 못박혀 있다. y 까지 넓히면 보정이 이중으로 겹쳐 `issue_3820_p33_table_frame_is_paint_only_inset` 이 깨진다(실제로 확인).

### 되돌린 대안

#3820 방식을 세로로 확장(`inset_vertical_border_group_at_left_clip`)해 봤다. 표 엣지 테두리는 고쳐지지만 좌단 세로선을 만드는 producer 가 문단 테두리(`paragraph_layout.rs:5779`)·표 외곽 상자(`table_layout.rs:2471`)·셀 상자 등 여럿이라 전부 패치해야 해 취약하다. clip 쪽 수정은 producer 와 무관하게 한 번에 닫힌다.

## 테스트

- `tests/cases/issue_6269_body_clip_left_border_stroke.rs` 신규 — body clipRect 아래 모든 line op 의 획 왼쪽 끝이 clip 안인지 판정. 샘플 4종(0.5/1.5/5.7px). `tableCell` clip 하위는 제외하고, 오른쪽·아래는 #5855 부동 상한 때문에 미판정. **수정을 원복하면 4건 모두 red** 를 확인했다.
- `tests/golden_svg/*` 5개 — body clipPath 의 `x`/`width` 만 반폭 확장. 다른 노드·글리프는 무변화(diff 확인).

| 게이트 | 결과 |
| --- | --- |
| `rust-test-suite-manifest.mjs --generate` | OK (신규 케이스는 `regression_suite_002` 에 자동 배정) |
| `cargo fmt --all -- --check` | OK |
| `cargo clippy --all-targets -- -D warnings` | 경고 0 |
| `rust-unit-test-tiers.mjs --check` | OK (4221, 증가 없음) |
| `cargo test` 전체 | 49/50 스위트 green. #3820 계약 2건(`regression_suite_010`) green |

실패 1건 `issue_4128…deep_cell_cursor_queries_build_few_page_trees` 는 본 변경과 무관한 flake 다 — 프로세스 누적 카운터 `PAGE_TREE_BUILDS` 상한을 보는데 생성 스위트가 133개 테스트와 한 프로세스에서 병렬 실행된다. 단독 실행과 `regression_suite_015` 단독 전체(134/134) 모두 green, 앞선 두 번의 전체 실행에서도 나오지 않았다. 별도 이슈로 올렸다.

## 검증 한계

- 이슈 원본 문서가 로컬에 없어 2·3쪽 픽셀 실측(잉크 51→94) 재현은 못 했다. 동형 샘플의 render tree 좌표로 대체했다.
- 브라우저 캔버스 실측 없음. studio 는 Rust 가 만든 clipRect 를 그대로 소비하므로 논리적으로 닫히지만, WASM 재빌드(`pkg/`) 없이는 studio 에서 바로 보이지 않는다.
- **한컴 정답지 대조 없음** — 한컴이 좌단 선을 clip 하는지(=획을 안쪽으로 미는 게 정답인지)는 미확인이다. PDF 가 획 중심 75.6 의 전체 폭을 그린다는 것만 이슈 실측으로 확인됐다.

## 남은 리스크

1. **좌우/상하 비대칭** — 좌단은 clip 확장, 상단은 #3820 paint 인셋으로 같은 문제에 두 메커니즘이 공존한다. 언젠가 한쪽으로 통일하는 게 맞고, 그때 #3820 의 계약 테스트를 함께 재정의해야 한다.
2. body clip 이 좌우로 최대 half-stroke(문서에 따라 ~0.25~2.85px) 넓어진다. 여유분은 선 자신의 획 두께를 넘지 않는다.
3. 하단·우측의 같은 잘림은 그대로다(우측은 clip 이 콘텐츠로 이미 확장돼 실사례 없음, 하단은 #5855 부동 상한과 얽혀 별도 판단 필요).

Closes #6269
