### PR TITLE
test(gate): 글자 겹침을 samples 전수 래칫으로 잡는다 — 판정기는 있는데 PR 에서 안 돌았다 (#6315)

### DIFF
--- a/mydocs/working/text_overlap_gate.md
+++ b/mydocs/working/text_overlap_gate.md
@@ -1,0 +1,170 @@
+---
+kind: working
+status: active
+issue: 6315
+---
+
+# 글자 겹침(text-overlap) 래칫 게이트 (#6315)
+
+## 무엇을
+
+`layout-anomaly` 의 text-overlap 판정을 samples 전수 래칫으로 묶어, PR 이 새 글자 겹침을
+만들면 `Build & Test` 에서 실패하게 한다.
+
+- `tests/cases/text_overlap_baseline.rs` — samples 전수 스캔, 문서별 건수 래칫
+- `tests/fixtures/text_overlap_baseline.tsv` — 현재값 고정(152 문서 / 4,371 건)
+
+판정 로직(`src/diagnostics/layout_anomaly.rs`)은 한 줄도 바꾸지 않는다.
+
+## 왜
+
+판정기는 이미 있고 정확한데, 그 판정을 PR 에서 돌리는 경로가 없다.
+`.github/workflows/layout-anomaly-advisory.yml` 는 nightly 전용이고
+(`pull_request` 트리거 주석 처리, `continue-on-error: true`), 그래서 글자 겹침 회귀가
+required check 를 전부 초록으로 통과한다.
+
+실사례가 PR #6083 이다. 같은 문서·같은 쪽에서:
+
+| 대상 | 편람 69쪽 text-overlap |
+| --- | --- |
+| `devel` b1485e0a14 | 0 건 |
+| PR #6083 head cfb2646e | 7 건 |
+
+7 건은 모두 `Table0/Cell4/TextLine16/TextRun0`(유의사항 상자 마지막 줄) 대
+`Body/Column0/TextLine2/TextRun1..7`(상자 다음 본문 줄) 짝이고 겹침은 102.6 x 13.3 px 다.
+검토자가 PNG 를 눈으로 비교해 발견했고, 검토 코멘트에 "CI가 통과한 이유는 이 겹침을
+검사하는 시험이 없기 때문입니다" 로 남아 있다.
+
+## 어떻게 — 왜 래칫인가
+
+`tools/layout_anomaly/ci_advisory.md` §2 가 게이트 승격을 미룬 이유는 "소표본에도 이미
+알려진 겹침이 있어 지금 강제 게이트로 켜면 devel PR 이 한꺼번에 막힌다" 였다. 실측이
+그 우려를 확인한다 — samples 524 건 중 **152 문서에서 4,371 건**이 이미 있다.
+
+이 저장소는 같은 상황을 다른 축에서 이미 래칫으로 풀었다.
+
+| 축 | 게이트 | 픽스처 |
+| --- | --- | --- |
+| `LAYOUT_OVERFLOW_CELL` (#3668) | `tests/overflow_cell_baseline.rs` | `overflow_cell_baseline.tsv` |
+| IR field sweep | `ir_field_sweep_baseline` | 동명 TSV |
+| **글자 겹침 (이 작업)** | `tests/cases/text_overlap_baseline.rs` | `text_overlap_baseline.tsv` |
+
+기존 발생은 baseline 에 싣고 **신규 발생·증가만** 실패시킨다. 감소는 통과다(dump 로
+확인한 뒤 래칫을 조인다). `local_validation.md` §4.3.0.1 의 "가능하면 최소 공개 fixture 와
+자동 래칫을 마련한다" 를 이 축에 적용한 것이다.
+
+### required check 를 건드리지 않는 이유
+
+required check / branch protection 변경은 운영 등급 O4 이고 #5400 이 명시적으로 범위 밖으로
+남긴 결정이다. 이 작업은 일반 integration test 로만 들어가므로 기존 `Build & Test` 가
+그대로 실행한다 — 워크플로 변경 없이 게이트가 서고, 메인테이너 결정 항목은 열어 둔다.
+
+### 판정 대상을 text-overlap 하나로 좁힌 이유
+
+overflow / off-canvas / overlap 은 컨테이너 기하라 정상 조판의 접합·장식으로도 흔히
+잡힌다. 보이는 글자끼리 겹치는 것은 두 글자 모두 읽을 수 없게 되는 확정 결함이다.
+모듈 머리말이 `--strict` 확정 신호에 text-overlap 을 포함한 근거와 같다.
+
+## baseline 의 성격 — 숨기지 않는 사실
+
+4,371 건은 "허용해도 되는 겹침"이 아니라 **아직 안 고친 겹침**이다. 이 게이트는 그 수를
+줄이지 않는다. 늘지 않게만 한다.
+
+최다 문서(`hwpx/2024년 연간 해외직접투자 보도자료 _ ff.hwpx`, 256 건) 표본 분류:
+
+| 분류 | 건수 | 비율 |
+| --- | --- | --- |
+| 줄 높이 전체가 겹침 | 190 | 74% |
+| 세로 부분 겹침(줄 높이의 50% 미만) | 66 | 26% |
+
+겹침 폭 중앙값 9.7px, 최대 38.5px. 본문 한글 글자 폭이 11~16px 이므로 다수는 글자
+하나 이상이 실제로 포개진다. 실제 형상도 인접 칸 침범이다.
+
+```
+Cell16/TextLine1/TextRun0  x=81.2..163.2
+Cell17/TextLine1/TextRun0  x=159.3..199.3   -> 4.0px 침범
+```
+
+세로 부분 겹침 26% 는 렌더 트리에 글자 단위 글리프 bbox 가 없어 `TextRun` 상자를
+글리프 묶음으로 쓰는 데서 오는 상자 여백 근접이 섞일 수 있다(모듈 머리말이 밝힌 한계).
+판정 자체를 조이는 것은 이 작업의 범위가 아니다 — 조이면 baseline 이 함께 내려가므로
+별도 축으로 다룬다.
+
+## 검증
+
+| 명령 | 결과 |
+| --- | --- |
+| `cargo fmt --all -- --check` | 통과 |
+| `cargo clippy --profile release-test --all-targets -- -D warnings` | 통과 (9분 04초, 경고 0) |
+| 래칫 테스트 on `devel` | 통과 (299.46s, 945 건 스캔 / 스킵 3) |
+| 래칫 테스트 + #6083 composer 변경 | **실패** — 게이트가 실제로 잡는다 |
+
+현재값 재생성:
+
+```bash
+RHWP_TEXT_OVERLAP_DUMP=<path> cargo test --profile release-test text_overlaps_do_not_grow
+```
+
+쪽 단위 위치 확인:
+
+```bash
+rhwp layout-anomaly "samples/2025 행정업무운영 편람(최종).hwp" -p 68 --json
+```
+
+## 실측
+
+### 1. `devel` 기준 — 통과
+
+```
+text-overlap 스윕: 샘플 945건(스킵 3) / 0 아닌 문서 152종 / 총 4371건
+test text_overlap_baseline::text_overlaps_do_not_grow ... ok
+finished in 299.46s
+```
+
+수집은 `overflow_cell_baseline.rs` 와 같은 규칙(하위 폴더 재귀, `.hwp`/`.hwpx`)이라
+`samples/` 최상위 524 건이 아니라 945 건이 대상이다. 스킵 3 건은 로드·렌더 실패로,
+이 게이트의 관심사가 아니다(크래시·파싱 회귀는 기존 스위트가 잡는다).
+
+### 2. #6083 의 `composer.rs` 변경을 얹으면 — 실패
+
+같은 워크트리에 PR #6083 head 의 `src/renderer/composer.rs` diff 만 적용하고
+같은 명령을 다시 돌렸다.
+
+```
+증가: 2025 행정업무운영 편람(최종).hwp — 15 → 20건
+증가: 2025 행정업무운영 편람(최종).hwpx — 15 → 20건
+증가: task2430/1382000_domestic_violence_survey.hwp — 20 → 21건
+test result: FAILED. finished in 208.77s
+```
+
+세 가지를 확인한다.
+
+1. 게이트가 그 회귀를 **잡는다**. 편람 HWP·HWPX 가 각각 +5 건이다. 그 PR 은 당시
+   required check 를 전부 초록으로 통과했다.
+2. 검토자가 눈으로 본 것보다 **넓게** 잡는다. 검토는 편람 한 문서였는데, 래칫은
+   `task2430/1382000_domestic_violence_survey.hwp` 의 +1 건도 함께 보고한다 —
+   사람이 렌더해 보지 않은 문서다.
+3. 판정은 문서 단위 수치라 **재현 가능**하다. 어느 쪽에서 늘었는지는
+   `rhwp layout-anomaly <문서> -p <쪽> --json` 으로 좁힌다.
+
+검증 뒤 `composer.rs` 는 되돌렸다. 이 PR 에는 `src/**` 변경이 없다.
+
+### 3. 커밋 대상
+
+```
+tests/cases/text_overlap_baseline.rs
+tests/fixtures/text_overlap_baseline.tsv
+mydocs/working/text_overlap_gate.md
+```
+
+`tests/generated/`, `tests/suites/manifest.json` 은 `.gitignore` 대상이라 커밋에 들어가지
+않는다(PR 템플릿 2번 체크박스 규약).
+
+## 남은 것 — 이 게이트의 사각지대
+
+`scan_page` 는 페이지 트리에서 `Body` 하나만 순회한다. `MasterPage`·`Header`·`Footer`·
+`FootnoteArea` 는 스캔 대상이 아니라, **본문 글자가 바탕쪽 사이드바를 덮어도 0 건**이다.
+편람 69쪽 `devel` 실측에서 본문↔바탕쪽 글자 겹침이 판정기와 같은 허용치로 4 건 있는데
+현재 명령은 0 을 낸다(#5952 의 "사이드바와 겹친다" 가 이 형상이다).
+
+이 게이트를 먼저 세운 뒤 별도 이슈로 다룬다 — 순서가 바뀌면 baseline 이 두 번 흔들린다.

--- a/tests/cases/text_overlap_baseline.rs
+++ b/tests/cases/text_overlap_baseline.rs
@@ -1,0 +1,174 @@
+//! 글자 겹침(`layout-anomaly` text-overlap) 원장 게이트 — samples 전수 렌더 래칫.
+//!
+//! `src/diagnostics/layout_anomaly.rs` 는 보이는 `TextRun` bbox 가 서로 교차하는
+//! 사건(text-overlap)을 이미 판정한다. 그런데 그 판정을 돌리는 워크플로는
+//! `.github/workflows/layout-anomaly-advisory.yml` 하나뿐이고, 그 잡은 nightly
+//! advisory 다 — `pull_request` 트리거가 주석 처리돼 있고 `continue-on-error: true`
+//! 라서 **PR 은 글자 겹침을 새로 만들어도 초록으로 통과한다**.
+//!
+//! advisory 설계문(`tools/layout_anomaly/ci_advisory.md` 2절)이 게이트 승격을
+//! 미룬 이유는 "소표본에도 이미 알려진 overflow/overlap 이 있어 지금 강제 게이트로
+//! 켜면 devel PR 이 한꺼번에 막힌다" 였다. 이 파일은 그 이유를 래칫으로 해소한다 —
+//! 기존 겹침은 baseline 에 그대로 실어 통과시키고, **신규 발생과 증가만** 실패로
+//! 잡는다. `overflow_cell_baseline.rs`(#3668)·`ir_field_sweep_baseline` 과 같은
+//! 규약이고, `local_validation.md` 4.3.0.1 의 "가능하면 최소 공개 fixture 와 자동
+//! 래칫을 마련한다" 를 이 축에 적용한 것이다.
+//!
+//! 판정 대상은 text-overlap 하나다. overflow·off-canvas·overlap 은 컨테이너 기하라
+//! 정상 조판에서도 접합·장식으로 흔히 잡히지만, **보이는 글자끼리 겹치는 것**은
+//! 문서로서 확정 결함이다(모듈 머리말의 `--strict` 포함 근거와 같다).
+//!
+//! 현재값 dump: `RHWP_TEXT_OVERLAP_DUMP=<path>` 로 실행하면 TSV 를 떨어뜨린다.
+//! baseline 은 0 이 아닌 문서만 `상대경로\t건수` 사전순으로 기록한다.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use rhwp::diagnostics::layout_anomaly::{scan_page, AnomalyOptions};
+use rhwp::document_core::DocumentCore;
+
+const SAMPLES_ROOT: &str = "samples";
+const BASELINE_PATH: &str = "tests/fixtures/text_overlap_baseline.tsv";
+
+/// 확장자로 샘플을 재귀 수집해 루트 기준 상대 경로(슬래시)로 돌려준다.
+fn collect_samples() -> Vec<(PathBuf, String)> {
+    fn walk(dir: &Path, root: &Path, acc: &mut Vec<(PathBuf, String)>) {
+        let entries = std::fs::read_dir(dir).expect("samples 읽기 실패");
+        for entry in entries {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                walk(&path, root, acc);
+            } else if matches!(
+                path.extension().and_then(|e| e.to_str()),
+                Some("hwp") | Some("hwpx")
+            ) {
+                let rel = path
+                    .strip_prefix(root)
+                    .expect("strip_prefix")
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                acc.push((path, rel));
+            }
+        }
+    }
+    let mut acc = Vec::new();
+    walk(Path::new(SAMPLES_ROOT), Path::new(SAMPLES_ROOT), &mut acc);
+    acc.sort_by(|a, b| a.1.cmp(&b.1));
+    assert!(!acc.is_empty(), "samples 에 hwp/hwpx 샘플이 없음");
+    acc
+}
+
+fn load_baseline() -> BTreeMap<String, u64> {
+    let text = std::fs::read_to_string(BASELINE_PATH)
+        .unwrap_or_else(|e| panic!("baseline 읽기 실패 {BASELINE_PATH}: {e}"));
+    text.lines()
+        .filter(|l| !l.trim().is_empty() && !l.starts_with('#'))
+        .map(|l| {
+            let (rel, n) = l.rsplit_once('\t').expect("baseline TSV 행 형식");
+            (rel.to_string(), n.parse::<u64>().expect("baseline 수치"))
+        })
+        .collect()
+}
+
+/// 문서 하나의 전 페이지를 스캔해 text-overlap 건수 합계를 센다.
+/// 로드·렌더 실패는 이 게이트의 관심사가 아니므로 None(건너뜀)으로 처리한다 —
+/// 크래시·파싱 회귀는 기존 스위트가 잡는다.
+fn count_doc(path: &Path) -> Option<u64> {
+    let bytes = std::fs::read(path).ok()?;
+    let doc = DocumentCore::from_bytes(&bytes).ok()?;
+    let opts = AnomalyOptions::default();
+    let page_count = doc.page_count();
+    let mut total = 0u64;
+    for page in 0..page_count {
+        let Ok(tree) = doc.build_page_render_tree(page) else {
+            continue;
+        };
+        let anomalies = scan_page(page, &tree.root, page_count, &opts);
+        total += anomalies.text_overlap.len() as u64;
+    }
+    Some(total)
+}
+
+#[test]
+fn text_overlaps_do_not_grow() {
+    let samples = collect_samples();
+    let baseline = load_baseline();
+
+    let workers = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4)
+        .min(8);
+    let queue = std::sync::Mutex::new(samples.into_iter());
+    let results = std::sync::Mutex::new(BTreeMap::<String, u64>::new());
+    let skipped = std::sync::atomic::AtomicUsize::new(0);
+
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| loop {
+                let item = queue.lock().unwrap().next();
+                let Some((path, rel)) = item else { break };
+                match count_doc(&path) {
+                    Some(n) => {
+                        results.lock().unwrap().insert(rel, n);
+                    }
+                    None => {
+                        skipped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                }
+            });
+        }
+    });
+
+    let results = results.into_inner().unwrap();
+    let nonzero: BTreeMap<&String, u64> = results
+        .iter()
+        .filter(|(_, &n)| n > 0)
+        .map(|(k, &v)| (k, v))
+        .collect();
+
+    eprintln!(
+        "text-overlap 스윕: 샘플 {}건(스킵 {}) / 0 아닌 문서 {}종 / 총 {}건",
+        results.len(),
+        skipped.load(std::sync::atomic::Ordering::Relaxed),
+        nonzero.len(),
+        nonzero.values().sum::<u64>(),
+    );
+
+    if let Ok(dump) = std::env::var("RHWP_TEXT_OVERLAP_DUMP") {
+        let mut out = String::new();
+        for (rel, n) in &nonzero {
+            out.push_str(&format!("{rel}\t{n}\n"));
+        }
+        std::fs::write(&dump, out).expect("dump 쓰기 실패");
+        eprintln!("현재값 dump → {dump}");
+    }
+
+    // 래칫 판정: 신규 발생 또는 증가만 실패. 감소·해소는 통과(dump 대조로 조인다).
+    let mut regressions = Vec::new();
+    for (rel, &n) in &nonzero {
+        match baseline.get(*rel) {
+            None => regressions.push(format!("신규 발생: {rel} — {n}건 (baseline 없음)")),
+            Some(&base) if n > base => regressions.push(format!("증가: {rel} — {base} → {n}건")),
+            _ => {}
+        }
+    }
+    assert!(
+        regressions.is_empty(),
+        "보이는 글자끼리 겹치는 사건(layout-anomaly text-overlap)이 늘었다.\n\
+         한 글자 위에 다른 글자가 그려지면 두 글자 모두 읽을 수 없는 확정 결함이다.\n\
+         원인 정정이 원칙이고, 의도된 변화만 baseline 에 반영한다(4.3.1 규약 준용).\n\
+         현재값 확인: RHWP_TEXT_OVERLAP_DUMP=<path> 로 재실행.\n\
+         쪽 단위 위치 확인: rhwp layout-anomaly \"<문서>\" -p <쪽> --json\n{}",
+        regressions.join("\n")
+    );
+
+    // baseline 부패 감지: 기록된 문서가 코퍼스에서 사라지면 행을 정리해야 한다.
+    let missing: Vec<&String> = baseline
+        .keys()
+        .filter(|rel| !results.contains_key(*rel))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "baseline 에 있으나 샘플에 없는 문서 — 행을 정리할 것: {missing:?}"
+    );
+}

--- a/tests/fixtures/text_overlap_baseline.tsv
+++ b/tests/fixtures/text_overlap_baseline.tsv
@@ -1,0 +1,152 @@
+2025 행정업무운영 편람(최종).hwp	15
+2025 행정업무운영 편람(최종).hwpx	15
+21_언어_기출_편집가능본.hwp	1
+3-09월_교육_통합_2023.hwp	14
+3-09월_교육_통합_2023.hwpx	14
+3-10월_교육_통합_2022.hwp	1
+3-10월_교육_통합_2022.hwpx	1
+3-11월_실전_통합_2022.hwp	11
+3-11월_실전_통합_2022.hwpx	11
+3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20.hwp	11
+3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20.hwpx	11
+3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0.hwp	14
+3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0.hwpx	14
+3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2.hwp	11
+3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2.hwpx	11
+3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2.hwp	11
+3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2.hwpx	11
+3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20.hwp	11
+3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20.hwpx	10
+3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.hwp	11
+3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.hwpx	13
+3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2.hwp	11
+3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2.hwpx	10
+3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.hwp	10
+3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.hwpx	10
+76076_regulatory_analysis.hwp	6
+80168_regulatory_analysis.hwp	9
+86712_regulatory_analysis.hwp	3
+SO-SUEOP.hwp	34
+SO-SUEOP.hwpx	34
+basic/issue1994_behindtext_table_20200830.hwp	4
+basic/sungeo.hwp	15
+exam_science.hwp	2
+group-drawing-02.hwp	5
+hwp-multi-001.hwp	202
+hwp3-sample-hwp5.hwp	3
+hwp3-sample-hwpx.hwpx	3
+hwp3-sample10-hwp5.hwp	132
+hwp3-sample10-hwpx.hwpx	132
+hwp3-sample10.hwp	189
+hwp3-sample16-hwp5-2010.hwp	20
+hwp3-sample16-hwp5-2018.hwp	20
+hwp3-sample16-hwp5-2022.hwp	20
+hwp3-sample16-hwp5-2024.hwp	20
+hwp3-sample16-hwp5.hwp	20
+hwp3-sample16-hwp5.hwpx	20
+hwp3-sample16.hwp	22
+hwp5-tbl-attr-1916.hwp	5
+hwpctl_API_v2.4.hwp	5
+hwpx/2024년 1분기 해외직접투자 보도자료 ff.hwp	78
+hwpx/2024년 1분기 해외직접투자 보도자료 ff.hwpx	78
+hwpx/2024년 2분기 해외직접투자 보도자료ff.hwpx	102
+hwpx/2024년 연간 해외직접투자 보도자료 _ ff.hwpx	256
+hwpx/2025년 1분기 해외직접투자 보도자료f.hwpx	76
+hwpx/2025년 2분기 해외직접투자 (최종).hwpx	109
+hwpx/hancom-hwp/2024년 1분기 해외직접투자 보도자료 ff.hwp	78
+hwpx/hancom-hwp/2024년 2분기 해외직접투자 보도자료ff.hwp	102
+hwpx/hancom-hwp/2024년 연간 해외직접투자 보도자료 _ ff.hwp	256
+hwpx/hancom-hwp/2025년 1분기 해외직접투자 보도자료f.hwp	76
+hwpx/hancom-hwp/2025년 2분기 해외직접투자 (최종).hwp	109
+hwpx/hancom-hwp/hang_job_01.hwp	1
+hwpx/hancom-hwp/hwpx-01.hwp	78
+hwpx/hancom-hwp/hwpx-02.hwp	256
+hwpx/hancom-hwp/hwpx-h-01.hwp	78
+hwpx/hancom-hwp/hwpx-h-02.hwp	109
+hwpx/hancom-hwp/hwpx-h-03.hwp	76
+hwpx/hancom-hwp/mel-001.hwp	7
+hwpx/hwpx-01.hwpx	78
+hwpx/hwpx-h-01.hwpx	78
+hwpx/hwpx-h-02.hwpx	109
+hwpx/hwpx-h-03.hwpx	76
+hwpx/k-water-rfp.hwpx	1
+hwpx/mel-001.hwpx	7
+hwpx/opengov/36382669_결재문서본문_’26년 제3차 강사선정 심의회 운영결과.hwpx	1
+hwpx/opengov/36384689_결재문서본문_화재발생종합보고서(제2026-298호).hwpx	3
+hwpx/opengov/36385226_결재문서본문_제2처리장 슬러지인발용 에어리프트 브로워 2호기 소모품 교체 보고.hwpx	4
+hwpx/opengov/36387103_결재문서본문_수질검사 신청 민원 처리 결과 안내.hwpx	4
+hwpx_sample2.hwp	35
+hwpx_sample2.hwpx	37
+issue-986-receipt.hwp	5
+issue1549_empty_host_float_clamp.hwpx	1
+issue1549_multipositive_float_tables.hwpx	6
+issue1853_caption_precedes_body_split.hwpx	11
+issue1858_paper_anchor_float_stack.hwpx	6
+issue1880_takeplace_host_before.hwpx	1
+issue1891/76076_regulatory_analysis.hwpx	7
+issue1891/80168_regulatory_analysis.hwpx	9
+issue1891/80250_regulatory_analysis.hwpx	2
+issue1891/86712_regulatory_analysis.hwpx	3
+issue1921/59043_regulatory_analysis.hwp	3
+issue1949_giant_cell_nested_tables_perf.hwp	8
+issue1949_giant_cell_nested_tables_perf.hwpx	8
+issue2004_cell_image_stack.hwp	1
+issue2004_cell_image_stack.hwpx	1
+issue2006/1790387_prep_final_report.hwpx	123
+issue2217/20200830.hwp	4
+issue2470/36341511_masked.hwpx	9
+issue2559/1341000_research_report_footnotes.hwp	10
+issue3637/regulatory_impact_nested_table_escape.hwpx	37
+issue3837/stored_vpos_rewind_form.hwp	4
+issue4491/30213_1.혼합단지등 제도개선 방안.hwp	3
+issue4514/sample1-repro.hwp	1
+issue4690/30098_indent_over_stored_cs.hwp	2
+issue5169_viewtext_changetracking.hwp	28
+issue5679/10857_delegation_rules.hwp	6
+issue5699/37787_regulatory_impact.hwp	2
+issue5714/1490000-200800034_vietnam_labor_report.hwp	2
+issue5724/2689441_wmf_contents_ole.hwp	1
+issue5788/tac_table_missing_anchor_line_spacing.hwp	5
+issue5793/pua_f0827_double_rule.hwp	1
+issue5870/empty_host_float_flow_advance.hwp	2
+issue5877/fragment_ghost_vrules.hwp	2
+issue5941/1490000-201600081_roadmap_research.hwp	7
+issue5966/1130000-202100008_franchise_review_report.hwp	10
+issue6030/2386771_agritech_review_form.hwp	2
+issue6031/3249937_asset_management_rules.hwpx	3
+issue6035/cgmp_evaluation_table.hwpx	1
+issue6036/156509073_police_press_release.hwpx	1
+issue6044/156513948.hwpx	3
+issue6060/30307_local_service_reform.hwp	2
+issue6086/30098_resident_registration_reform.hwp	2
+issue6111/56345_regulatory_impact_analysis.hwp	2
+issue6121/156531618_police_press_header.hwpx	1
+issue6269/156739836_public_sector_jobs_stats.hwpx	1
+issue6284/child_policy_top_caption_charts.hwpx	52
+k-water-rfp-2024.hwp	1
+k-water-rfp.hwp	1
+kps-ai.hwp	2
+mel-001.hwp	7
+multi-table-001.hwp	1
+multi-table-002.hwp	1
+synam-001.hwp	15
+table_giant_cell_overfill.hwpx	16
+table_scattered_header_rowbreak.hwp	1
+tac-img-02.hwp	1
+tac-img-02.hwpx	1
+task1716/table_scattered_header_rowbreak.hwpx	1
+task1718/table_giant_cell_overfill.hwp	1
+task1725/text_footnote_tail_overpagination.hwp	12
+task1725/text_footnote_tail_overpagination.hwpx	12
+task1753/deferred_takeplace_fill_ahead.hwp	3
+task1753/deferred_takeplace_fill_ahead.hwpx	3
+task1768/distribution_doc.hwpx	1
+task2070/1130000-201900011_D0150004-1-002_2017년기준 시장구조조사.hwp	49
+task2097/21217935_simsa_jipyo.hwp	75
+task2097/75544_pii_bunseok.hwpx	6
+task2279/36404953_gyeoljae.hwpx	1
+task2287/1342000_edu_curriculum_map.hwp	56
+task2430/1382000_domestic_violence_survey.hwp	20
+task3307/issue3307_outline_number.hwpx	3
+정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp	57
+정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwpx	77

--- a/tests/fixtures/text_overlap_baseline.tsv
+++ b/tests/fixtures/text_overlap_baseline.tsv
@@ -1,4 +1,4 @@
-2025 행정업무운영 편람(최종).hwp	15
+2025 행정업무운영 편람(최종).hwp	24
 2025 행정업무운영 편람(최종).hwpx	15
 21_언어_기출_편집가능본.hwp	1
 3-09월_교육_통합_2023.hwp	14
@@ -30,6 +30,7 @@ SO-SUEOP.hwp	34
 SO-SUEOP.hwpx	34
 basic/issue1994_behindtext_table_20200830.hwp	4
 basic/sungeo.hwp	15
+exam_kor.hwp	4
 exam_science.hwp	2
 group-drawing-02.hwp	5
 hwp-multi-001.hwp	202
@@ -64,7 +65,7 @@ hwpx/hancom-hwp/hwpx-02.hwp	256
 hwpx/hancom-hwp/hwpx-h-01.hwp	78
 hwpx/hancom-hwp/hwpx-h-02.hwp	109
 hwpx/hancom-hwp/hwpx-h-03.hwp	76
-hwpx/hancom-hwp/mel-001.hwp	7
+hwpx/hancom-hwp/mel-001.hwp	21
 hwpx/hwpx-01.hwpx	78
 hwpx/hwpx-h-01.hwpx	78
 hwpx/hwpx-h-02.hwpx	109
@@ -75,7 +76,7 @@ hwpx/opengov/36382669_결재문서본문_’26년 제3차 강사선정 심의회
 hwpx/opengov/36384689_결재문서본문_화재발생종합보고서(제2026-298호).hwpx	3
 hwpx/opengov/36385226_결재문서본문_제2처리장 슬러지인발용 에어리프트 브로워 2호기 소모품 교체 보고.hwpx	4
 hwpx/opengov/36387103_결재문서본문_수질검사 신청 민원 처리 결과 안내.hwpx	4
-hwpx_sample2.hwp	35
+hwpx_sample2.hwp	37
 hwpx_sample2.hwpx	37
 issue-986-receipt.hwp	5
 issue1549_empty_host_float_clamp.hwpx	1
@@ -101,7 +102,7 @@ issue3837/stored_vpos_rewind_form.hwp	4
 issue4491/30213_1.혼합단지등 제도개선 방안.hwp	3
 issue4514/sample1-repro.hwp	1
 issue4690/30098_indent_over_stored_cs.hwp	2
-issue5169_viewtext_changetracking.hwp	28
+issue5169_viewtext_changetracking.hwp	24
 issue5679/10857_delegation_rules.hwp	6
 issue5699/37787_regulatory_impact.hwp	2
 issue5714/1490000-200800034_vietnam_labor_report.hwp	2
@@ -126,7 +127,7 @@ issue6284/child_policy_top_caption_charts.hwpx	52
 k-water-rfp-2024.hwp	1
 k-water-rfp.hwp	1
 kps-ai.hwp	2
-mel-001.hwp	7
+mel-001.hwp	21
 multi-table-001.hwp	1
 multi-table-002.hwp	1
 synam-001.hwp	15
@@ -138,15 +139,15 @@ task1716/table_scattered_header_rowbreak.hwpx	1
 task1718/table_giant_cell_overfill.hwp	1
 task1725/text_footnote_tail_overpagination.hwp	12
 task1725/text_footnote_tail_overpagination.hwpx	12
-task1753/deferred_takeplace_fill_ahead.hwp	3
+task1753/deferred_takeplace_fill_ahead.hwp	4
 task1753/deferred_takeplace_fill_ahead.hwpx	3
 task1768/distribution_doc.hwpx	1
 task2070/1130000-201900011_D0150004-1-002_2017년기준 시장구조조사.hwp	49
 task2097/21217935_simsa_jipyo.hwp	75
 task2097/75544_pii_bunseok.hwpx	6
 task2279/36404953_gyeoljae.hwpx	1
-task2287/1342000_edu_curriculum_map.hwp	56
-task2430/1382000_domestic_violence_survey.hwp	20
+task2287/1342000_edu_curriculum_map.hwp	55
+task2430/1382000_domestic_violence_survey.hwp	18
 task3307/issue3307_outline_number.hwpx	3
 정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp	57
 정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwpx	77


### PR DESCRIPTION
## 변경 요약

`layout-anomaly` 의 글자 겹침(text-overlap) 판정을 samples 전수 래칫으로 묶어, PR 이 새
겹침을 만들면 `Build & Test` 에서 실패하게 합니다.

- `tests/cases/text_overlap_baseline.rs` — 문서별 겹침 건수 래칫
- `tests/fixtures/text_overlap_baseline.tsv` — 현재값 고정 (152 문서 / 4,371 건)
- `mydocs/working/text_overlap_gate.md` — 처리 결과

**판정 로직(`src/diagnostics/layout_anomaly.rs`)은 한 줄도 바꾸지 않았습니다.** 이 PR 에
`src/**` 변경은 없습니다. 판정기는 이미 정확합니다 — 문제는 **PR 에서 아무도 그 판정을
돌리지 않는 것**입니다.

## 왜

`.github/workflows/layout-anomaly-advisory.yml` 는 nightly advisory 입니다
(`pull_request` 트리거 주석 처리, `continue-on-error: true`). 그래서 글자 겹침 회귀가
required check 를 전부 초록으로 통과합니다.

가정이 아니라 최근에 실제로 일어난 일이고, **제 PR 이 그 사례입니다**(#6083).

| 대상 | 편람 69쪽 text-overlap |
| --- | --- |
| `devel` b1485e0a14 | 0 건 |
| PR #6083 head `cfb2646e` | **7 건** |

```
A: Page/Body/Column0/Table0/Cell4/TextLine16/TextRun0   (유의사항 상자 마지막 줄)
B: Page/Body/Column0/TextLine2/TextRun1..7              (상자 다음 본문 줄)
overlapW=102.6  overlapH=13.3  (px)
```

그 PR 은 required check 가 전부 초록이었고, 검토자가 `devel` 과 PR head 를 각각 PNG 로
렌더해 눈으로 비교한 뒤에야 발견됐습니다. 검토 코멘트에도 "CI가 통과한 이유는 이 겹침을
검사하는 시험이 없기 때문입니다" 로 남아 있습니다.

## 왜 래칫인가

`tools/layout_anomaly/ci_advisory.md` §2 가 게이트 승격을 미룬 이유는 이것이었습니다.

> 소표본에도 이미 알려진 overflow/overlap 이 있을 수 있다. 지금 강제 게이트로 켜면
> devel PR 이 한꺼번에 막힌다.

실측이 그 우려를 확인합니다 — **945 건 중 152 문서에서 4,371 건**이 이미 있습니다.
그래서 이 저장소가 같은 상황을 다른 축에서 이미 푼 방식을 그대로 씁니다.

| 축 | 게이트 | 픽스처 |
| --- | --- | --- |
| `LAYOUT_OVERFLOW_CELL` (#3668) | `tests/overflow_cell_baseline.rs` | `overflow_cell_baseline.tsv` |
| IR field sweep | `ir_field_sweep_baseline` | 동명 TSV |
| **글자 겹침 (이 PR)** | `tests/cases/text_overlap_baseline.rs` | `text_overlap_baseline.tsv` |

기존 발생은 baseline 에 싣고 **신규 발생·증가만** 실패시킵니다. 감소는 통과입니다
(dump 로 확인한 뒤 래칫을 조입니다). `local_validation.md` §4.3.0.1 의 "가능하면 최소
공개 fixture 와 자동 래칫을 마련한다" 를 이 축에 적용한 것입니다.

### required check 를 건드리지 않았습니다

required check / branch protection 변경은 운영 등급 O4 이고 #5400 이 명시적으로 범위 밖으로
남긴 결정입니다. 이 PR 은 일반 integration test 로만 들어가므로 기존 `Build & Test` 가
그대로 실행합니다 — **워크플로 변경 없이 게이트가 서고, 메인테이너 결정 항목은 열어 둡니다.**
`scripts/visual_sweep.py` 도 호출·수정하지 않았습니다.

### 판정 대상을 text-overlap 하나로 좁힌 이유

overflow / off-canvas / overlap 은 컨테이너 기하라 정상 조판의 접합·장식으로도 흔히
잡힙니다. 보이는 글자끼리 겹치는 것은 두 글자 모두 읽을 수 없게 되는 확정 결함입니다.
모듈 머리말이 `--strict` 확정 신호에 text-overlap 을 포함한 근거와 같습니다.

## 게이트가 실제로 잡는지 — 실측

말로 두지 않고 재현했습니다. 같은 워크트리에 **PR #6083 head 의 `composer.rs` diff 만**
적용하고 같은 명령을 다시 돌렸습니다.

```
증가: 2025 행정업무운영 편람(최종).hwp — 15 → 20건
증가: 2025 행정업무운영 편람(최종).hwpx — 15 → 20건
증가: task2430/1382000_domestic_violence_survey.hwp — 20 → 21건
test result: FAILED. finished in 208.77s
```

1. 게이트가 그 회귀를 **잡습니다**(편람 HWP·HWPX 각각 +5).
2. 검토자가 눈으로 본 것보다 **넓게** 잡습니다 — 검토는 편람 한 문서였는데, 래칫은
   `task2430/1382000_domestic_violence_survey.hwp` 의 +1 도 함께 보고합니다. 사람이
   렌더해 보지 않은 문서입니다.
3. 확인 뒤 `composer.rs` 는 되돌렸습니다. 이 PR 에 `src/**` 변경은 없습니다.

## baseline 의 성격 — 숨기지 않습니다

4,371 건은 "허용해도 되는 겹침"이 아니라 **아직 안 고친 겹침**입니다. 이 게이트는 그 수를
줄이지 않습니다. 늘지 않게만 합니다.

최다 문서(`hwpx/2024년 연간 해외직접투자 보도자료 _ ff.hwpx`, 256 건) 표본 분류입니다.

| 분류 | 건수 | 비율 |
| --- | --- | --- |
| 줄 높이 전체가 겹침 | 190 | 74% |
| 세로 부분 겹침(줄 높이 50% 미만) | 66 | 26% |

겹침 폭 중앙값 9.7px, 최대 38.5px 입니다. 본문 한글 글자 폭이 11~16px 이므로 다수는 글자
하나 이상이 실제로 포개집니다. 실제 형상도 인접 칸 침범입니다.

```
Cell16/TextLine1/TextRun0  x=81.2..163.2
Cell17/TextLine1/TextRun0  x=159.3..199.3   -> 4.0px 침범
```

세로 부분 겹침 26% 에는, 렌더 트리에 글자 단위 글리프 bbox 가 없어 `TextRun` 상자를
글리프 묶음으로 쓰는 데서 오는 상자 여백 근접이 섞일 수 있습니다(모듈 머리말이 밝힌
한계입니다). 판정을 조이면 baseline 이 함께 내려가므로 이 PR 범위로 넣지 않았습니다.

## 알려진 사각지대 (후속)

`scan_page` 는 페이지 트리에서 `Body` 하나만 순회합니다. `MasterPage`·`Header`·`Footer`·
`FootnoteArea` 는 스캔 대상이 아니라, 본문 글자가 바탕쪽 사이드바를 덮어도 0 건입니다.
편람 69쪽 `devel` 실측에서 본문↔바탕쪽 글자 겹침이 같은 허용치로 4 건 있는데 현재 명령은
0 을 냅니다(#5952 의 "사이드바와 겹친다" 가 이 형상입니다).

이 게이트를 먼저 세운 뒤 별도 이슈로 다루겠습니다 — 순서가 바뀌면 baseline 이 두 번
흔들립니다.

## 재생성 절차

```bash
RHWP_TEXT_OVERLAP_DUMP=<path> cargo test --profile release-test text_overlaps_do_not_grow
rhwp layout-anomaly "samples/2025 행정업무운영 편람(최종).hwp" -p 68 --json
```

## 관련 이슈

closes #6315

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음
- [x] `src/**`의 `#[cfg(test)]` 변경 없음 — 해당 없음
- [x] `cargo test` 통과 — `regression_suite_006 text_overlaps_do_not_grow` 통과 (299.46s, 945 건 스캔 / 스킵 3)
- [x] `cargo clippy -- -D warnings` 통과 (`--profile release-test --all-targets`, 9분 04초, 경고 0)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **해당 없음**. `src/**` 변경이 없어 렌더 산출물이 바뀌지 않습니다. 대신 판정 재현 명령을 위에 적었습니다.
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음 (`src/**` 변경 없음)
- [ ] rhwp-studio 변경 — 해당 없음
- [ ] 작업 증빙 캡슐 — 문서 편집이 아니라 테스트 추가라 해당 없음. 대신 위 실측 로그 원문을 실었습니다.
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 — 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: `Build & Test` 에 문서 전수 스캔 1 건이 추가됩니다.
- 재현·측정: 이 기계(Windows, release-test, worker 8)에서 **299.46s**. 선례
  `overflow_cell_baseline`(같은 수집 규칙의 전수 렌더 래칫)과 같은 자릿수이고, 그 케이스는
  `suite-policy.json` 의 `nextestPriorities` 에 `priority: 100` 으로 등재돼 있습니다.
  이 테스트도 같은 취급이 맞다고 보이면 등재는 메인테이너 판단에 맡깁니다.
- CI 러너 절대 시간은 측정하지 않았습니다.

## 스크린샷

`src/**` 변경이 없어 렌더 산출물이 바뀌지 않으므로 전후 이미지가 없습니다. 대신 이 게이트가
잡는 대상의 시각 증적은 #6083 검토에 이미 있습니다 — 같은 쪽의 `devel` / PR head 렌더
비교이고, 그때 눈으로 찾은 겹침이 이 PR 의 래칫에서 `15 → 20` 으로 나타납니다.
