### PR TITLE
게이트: 글자 겹침(text-overlap) 원장 래칫을 세운다 (#6315)

### DIFF
--- a/tests/cases/text_overlap_baseline.rs
+++ b/tests/cases/text_overlap_baseline.rs
@@ -1,0 +1,173 @@
+//! [#6315] 글자 겹침(text-overlap) 원장 게이트 — samples 전수 렌더 래칫.
+//!
+//! `layout_anomaly` 의 text-overlap 판정(#5372)은 이미 있고 정확하다. 문제는 그
+//! 판정을 **PR 에서 아무도 돌리지 않는 것**이었다 —
+//! `.github/workflows/layout-anomaly-advisory.yml` 은 nightly advisory 이고
+//! `continue-on-error: true` 라, 보이는 글자끼리 겹치는 회귀를 새로 만들어도 PR 은
+//! 초록으로 통과했다. PR #6083 이 실제 사례다(편람 69쪽: devel 0건 → head 7건,
+//! 상자 하단이 넘쳐 다음 본문 줄과 겹침). 검토자가 PNG 를 눈으로 대조한 뒤에야
+//! 발견됐다.
+//!
+//! `ci_advisory.md` §2 가 게이트 승격을 미룬 이유는 "소표본에도 이미 알려진
+//! overflow/overlap 이 있어 지금 강제하면 PR 이 한꺼번에 막힌다" 였다. 이 저장소는
+//! 같은 문제를 `LAYOUT_OVERFLOW_CELL`(#3668)·`ir_field_sweep_baseline` 에서
+//! **기존 발생은 baseline 에 싣고 신규·증가만 실패**시키는 래칫으로 이미 풀었다.
+//! 이 게이트는 그 규약을 그대로 따른다.
+//!
+//! **판정 대상은 text-overlap 하나다.** overflow·off-canvas·overlap 은 컨테이너
+//! 기하라 정상 조판의 접합·장식으로도 흔히 잡히지만, **보이는 글자끼리 겹치는 것은
+//! 두 글자 모두 읽을 수 없게 되는 확정 결함**이다(모듈 머리말이 `--strict` 에
+//! text-overlap 을 포함한 근거와 같다).
+//!
+//! ## baseline 재생성
+//!
+//! ```text
+//! RHWP_TEXT_OVERLAP_DUMP=tests/fixtures/text_overlap_baseline.tsv \
+//!   cargo test --profile release-test text_overlap_baseline -- --nocapture
+//! ```
+//!
+//! 0 이 아닌 문서만 `상대경로\t건수` 로 사전순 기록한다. **감소는 통과**이므로,
+//! 결함을 고쳤으면 dump 로 확인한 뒤 래칫을 조인다.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use rhwp::diagnostics::layout_anomaly::{scan_document, AnomalyOptions};
+use rhwp::document_core::DocumentCore;
+
+const SAMPLES_ROOT: &str = "samples";
+const BASELINE_PATH: &str = "tests/fixtures/text_overlap_baseline.tsv";
+
+/// 확장자로 샘플을 재귀 수집해 루트 기준 상대 경로(슬래시)로 돌려준다.
+fn collect_samples() -> Vec<(PathBuf, String)> {
+    fn walk(dir: &Path, root: &Path, acc: &mut Vec<(PathBuf, String)>) {
+        let entries = std::fs::read_dir(dir).expect("samples 읽기 실패");
+        for entry in entries {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                walk(&path, root, acc);
+            } else if matches!(
+                path.extension().and_then(|e| e.to_str()),
+                Some("hwp") | Some("hwpx")
+            ) {
+                let rel = path
+                    .strip_prefix(root)
+                    .expect("strip_prefix")
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                acc.push((path, rel));
+            }
+        }
+    }
+    let mut acc = Vec::new();
+    walk(Path::new(SAMPLES_ROOT), Path::new(SAMPLES_ROOT), &mut acc);
+    acc.sort_by(|a, b| a.1.cmp(&b.1));
+    assert!(!acc.is_empty(), "samples 에 hwp/hwpx 샘플이 없음");
+    acc
+}
+
+fn load_baseline() -> BTreeMap<String, u64> {
+    let text = std::fs::read_to_string(BASELINE_PATH)
+        .unwrap_or_else(|e| panic!("baseline 읽기 실패 {BASELINE_PATH}: {e}"));
+    text.lines()
+        .filter(|l| !l.trim().is_empty() && !l.starts_with('#'))
+        .map(|l| {
+            let (rel, n) = l.rsplit_once('\t').expect("baseline TSV 행 형식");
+            (rel.to_string(), n.parse::<u64>().expect("baseline 수치"))
+        })
+        .collect()
+}
+
+/// 문서 하나의 전 페이지 text-overlap 건수.
+///
+/// 로드·렌더 실패는 이 게이트의 관심사가 아니므로 None(건너뜀)으로 처리한다 —
+/// 크래시·파싱 회귀는 기존 스위트가 잡는다(overflow_cell_baseline 과 같은 규약).
+fn count_doc(path: &Path) -> Option<u64> {
+    let bytes = std::fs::read(path).ok()?;
+    let doc = DocumentCore::from_bytes(&bytes).ok()?;
+    let anomalies = scan_document(&doc, &AnomalyOptions::default()).ok()?;
+    Some(anomalies.text_overlap_count() as u64)
+}
+
+#[test]
+fn text_overlaps_do_not_grow() {
+    let samples = collect_samples();
+    let baseline = load_baseline();
+
+    let workers = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4)
+        .min(8);
+    let queue = std::sync::Mutex::new(samples.into_iter());
+    let results = std::sync::Mutex::new(BTreeMap::<String, u64>::new());
+    let skipped = std::sync::atomic::AtomicUsize::new(0);
+
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| loop {
+                let item = queue.lock().unwrap().next();
+                let Some((path, rel)) = item else { break };
+                match count_doc(&path) {
+                    Some(n) => {
+                        results.lock().unwrap().insert(rel, n);
+                    }
+                    None => {
+                        skipped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                }
+            });
+        }
+    });
+
+    let results = results.into_inner().unwrap();
+    let nonzero: BTreeMap<&String, u64> = results
+        .iter()
+        .filter(|(_, &n)| n > 0)
+        .map(|(k, &v)| (k, v))
+        .collect();
+
+    eprintln!(
+        "text-overlap 스윕: 샘플 {}건(스킵 {}) / 0 아닌 문서 {}종 / 총 {}건",
+        results.len(),
+        skipped.load(std::sync::atomic::Ordering::Relaxed),
+        nonzero.len(),
+        nonzero.values().sum::<u64>(),
+    );
+
+    if let Ok(dump) = std::env::var("RHWP_TEXT_OVERLAP_DUMP") {
+        let mut out = String::new();
+        for (rel, n) in &nonzero {
+            out.push_str(&format!("{rel}\t{n}\n"));
+        }
+        std::fs::write(&dump, out).expect("dump 쓰기 실패");
+        eprintln!("현재값 dump → {dump}");
+    }
+
+    // 래칫 판정: 신규 발생 또는 증가만 실패. 감소·해소는 통과(dump 대조로 조인다).
+    let mut regressions = Vec::new();
+    for (rel, &n) in &nonzero {
+        match baseline.get(*rel) {
+            None => regressions.push(format!("신규 발생: {rel} — {n}건 (baseline 없음)")),
+            Some(&base) if n > base => regressions.push(format!("증가: {rel} — {base} → {n}건")),
+            _ => {}
+        }
+    }
+    assert!(
+        regressions.is_empty(),
+        "보이는 글자끼리 겹치는 회귀(text-overlap)가 늘었다.\n\
+         겹친 두 글자는 **모두** 읽을 수 없게 되므로 확정 결함이다(#5372 판정).\n\
+         `rhwp layout-anomaly <파일> -p <쪽> --json` 으로 짝을 확인할 수 있다.\n\
+         원인 정정이 원칙이고, 의도된 변화만 baseline 에 반영한다(4.3.1 규약 준용).\n{}",
+        regressions.join("\n")
+    );
+
+    // baseline 부패 감지: 기록된 문서가 코퍼스에서 사라지면 행을 정리해야 한다.
+    let missing: Vec<&String> = baseline
+        .keys()
+        .filter(|rel| !results.contains_key(*rel))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "baseline 에 있으나 샘플에 없는 문서 — 행을 정리할 것: {missing:?}"
+    );
+}

--- a/tests/fixtures/text_overlap_baseline.tsv
+++ b/tests/fixtures/text_overlap_baseline.tsv
@@ -1,0 +1,152 @@
+2025 행정업무운영 편람(최종).hwp	15
+2025 행정업무운영 편람(최종).hwpx	15
+21_언어_기출_편집가능본.hwp	1
+3-09월_교육_통합_2023.hwp	14
+3-09월_교육_통합_2023.hwpx	14
+3-10월_교육_통합_2022.hwp	1
+3-10월_교육_통합_2022.hwpx	1
+3-11월_실전_통합_2022.hwp	11
+3-11월_실전_통합_2022.hwpx	11
+3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20.hwp	11
+3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20.hwpx	11
+3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0.hwp	14
+3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0.hwpx	14
+3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2.hwp	11
+3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2.hwpx	11
+3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2.hwp	11
+3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2.hwpx	11
+3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20.hwp	11
+3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20.hwpx	10
+3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.hwp	11
+3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.hwpx	13
+3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2.hwp	11
+3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2.hwpx	10
+3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.hwp	10
+3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.hwpx	10
+76076_regulatory_analysis.hwp	6
+80168_regulatory_analysis.hwp	9
+86712_regulatory_analysis.hwp	3
+SO-SUEOP.hwp	34
+SO-SUEOP.hwpx	34
+basic/issue1994_behindtext_table_20200830.hwp	4
+basic/sungeo.hwp	15
+exam_science.hwp	2
+group-drawing-02.hwp	5
+hwp-multi-001.hwp	202
+hwp3-sample-hwp5.hwp	3
+hwp3-sample-hwpx.hwpx	3
+hwp3-sample10-hwp5.hwp	132
+hwp3-sample10-hwpx.hwpx	132
+hwp3-sample10.hwp	189
+hwp3-sample16-hwp5-2010.hwp	20
+hwp3-sample16-hwp5-2018.hwp	20
+hwp3-sample16-hwp5-2022.hwp	20
+hwp3-sample16-hwp5-2024.hwp	20
+hwp3-sample16-hwp5.hwp	20
+hwp3-sample16-hwp5.hwpx	20
+hwp3-sample16.hwp	22
+hwp5-tbl-attr-1916.hwp	5
+hwpctl_API_v2.4.hwp	5
+hwpx/2024년 1분기 해외직접투자 보도자료 ff.hwp	78
+hwpx/2024년 1분기 해외직접투자 보도자료 ff.hwpx	78
+hwpx/2024년 2분기 해외직접투자 보도자료ff.hwpx	102
+hwpx/2024년 연간 해외직접투자 보도자료 _ ff.hwpx	256
+hwpx/2025년 1분기 해외직접투자 보도자료f.hwpx	76
+hwpx/2025년 2분기 해외직접투자 (최종).hwpx	109
+hwpx/hancom-hwp/2024년 1분기 해외직접투자 보도자료 ff.hwp	78
+hwpx/hancom-hwp/2024년 2분기 해외직접투자 보도자료ff.hwp	102
+hwpx/hancom-hwp/2024년 연간 해외직접투자 보도자료 _ ff.hwp	256
+hwpx/hancom-hwp/2025년 1분기 해외직접투자 보도자료f.hwp	76
+hwpx/hancom-hwp/2025년 2분기 해외직접투자 (최종).hwp	109
+hwpx/hancom-hwp/hang_job_01.hwp	1
+hwpx/hancom-hwp/hwpx-01.hwp	78
+hwpx/hancom-hwp/hwpx-02.hwp	256
+hwpx/hancom-hwp/hwpx-h-01.hwp	78
+hwpx/hancom-hwp/hwpx-h-02.hwp	109
+hwpx/hancom-hwp/hwpx-h-03.hwp	76
+hwpx/hancom-hwp/mel-001.hwp	7
+hwpx/hwpx-01.hwpx	78
+hwpx/hwpx-h-01.hwpx	78
+hwpx/hwpx-h-02.hwpx	109
+hwpx/hwpx-h-03.hwpx	76
+hwpx/k-water-rfp.hwpx	1
+hwpx/mel-001.hwpx	7
+hwpx/opengov/36382669_결재문서본문_’26년 제3차 강사선정 심의회 운영결과.hwpx	1
+hwpx/opengov/36384689_결재문서본문_화재발생종합보고서(제2026-298호).hwpx	3
+hwpx/opengov/36385226_결재문서본문_제2처리장 슬러지인발용 에어리프트 브로워 2호기 소모품 교체 보고.hwpx	4
+hwpx/opengov/36387103_결재문서본문_수질검사 신청 민원 처리 결과 안내.hwpx	4
+hwpx_sample2.hwp	35
+hwpx_sample2.hwpx	37
+issue-986-receipt.hwp	5
+issue1549_empty_host_float_clamp.hwpx	1
+issue1549_multipositive_float_tables.hwpx	6
+issue1853_caption_precedes_body_split.hwpx	11
+issue1858_paper_anchor_float_stack.hwpx	6
+issue1880_takeplace_host_before.hwpx	1
+issue1891/76076_regulatory_analysis.hwpx	7
+issue1891/80168_regulatory_analysis.hwpx	9
+issue1891/80250_regulatory_analysis.hwpx	2
+issue1891/86712_regulatory_analysis.hwpx	3
+issue1921/59043_regulatory_analysis.hwp	3
+issue1949_giant_cell_nested_tables_perf.hwp	8
+issue1949_giant_cell_nested_tables_perf.hwpx	8
+issue2004_cell_image_stack.hwp	1
+issue2004_cell_image_stack.hwpx	1
+issue2006/1790387_prep_final_report.hwpx	123
+issue2217/20200830.hwp	4
+issue2470/36341511_masked.hwpx	9
+issue2559/1341000_research_report_footnotes.hwp	10
+issue3637/regulatory_impact_nested_table_escape.hwpx	37
+issue3837/stored_vpos_rewind_form.hwp	4
+issue4491/30213_1.혼합단지등 제도개선 방안.hwp	3
+issue4514/sample1-repro.hwp	1
+issue4690/30098_indent_over_stored_cs.hwp	2
+issue5169_viewtext_changetracking.hwp	28
+issue5679/10857_delegation_rules.hwp	6
+issue5699/37787_regulatory_impact.hwp	2
+issue5714/1490000-200800034_vietnam_labor_report.hwp	2
+issue5724/2689441_wmf_contents_ole.hwp	1
+issue5788/tac_table_missing_anchor_line_spacing.hwp	5
+issue5793/pua_f0827_double_rule.hwp	1
+issue5870/empty_host_float_flow_advance.hwp	2
+issue5877/fragment_ghost_vrules.hwp	2
+issue5941/1490000-201600081_roadmap_research.hwp	7
+issue5966/1130000-202100008_franchise_review_report.hwp	10
+issue6030/2386771_agritech_review_form.hwp	2
+issue6031/3249937_asset_management_rules.hwpx	3
+issue6035/cgmp_evaluation_table.hwpx	1
+issue6036/156509073_police_press_release.hwpx	1
+issue6044/156513948.hwpx	3
+issue6060/30307_local_service_reform.hwp	2
+issue6086/30098_resident_registration_reform.hwp	2
+issue6111/56345_regulatory_impact_analysis.hwp	2
+issue6121/156531618_police_press_header.hwpx	1
+issue6269/156739836_public_sector_jobs_stats.hwpx	1
+issue6284/child_policy_top_caption_charts.hwpx	52
+k-water-rfp-2024.hwp	1
+k-water-rfp.hwp	1
+kps-ai.hwp	2
+mel-001.hwp	7
+multi-table-001.hwp	1
+multi-table-002.hwp	1
+synam-001.hwp	15
+table_giant_cell_overfill.hwpx	16
+table_scattered_header_rowbreak.hwp	1
+tac-img-02.hwp	1
+tac-img-02.hwpx	1
+task1716/table_scattered_header_rowbreak.hwpx	1
+task1718/table_giant_cell_overfill.hwp	1
+task1725/text_footnote_tail_overpagination.hwp	12
+task1725/text_footnote_tail_overpagination.hwpx	12
+task1753/deferred_takeplace_fill_ahead.hwp	3
+task1753/deferred_takeplace_fill_ahead.hwpx	3
+task1768/distribution_doc.hwpx	1
+task2070/1130000-201900011_D0150004-1-002_2017년기준 시장구조조사.hwp	49
+task2097/21217935_simsa_jipyo.hwp	75
+task2097/75544_pii_bunseok.hwpx	6
+task2279/36404953_gyeoljae.hwpx	1
+task2287/1342000_edu_curriculum_map.hwp	56
+task2430/1382000_domestic_violence_survey.hwp	20
+task3307/issue3307_outline_number.hwpx	3
+정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp	57
+정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwpx	77


### PR DESCRIPTION
## 무엇을 했나

`#6315` — 글자 겹침(text-overlap) 판정이 PR 에서 안 돌아 회귀가 초록으로 통과하는
문제를, `overflow_cell_baseline`(#3668)·`ir_field_sweep_baseline` 과 **같은 래칫**으로
게이트화했다.

판정 로직(`src/diagnostics/layout_anomaly.rs`)은 **한 줄도 건드리지 않았다.** 이 PR 은
판정을 바꾸지 않고 **돌리지 않는 문제**만 다룬다.

## 게이트가 실제로 이 결함군을 잡는다 — 실측

DoD 의 핵심 항목이다. 이슈가 지목한 **PR #6083 의 소스 변경**(`src/renderer/composer.rs`,
head `cfb2646e`)만 떼어 현재 `devel` 에 얹고 래칫을 돌렸다.

```
증가: 2025 행정업무운영 편람(최종).hwp   — 15 → 20건
증가: 2025 행정업무운영 편람(최종).hwpx  — 15 → 20건
증가: task2430/1382000_domestic_violence_survey.hwp — 20 → 21건
test result: FAILED
```

**required check 전부 초록이었던 그 변경이, 이 게이트에서는 실패한다.** (검증 후
소스는 원복했다 — 이 PR 에 #6083 의 변경은 들어 있지 않다.)

## 왜 래칫인가

`tools/layout_anomaly/ci_advisory.md` §2 가 게이트 승격을 미룬 이유는 이랬다.

> 소표본에도 이미 알려진 overflow/overlap 이 있을 수 있다. 지금 강제 게이트로 켜면
> devel PR 이 한꺼번에 막힌다.

기존 발생을 baseline 에 싣고 **신규·증가만** 실패시키면 그 이유가 그대로 해소된다.
현재값은 **샘플 945건 중 152문서 / 총 4371건**이고, 이 값을 고정했다.

## 판정 대상을 text-overlap 하나로 한정한 이유

overflow·off-canvas·overlap 은 컨테이너 기하라 정상 조판의 접합·장식으로도 흔히
잡힌다. 반면 **보이는 글자끼리 겹치는 것은 두 글자가 모두 읽을 수 없게 되는 확정
결함**이다 — 모듈 머리말이 `--strict` 에 text-overlap 을 포함한 근거와 같다.

## 만진 것 / 만지지 않은 것

| | |
| --- | --- |
| 신규 | `tests/cases/text_overlap_baseline.rs` — samples 전수 스캔 래칫 |
| 신규 | `tests/fixtures/text_overlap_baseline.tsv` — 현재값 152행 고정 |
| **불변** | `src/diagnostics/layout_anomaly.rs` (판정 로직) |
| **불변** | `.github/workflows/**` (required check / branch protection 은 O4) |
| **불변** | `scripts/visual_sweep.py`, `gym/` |

⚠ **배치 위치 하나만 이슈 계획과 다르다.** 이슈는 `tests/text_overlap_baseline.rs`
(독립 타깃)를 적었는데, `suite-policy.json` 의 `maximumIntegrationTargets: 48` 예산을
넘겨(`49 > 48`) 매니페스트가 거부한다. 그래서 `tests/cases/` 로 넣어 생성 suite
(`regression_suite_020`)에 배정했다 — 이슈가 적은 "일반 integration test 로 넣으면
기존 `Build & Test` 가 그대로 실행한다"는 목적은 그대로 달성되고, 링크 타깃 예산도
건드리지 않는다.

## baseline 재생성

```text
RHWP_TEXT_OVERLAP_DUMP=tests/fixtures/text_overlap_baseline.tsv \
  cargo test --profile release-test text_overlap_baseline -- --nocapture
```

**감소는 통과**다 — 결함을 고쳤으면 dump 로 확인한 뒤 래칫을 조인다.

## 검증

- 신규 래칫이 `devel` 에서 통과 (67초)
- **PR #6083 head 의 소스 변경을 얹으면 실패** (위 실측)
- `cargo nextest run --cargo-profile release-test --no-fail-fast` 전체 게이트
- `rustfmt`(신규 파일) · `cargo clippy --lib --bins --tests` 무경고

🤖 Generated with [Claude Code](https://claude.com/claude-code)
