### PR TITLE
Task #6335: 전문 소스 가드 pin 을 주석 오염에서 차단 — codeOnly 헬퍼 + 고위험 48곳 전환

### DIFF
--- a/rhwp-studio/tests/accessibility-shell.test.ts
+++ b/rhwp-studio/tests/accessibility-shell.test.ts
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import { codeOnly } from './support/source-guard.ts';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -54,7 +55,7 @@ test('문서 렌더링 이미지와 스크롤 영역은 보조 기술 및 키보
     html,
     /<div id="scroll-container" role="region" aria-label="문서 페이지" tabindex="0">/,
   );
-  assert.match(pageRenderer, /const element = new Image\(\);\s*element\.alt = '';/);
+  assert.match(codeOnly(pageRenderer), /const element = new Image\(\);\s*element\.alt = '';/);
 });
 
 test('서식 도구 모음 컨트롤은 테마 토큰으로 전경색과 배경색을 명시한다', () => {

--- a/rhwp-studio/tests/caret-cell-bounds.test.ts
+++ b/rhwp-studio/tests/caret-cell-bounds.test.ts
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import { codeOnly } from './support/source-guard.ts';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
@@ -7,7 +8,7 @@ const inputHandler = readFileSync(new URL('../src/engine/input-handler.ts', impo
 
 test('표 셀 IME 조합창은 Canvas clip과 별도로 cellBounds 안에 제한한다', () => {
   assert.match(caretRenderer, /private clampCompositionBox\(/);
-  assert.match(caretRenderer, /const bounds = rect\.cellBounds;/);
+  assert.match(codeOnly(caretRenderer), /const bounds = rect\.cellBounds;/);
   assert.match(caretRenderer, /w = Math\.min\(w, Math\.max\(0, bounds\.w\)\);/);
   assert.match(caretRenderer, /x = Math\.min\(Math\.max\(x, bounds\.x\), maxX\);/);
   assert.match(caretRenderer, /y = Math\.min\(Math\.max\(y, bounds\.y\), maxY\);/);

--- a/rhwp-studio/tests/cell-block-format.test.ts
+++ b/rhwp-studio/tests/cell-block-format.test.ts
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import { codeOnly } from './support/source-guard.ts';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -65,7 +66,7 @@ test('제외 셀 키 형식은 CursorState 가 조립하는 것과 같은 함수
   // 조립하는 쪽과 조회하는 쪽이 형식을 따로 갖고 있으면 한쪽만 바뀌어도 조회가 조용히
   // 빗나가 제외 셀이 무시된다. 리터럴 재조립을 금지하고 단일 함수를 쓰는지 본다.
   const cursor = source('src/engine/cursor.ts');
-  assert.match(cursor, /const key = excludedCellKey\(row, col\)/,
+  assert.match(codeOnly(cursor), /const key = excludedCellKey\(row, col\)/,
     'CursorState.ctrlToggleCell 이 공유 키 함수를 쓰지 않는다');
   assert.doesNotMatch(cursor, /const key = `\$\{row\},\$\{col\}`/,
     'CursorState 가 제외 셀 키를 리터럴로 재조립한다');

--- a/rhwp-studio/tests/chrome-mode.test.ts
+++ b/rhwp-studio/tests/chrome-mode.test.ts
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import { codeOnly } from './support/source-guard.ts';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
@@ -82,7 +83,7 @@ test('main은 embed에서 수명주기 커맨드 등록만 거르고 메뉴는 �
     /if \(chromeMode !== 'embed'\) await offerAutosaveRecoveryIfIdle\(\);/,
   );
   // 시작 시 빈 문서도 호스트가 감지할 수 없는 문서 교체이므로 embed에서는 열지 않는다.
-  assert.match(mainSource, /async function openBlankDocumentIfIdle[\s\S]*?if \(chromeMode === 'embed'\) return;/);
+  assert.match(codeOnly(mainSource), /async function openBlankDocumentIfIdle[\s\S]*?if \(chromeMode === 'embed'\) return;/);
   // index.html은 수정하지 않는다 — 기본 full 프로파일의 정적 마크업 검사가 그대로 유효하다.
   const indexHtml = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
   assert.match(indexHtml, /data-cmd="file:save"/);
@@ -212,7 +213,7 @@ test('embed의 unsaved guard는 로컬 저장 선택지를 막고 자동 discard
   assert.match(fileSource, /if \(!allowLocalSave\) return false;/);
 
   const mainSource = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8');
-  assert.match(mainSource, /allowLocalSave: chromeMode !== 'embed'/);
+  assert.match(codeOnly(mainSource), /allowLocalSave: chromeMode !== 'embed'/);
 
   // 다이얼로그는 저장 비활성 사유를 받아 표시하고, '저장 안 함'/'취소' 선택은
   // 사용자에게 남는다(자동 discard 없음).

--- a/rhwp-studio/tests/cursor-hit-coherence.test.ts
+++ b/rhwp-studio/tests/cursor-hit-coherence.test.ts
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import { codeOnly } from './support/source-guard.ts';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
@@ -36,5 +37,5 @@ test('#2400 pointer hit 좌표가 있으면 선행 경로 재조회를 수행하
 test('일반 클릭·셀 재진입·드래그 pointer 경로가 moveToHit을 사용한다', () => {
   assert.equal(mouseSource.match(/cursor\.moveTo\(hit\)/g), null);
   assert.ok((mouseSource.match(/cursor\.moveToHit\(hit\)/g)?.length ?? 0) >= 8);
-  assert.match(inputSource, /const hit = this\.hitTestFromClientPoint[\s\S]*cursor\.moveToHit\(hit\);/);
+  assert.match(codeOnly(inputSource), /const hit = this\.hitTestFromClientPoint[\s\S]*cursor\.moveToHit\(hit\);/);
 });

--- a/rhwp-studio/tests/hwp-password-open.test.ts
+++ b/rhwp-studio/tests/hwp-password-open.test.ts
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import { codeOnly } from './support/source-guard.ts';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
@@ -67,11 +68,11 @@ test('WasmBridge는 다음 문서를 모두 준비한 뒤에만 기존 문서를
 });
 
 test('암호 대화상자는 마스킹·접근성·취소 시 DOM 값 제거를 제공한다', () => {
-  assert.match(dialogSource, /this\.input\.type = 'password';/, '암호 입력을 마스킹한다');
-  assert.match(dialogSource, /this\.input\.autocomplete = 'off';/, '브라우저 암호 자동완성을 요청하지 않는다');
-  assert.match(dialogSource, /label\.htmlFor = 'hwp-password-input';/, '입력 레이블을 연결한다');
+  assert.match(codeOnly(dialogSource), /this\.input\.type = 'password';/, '암호 입력을 마스킹한다');
+  assert.match(codeOnly(dialogSource), /this\.input\.autocomplete = 'off';/, '브라우저 암호 자동완성을 요청하지 않는다');
+  assert.match(codeOnly(dialogSource), /label\.htmlFor = 'hwp-password-input';/, '입력 레이블을 연결한다');
   assert.match(dialogSource, /this\.dialog\.setAttribute\('role', 'dialog'\)/, '대화상자 역할을 선언한다');
   assert.match(dialogSource, /this\.dialog\.setAttribute\('aria-modal', 'true'\)/, '모달 상태를 알린다');
-  assert.match(dialogSource, /if \(this\.input\) this\.input\.value = '';/, '닫을 때 DOM의 입력값을 비운다');
-  assert.match(dialogSource, /event\.key === 'Enter'/, 'Enter 확인을 지원한다');
+  assert.match(codeOnly(dialogSource), /if \(this\.input\) this\.input\.value = '';/, '닫을 때 DOM의 입력값을 비운다');
+  assert.match(codeOnly(dialogSource), /event\.key === 'Enter'/, 'Enter 확인을 지원한다');
 });

--- a/rhwp-studio/tests/hwp-password-save.test.ts
+++ b/rhwp-studio/tests/hwp-password-save.test.ts
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import { codeOnly } from './support/source-guard.ts';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
@@ -34,7 +35,7 @@ test('암호 저장 dialog는 확인 입력, 최소 길이, 닫기 시 DOM 초�
 test('다른 이름·HWP·HWPX 저장은 공통 대화상자에서 암호 설정을 선택한다', () => {
   assert.match(commandSource, /async function promptSaveAsOptions/, '공통 저장 옵션 대화상자 경로가 있어야 합니다');
   assert.match(commandSource, /showSaveAs\(/, '파일명을 먼저 받는 대화상자를 열어야 합니다');
-  assert.match(commandSource, /allowPassword: format !== 'hml'/, 'HWP/HWPX에만 암호 설정을 노출해야 합니다');
+  assert.match(codeOnly(commandSource), /allowPassword: format !== 'hml'/, 'HWP/HWPX에만 암호 설정을 노출해야 합니다');
   assert.match(commandSource, /showHwpSavePasswordDialog\(selection\.fileName\)/, '암호 설정을 누르면 암호/확인 대화상자를 열어야 합니다');
   assert.match(commandSource, /exportPasswordProtectedDocumentWithReportForFormat/, '내용 손실 보고를 포함한 전용 암호 serializer를 선택해야 합니다');
   assert.match(commandSource, /암호 설정 저장은 HWP 또는 HWPX 형식에서만 지원합니다/, 'HML 암호 저장을 거부해야 합니다');
@@ -48,7 +49,7 @@ test('다른 이름·HWP·HWPX 저장은 공통 대화상자에서 암호 설정
 test('저장 대화상자는 HWP/HWPX에서만 암호 설정 action을 반환한다', () => {
   assert.match(saveAsDialogSource, /export interface SaveAsDialogResult/, '파일명과 암호 설정 선택을 함께 반환해야 합니다');
   assert.match(saveAsDialogSource, /configurePassword: boolean/, '암호 설정 여부가 명시되어야 합니다');
-  assert.match(saveAsDialogSource, /passwordButton\.textContent = '암호 설정\.\.\.'/, '대화상자에 암호 설정 button이 있어야 합니다');
+  assert.match(codeOnly(saveAsDialogSource), /passwordButton\.textContent = '암호 설정\.\.\.'/, '대화상자에 암호 설정 button이 있어야 합니다');
   assert.match(saveAsDialogSource, /options\.allowPassword === true/, '호출자가 암호 설정 노출 여부를 제어해야 합니다');
 });
 
@@ -84,7 +85,7 @@ test('다른 이름 저장은 새 문서명 상태와 최근 문서를 함께 �
   assert.match(protectedSave, /services\.refreshDocumentStatus\(\)/, '저장 뒤 상태바 문서명을 갱신해야 합니다');
   assert.match(commandSource, /function completeHandleSave[\s\S]*?addRecentDoc\(/, '파일 handle 저장본도 최근 문서에 기록해야 합니다');
   assert.match(mainSource, /refreshDocumentStatus: \(\) => \{[\s\S]*?wasm\.fileName/, '상태바 갱신은 현재 문서명을 사용해야 합니다');
-  assert.match(mainSource, /RECENT_SUBMENU_COLLAPSED_LIMIT = 8/, '최근 문서는 기본 8개만 보여야 합니다');
+  assert.match(codeOnly(mainSource), /RECENT_SUBMENU_COLLAPSED_LIMIT = 8/, '최근 문서는 기본 8개만 보여야 합니다');
   assert.match(mainSource, /최근 문서 더보기/, '9개 이상이면 더보기 항목을 제공해야 합니다');
 });
 

--- a/rhwp-studio/tests/input-edit-invalidation.test.ts
+++ b/rhwp-studio/tests/input-edit-invalidation.test.ts
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import { codeOnly } from './support/source-guard.ts';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
@@ -223,7 +224,7 @@ test('document pagination은 작은 문서의 120ms idle과 명시 boundary에�
   // #2214 의 재개형 러너를 취소해 페이지-로컬 리페인트 계약(flush 0)을 깬다.
   // 그래서 idle 병합은 유지하되 대상은 작은 문서로 되돌린다. 큰 문서는 재개형 러너와
   // 명시 boundary flush(undo/redo/navigation/blur/저장·인쇄)로 마감한다.
-  assert.match(inputHandlerSource, /const DOCUMENT_PAGINATION_IDLE_FLUSH_PAGE_LIMIT = 30;/);
+  assert.match(codeOnly(inputHandlerSource), /const DOCUMENT_PAGINATION_IDLE_FLUSH_PAGE_LIMIT = 30;/);
   assert.match(
     inputHandlerSource,
     /if \(!this\.shouldAutoFlushDeferredPagination\(\)\) return;/,

--- a/rhwp-studio/tests/issue-3414-modal-focus.test.ts
+++ b/rhwp-studio/tests/issue-3414-modal-focus.test.ts
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import { codeOnly } from './support/source-guard.ts';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -18,7 +19,7 @@ test('마지막 ModalDialog 종료만 편집기 포커스 복원 이벤트를 �
   const dialog = source('src/ui/dialog.ts');
   const hide = slice(dialog, 'hide(): void {', '\n  /** 서브클래스에서 본문 DOM을 생성 */');
 
-  assert.match(dialog, /export const MODAL_DIALOG_CLOSED_EVENT = 'rhwp-modal-dialog-closed'/,
+  assert.match(codeOnly(dialog), /export const MODAL_DIALOG_CLOSED_EVENT = 'rhwp-modal-dialog-closed'/,
     '공통 이벤트 이름을 dialog 모듈이 소유');
   assert.match(hide, /document\.querySelector\('\.modal-overlay'\)/,
     '중첩 모달이 남았는지 확인');

--- a/rhwp-studio/tests/print-command-contract.test.ts
+++ b/rhwp-studio/tests/print-command-contract.test.ts
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import { codeOnly } from './support/source-guard.ts';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
@@ -88,8 +89,8 @@ test('PDF 경로는 안내·진행 모달을 닫은 뒤 native 인쇄창을 호�
 test('인쇄 전용 문서는 same-origin 미리보기 loading surface를 제공한다', () => {
   assert.match(printHtml, /인쇄 미리보기를 준비하고 있습니다/);
   assert.match(commandSource, /appendPrintPreviewBar/);
-  assert.match(commandSource, /id = 'print-btn'/);
-  assert.match(commandSource, /id = 'close-btn'/);
+  assert.match(codeOnly(commandSource), /id = 'print-btn'/);
+  assert.match(codeOnly(commandSource), /id = 'close-btn'/);
 });
 
 test('print pipeline은 저장 handle·파일명·dirty 상태를 변경하지 않는다', () => {

--- a/rhwp-studio/tests/render-backend.test.ts
+++ b/rhwp-studio/tests/render-backend.test.ts
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import { codeOnly } from './support/source-guard.ts';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
@@ -184,7 +185,7 @@ test('CanvasKit text replay preserves LayerTree positions for regular runs', () 
 
 test('CanvasKit text replay uses positioned fallback glyphs and external text visuals', () => {
   const source = readFileSync(new URL('../src/view/canvaskit-renderer.ts', import.meta.url), 'utf8');
-  assert.match(source, /const candidateFonts = \[font\][\s\S]*?selectedFontIndices[\s\S]*?canvas\.drawGlyphs/);
+  assert.match(codeOnly(source), /const candidateFonts = \[font\][\s\S]*?selectedFontIndices[\s\S]*?canvas\.drawGlyphs/);
   assert.match(source, /case 'charOverlap':\s+this\.renderCharOverlap/);
   assert.match(source, /case 'textControlMark':\s+this\.renderTextControlMark/);
   assert.match(source, /case 'tabLeader':\s+this\.renderTabLeader/);
@@ -206,12 +207,12 @@ test('CanvasKit contains malformed images and bounds both decode caches', () => 
   );
   assert.match(source, /try \{\s*image = this\.canvasKit\.MakeImageFromEncoded/);
   assert.match(source, /image:decodeFailed/);
-  assert.match(source, /MAX_IMAGE_CACHE_ENTRIES = 128/);
-  assert.match(source, /MAX_IMAGE_FAILURE_CACHE_ENTRIES = 128/);
+  assert.match(codeOnly(source), /MAX_IMAGE_CACHE_ENTRIES = 128/);
+  assert.match(codeOnly(source), /MAX_IMAGE_FAILURE_CACHE_ENTRIES = 128/);
   assert.match(source, /replayableEncodedImageHeader\(bytes\)/);
-  assert.match(admissionSource, /CANVASKIT_MAX_IMAGE_DIMENSION = 8192/);
-  assert.match(admissionSource, /CANVASKIT_MAX_DECODED_IMAGE_PIXELS = 32 \* 1024 \* 1024/);
-  assert.match(source, /MAX_IMAGE_CACHE_PIXELS = 64 \* 1024 \* 1024/);
+  assert.match(codeOnly(admissionSource), /CANVASKIT_MAX_IMAGE_DIMENSION = 8192/);
+  assert.match(codeOnly(admissionSource), /CANVASKIT_MAX_DECODED_IMAGE_PIXELS = 32 \* 1024 \* 1024/);
+  assert.match(codeOnly(source), /MAX_IMAGE_CACHE_PIXELS = 64 \* 1024 \* 1024/);
   assert.match(source, /oldest\?\.image\.delete\?\.\(\)/);
   assert.match(source, /'base64DecodeFailed'/);
   assert.match(source, /'encodedImageRejected'/);
@@ -223,16 +224,16 @@ test('CanvasKit contains malformed images and bounds both decode caches', () => 
 
 test('CanvasKit distinguishes missing-picture editor and print replay', () => {
   const source = readFileSync(new URL('../src/view/canvaskit-renderer.ts', import.meta.url), 'utf8');
-  assert.match(source, /op\.kind === 'missingPicture'/);
-  assert.match(source, /profile === 'print' \|\| profile === 'highQuality'/);
-  assert.match(source, /MAX_PLACEHOLDER_DASH_SEGMENTS_PER_AXIS = 2048/);
+  assert.match(codeOnly(source), /op\.kind === 'missingPicture'/);
+  assert.match(codeOnly(source), /profile === 'print' \|\| profile === 'highQuality'/);
+  assert.match(codeOnly(source), /MAX_PLACEHOLDER_DASH_SEGMENTS_PER_AXIS = 2048/);
   assert.match(source, /\.every\(Number\.isFinite\)/);
 });
 
 test('CanvasKit form replay accepts the canonical LayerTree form type names', () => {
   const source = readFileSync(new URL('../src/view/canvaskit-renderer.ts', import.meta.url), 'utf8');
-  assert.match(source, /op\.formType === 'checkBox'/);
-  assert.match(source, /op\.formType === 'radioButton'/);
+  assert.match(codeOnly(source), /op\.formType === 'checkBox'/);
+  assert.match(codeOnly(source), /op\.formType === 'radioButton'/);
 });
 
 test('PageLayerTree bridge verifies the returned profile instead of relabeling it', () => {
@@ -314,7 +315,7 @@ test('CanvasKit replay plane caps master-page layers at behindText (#2318)', () 
 
 test('CanvasKit renderer source replays the root once per replay plane', () => {
   const source = readFileSync(new URL('../src/view/canvaskit-renderer.ts', import.meta.url), 'utf8');
-  assert.match(source, /for \(const replayPlane of CANVASKIT_REPLAY_PLANES\)/);
+  assert.match(codeOnly(source), /for \(const replayPlane of CANVASKIT_REPLAY_PLANES\)/);
   assert.match(source, /layerPaintOpReplayPlane\(op,\s*activeLayer\) !== replayPlane/);
 });
 
@@ -362,10 +363,10 @@ test('PageRenderer prefers lightweight overlay summary before full PageLayerTree
   assert.match(source, /getLayerPlaneSummaryFromTree\(pageIdx\)/);
   assert.match(source, /this\.layerSummaryCache\.set\(pageIdx,\s*\{ key: cacheKey,\s*summary: treeSummary \}\)/);
   assert.match(source, /this\.wasm\.getPageLayerTree\(pageIdx\)/);
-  assert.match(source, /typeof wrapper\?\.hasBehind !== 'boolean'/);
-  assert.match(source, /const rawSvgCount = finiteCount\(wrapper\.rawSvgCount\)/);
-  assert.match(source, /const flowImageCount =/);
-  assert.match(source, /const flowRawSvgCount =/);
+  assert.match(codeOnly(source), /typeof wrapper\?\.hasBehind !== 'boolean'/);
+  assert.match(codeOnly(source), /const rawSvgCount = finiteCount\(wrapper\.rawSvgCount\)/);
+  assert.match(codeOnly(source), /const flowImageCount =/);
+  assert.match(codeOnly(source), /const flowRawSvgCount =/);
   assert.match(source, /flowStaticCount/);
 });
 
@@ -378,7 +379,7 @@ test('PageRenderer skips full flow-image JSON when the summary has no flow image
 test('CanvasView forwards text-edit invalidation as static overlay reuse context', () => {
   const source = readFileSync(new URL('../src/view/canvas-view.ts', import.meta.url), 'utf8');
   assert.match(source, /type PageRenderContext/);
-  assert.match(source, /reason === 'text-edit'/);
+  assert.match(codeOnly(source), /reason === 'text-edit'/);
   assert.match(source, /allowStaticOverlayReuse:\s*true/);
   assert.match(source, /allowStaticOverlayReuse:\s*false/);
   assert.match(source, /renderCanvas\(pageIndex,\s*canvas,\s*renderContext\)/);
@@ -427,7 +428,7 @@ test('PageRenderer reuses static overlay canvases only when the overlay key matc
   assert.match(source, /export interface PageRenderContext/);
   assert.match(source, /export interface PageRenderResult/);
   assert.match(source, /needsTextEditStaticLayerVerification/);
-  assert.match(source, /context\.reason === 'text-edit' && context\.allowStaticOverlayReuse === true/);
+  assert.match(codeOnly(source), /context\.reason === 'text-edit' && context\.allowStaticOverlayReuse === true/);
   assert.match(source, /if \(!allowReuse\) \{/);
   assert.match(source, /this\.removePageLayers\(parent,\s*pageIdx\);/);
   assert.match(source, /reusableLayer\?\.dataset\.rhwpStaticOverlayKey === key/);
@@ -443,7 +444,7 @@ test('PageRenderer reuses layer summaries on the text-edit fast path', () => {
   const source = readFileSync(new URL('../src/view/page-renderer.ts', import.meta.url), 'utf8');
   assert.match(source, /layerSummaryCache = new Map<number,\s*LayerSummaryCacheEntry>\(\)/);
   assert.match(source, /buildLayerSummaryCacheKey\(pageIdx,\s*canvas,\s*renderScale\)/);
-  assert.match(source, /context\.reason === 'text-edit' && context\.allowStaticOverlayReuse === true/);
+  assert.match(codeOnly(source), /context\.reason === 'text-edit' && context\.allowStaticOverlayReuse === true/);
   assert.match(source, /cached\?\.key === cacheKey/);
   assert.match(source, /return \{ \.\.\.cached\.summary \}/);
   assert.match(source, /rememberLayerPlaneSummary\(pageIdx,\s*canvas,\s*renderScale,\s*layers\)/);
@@ -471,7 +472,7 @@ test('PageRenderer splits flow static images before the first Canvas2D flow rend
   // [#3315] DOM <img> 는 생산자가 정한 src 를 그대로 쓴다 — 전체 트리 경로의 data URL 이든
   // 좁은 질의 경로의 신원 키별 object URL 이든 조립부는 분기하지 않는다.
   assert.match(source, /element\.src = image\.src/);
-  assert.match(source, /HWP_UNITS_PER_CSS_PIXEL = 75/);
+  assert.match(codeOnly(source), /HWP_UNITS_PER_CSS_PIXEL = 75/);
   // [#6099] 90/270° 프레임은 회전 전 치수로 만들어지므로 crop 사영도 프레임
   // 치수를 받는다.
   assert.match(source, /applyFlowImageCrop\(element, image, displayScale, frameWidth, frameHeight\)/);
@@ -568,7 +569,7 @@ test('PageRenderer deferred image rerender preserves static layer reuse policy',
   assert.match(source, /reuseStaticOverlay/);
   // [#3315] 재시도 키는 개수·overlay 서명만으로는 그림 **내용** 변화를 못 본다. 문서 신원과
   // 그림 신원 키를 함께 들어야 blanket 리셋 없이 재사용 판정이 성립한다.
-  assert.match(source, /const retryKey = this\.buildImageRetryKey\(/);
+  assert.match(codeOnly(source), /const retryKey = this\.buildImageRetryKey\(/);
   const keyBuilder = source.slice(source.indexOf('private buildImageRetryKey('));
   const keyBody = keyBuilder.slice(0, keyBuilder.indexOf('\n  }'));
   assert.match(keyBody, /getPageSourceImageKeys\(pageIdx\)/, '그림 신원 키를 재료로 쓴다');
@@ -588,9 +589,9 @@ test('PageRenderer deferred image rerender preserves static layer reuse policy',
   );
   assert.match(source, /retryKey !== null && this\.imageRetryCounts\.get\(pageIdx\) === retryKey/,
     'null 키로는 재사용 조기 반환이 일어나면 안 된다');
-  assert.match(source, /IMAGE_RE_RENDER_FALLBACK_DELAY_MS = 1500/);
+  assert.match(codeOnly(source), /IMAGE_RE_RENDER_FALLBACK_DELAY_MS = 1500/);
   assert.match(source, /RAW_SVG_EARLY_RE_RENDER_DELAYS_MS = \[0, 32, 96, 240\]/);
-  assert.match(source, /const job: ReRenderJob/);
+  assert.match(codeOnly(source), /const job: ReRenderJob/);
   assert.match(source, /if \(rawSvgCount > 0\)/);
   assert.match(source, /earlyRawSvgTimers/);
   assert.match(
@@ -638,7 +639,7 @@ test('순수 RawSvg 프리페치는 PageLayerTree bbox 계약으로 SVG URL을 �
 
 test('CanvasView renders visible pages before deferred prefetch work', () => {
   const source = readFileSync(new URL('../src/view/canvas-view.ts', import.meta.url), 'utf8');
-  assert.match(source, /for \(const pageIdx of visiblePages\)/);
+  assert.match(codeOnly(source), /for \(const pageIdx of visiblePages\)/);
   assert.match(source, /this\.schedulePrefetchPages\(prefetchPages\.filter/);
   assert.match(source, /requestIdleCallback\(run, \{ timeout: 1000 \}\)/);
   assert.match(source, /cancelPendingPrefetch\(\)/);

--- a/rhwp-studio/tests/source-guard-support.test.ts
+++ b/rhwp-studio/tests/source-guard-support.test.ts
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import { codeOnly } from './support/source-guard.ts';
+import assert from 'node:assert/strict';
+
+// [#6335] codeOnly — 전문 pin 의 주석 인용 오염 방지 헬퍼의 계약.
+// 실전 실패 모드 그대로 고정한다: 주석에 종전 선언을 인용한 채 실값을 바꾸면
+// 원문 첫-매치는 통과(무검출)하지만 codeOnly 사본에서는 실패해야 한다.
+
+const FIXTURE = [
+  "// UI 조정 이력: 종전에는 const LIMIT = 8; 이었다.",
+  "/* 블록 주석 안의 const BLOCK = 1; 도 제거된다 */",
+  "const LIMIT = 12;",
+  "const url = 'https://example.com/a'; // 문자열 뒤 주석",
+  "const label = '주석처럼 보이는 문자열 // 은 보존';",
+].join(String.fromCharCode(10));
+
+test('주석 속 선언 인용은 매치되지 않는다 (디코이 차단)', () => {
+  const code = codeOnly(FIXTURE);
+  assert.doesNotMatch(code, /const LIMIT = 8;/, '줄 주석 인용이 살아 있으면 디코이 오염 재발');
+  assert.doesNotMatch(code, /const BLOCK = 1;/, '블록 주석 인용이 살아 있으면 디코이 오염 재발');
+  assert.match(FIXTURE, /const LIMIT = 8;/, '전제: 원문 첫-매치는 디코이에 걸린다(무검출 계급)');
+});
+
+test('실제 선언과 문자열은 보존된다', () => {
+  const code = codeOnly(FIXTURE);
+  assert.match(code, /const LIMIT = 12;/, '실선언은 남아야 한다');
+  assert.match(code, /'https:..example\.com.a'/, '문자열 내부(//)는 주석으로 오인하지 않는다');
+  assert.match(code, /은 보존/, '문자열 속 주석 유사 문자열은 보존');
+  assert.doesNotMatch(code, /문자열 뒤 주석/, '문자열 밖 꼬리 주석은 제거');
+});
+
+test('줄 구조가 보존된다 — 진단 줄 번호 유지', () => {
+  const nl = String.fromCharCode(10);
+  assert.equal(codeOnly(FIXTURE).split(nl).length, FIXTURE.split(nl).length);
+});

--- a/rhwp-studio/tests/support/source-guard.ts
+++ b/rhwp-studio/tests/support/source-guard.ts
@@ -117,3 +117,31 @@ export function matchesOutside(src: string, pattern: RegExp, ranges: string[]): 
   }
   return outside;
 }
+
+/**
+ * [#6335] 주석만 공백으로 치환한 사본 — 코드·문자열·줄 구조(개행)는 보존한다.
+ * 전문(full-source) pin 이 주석 속 선언 인용에 첫-매치되는 오염을 막는 데 쓴다
+ * (#6333 리뷰에서 적발된 계급의 전수 일반화). 문자열을 매치하는 pin 이 많아
+ * 문자열은 보존이 관건이다. CSS 등 비 TS/JS 소스에는 쓰지 않는다.
+ */
+export function codeOnly(src: string): string {
+  let out = '';
+  for (let i = 0; i < src.length; ) {
+    const ch = src[i];
+    if (ch === '/' && (src[i + 1] === '/' || src[i + 1] === '*')) {
+      const end = skipNonCode(src, i);
+      for (let j = i; j < end; j += 1) out += src[j] === String.fromCharCode(10) ? src[j] : ' ';
+      i = end;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const end = skipNonCode(src, i);
+      out += src.slice(i, end);
+      i = end;
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}

--- a/rhwp-studio/tests/toolbar-font-size-clamp.test.ts
+++ b/rhwp-studio/tests/toolbar-font-size-clamp.test.ts
@@ -1,10 +1,11 @@
 import test from 'node:test';
+import { codeOnly } from './support/source-guard.ts';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 const toolbar = readFileSync(new URL('../src/ui/toolbar.ts', import.meta.url), 'utf8');
 
 test('툴바 글자 크기 입력은 char-shape-dialog와 동일하게 1~4096pt로 clamp한다', () => {
-  assert.match(toolbar, /const clampedPt = Math\.min\(4096, Math\.max\(1, pt\)\);/);
-  assert.match(toolbar, /const newPt = Math\.min\(4096, pt \+ 1\);/);
+  assert.match(codeOnly(toolbar), /const clampedPt = Math\.min\(4096, Math\.max\(1, pt\)\);/);
+  assert.match(codeOnly(toolbar), /const newPt = Math\.min\(4096, pt \+ 1\);/);
 });

--- a/rhwp-studio/tests/toolbar-line-spacing-clamp.test.ts
+++ b/rhwp-studio/tests/toolbar-line-spacing-clamp.test.ts
@@ -1,10 +1,11 @@
 import test from 'node:test';
+import { codeOnly } from './support/source-guard.ts';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 const toolbar = readFileSync(new URL('../src/ui/toolbar.ts', import.meta.url), 'utf8');
 
 test('툴바 줄 간격 직접입력/증가버튼은 format:line-spacing-increase 커맨드와 동일하게 500%로 clamp한다', () => {
-  assert.match(toolbar, /const clamped = Math\.min\(500, num\);/);
-  assert.match(toolbar, /const next = Math\.min\(500, cur \+ 5\);/);
+  assert.match(codeOnly(toolbar), /const clamped = Math\.min\(500, num\);/);
+  assert.match(codeOnly(toolbar), /const next = Math\.min\(500, cur \+ 5\);/);
 });

--- a/rhwp-studio/tests/toolbar-local-font-options.test.ts
+++ b/rhwp-studio/tests/toolbar-local-font-options.test.ts
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import { codeOnly } from './support/source-guard.ts';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
@@ -26,7 +27,7 @@ test('한컴형 글꼴 메뉴는 범주 목록과 기존 글꼴 적용 이벤트
   assert.match(source, /label: '문서 글꼴'/);
   assert.match(source, /label: '대표 글꼴'/);
   assert.match(source, /label: '시스템 글꼴'/);
-  assert.match(source, /menu\.className = 'font-picker-menu'/);
+  assert.match(codeOnly(source), /menu\.className = 'font-picker-menu'/);
   assert.match(source, /this\.fontName\.dispatchEvent\(new Event\('change', \{ bubbles: true \}\)\)/);
 });
 

--- a/rhwp-studio/tests/undo-formula-dialog.test.ts
+++ b/rhwp-studio/tests/undo-formula-dialog.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { balancedFrom } from './support/source-guard.ts';
+import { codeOnly, balancedFrom } from './support/source-guard.ts';
 
 // [Task #formula-dialog] 계산식 다이얼로그 히스토리 라우팅 소스 가드.
 //
@@ -18,7 +18,7 @@ const src = readFileSync(join(rootDir, 'src/ui/formula-dialog.ts'), 'utf8');
 
 test('formula-dialog 는 services 주입 + tableFormula snapshot 라우팅 + fallback 을 갖춘다', () => {
   assert.match(src, /services\?:\s*CommandServices/, '생성자에 services 주입');
-  assert.match(src, /import type \{ CommandServices \}/, 'CommandServices import');
+  assert.match(codeOnly(src), /import type \{ CommandServices \}/, 'CommandServices import');
   assert.match(src, /this\.services\?\.getInputHandler\(\)/, 'getInputHandler 로 라우터 도달');
   assert.match(src, /operationType:\s*'tableFormula'/, 'tableFormula snapshot 라우팅');
   assert.match(src, /this\.eventBus\.emit\('document-changed'\)/, 'fallback emit 유지');


### PR DESCRIPTION
관련 이슈: #6335

## 문제

전문(full-source) 대상 소스 가드 pin 이 첫-매치 의미론이라, 주석에 종전 선언을 인용하면 실제 값이 바뀌어도 가드가 그린입니다(이슈 재현: `RECENT_SUBMENU_COLLAPSED_LIMIT` 8→12 + 인용 주석 1줄 → `hwp-password-save.test.ts` 7/7 무검출).

## 원인

이슈 참조 — 감사 실측으로 `assert.match` 1,372곳 중 전문 대상 미앵커 508곳, 그중 상수·선언·설정값 pin 51곳. #6333 리뷰가 적발한 계급(`WASM_MAX_SNAPSHOTS` 디코이)의 전수 일반화입니다.

## 변경

- **`tests/support/source-guard.ts` 에 `codeOnly(src)` 추가** — 기존 `skipNonCode` 스캐너(#2370 클러스터 D)를 재사용해 **주석만 공백화**하고 문자열·줄 구조(개행)는 보존합니다. 문자열을 매치하는 pin 이 다수라 문자열 보존이 관건이고, 줄 보존은 진단 줄번호를 유지합니다.
- **고위험 pin 48곳/15파일을 `assert.match(codeOnly(x), …)` 로 표적 전환** — 정규식은 무수정, per-assert 외과 수술이라 주석을 의도적으로 매치할 수 있는 다른 가드에 부수 파손이 없습니다. 51곳 개별 `^` 앵커 수리 대신 한 곳의 표현 변환을 택했습니다(유지 지점 1곳 + 향후 pin 재사용).
- 헬퍼 계약 테스트 3종 신설(`source-guard-support.test.ts`): 디코이 차단(원문 첫-매치는 걸림을 전제로 고정), 문자열 보존(`//` 포함 URL·주석 유사 문자열), 줄 구조 보존.

## 검증

devel `f6a6bee8f` 기준.

- **수정 전 무검출 ↔ 수정 후 발화 뒤집힘**: 같은 교란(8→12 + 인용 주석)이 전환 전 7/7 그린 → 전환 후 `'최근 문서는 기본 8개만 보여야 합니다'` 로 실패. 원복 후 그린.
- **감사 재실행**: 고위험 51 → 잔여 3 — `command-history-snapshot.test.ts` 2곳(PR #6333 이 `^…/m` 앵커로 수정 진행 중), `zoom-dialog-integration.test.ts` 1곳(CSS 소스 — `codeOnly` 는 TS/JS 주석 문법 전제라 제외). 모두 이슈 범위 외에 명시.
- 전체 `npm run test` 1,109 중 1,094 pass / 14 fail — 실패 14건은 wasm 미빌드 worktree 환경 기인으로 수정 전 baseline 과 동일(신규 실패 0). 신설 3건 포함 전환 15파일 전부 통과.

## 범위 외

- 저위험 457곳(전문 대상이지만 코드 패턴 pin) — 같은 헬퍼로 전환 가능, 필요 시 후속.
- Rust 텍스트 계약(`tests/*_contract.rs`) 감사 — 별도 점검 후보.
