### PR TITLE
수정(렌더러): 어울림 개체와 같은 y 에서 시작하는 문단에 배제 밴드를 건다 (#6175)

### DIFF
--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -2756,17 +2756,44 @@ fn stored_rows_require_external_geometry(para: &Paragraph, frame: &LayoutFrame) 
     // With no text and no control, this paragraph provides no local geometry
     // from which a scalar Frame could derive that inset. Reflowing it full
     // width destroys the carrier contract; leave it with the external owner.
+    let differs_from_frame = |segment: &crate::model::paragraph::LineSeg| {
+        segment.column_start != frame.horizontal.start
+            || segment.column_start.checked_add(segment.segment_width) != Some(frame.horizontal.end)
+    };
     let empty_carrier = para.controls.is_empty()
         && para
             .text
             .chars()
             .all(|ch| ch.is_whitespace() || ch == '\r' || ch == '\n');
-    empty_carrier
-        && line_segs.iter().any(|segment| {
-            segment.column_start != frame.horizontal.start
-                || segment.column_start.checked_add(segment.segment_width)
-                    != Some(frame.horizontal.end)
-        })
+    if empty_carrier {
+        return line_segs.iter().any(differs_from_frame);
+    }
+
+    // [#6175] The same argument holds for a text paragraph whose every stored
+    // row is one complete slot *inset inside* this frame. A scalar frame has
+    // one horizontal range and applies the paragraph's own indents inside it,
+    // so it cannot derive an inset narrower than its own carve — the inset
+    // came from an owner this frame does not model, and the only float band
+    // that produces a uniform inset is a side-wrap (Square) object anchored
+    // where the paragraph's first row already starts. Reflowing full width
+    // there runs the text under the object (156518601 p1: four stored
+    // `0+29138` rows reflowed to three `0+48188` rows, 246px of each line
+    // hidden behind the picture).
+    //
+    // Bounded by the frame's own geometry pitch so a rounding-scale
+    // disagreement — which the frame *can* explain — still reflows: only an
+    // inset wider than one pitch counts as evidence of a second owner.
+    let inset_inside_frame = |segment: &crate::model::paragraph::LineSeg| {
+        let end = match segment.column_start.checked_add(segment.segment_width) {
+            Some(end) => end,
+            None => return false,
+        };
+        segment.column_start >= frame.horizontal.start
+            && end <= frame.horizontal.end
+            && (frame.horizontal.end - frame.horizontal.start) - segment.segment_width
+                > crate::renderer::layout_frame::COLUMN_WIDTH_QUANTUM_HWP
+    };
+    line_segs.iter().any(differs_from_frame) && line_segs.iter().all(inset_inside_frame)
 }
 
 /// Whether the frame's own carve reproduces every stored row — §1.4.1's

--- a/src/renderer/layout_frame.rs
+++ b/src/renderer/layout_frame.rs
@@ -27,7 +27,7 @@ const MINIMUM_USABLE_INTERVAL_HWP: i32 = 1_440;
 /// 4-HWPUNIT grid, not a constant inset, which is why a flat `-2` fixed the
 /// `bw%4==2` documents and broke the `bw%4==0` ones.
 ///
-const COLUMN_WIDTH_QUANTUM_HWP: i32 = 4;
+pub(crate) const COLUMN_WIDTH_QUANTUM_HWP: i32 = 4;
 
 /// Snap a base edge down to `pitch`.
 ///

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -1142,6 +1142,9 @@ struct TypesetState {
     /// 비-TAC Picture/Shape Square wrap: any_seg_matches만으로 후속 문단 판정 허용.
     /// 그림의 lineseg는 첫 seg cs=0일 수 있어 전체 seg 중 하나라도 일치하면 흡수.
     wrap_around_any_seg: bool,
+    /// [#6175] 밴드가 호스트 문단의 저장 사다리가 아니라 어울림 개체의 기하에서
+    /// 유도됐다 — 개체 종류(묶음 포함)와 무관하게 뒤따르는 문단을 개체 옆으로 흘린다.
+    wrap_around_derived_band: bool,
     /// [#1955] 글뒤로/글앞으로(BehindText/InFrontOfText) 비-TAC 표 anchor 문단.
     /// 이 wrap 은 본문 플로우를 소비하지 않으므로(한글: 후속 문단이 anchor 쪽에
     /// 남음), 직후의 빈 후행 문단들을 anchor 첫 fragment 단에 소급 흡수한다.
@@ -1713,6 +1716,44 @@ fn non_tac_square_picture_common(ctrl: &Control) -> Option<&crate::model::shape:
         .then_some(common)
 }
 
+/// [#6175] 비-TAC 어울림(Square) 개체의 공통 속성 — 그림뿐 아니라 묶음(GroupShape)
+/// 등 모든 개체 종류를 받는다. 묶음 그림도 한컴에서는 같은 배제 밴드를 만든다.
+fn non_tac_square_float_common(ctrl: &Control) -> Option<&crate::model::shape::CommonObjAttr> {
+    let common = match ctrl {
+        Control::Picture(pic) => Some(&pic.common),
+        Control::Shape(shape) => Some(shape.common()),
+        _ => None,
+    }?;
+    (!common.treat_as_char && matches!(common.text_wrap, crate::model::shape::TextWrap::Square))
+        .then_some(common)
+}
+
+/// [#6175] 어울림 개체의 **자기 기하**만으로 유도되는 우측 밴드의 좌측 레인 폭.
+///
+/// 호스트 문단의 첫 줄이 전폭이면(그림이 그 줄보다 아래에서 시작하는 형상) 기존
+/// arming 은 밴드를 못 만든다. 그러나 개체가 단 우단까지 닿는 문단/단 기준 개체라면
+/// 옆으로 흐를 레인은 개체 자신의 `horizontal_offset` 이 그대로 규정한다 — 한컴이
+/// 뒤따르는 문단의 `segment_width` 로 저장하는 값과 같은 수다(156518601 1쪽:
+/// horzOffset 29138 = 저장 사다리 4줄 전부의 horzsize).
+fn square_float_left_lane_width(para: &Paragraph, col_w_hu: i32) -> Option<i32> {
+    use crate::model::shape::HorzRelTo;
+    let mut floats = para.controls.iter().filter_map(non_tac_square_float_common);
+    let common = floats.next()?;
+    if floats.next().is_some() {
+        return None;
+    }
+    if !matches!(common.horz_rel_to, HorzRelTo::Para | HorzRelTo::Column) {
+        return None;
+    }
+    let lane = common.horizontal_offset as i32;
+    let right_edge = lane
+        .saturating_add(common.width as i32)
+        .saturating_add(common.margin.right as i32);
+    // 개체가 단 우단까지 닿아야 좌측 레인 하나로 정의된다. 가운데 놓인 개체는
+    // 좌·우 두 레인을 만들므로 이 유도가 성립하지 않는다.
+    (lane > 0 && lane < col_w_hu && right_edge >= col_w_hu - 200).then_some(lane)
+}
+
 fn paragraph_by_global_index<'a>(
     body_paragraphs: &'a [Paragraph],
     endnote_paragraphs: &'a [Paragraph],
@@ -1848,6 +1889,7 @@ fn maybe_register_square_picture_wrap_anchor(
         st.wrap_around_cs = -1;
         st.wrap_around_sw = -1;
         st.wrap_around_any_seg = false;
+        st.wrap_around_derived_band = false;
         st.close_square_band();
     }
 }
@@ -1876,6 +1918,7 @@ fn activate_square_picture_wrap_for_para(
         st.wrap_around_sw = anchor_sw;
         st.wrap_around_table_para = para_index;
         st.wrap_around_any_seg = true;
+        st.wrap_around_derived_band = false;
     }
 }
 
@@ -4406,6 +4449,7 @@ impl TypesetState {
             wrap_around_sw: -1,
             wrap_around_table_para: 0,
             wrap_around_any_seg: false,
+            wrap_around_derived_band: false,
             behind_float_table_para: None,
             next_para_first_stored_vpos: None,
             next_para_is_empty_float_table_anchor: false,
@@ -6300,6 +6344,7 @@ impl TypesetEngine {
                     st.wrap_around_sw = anchor_sw;
                     st.wrap_around_table_para = para_idx;
                     st.wrap_around_any_seg = true;
+                    st.wrap_around_derived_band = false;
                     // [Task #722] anchor host paragraph 자체도 wrap_anchors 등록.
                     // LINE_SEG cs/sw 가 wrap zone 으로 인코딩되어 있으면 host paragraph 의
                     // 줄도 image 우측 wrap zone 에 layout 되어야 한다 (한컴 PDF 권위 정합).
@@ -6363,6 +6408,23 @@ impl TypesetEngine {
                             },
                         );
                     }
+                }
+            }
+
+            // [#6175] 호스트 문단의 저장 사다리가 밴드를 담고 있지 않은 형상 —
+            // 어울림 개체가 호스트 줄보다 아래에서 시작해 배제가 **다음** 문단부터
+            // 걸린다. 이때는 개체 자신의 기하가 유일한 근거다. 위 arming 이 밴드를
+            // 잡지 못했을 때만, 그리고 개체가 단 우단까지 닿아 좌측 레인이 하나로
+            // 정해질 때만 유도한다. `any_seg` 는 켜지 않는다 — 유도 밴드는 저장
+            // segment_width 가 정확히 일치하는 문단만 받고, 첫 불일치에서 닫힌다.
+            if st.wrap_around_cs < 0 {
+                let col_w_hu = st.layout.column_width_hu();
+                if let Some(lane) = square_float_left_lane_width(para, col_w_hu) {
+                    st.wrap_around_cs = 0;
+                    st.wrap_around_sw = lane;
+                    st.wrap_around_table_para = para_idx;
+                    st.wrap_around_any_seg = false;
+                    st.wrap_around_derived_band = true;
                 }
             }
         }
@@ -6615,7 +6677,10 @@ impl TypesetEngine {
                         })
                     })
                     .unwrap_or(false);
-                if anchor_is_picture {
+                // [#6175] 유도 밴드의 앵커는 묶음(GroupShape)일 수 있다 — 개체
+                // 종류로 흡수/통과를 가르는 이 판정에서 묶음 그림을 표로 오인하면
+                // 밴드 옆 본문 문단이 통째로 흡수된다.
+                if anchor_is_picture || st.wrap_around_derived_band {
                     // Picture anchor: wrap_anchors 등록 + FullParagraph 통과
                     // [Task #722] anchor image 의 outer margin_right (HU) 추출
                     let anchor_margin_right = paragraphs
@@ -6788,6 +6853,7 @@ impl TypesetEngine {
                             st.wrap_around_cs = -1;
                             st.wrap_around_sw = -1;
                             st.wrap_around_any_seg = false;
+                            st.wrap_around_derived_band = false;
                             st.close_square_band();
                             if !st.current_items.is_empty()
                                 && st.current_height + suffix_height > st.available_height() + 0.5
@@ -6807,6 +6873,7 @@ impl TypesetEngine {
                     st.wrap_around_cs = -1;
                     st.wrap_around_sw = -1;
                     st.wrap_around_any_seg = false;
+                    st.wrap_around_derived_band = false;
                     // 이 문단은 첫 줄만 Square 띠에 있고 나머지는 표 아래 전폭으로
                     // 복귀한다. 일반 fit 전에 띠 바닥을 흐름 하한으로 반영하지 않으면
                     // 아래 줄이 표와 겹치는 높이를 아직 사용할 수 있다고 오판한다.
@@ -6818,6 +6885,7 @@ impl TypesetEngine {
                 st.wrap_around_cs = -1;
                 st.wrap_around_sw = -1;
                 st.wrap_around_any_seg = false;
+                st.wrap_around_derived_band = false;
                 st.close_square_band();
                 // [Task #741 Stage 4] 매칭 실패 paragraph 의 vpos=0 hint (page break 의도)
                 // 발견 시 advance_column_or_new_page. wrap_around active 종료 후 추가 가드.
@@ -7240,6 +7308,7 @@ impl TypesetEngine {
                 st.wrap_around_cs = -1;
                 st.wrap_around_sw = -1;
                 st.wrap_around_any_seg = false;
+                st.wrap_around_derived_band = false;
                 st.close_square_band();
             }
             // [#1955] 명시적 쪽나누기부터는 글뒤로 표 후행 흡수도 해제 (사용자 의도 새 쪽).
@@ -7517,6 +7586,7 @@ impl TypesetEngine {
                             st.wrap_around_cs = -1;
                             st.wrap_around_sw = -1;
                             st.wrap_around_any_seg = false;
+                            st.wrap_around_derived_band = false;
                             st.close_square_band();
                         }
                         if st.wrap_around_cs < 0 {
@@ -8278,6 +8348,7 @@ impl TypesetEngine {
                             st.wrap_around_sw = strip_sw;
                             st.wrap_around_table_para = para_idx;
                             st.wrap_around_any_seg = false;
+                            st.wrap_around_derived_band = false;
                         } else {
                             let anchor_cs =
                                 para.line_segs.first().map(|s| s.column_start).unwrap_or(0);
@@ -8297,6 +8368,7 @@ impl TypesetEngine {
                                 st.wrap_around_sw = anchor_sw;
                                 st.wrap_around_table_para = para_idx;
                                 st.wrap_around_any_seg = false;
+                                st.wrap_around_derived_band = false;
                             }
                         }
                     }

--- a/tests/cases/issue_6175_square_band_uniform_ladder.rs
+++ b/tests/cases/issue_6175_square_band_uniform_ladder.rs
@@ -1,0 +1,86 @@
+//! [#6175 실측] 어울림(Square) 개체와 **같은 y 에서 시작하는** 문단의 배제 밴드.
+//!
+//! 156518601(모바일 운전면허증 보도자료) 1쪽 — `경찰청(청장 후보자 윤희근)은 …`
+//! 문단(pi=8)의 저장 사다리는 네 줄 전부 `horzsize=29138`(=388.5px)이다. 이는
+//! 묶음 그림(`horzOffset=29138`)이 만든 밴드의 왼쪽 레인 폭이다.
+//!
+//! 수정 전 rhwp 는 이 문단만 전폭(48188HU=642.5px)으로 다시 흘려 세 줄로 만들었고,
+//! 그 세 줄의 471.6~718.1 구간이 그림에 덮여 사라졌다. 원인은 두 곳이다.
+//!
+//! 1. 저장 줄 전부가 **같은 폭**으로 좁아진 문단은 "폭이 섞였다"는 국소 증거가
+//!    없어 프레임이 관할을 주장하고 전폭으로 재래핑했다.
+//! 2. 밴드 arming 이 호스트 문단의 저장 사다리에만 기대는데, 이 문서의 호스트
+//!    문단(pi=7)의 줄은 전폭이다 — 개체가 그 줄보다 아래에서 시작한다.
+//!
+//! 한글 2020 오라클(`pdf/pr6017/156518601_p1_square_host-2020.pdf`)의 같은 문단은
+//! 네 줄이고 오른쪽 끝이 347.8pt(=463.7px)다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+use std::fs;
+use std::path::Path;
+
+const SAMPLE: &str = "samples/issue5809/156518601_p1_square_host.hwpx";
+
+/// 묶음 그림의 왼쪽 모서리(px) — 본문 좌단 75.6 + horzOffset 29138HU(388.5px).
+const BAND_LEFT_PX: f64 = 471.6;
+
+fn line_text(node: &RenderNode) -> String {
+    node.children
+        .iter()
+        .filter_map(|c| match &c.node_type {
+            RenderNodeType::TextRun(run) => Some(run.text.as_str()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// 첫 줄이 `prefix` 로 시작하는 문단의 모든 줄을 문서 순서대로 모은다.
+fn collect_lines(node: &RenderNode, out: &mut Vec<(f64, f64, f64, String)>) {
+    if let RenderNodeType::TextLine(_) = &node.node_type {
+        out.push((
+            node.bbox.x,
+            node.bbox.y,
+            node.bbox.width,
+            line_text(node).trim().to_string(),
+        ));
+    }
+    for child in &node.children {
+        collect_lines(child, out);
+    }
+}
+
+#[test]
+fn issue_6175_uniformly_narrowed_ladder_keeps_square_band() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(path).expect("read #6175 fixture");
+    let core = DocumentCore::from_bytes(&bytes).expect("parse #6175 fixture");
+    let page = core.build_page_render_tree(0).expect("render p1");
+
+    let mut lines = Vec::new();
+    collect_lines(&page.root, &mut lines);
+
+    let start = lines
+        .iter()
+        .position(|(_, _, _, text)| text.starts_with("경찰청(청장"))
+        .expect("`경찰청(청장…` 문단 첫 줄");
+    let end = lines
+        .iter()
+        .position(|(_, _, _, text)| text.starts_with("일제히 발급한다고"))
+        .expect("`일제히 발급한다고 밝혔다.` 줄 — 수정 전엔 3줄로 뭉쳐 존재하지 않았다");
+    assert_eq!(
+        end - start + 1,
+        4,
+        "한글 오라클과 저장 사다리 모두 네 줄이다: {:?}",
+        &lines[start..=end]
+    );
+
+    for (x, y, width, text) in &lines[start..=end] {
+        let right = x + width;
+        assert!(
+            right <= BAND_LEFT_PX + 1.0,
+            "줄 우단 {right:.1} 이 밴드 좌단 {BAND_LEFT_PX} 을 넘는다 \
+             (y={y:.1}, 수정 전 718.1) — 그림에 가려진다: {text}"
+        );
+    }
+}


### PR DESCRIPTION
## 증상

어울림(Square) 그림과 **같은 y 에서 시작하는 문단**에 배제 밴드를 걸지 않아, 본문이 그림 아래로 들어가 가려진다(156518601 1쪽). 저장 사다리는 네 줄 전부 좁은 폭(`horzsize=29138`)을 적고 있는데 rhwp 는 전폭으로 재래핑한다.

## 재현

`samples/issue5809/156518601_p1_square_host.hwpx` 1쪽, `export-render-tree -p 0`:

- 수정 전 pi=8(`경찰청(청장 후보자 윤희근)은 …`)이 **3줄, w=642.50px**, 마지막 런 우단 **718.1px**. 묶음 그림 밴드는 x=471.6~725.6 이므로 줄마다 246px 가 그림 뒤로 들어간다.
- 저장 사다리는 네 줄 전부 `cs=0, sw=29138`(=388.5px) — 이슈 본문과 일치.
- 한컴 2020 오라클(`pdf/pr6017/156518601_p1_square_host-2020.pdf`)도 4줄, 우단 347.8pt(=463.7px).

## 근인 — 두 곳이 동시에 침묵한다

### ① 균일하게 좁아진 사다리는 "외부 기하 증거"로 인정받지 못한다

`stored_rows_require_external_geometry`(`line_breaking.rs`)는 **폭이 섞인 사다리**만 외부 소유의 증거로 본다. 모든 줄이 같은 폭으로 좁아진 문단은 국소 증거를 내지 못해 스칼라 프레임이 관할을 주장하고, `resolve_stored_line_segs_in_frame` 이 전폭으로 재래핑한다.

`RHWP_DIAG_STORED_ROW_KEY` 로 확인: `mismatch rows=4 stored=[0+29138 ×4]`.

바로 다음 문단 pi=10 은 `29138×3 + 48188×1` 이라 **우연히** 폭이 섞여 통과하고 있었다 — 같은 밴드인데 한 문단만 살아남은 이유다.

### ② 밴드 arming 이 호스트 문단의 저장 사다리에만 의존한다

typeset 의 밴드 arming 은 호스트 문단의 저장 사다리를 본다. 그런데 이 문서의 호스트(pi=7)는 **빈 문단**이고 자기 줄은 전폭(48188)이라 `band_full_width` 로 판정돼 arming 자체가 일어나지 않는다. 게다가 개체가 `묶음(GroupShape)`이라 `non_tac_square_picture_common`(Picture 전용)에도 걸리지 않는다. 결과적으로 `wrap_anchors` 에 등록되지 않아 `paragraph_layout` 의 stored cs/sw 경로에 진입하지 못한다.

## 수정

- `line_breaking.rs` — 텍스트 문단도 **모든 줄이 프레임 안쪽으로 균일하게 inset(≥ pitch)** 이면 외부 기하로 판정해 프레임이 관할을 사양한다. empty-carrier 규칙은 그대로 둔다.
- `typeset.rs` — `non_tac_square_float_common`(묶음 포함)과 `square_float_left_lane_width`(개체가 문단/단 기준이고 단 우단까지 닿을 때 `horizontal_offset` 을 좌측 레인으로) 추가. **기존 arming 이 실패했을 때만** 유도 밴드를 arming 한다(`wrap_around_derived_band`, `any_seg=false` → 저장 폭이 정확히 일치할 때만 수용하고 첫 불일치에서 닫힘). 유도 밴드의 앵커는 `anchor_is_picture` 판정을 통과시켜 표 취급 흡수를 막는다.
- `layout_frame.rs` — `COLUMN_WIDTH_QUANTUM_HWP` 를 `pub(crate)` 로(pitch 임계값 참조).

## 수치 근거

| | 수정 전 | 수정 후 | 한컴 2020 |
| --- | --- | --- | --- |
| pi=8 줄 수 | 3 | **4** | 4 |
| 줄 폭 | 642.50px | **388.50px** | — |
| 줄 우단 | 718.1px (538.2pt) | **PDF 348.2pt** | 347.8pt |
| 줄 나눔 | 다름 | `…7월 28일` / `(목)부터…(27개)` / `및 경찰서(258개)…` / `일제히 발급한다고 밝혔다.` | **동일** |

pi=10 은 수정 전후 동일(`388.5×3 + 642.5`), pi=11~13 도 불변이다.

## 게이트

| 게이트 | 결과 |
| --- | --- |
| `rust-test-suite-manifest.mjs --prepare` | OK (988 sources, 신규 케이스는 `regression_suite_014` 에 배정) |
| `cargo fmt --all -- --check` | OK |
| `cargo clippy --all-targets -- -D warnings` | exit 0 |
| `cargo test --no-fail-fast` 전체(75 타깃) | 신규 `issue_6175_uniformly_narrowed_ladder_keeps_square_band` 통과 |

실패 3건(`issue_4128…`·`issue_4179…build_few_page_trees`, `issue_2833…does_not_slow_down_parsing`)은 **셋 다 단독 실행 시 통과**하며 레이아웃과 무관하다. 생성 suite 가 전역 카운터·벽시계 예산 테스트를 한 프로세스에 120~147개와 묶어 병렬 실행하는 저장소 공통 문제로, #6308 로 분리해 올렸다.

## 회귀 가드

`tests/cases/issue_6175_square_band_uniform_ladder.rs` — 균일하게 좁아진 저장 사다리가 어울림 밴드를 유지하는지 판정.

## 남은 리스크

- `line_breaking` 의 완화는 "균일 inset 문단"이면 **소스와 무관하게** 프레임이 사양한다. 문단 테두리 inset(#547 계열)처럼 밴드가 아닌 이유로 좁아진 저장 사다리도 이제 재래핑 대신 저장값을 쓴다. 전체 통합 테스트에서 회귀는 나오지 않았지만, 밴드의 실재 여부를 증거로 쓰지 않는 점은 약점이다.
- typeset 유도 밴드는 Square 인 어떤 개체(사각형·글상자·차트 등)에도 발화할 수 있다. 다만 후속 문단은 저장 `segment_width` 가 `horizontal_offset` 과 정확히(±0) 일치할 때만 수용하므로 실질 필터는 강하다.

Closes #6175
