### PR TITLE
Task #6330: [ci] command 층을 package 레인으로 — undo depth 게이트 skip 사각 해소

### DIFF
--- a/scripts/ci-impact-classifier.cjs
+++ b/scripts/ci-impact-classifier.cjs
@@ -2,7 +2,7 @@
 
 const fs = require('node:fs');
 
-const CLASSIFIER_VERSION = '4';
+const CLASSIFIER_VERSION = '5';
 const CODEQL_LANGUAGE_ORDER = ['javascript-typescript', 'python', 'rust'];
 const FRONTEND_MODE_RANK = { none: 0, unit: 1, package: 2 };
 
@@ -314,7 +314,11 @@ function classifyChanges(input = {}) {
     }
 
     if (isStudioKnownNonRenderSource(filename)) {
-      requireFrontend('unit', 'studio-unit');
+      // [#6330] command 층과 히스토리 코어(engine/command.ts)는 스냅샷 진입점이
+      // 밀집한 undo 경로다 — undo depth 게이트(#5769)는 frontend-package-gates
+      // (실 wasm)에서만 돌므로 unit 레인이면 게이트가 통째로 skip 된다.
+      // 렌더 축은 계속 끈 채(Render Diff 불필요) package 레인만 강제한다.
+      requireFrontend('package', 'studio-undo-package');
       continue;
     }
 

--- a/scripts/ci-impact-classifier.cjs
+++ b/scripts/ci-impact-classifier.cjs
@@ -318,6 +318,9 @@ function classifyChanges(input = {}) {
       // 밀집한 undo 경로다 — undo depth 게이트(#5769)는 frontend-package-gates
       // (실 wasm)에서만 돌므로 unit 레인이면 게이트가 통째로 skip 된다.
       // 렌더 축은 계속 끈 채(Render Diff 불필요) package 레인만 강제한다.
+      // 디렉터리 단위 과근사는 의도다: 스냅샷 없는 command 파일(shortcut-map 등)도
+      // 함께 승격되지만, 목록을 파일 단위로 좁히면 신규 command 파일이 아래
+      // rhwp-studio/ catch-all(render_required 동반)로 떨어져 더 비싸진다.
       requireFrontend('package', 'studio-undo-package');
       continue;
     }

--- a/scripts/tests/ci-impact-classifier.test.cjs
+++ b/scripts/tests/ci-impact-classifier.test.cjs
@@ -72,7 +72,7 @@ test('review-only changes require no code worker', () => {
       native_skia_required: 'false',
       codeql_languages: 'none',
       classification_status: 'classified',
-      classifier_version: '4',
+      classifier_version: '5',
       reason: 'classified:review-only',
     },
   );
@@ -94,7 +94,7 @@ test('mixed Studio package and Rust changes union modes and CodeQL languages', (
       native_skia_required: 'false',
       codeql_languages: 'javascript-typescript,rust',
       classification_status: 'classified',
-      classifier_version: '4',
+      classifier_version: '5',
       reason: 'classified:rust+studio-package',
     },
   );
@@ -164,7 +164,7 @@ test('every CLI output adapter belongs to one explicit impact bucket', () => {
     assert.equal(result.native_skia_required, nativeSkiaRequired, filename);
     assert.equal(result.codeql_languages, 'rust', filename);
     assert.equal(result.classification_status, 'classified', filename);
-    assert.equal(result.classifier_version, '4', filename);
+    assert.equal(result.classifier_version, '5', filename);
     assert.equal(result.reason, reason, filename);
   }
 });
@@ -190,7 +190,7 @@ test('Native Skia integration test and support changes run Rust and Native Skia 
     assert.equal(result.native_skia_required, 'true', filename);
     assert.equal(result.codeql_languages, 'rust', filename);
     assert.equal(result.classification_status, 'classified', filename);
-    assert.equal(result.classifier_version, '4', filename);
+    assert.equal(result.classifier_version, '5', filename);
     assert.equal(result.reason, 'classified:native-skia-rust', filename);
   }
 });
@@ -210,7 +210,7 @@ test('Rust test input changes keep default Rust tests alongside render gates', (
     assert.equal(result.native_skia_required, 'true', filename);
     assert.equal(result.codeql_languages, 'none', filename);
     assert.equal(result.classification_status, 'classified', filename);
-    assert.equal(result.classifier_version, '4', filename);
+    assert.equal(result.classifier_version, '5', filename);
     assert.equal(result.reason, 'classified:rust-test-input', filename);
   }
 });
@@ -251,10 +251,27 @@ test('Studio package configuration and broad runtime sources remain render-impac
   }
 });
 
-test('known command sources and non-render tests stay on the unit lane', () => {
+test('command-layer sources require the package lane for the undo depth gate', () => {
+  // [#6330] undo depth 게이트(#5769)는 frontend-package-gates 에서만 돈다 —
+  // 스냅샷 진입점이 밀집한 command 층이 unit 으로 분류되면 게이트가 skip 된다.
   for (const filename of [
     'rhwp-studio/src/command/shortcut-map.ts',
+    'rhwp-studio/src/command/commands/table.ts',
+    'rhwp-studio/src/command/commands/page.ts',
     'rhwp-studio/src/engine/command.ts',
+  ]) {
+    const result = classifyChanges({
+      eventName: 'pull_request',
+      files: [{ filename, status: 'modified' }],
+    });
+    assert.equal(result.frontend_mode, 'package', filename);
+    assert.equal(result.render_required, 'false', filename);
+    assert.equal(result.reason, 'classified:studio-undo-package', filename);
+  }
+});
+
+test('studio test-only changes stay on the unit lane', () => {
+  for (const filename of [
     'rhwp-studio/tests/shortcut-map.test.ts',
     'rhwp-studio/tests/canvaskit-readiness.test.ts',
     'rhwp-studio/tests/render-page.test.ts',
@@ -288,7 +305,7 @@ test('new review reference assets require no product or CodeQL worker', () => {
     assert.equal(result.native_skia_required, 'false', filename);
     assert.equal(result.codeql_languages, 'none', filename);
     assert.equal(result.classification_status, 'classified', filename);
-    assert.equal(result.classifier_version, '4', filename);
+    assert.equal(result.classifier_version, '5', filename);
     assert.equal(result.reason, 'classified:review-only', filename);
   }
 });

--- a/scripts/tests/ci-impact-policy.test.cjs
+++ b/scripts/tests/ci-impact-policy.test.cjs
@@ -48,7 +48,7 @@ function classificationFor(files) {
 
 function policyInput(overrides = {}) {
   const files = overrides.files || [
-    { filename: 'rhwp-studio/src/command/shortcut-map.ts', status: 'modified' },
+    { filename: 'rhwp-studio/tests/shortcut-map.test.ts', status: 'modified' },
   ];
   return {
     repository: 'edwardkim/rhwp',
@@ -369,7 +369,7 @@ test('compact status description round-trips workflow and impact axes', () => {
   assert.ok(policy.status_description.length <= 140);
   assert.deepEqual(parseStatusDescription(policy.status_description), {
     v: '5',
-    cv: '4',
+    cv: '5',
     mode: 'selective',
     rfp: '0',
     wf: '111',

--- a/scripts/tests/ci-impact-policy.test.cjs
+++ b/scripts/tests/ci-impact-policy.test.cjs
@@ -48,6 +48,9 @@ function classificationFor(files) {
 
 function policyInput(overrides = {}) {
   const files = overrides.files || [
+    // [#6330] 기본 예시는 unit 레인을 유지해야 한다 — 이 기본값을 쓰는 테스트들이
+    // frontendExpected 의 unit 분기(['success','skipped'])를 커버한다. src/command
+    // 경로는 studio-undo-package 로 package 레인이 되므로 tests/ 파일을 쓴다.
     { filename: 'rhwp-studio/tests/shortcut-map.test.ts', status: 'modified' },
   ];
   return {

--- a/scripts/tests/fixtures/ci-impact-classifier-output-adapters.json
+++ b/scripts/tests/fixtures/ci-impact-classifier-output-adapters.json
@@ -14,7 +14,7 @@
       "native_skia_required": "true",
       "codeql_languages": "rust",
       "classification_status": "classified",
-      "classifier_version": "4",
+      "classifier_version": "5",
       "reason": "classified:native-skia-rust+rust+rust-render"
     }
   }

--- a/scripts/tests/fixtures/ci-impact-classifier-prs.json
+++ b/scripts/tests/fixtures/ci-impact-classifier-prs.json
@@ -14,13 +14,13 @@
     ],
     "expected": {
       "rust_required": "false",
-      "frontend_mode": "unit",
+      "frontend_mode": "package",
       "render_required": "false",
       "native_skia_required": "false",
       "codeql_languages": "javascript-typescript",
       "classification_status": "classified",
-      "classifier_version": "4",
-      "reason": "classified:studio-unit"
+      "classifier_version": "5",
+      "reason": "classified:studio-undo-package+studio-unit"
     }
   },
   {
@@ -32,13 +32,30 @@
     ],
     "expected": {
       "rust_required": "false",
-      "frontend_mode": "unit",
+      "frontend_mode": "package",
       "render_required": "false",
       "native_skia_required": "false",
       "codeql_languages": "javascript-typescript",
       "classification_status": "classified",
-      "classifier_version": "4",
-      "reason": "classified:studio-unit"
+      "classifier_version": "5",
+      "reason": "classified:studio-undo-package+studio-unit"
+    }
+  },
+  {
+    "pr": 5953,
+    "title": "[undo][draft] 교차 구역 선택 삭제의 스냅샷 폴백 방어 (#5769 정산)",
+    "files": [
+      { "filename": "rhwp-studio/src/engine/command.ts", "status": "modified" }
+    ],
+    "expected": {
+      "rust_required": "false",
+      "frontend_mode": "package",
+      "render_required": "false",
+      "native_skia_required": "false",
+      "codeql_languages": "javascript-typescript",
+      "classification_status": "classified",
+      "classifier_version": "5",
+      "reason": "classified:studio-undo-package"
     }
   },
   {
@@ -59,7 +76,7 @@
       "native_skia_required": "false",
       "codeql_languages": "javascript-typescript",
       "classification_status": "classified",
-      "classifier_version": "4",
+      "classifier_version": "5",
       "reason": "classified:studio-package+studio-unit"
     }
   },
@@ -78,7 +95,7 @@
       "native_skia_required": "false",
       "codeql_languages": "javascript-typescript",
       "classification_status": "classified",
-      "classifier_version": "4",
+      "classifier_version": "5",
       "reason": "classified:studio-render-package+studio-unit"
     }
   },
@@ -144,7 +161,7 @@
       "native_skia_required": "true",
       "codeql_languages": "javascript-typescript,python,rust",
       "classification_status": "full",
-      "classifier_version": "4",
+      "classifier_version": "5",
       "reason": "fail-closed:cargo-contract"
     }
   },
@@ -163,7 +180,7 @@
       "native_skia_required": "true",
       "codeql_languages": "rust",
       "classification_status": "classified",
-      "classifier_version": "4",
+      "classifier_version": "5",
       "reason": "classified:native-skia-rust"
     }
   }


### PR DESCRIPTION
관련 이슈: #6330

## 문제

undo depth 게이트(#5769)는 `frontend-package-gates` 에서만 도는데, 분류기가 스냅샷 진입점이 밀집한 command 층(`rhwp-studio/src/command/**`, `rhwp-studio/src/engine/command.ts`)을 unit 레인으로 판정해 정작 undo 예산을 바꾸는 PR 에서 게이트가 skip 됩니다(실물: PR #5953 — `engine/command.ts` 단독 변경에 `Frontend package gates: skipping`).

## 원인

`scripts/ci-impact-classifier.cjs:316` 의 `requireFrontend('unit', 'studio-unit')`. #3790 Stage 4 시점에는 "렌더 무관 = unit 으로 충분"이 참이었지만, #6072 로 실 wasm 전제 undo depth 게이트가 package 레인에 들어오며 전제가 무효화됐습니다. 상세는 이슈 참조.

## 변경

- **분류기**: command 층을 `requireFrontend('package', 'studio-undo-package')` 로 승격. 렌더 축은 그대로 끔(`render_required=false` — Render Diff·Native Skia 불필요, 기존 hwpctl 의 `studio-package` 와 동형). `CLASSIFIER_VERSION` 4 → 5.
- **분류기 테스트**: 기존 통합 테스트("command 소스와 비렌더 테스트는 unit")를 둘로 분리 —
  - command 층 → package 레인 + `render_required=false` + reason pin (회귀 가드),
  - `rhwp-studio/tests/**` 전용 → unit 레인 유지.
- **기록 PR fixture**: #3785·#3656 기대를 package 로 갱신하고, 이 사각의 실물 표본 **#5953 을 fixture 로 추가**(단독 `engine/command.ts` → package). cv pin 전체 5 로 bump.
- **policy 테스트**: 기본 unit 예시 파일을 `src/command/shortcut-map.ts` → `tests/shortcut-map.test.ts` 로 교체(분류 결과 불변 유지), status description cv pin 5.

워크플로(yml)·게이트 본문은 변경하지 않습니다 — 분류만 고칩니다.

## 검증

devel `f6a6bee8f` 기준.

- **수정 전 실패 증명**: devel 분류기 그대로 두고 이 PR 의 테스트만 적용하면 15건 실패 — historical PR fixture #3656(스냅샷 롤백 수정 PR)·#5953 이 `frontend_mode=unit` 으로 판정되어 기대 `package` 와 어긋남. 분류기 CLI 실측도 동일(`engine/command.ts` 단독 → `unit`).
- 수정 후: `node --test scripts/tests/ci-impact-classifier.test.cjs scripts/tests/ci-impact-policy.test.cjs` 67/67 통과.
- `python scripts/tests/test_ci_impact_workflow.py` 31 OK · `test_undo_depth_e2e_workflow.py` 5 OK · `test_codeql_workflow.py` 16 OK (reason 은 languages 축과 달리 allowlist 검증이 없어 신규 토큰 추가 없이 통과 — `codeql.yml` 의 finalizer 는 언어 조합만 검증).
- 레인 비용: command 층 PR 의 frontend job 이 unit(~1분) → package(~6.5분, #6297 실측 6m37s). package 잡은 Studio unit tests·실 wasm 타입 tsc·Build 를 포함하므로 검증 커버리지는 상위집합.

## 범위 외

- `rhwp-studio/tests/**` 전용 변경은 unit 레인 유지.
- 게이트 자체(`e2e/undo-depth-issue5769.test.mjs`)·ci.yml 변경 없음.


## 독립 리뷰 반영 (2026-08-29, head `069cbfcff`)

- **Rust 절반 사각**: `document_core`의 `MAX_SNAPSHOTS`(studio `WASM_MAX_SNAPSHOTS`와 양방향 결합, `document.rs:2021`)만 바꾸는 순 Rust PR은 여전히 `frontend_mode=none`으로 게이트가 안 돕니다. 분류 문제가 아니라 상수 결합 가드 부재가 본질이라(모든 `.rs` 변경에 브라우저 e2e는 과대) **#6332로 분리 추적**합니다 — 이 PR의 "사각 해소"는 studio 절반입니다.
- **unit 레인 축퇴**: 이 변경 후 unit 레인은 `rhwp-studio/tests/**` 전용 변경에서만 발화합니다(합성 테스트로 도달성 pin). 골든 코퍼스의 unit 표본은 0이 됐는데, tests-전용 실물 PR이 이력에 없어 표본 추가는 보류했습니다. unit 레인·전용 인프라(`tsconfig.ci-unit.json` 등)의 존치/은퇴 판단은 메인테이너께 위임합니다.
- **레인 비용 근거**: package 잡 실측 6m37s — [run 33168892716](https://github.com/edwardkim/rhwp/actions/runs/33168892716) (#6297 devel push, Frontend package gates 11:54:21→12:00:58). 캐시 미스 시 이를 상회할 수 있습니다.
- 과근사 의도(비스냅샷 command 파일 동반 승격)와 policy 기본값 교체 의도는 `069cbfcff`에서 주석으로 고정했습니다.
