### PR TITLE
Task #6332: 스냅샷 예산 상수의 Rust–studio 결합을 양 레인에서 기계 검증

### DIFF
--- a/rhwp-studio/tests/command-history-snapshot.test.ts
+++ b/rhwp-studio/tests/command-history-snapshot.test.ts
@@ -155,6 +155,18 @@ test('[결함1] 스냅샷 예산은 WASM 상한에서 순간 여유를 뺀 값�
     'WASM MAX_SNAPSHOTS(document.rs) 미러 상수가 있어야 함');
   assert.match(history, /const SNAPSHOT_ID_BUDGET = WASM_MAX_SNAPSHOTS - 2;/,
     '예산은 MAX - 2 (순간 +2 여유) 여야 함 — MAX 와 같으면 orphan 회귀');
+  // [#6332] 상수 결합의 studio 레인 절반 — 리터럴 pin 만으로는 결합 자체가 검증되지
+  // 않아, Rust store 상한이 studio 피크 참조 수(예산 + 순간 2 = WASM_MAX_SNAPSHOTS)를
+  // 항상 덮는지 document.rs 를 직접 읽어 기계 검증한다. rust 레인 절반(순 Rust 변경은
+  // 이 파일이 안 돎)은 tests/cases/issue_6332_snapshot_budget_coupling.rs 가 담당한다.
+  const documentRs = source('../src/document_core/commands/document.rs');
+  const rustMax = Number(/const MAX_SNAPSHOTS: usize = (\d+);/.exec(documentRs)?.[1]);
+  const wasmMax = Number(/const WASM_MAX_SNAPSHOTS = (\d+);/.exec(history)?.[1]);
+  assert.ok(Number.isInteger(rustMax),
+    'document.rs 의 MAX_SNAPSHOTS 선언을 찾지 못함 — 선언 형태가 바뀌었으면 이 가드를 갱신');
+  assert.ok(Number.isInteger(wasmMax), 'WASM_MAX_SNAPSHOTS 선언을 찾지 못함');
+  assert.ok(rustMax >= wasmMax,
+    `Rust MAX_SNAPSHOTS(${rustMax}) < studio 피크 참조 수(${wasmMax}) — 참조 중 스냅샷 무통보 축출 (#2328/#6332)`);
   // 예산 강제 헬퍼: 예산 초과 시 undo 스택 front 를 shift + discard.
   const block = methodBlock(history, 'enforceSnapshotBudget(wasm: WasmBridge): void {');
   assert.match(block, /liveSnapshotIds\(\)\s*>\s*SNAPSHOT_ID_BUDGET/, '예산 초과 판정');

--- a/rhwp-studio/tests/command-history-snapshot.test.ts
+++ b/rhwp-studio/tests/command-history-snapshot.test.ts
@@ -151,22 +151,26 @@ test('[결함1] 스냅샷 예산은 WASM 상한에서 순간 여유를 뺀 값�
   // [Task #5769] after 지연 저장 이후 execute 의 순간 저장은 before 하나(+1)이고 undo 의
   // 순간 저장도 +1 이라 여유 2 는 그대로 충분하다 — 상수는 Rust MAX_SNAPSHOTS 와
   // 양방향 결합이므로 여유가 남는다고 좁히지 않는다.
-  assert.match(history, /const WASM_MAX_SNAPSHOTS = 100;/,
+  assert.match(history, /^const WASM_MAX_SNAPSHOTS = 100;/m,
     'WASM MAX_SNAPSHOTS(document.rs) 미러 상수가 있어야 함');
-  assert.match(history, /const SNAPSHOT_ID_BUDGET = WASM_MAX_SNAPSHOTS - 2;/,
+  assert.match(history, /^const SNAPSHOT_ID_BUDGET = WASM_MAX_SNAPSHOTS - 2;/m,
     '예산은 MAX - 2 (순간 +2 여유) 여야 함 — MAX 와 같으면 orphan 회귀');
   // [#6332] 상수 결합의 studio 레인 절반 — 리터럴 pin 만으로는 결합 자체가 검증되지
-  // 않아, Rust store 상한이 studio 피크 참조 수(예산 + 순간 2 = WASM_MAX_SNAPSHOTS)를
-  // 항상 덮는지 document.rs 를 직접 읽어 기계 검증한다. rust 레인 절반(순 Rust 변경은
-  // 이 파일이 안 돎)은 tests/cases/issue_6332_snapshot_budget_coupling.rs 가 담당한다.
+  // 않아, Rust store 상한이 studio 피크 동시 참조 수를 항상 덮는지 document.rs 를
+  // 직접 읽어 기계 검증한다. 피크는 예산(W-2) + 순간 저장 1 = W-1 이다 — #5769 이후
+  // before/after 저장은 서로 다른 시점이고 각 저장 사이에 예산 강제가 돈다(위 주석과
+  // 동일 사실). 가드는 미러 관습대로 동치 이상(MAX >= W, 여유 1)을 요구한다.
+  // rust 레인 절반(순 Rust 변경은 이 파일이 안 돎)은
+  // tests/cases/issue_6332_snapshot_budget_coupling.rs 가 담당한다.
+  // 선언 앵커는 줄 시작(^…/m) — 주석 속 인용의 첫-매치 오염을 막는다.
   const documentRs = source('../src/document_core/commands/document.rs');
-  const rustMax = Number(/const MAX_SNAPSHOTS: usize = (\d+);/.exec(documentRs)?.[1]);
-  const wasmMax = Number(/const WASM_MAX_SNAPSHOTS = (\d+);/.exec(history)?.[1]);
+  const rustMax = Number(/^\s*const MAX_SNAPSHOTS: usize = (\d+);/m.exec(documentRs)?.[1]);
+  const wasmMax = Number(/^const WASM_MAX_SNAPSHOTS = (\d+);/m.exec(history)?.[1]);
   assert.ok(Number.isInteger(rustMax),
-    'document.rs 의 MAX_SNAPSHOTS 선언을 찾지 못함 — 선언 형태가 바뀌었으면 이 가드를 갱신');
-  assert.ok(Number.isInteger(wasmMax), 'WASM_MAX_SNAPSHOTS 선언을 찾지 못함');
+    'document.rs 의 MAX_SNAPSHOTS 선언 줄을 찾지 못함 — 선언 형태가 바뀌었으면 이 가드를 갱신');
+  assert.ok(Number.isInteger(wasmMax), 'history.ts 의 WASM_MAX_SNAPSHOTS 선언 줄을 찾지 못함');
   assert.ok(rustMax >= wasmMax,
-    `Rust MAX_SNAPSHOTS(${rustMax}) < studio 피크 참조 수(${wasmMax}) — 참조 중 스냅샷 무통보 축출 (#2328/#6332)`);
+    `Rust MAX_SNAPSHOTS(${rustMax}) < studio WASM_MAX_SNAPSHOTS(${wasmMax}) — 피크 동시 참조(${wasmMax}-1)를 덮지 못해 참조 중 스냅샷이 무통보 축출된다 (#2328/#6332)`);
   // 예산 강제 헬퍼: 예산 초과 시 undo 스택 front 를 shift + discard.
   const block = methodBlock(history, 'enforceSnapshotBudget(wasm: WasmBridge): void {');
   assert.match(block, /liveSnapshotIds\(\)\s*>\s*SNAPSHOT_ID_BUDGET/, '예산 초과 판정');

--- a/tests/cases/issue_6332_snapshot_budget_coupling.rs
+++ b/tests/cases/issue_6332_snapshot_budget_coupling.rs
@@ -1,0 +1,52 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! [#6332] 스냅샷 예산 상수의 Rust–studio 결합 가드 (rust 레인 절반).
+//!
+//! document_core 의 store 축출 상한 `MAX_SNAPSHOTS`(document.rs)와 studio 의
+//! `WASM_MAX_SNAPSHOTS`(history.ts)는 주석으로만 결합돼 있었다 — 순 Rust 변경은
+//! frontend 두 레인이 모두 skip 되므로(undo depth 게이트 #5769 포함) 상수를
+//! 낮추고 studio 갱신을 잊어도 CI 가 그린이었다. 이 테스트가 rust 레인에서
+//! 결합을 기계 검증한다. studio 방향 절반은
+//! rhwp-studio/tests/command-history-snapshot.test.ts 의 소스 가드가 담당한다.
+//!
+//! 안전 관계: studio 는 예산 `SNAPSHOT_ID_BUDGET = WASM_MAX_SNAPSHOTS - 2` 개의
+//! live id 에 순간 저장 +2(execute 의 before, undo 시점의 after)를 더해 최대
+//! `WASM_MAX_SNAPSHOTS` 개를 동시 참조한다. store 상한이 그보다 작으면 참조 중
+//! 스냅샷이 무통보 축출돼 undo 예외가 재발한다(#2328).
+//! 따라서 `MAX_SNAPSHOTS >= WASM_MAX_SNAPSHOTS`.
+
+use std::path::Path;
+
+fn read(rel: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{rel} 읽기 실패: {e}"))
+}
+
+fn parse_const(source: &str, pattern: &str, label: &str) -> usize {
+    let start = source.find(pattern).unwrap_or_else(|| {
+        panic!("{label} 선언(`{pattern}`)이 없다 — 선언 형태가 바뀌었으면 이 가드를 함께 갱신하라")
+    });
+    let digits: String = source[start + pattern.len()..]
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    digits
+        .parse()
+        .unwrap_or_else(|_| panic!("{label} 값 파싱 실패"))
+}
+
+#[test]
+fn rust_store_cap_covers_studio_peak_references() {
+    let rust = read("src/document_core/commands/document.rs");
+    let studio = read("rhwp-studio/src/engine/history.ts");
+
+    let max_snapshots = parse_const(&rust, "const MAX_SNAPSHOTS: usize = ", "MAX_SNAPSHOTS");
+    let wasm_max = parse_const(&studio, "const WASM_MAX_SNAPSHOTS = ", "WASM_MAX_SNAPSHOTS");
+
+    assert!(
+        max_snapshots >= wasm_max,
+        "document.rs MAX_SNAPSHOTS({max_snapshots}) < studio 피크 참조 수({wasm_max} = \
+         SNAPSHOT_ID_BUDGET + 순간 2) — studio 가 참조 중인 스냅샷이 무통보 축출된다. \
+         양쪽 상수를 함께 갱신하라 (#2328, #6332)"
+    );
+}

--- a/tests/cases/issue_6332_snapshot_budget_coupling.rs
+++ b/tests/cases/issue_6332_snapshot_budget_coupling.rs
@@ -9,11 +9,18 @@
 //! 결합을 기계 검증한다. studio 방향 절반은
 //! rhwp-studio/tests/command-history-snapshot.test.ts 의 소스 가드가 담당한다.
 //!
-//! 안전 관계: studio 는 예산 `SNAPSHOT_ID_BUDGET = WASM_MAX_SNAPSHOTS - 2` 개의
-//! live id 에 순간 저장 +2(execute 의 before, undo 시점의 after)를 더해 최대
-//! `WASM_MAX_SNAPSHOTS` 개를 동시 참조한다. store 상한이 그보다 작으면 참조 중
-//! 스냅샷이 무통보 축출돼 undo 예외가 재발한다(#2328).
-//! 따라서 `MAX_SNAPSHOTS >= WASM_MAX_SNAPSHOTS`.
+//! 안전 관계: studio 의 피크 동시 참조는 예산 `SNAPSHOT_ID_BUDGET`(= W−2)에
+//! 순간 저장 1 을 더한 **W−1** 이다 — #5769 이후 execute 의 before 와 undo
+//! 시점의 after 는 서로 다른 시점에 저장되고 각 저장 사이에 예산 강제가 돈다
+//! (saveSnapshot 호출부는 command.ts 두 곳뿐). store 상한이 피크 밑이면 참조 중
+//! 스냅샷이 무통보 축출된다(#2328). 가드는 미러 관습(양쪽 동치 유지)대로
+//! `MAX_SNAPSHOTS >= WASM_MAX_SNAPSHOTS` 를 요구한다 — 최소 충분(W−1)보다
+//! 한 슬롯 엄격하며, 여유 1 을 계약으로 고정하는 선택이다.
+//! (부기: 축출 루프의 length>1 바닥 때문에 W<6 미소값에서는 예산 자체가 안
+//! 지켜질 수 있으나 현행 100 에서는 무관하다.)
+//!
+//! 파싱은 줄 단위 구조 매칭 — 주석 줄(`//`·`*` 시작)은 trim 후 선언 접두사로
+//! 시작할 수 없어 구조적으로 탈락한다(주석 인용의 첫-매치 오염 방지, 리뷰 P1-1).
 
 use std::path::Path;
 
@@ -22,17 +29,18 @@ fn read(rel: &str) -> String {
     std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{rel} 읽기 실패: {e}"))
 }
 
-fn parse_const(source: &str, pattern: &str, label: &str) -> usize {
-    let start = source.find(pattern).unwrap_or_else(|| {
-        panic!("{label} 선언(`{pattern}`)이 없다 — 선언 형태가 바뀌었으면 이 가드를 함께 갱신하라")
-    });
-    let digits: String = source[start + pattern.len()..]
-        .chars()
-        .take_while(|c| c.is_ascii_digit())
-        .collect();
+/// 선언 줄(들여쓰기 허용)에서만 값을 읽는다 — 주석 속 인용은 매치되지 않는다.
+fn parse_decl(source: &str, rel: &str, prefix: &str) -> usize {
+    let rest = source
+        .lines()
+        .find_map(|line| line.trim_start().strip_prefix(prefix))
+        .unwrap_or_else(|| {
+            panic!("{rel}: 선언 줄(`{prefix}…`)이 없다 — 선언 형태가 바뀌었으면 이 가드를 함께 갱신하라")
+        });
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
     digits
         .parse()
-        .unwrap_or_else(|_| panic!("{label} 값 파싱 실패"))
+        .unwrap_or_else(|_| panic!("{rel}: `{prefix}` 값 파싱 실패"))
 }
 
 #[test]
@@ -40,13 +48,22 @@ fn rust_store_cap_covers_studio_peak_references() {
     let rust = read("src/document_core/commands/document.rs");
     let studio = read("rhwp-studio/src/engine/history.ts");
 
-    let max_snapshots = parse_const(&rust, "const MAX_SNAPSHOTS: usize = ", "MAX_SNAPSHOTS");
-    let wasm_max = parse_const(&studio, "const WASM_MAX_SNAPSHOTS = ", "WASM_MAX_SNAPSHOTS");
+    let max_snapshots = parse_decl(
+        &rust,
+        "src/document_core/commands/document.rs",
+        "const MAX_SNAPSHOTS: usize = ",
+    );
+    let wasm_max = parse_decl(
+        &studio,
+        "rhwp-studio/src/engine/history.ts",
+        "const WASM_MAX_SNAPSHOTS = ",
+    );
 
     assert!(
         max_snapshots >= wasm_max,
-        "document.rs MAX_SNAPSHOTS({max_snapshots}) < studio 피크 참조 수({wasm_max} = \
-         SNAPSHOT_ID_BUDGET + 순간 2) — studio 가 참조 중인 스냅샷이 무통보 축출된다. \
+        "document.rs MAX_SNAPSHOTS({max_snapshots}) < studio WASM_MAX_SNAPSHOTS({wasm_max}) — \
+         studio 피크 동시 참조는 {wasm_max}-1(예산 + 순간 저장 1)이고 미러 계약은 동치 이상을 \
+         요구한다. 상한이 피크 밑이면 참조 중 스냅샷이 무통보 축출된다. \
          양쪽 상수를 함께 갱신하라 (#2328, #6332)"
     );
 }


### PR DESCRIPTION
관련 이슈: #6332

## 문제

스냅샷 예산 상수의 Rust–studio 결합(`document.rs` `MAX_SNAPSHOTS` ↔ `history.ts` `WASM_MAX_SNAPSHOTS`)이 주석으로만 지켜져, 순 Rust 변경에서는 frontend 레인이 전부 skip이라(undo depth 게이트 #5769 포함) 결합 위반이 CI 그린으로 통과합니다.

## 원인

결합 계약의 기계 검증이 어느 레인에도 없습니다. 게이트는 실 wasm+브라우저 전제라 package 레인 전용이 정당하고, 모든 `.rs` 변경에 브라우저 e2e를 도는 레인 확장은 과대합니다 — 각 레인에 결합 가드를 두는 것이 맞습니다(상세: #6332).

## 변경

- **rust 레인 절반** — `tests/cases/issue_6332_snapshot_budget_coupling.rs`(신규): 두 선언을 텍스트로 읽어 `MAX_SNAPSHOTS >= WASM_MAX_SNAPSHOTS` 를 검증합니다. 관계 도출(리뷰 반영으로 정정): studio 피크 **동시** 참조 = `SNAPSHOT_ID_BUDGET`(=W−2) + 순간 저장 1 = **W−1** — #5769 이후 execute 의 before 와 undo 시점의 after 는 서로 다른 시점에 저장되고 각 저장 사이에 예산 강제가 돕니다(`saveSnapshot` 호출부는 command.ts 2곳뿐). 최소 충분은 `MAX >= W−1`이지만, 가드는 미러 관습(양쪽 동치 유지)대로 `MAX >= W`(여유 1)를 계약으로 고정합니다. store 상한이 피크 밑이면 참조 중 스냅샷이 무통보 축출됩니다(#2328). 테스트 매니페스트 자동 배정: `regression_suite_025`.
- **studio 레인 절반** — 기존 소스 가드 `rhwp-studio/tests/command-history-snapshot.test.ts` [결함1]에 관계 검증 추가: 리터럴 pin(100)만으로는 결합 자체가 검증되지 않아 `document.rs` 를 직접 읽어 같은 관계를 확인합니다.
- 텍스트 계약 방식은 저장소 관용구를 따랐습니다(`tests/*_contract.rs` 의 read_to_string 계약, studio 소스 가드, `scripts/tests` 의 ci.yml 텍스트 계약). 선언을 못 찾으면 그 자체로 실패 — 선언 형태 변경 시 가드 갱신을 강제합니다.

## 검증

devel `f6a6bee8f` 기준.

- **수정 전 실패 증명(교란)**: ① `document.rs` 100→98 — rust 가드 FAILED(`MAX_SNAPSHOTS(98) < studio 피크 참조 수(100)`) + studio 가드도 동일 관계로 fail. ② `history.ts` 100→128 — studio 가드 fail. 각각 원복 후 그린(`git diff src` 0줄 확인).
- rust: `cargo test --release --test regression_suite_025 rust_store_cap` 1 passed. rustfmt·clippy(해당 target) 클린.
- studio: 해당 테스트 파일 10/10. 전체 `npm run test` 1106 중 1091 pass / 14 fail — 실패 14건은 wasm 미빌드 worktree 환경 기인으로, **변경 stash 전후 결과가 동일**함을 대조해 변경 무관을 증명했습니다.

## 범위 외

- 런타임 단일 소스화(wasm API 로 예산을 export 해 studio 가 파생) — wasm-contract 확장이라 별개 판단, #5890 계열 후속 후보.
- 상수 값 자체의 조정(#5769 실측 확정값) · 게이트(`e2e/undo-depth-issue5769.test.mjs`) 내용.



## 독립 리뷰 반영 (head `fa3220f6a`)

- **P1-1 파싱 오염**: 두 가드의 첫-매치 파싱이 주석 속 선언 인용(예: "종전 값은 `const WASM_MAX_SNAPSHOTS = 100;`")에 잡혀, 실제 상수를 200 으로 올린 2배 위반을 양 레인 그린으로 통과시켰습니다(리뷰 재현). rust 는 줄 단위 `trim_start().strip_prefix`(주석 줄 구조 탈락), studio 는 `^…/m` 앵커 정규식으로 교체했고, 같은 오염에 함께 무력화되던 **기존 리터럴 pin 2개**(`WASM_MAX_SNAPSHOTS = 100`, `SNAPSHOT_ID_BUDGET = … - 2`)도 앵커로 강화했습니다. 수정 후 디코이+200 교란에서 양 가드 발화를 재확인했습니다.
- **P1-2 근거 정정**: 위 "관계 도출" 문단을 사실(피크 = W−1)로 교체했습니다 — 초판의 "순간 저장 2 동시" 서술과 "rust=99 축출 경로" 예시는 오류였습니다(99 는 실제로 안전한 구성). 경계값 `MAX >= W` 자체는 안전 방향이라 유지 — 미러 동치 관습을 계약으로 고정하는 선택이며, W−1 완화 여부는 메인테이너 판단에 맡깁니다.
- **P3**: 축출 바닥(`length>1`) 때문에 W<6 미소값에서 관계가 불충분하다는 부기, 파싱 실패 메시지의 파일명 라벨을 반영했습니다. `recordWithoutExecute` 의 예산 미강제(기존 문제, 현재 무해)는 P3 적립 PR #5953 원장에 기록했습니다.
