### PR TITLE
fix(parser/hwp5): 확장 바탕쪽이 기본 바탕쪽을 대체하게 한다 — 정답지에 없는 쪽번호가 포개진다 (#6334)

### DIFF
--- a/mydocs/working/hwp5_extension_master_replace.md
+++ b/mydocs/working/hwp5_extension_master_replace.md
@@ -1,0 +1,131 @@
+---
+kind: working
+status: active
+issue: 6334
+---
+
+# HWP5 확장 바탕쪽이 기본 바탕쪽을 대체하지 않는다 (#6334)
+
+## 증상
+
+HWP5 문서에서 확장 바탕쪽(마지막 쪽·임의 쪽)이 기본 홀/짝 바탕쪽을 대체하지 않고 그
+**위에 덧그려진다.** 두 바탕쪽의 쪽번호·머리말이 같은 자리에 포개진다.
+
+`samples/exam_science.hwp` 4쪽(0 기준 3) 실측이다.
+
+| | 바탕쪽이 그리는 글자 |
+| --- | --- |
+| 한컴 정답지 `pdf/exam_science-2022.pdf` p4 | `32 32`, `* 확인 사항`, `4 (화학 I) 과학탐구 영역` |
+| rhwp `devel` | **2 겹** — `['31','32']` + `['32','32','* 확인 사항', …]` |
+
+**정답지에 `31` 이 없다.** 기본 짝수 바탕쪽이 그려지면 안 되는데 그려지고 있다.
+`layout-anomaly` 가 이 쪽에서 18.0 x 15.3px 글자 겹침을 잡는다.
+`samples/exam-kor-3p.hwp` 3쪽도 같은 형상이다(겹침 15.8 x 27.3px).
+
+## 원인
+
+```rust
+// src/parser/body_text.rs (수정 전)
+let overlap = ext_flags & 0x01 != 0;
+let is_extension = (ext_flags & 0x02 != 0) || /* 같은 apply_to 중복 휴리스틱 */;
+
+master_pages.push(MasterPage {
+    overlap,
+    replace_base: false,      // <- 하드코딩
+    ...
+});
+```
+
+렌더 선택(`document_core/queries/rendering.rs`)은 확장 바탕쪽을 이렇게 가른다.
+
+```rust
+let replace_exts = ext_mp_indices.iter().filter(|&&i| !mps[i].overlap || mps[i].replace_base);
+let overlap_exts = ext_mp_indices.iter().filter(|&&i| mps[i].overlap && !mps[i].replace_base);
+```
+
+HWP5 는 `overlap = true`(아래) · `replace_base = false` 이므로 **`replace_exts` 에 절대
+들어가지 못하고** 항상 `extra_master_pages` 로 가서 덧그려진다.
+
+## 판정 근거는 파일이 아니라 정답지다
+
+HWPX 는 `pageDuplicate` 로 "겹치게 하기" 의도를 명시한다(#6323 / PR #6329 가 그 경로를
+고쳤다). HWP5 에는 그 속성이 없고 `ext_flags` 의 overlap 비트만 있는데, 그 비트는 의도를
+구분하지 못한다.
+
+> 한컴 HWPX -> HWP5 저장본은 LAST_PAGE 바탕쪽을 확장 바탕쪽으로 저장하면서
+> `pageDuplicate="0"` 인 경우에도 overlap bit 를 함께 세운다.
+> — `parser/hwpx/section.rs` 의 같은 지점 주석
+
+즉 **파일 안에는 판정 근거가 없다.** 그런데 한컴이 실제로 어떻게 그리는지는 저장소 안에
+있다 — `pdf/` 의 정답지다. 정답지가 대체를 보이므로 대체로 맞춘다.
+
+이슈에 세 선택지를 적고 방향을 여쭈었는데, 정답지로 1 번(확장 바탕쪽은 항상 대체)이
+확인됐다. 우려했던 폭발 반경은 아래 실측으로 없음이 확인됐다.
+
+## 수정
+
+```rust
+replace_base: is_extension,
+```
+
+## 검증
+
+### 전/후
+
+| 문서 | 쪽 | 수정 전 | 수정 후 |
+| --- | ---: | --- | --- |
+| `exam_science.hwp` | 4 | 2 겹 — `['31','32']` + `['32','32', …]` | **1 겹** — `['32','32','* 확인 사항', …]` |
+| `exam-kor-3p.hwp` | 3 | 2 겹 | **1 겹** |
+
+`exam_science` 는 정답지와 정확히 일치한다 — `31` 이 그려지지 않는다.
+
+### 폭발 반경 — 세 원장 전수
+
+`replace_base = is_extension` 은 확장 바탕쪽을 쓰는 **모든 HWP5 문서**에 닿으므로 전수로
+쟀다.
+
+| 원장 | 결과 |
+| --- | --- |
+| `overflow_cell_baseline` (945 문서 전 페이지 렌더) | 통과 (230.48s) |
+| `visual_roundtrip_baseline` (parse -> serialize -> reparse) | 통과 (8.23s) |
+| `cargo fmt --all -- --check` | 통과 |
+| `rust-unit-test-tiers --check --base-ref f6a6bee8f3` | 통과 (4221) |
+| `rust-test-suite-manifest --check --base-ref f6a6bee8f3` | 통과 |
+| `issue_6334_hwp5_extension_master_replaces_base` | 2 통과 |
+
+두 원장이 무증감이라는 것은 이 변경이 **다른 문서의 조판을 건드리지 않았다**는 뜻이다.
+대체가 일어나는 것은 확장 바탕쪽이 실제로 있는 소수 문서뿐이다.
+
+글자 겹침 전수도 쟀다. 이 브랜치에는 #6322 의 범위 확장(본문 밖 후보 수집)이 없어
+`Body x Body` 축만 보이는데, **4,408 건으로 devel 기준선과 정확히 같다.** 즉 본문 안
+겹침은 한 건도 움직이지 않았다. 바탕쪽끼리 겹침(현재 15 건)의 감소는 #6322 가 병합된 뒤
+그 래칫에서 확인된다.
+
+### 시험이 결함을 실제로 잡는가 — 수정을 되돌려 확인
+
+`src/parser/body_text.rs` 만 stash 로 되돌리고 같은 시험을 다시 돌렸다.
+
+```
+test hwp5_extension_master_matches_hancom_oracle_text ... FAILED
+test hwp5_extension_master_does_not_stack_on_base ... FAILED
+
+기본 짝수 바탕쪽의 쪽번호 '31' 은 정답지에 없다 — 덧그리기로 되돌아갔다:
+  ["31", "32", "32", "32", "*", "확인 사항", …]
+바탕쪽이 겹쳐 그려지면 쪽번호·머리말이 같은 좌표에 포개진다. 그려진 바탕쪽 2겹:
+  [["31", "32"], ["32", "32", "*", "확인 사항", …]]
+```
+
+실패 메시지가 결함 형상을 그대로 낸다 — `31` 이 다시 나타나고 `32` 가 세 번 그려진다.
+확인 뒤 수정을 복원했다.
+
+## 회귀 시험을 정답지 기준으로 썼다
+
+`hwp5_extension_master_does_not_stack_on_base` 는 바탕쪽이 1 겹인지 보고,
+`hwp5_extension_master_matches_hancom_oracle_text` 는 **`31` 이 그려지지 않는지**를 본다.
+"겹이 하나" 만 보면 잘못된 한 겹이 남아도 통과하므로, 정답지에 없는 글자가 나타나면
+실패하도록 했다.
+
+## 남는 것
+
+이 수정은 HWP5 파서 경로만 다룬다. 같은 형상의 HWPX 경로는 #6323 / PR #6329 다.
+두 PR 은 서로 다른 파일을 만지므로 독립적으로 병합할 수 있다.

--- a/src/parser/body_text.rs
+++ b/src/parser/body_text.rs
@@ -974,11 +974,23 @@ fn parse_master_pages_from_raw(raw_records: &[RawRecord], section_flags: u32) ->
         let para_records = &records[start + 1..end];
         let paragraphs = parse_paragraph_list(para_records);
 
+        // [#6334] 확장 바탕쪽(마지막 쪽·임의 쪽)은 기본 홀/짝 바탕쪽을 **대체**한다.
+        //
+        // HWPX 는 `pageDuplicate` 로 "겹치게 하기" 의도를 명시하지만 HWP5 에는 그 속성이
+        // 없고 overlap 비트만 있다. 그런데 그 비트는 의도를 구분하지 못한다 — 한컴의
+        // HWPX -> HWP5 저장본은 `pageDuplicate="0"`(겹치지 않음)인 바탕쪽도 overlap 비트를
+        // 함께 세운다(`parser/hwpx/section.rs` 의 같은 지점 주석). 그래서 종전처럼
+        // `replace_base: false` 로 두면 확장 바탕쪽이 `rendering.rs` 의 `replace_exts`
+        // 필터(`!overlap || replace_base`)에 **절대 들어가지 못하고** 항상 덧그려진다.
+        //
+        // 한컴 정답지가 대체임을 보인다 — `pdf/exam_science-2022.pdf` 4쪽의 바탕쪽 글자는
+        // `32 32`·`* 확인 사항` 뿐이고 기본 짝수 바탕쪽의 `31` 이 없다. 종전 rhwp 는 두 겹을
+        // 그려 `['31','32']` 와 `['32','32', …]` 가 18.0 x 15.3px 겹쳤다.
         master_pages.push(MasterPage {
             apply_to,
             is_extension,
             overlap,
-            replace_base: false,
+            replace_base: is_extension,
             ext_flags,
             page_front: false, // HWP5 바이너리 바탕쪽엔 pageFront 개념 없음
             text_direction: 0, // HWP5 바이너리 바탕쪽엔 textDirection 개념 없음

--- a/tests/cases/issue_6334_hwp5_extension_master_replaces_base.rs
+++ b/tests/cases/issue_6334_hwp5_extension_master_replaces_base.rs
@@ -1,0 +1,98 @@
+//! [#6334] HWP5 확장 바탕쪽(마지막 쪽·임의 쪽)이 기본 홀/짝 바탕쪽을 **대체**하는지 고정한다.
+//!
+//! 종전에는 `parser/body_text.rs` 가 `replace_base: false` 로 고정해, 확장 바탕쪽이
+//! `rendering.rs` 의 `replace_exts` 필터(`!overlap || replace_base`)에 절대 들어가지 못하고
+//! 기본 바탕쪽 **위에 덧그려졌다.** 두 바탕쪽의 쪽번호·머리말이 같은 자리에 포개진다.
+//!
+//! # 판정 근거 — 저장소 안의 한컴 정답지
+//!
+//! `pdf/exam_science-2022.pdf` 4쪽의 바탕쪽 글자는 `32 32`·`* 확인 사항`·
+//! `4 (화학 I) 과학탐구 영역` 이고 **기본 짝수 바탕쪽의 `31` 이 없다.** 종전 rhwp 는 두 겹을
+//! 그려 `['31','32']` 와 `['32','32', …]` 가 18.0 x 15.3px 겹쳤다.
+//!
+//! 정답지는 sparse-checkout 대상이 아니라 작업 트리엔 안 보이지만 오브젝트엔 있다.
+//!
+//! ```bash
+//! git show "HEAD:pdf/exam_science-2022.pdf" > oracle.pdf
+//! ```
+//!
+//! # HWPX 경로와의 관계
+//!
+//! 같은 형상의 HWPX 경로는 #6323 / PR #6329 가 다뤘다. 거기서는 `pageDuplicate="0"` 이라는
+//! 문서의 명시적 선언이 있었지만, HWP5 에는 그 속성이 없고 overlap 비트만 있다. 그 비트는
+//! 의도를 구분하지 못한다 — 한컴의 HWPX -> HWP5 저장본은 `pageDuplicate="0"` 인 바탕쪽도
+//! overlap 비트를 함께 세운다(`parser/hwpx/section.rs` 의 같은 지점 주석). 그래서 판정
+//! 근거가 파일 안이 아니라 **한컴이 실제로 어떻게 그리는가**(정답지)다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+fn scan(sample: &str, page: u32) -> Option<Vec<Vec<String>>> {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(sample);
+    let bytes = std::fs::read(path).ok()?;
+    let doc = DocumentCore::from_bytes(&bytes).ok()?;
+    let tree = doc.build_page_render_tree(page).ok()?;
+    Some(
+        tree.root
+            .children
+            .iter()
+            .filter(|c| matches!(c.node_type, RenderNodeType::MasterPage))
+            .map(|m| {
+                let mut acc = Vec::new();
+                collect_text(m, &mut acc);
+                acc
+            })
+            .collect(),
+    )
+}
+
+fn collect_text(node: &RenderNode, out: &mut Vec<String>) {
+    if let RenderNodeType::TextRun(tr) = &node.node_type {
+        let t = tr.display_or_text().trim();
+        if !t.is_empty() {
+            out.push(t.to_string());
+        }
+    }
+    for child in &node.children {
+        collect_text(child, out);
+    }
+}
+
+/// 확장 바탕쪽이 있는 쪽에는 바탕쪽이 하나만 그려진다.
+#[test]
+fn hwp5_extension_master_does_not_stack_on_base() {
+    // (샘플, 쪽 0기준) — 둘 다 구역 마지막 쪽에 "확인 사항" 안내문 바탕쪽이 붙는다.
+    for (sample, page) in [("samples/exam_science.hwp", 3), ("samples/exam-kor-3p.hwp", 2)] {
+        let Some(masters) = scan(sample, page) else {
+            continue;
+        };
+        assert_eq!(
+            masters.len(),
+            1,
+            "{sample} {page}쪽: 바탕쪽이 겹쳐 그려지면 쪽번호·머리말이 같은 좌표에 포개진다. \
+             그려진 바탕쪽 {}겹, 각 글자: {masters:?}",
+            masters.len()
+        );
+    }
+}
+
+/// 그려진 바탕쪽이 한컴 정답지와 같은 것이다.
+///
+/// `pdf/exam_science-2022.pdf` 4쪽에는 `32`·`확인 사항` 이 있고 `31` 이 없다.
+/// 대체가 아니라 덧그리기로 되돌아가면 기본 짝수 바탕쪽의 `31` 이 함께 나타난다.
+#[test]
+fn hwp5_extension_master_matches_hancom_oracle_text() {
+    let Some(masters) = scan("samples/exam_science.hwp", 3) else {
+        return;
+    };
+    let all: Vec<&String> = masters.iter().flatten().collect();
+    assert!(
+        all.iter().any(|t| t.contains("확인 사항")),
+        "확장 바탕쪽의 안내문이 그려져야 한다: {all:?}"
+    );
+    assert!(
+        !all.iter().any(|t| t.as_str() == "31"),
+        "기본 짝수 바탕쪽의 쪽번호 '31' 은 정답지에 없다 — 덧그리기로 되돌아갔다: {all:?}"
+    );
+}

--- a/tests/cases/issue_6334_hwp5_extension_master_replaces_base.rs
+++ b/tests/cases/issue_6334_hwp5_extension_master_replaces_base.rs
@@ -63,7 +63,10 @@ fn collect_text(node: &RenderNode, out: &mut Vec<String>) {
 #[test]
 fn hwp5_extension_master_does_not_stack_on_base() {
     // (샘플, 쪽 0기준) — 둘 다 구역 마지막 쪽에 "확인 사항" 안내문 바탕쪽이 붙는다.
-    for (sample, page) in [("samples/exam_science.hwp", 3), ("samples/exam-kor-3p.hwp", 2)] {
+    for (sample, page) in [
+        ("samples/exam_science.hwp", 3),
+        ("samples/exam-kor-3p.hwp", 2),
+    ] {
         let Some(masters) = scan(sample, page) else {
             continue;
         };


### PR DESCRIPTION
## 변경 요약

HWP5 확장 바탕쪽(마지막 쪽·임의 쪽)이 기본 홀/짝 바탕쪽을 대체하지 않고 **위에
덧그려지던** 문제를 고칩니다. 두 바탕쪽의 쪽번호·머리말이 같은 자리에 포개집니다.

| 문서 | 쪽 | 수정 전 | 수정 후 |
| --- | ---: | --- | --- |
| `exam_science.hwp` | 4 | 2 겹 — `['31','32']` + `['32','32','* 확인 사항', …]` | **1 겹** — `['32','32','* 확인 사항', …]` |
| `exam-kor-3p.hwp` | 3 | 2 겹 | **1 겹** |

## 판정 근거는 저장소 안의 한컴 정답지입니다

`pdf/exam_science-2022.pdf` 4쪽의 바탕쪽 글자는 `32 32`·`* 확인 사항`·
`4 (화학 I) 과학탐구 영역` 이고 **기본 짝수 바탕쪽의 `31` 이 없습니다.**

```bash
git show "HEAD:pdf/exam_science-2022.pdf" > oracle.pdf
```

수정 후 rhwp 도 `31` 을 그리지 않습니다.

## 원인

```rust
// src/parser/body_text.rs (수정 전)
let overlap = ext_flags & 0x01 != 0;
master_pages.push(MasterPage {
    overlap,
    replace_base: false,      // <- 하드코딩
    ...
});
```

렌더 선택은 확장 바탕쪽을 이렇게 가릅니다.

```rust
// document_core/queries/rendering.rs
let replace_exts = ext_mp_indices.iter().filter(|&&i| !mps[i].overlap || mps[i].replace_base);
let overlap_exts = ext_mp_indices.iter().filter(|&&i| mps[i].overlap && !mps[i].replace_base);
```

HWP5 는 `overlap = true` · `replace_base = false` 이므로 **`replace_exts` 에 절대 들어가지
못하고** 항상 `extra_master_pages` 로 가서 덧그려집니다.

### HWP5 에는 파일 안에 판정 근거가 없습니다

HWPX 는 `pageDuplicate` 로 "겹치게 하기" 의도를 명시합니다(#6323 / PR #6329 가 그 경로를
고쳤습니다). HWP5 에는 그 속성이 없고 overlap 비트만 있는데, 그 비트는 의도를 구분하지
못합니다.

> 한컴 HWPX -> HWP5 저장본은 LAST_PAGE 바탕쪽을 확장 바탕쪽으로 저장하면서
> `pageDuplicate="0"` 인 경우에도 overlap bit 를 함께 세운다.
> — `parser/hwpx/section.rs` 의 같은 지점 주석

이슈 #6334 에 세 선택지를 적고 방향을 여쭈었는데, **정답지가 답이었습니다.** 파일이
의도를 말하지 않아도 한컴이 실제로 어떻게 그리는지는 저장소 안에 있습니다.

## 수정

```rust
replace_base: is_extension,
```

## 폭발 반경 — 전수로 쟀습니다

`replace_base = is_extension` 은 확장 바탕쪽을 쓰는 **모든 HWP5 문서**에 닿으므로,
이슈에 적은 대로 전수 원장을 돌렸습니다.

| 원장 | 결과 |
| --- | --- |
| `overflow_cell_baseline` (945 문서 전 페이지 렌더) | **통과** (230.48s) |
| `visual_roundtrip_baseline` (parse → serialize → reparse) | **통과** (8.23s) |
| 글자 겹침 전수 `Body x Body` | **4,408** — devel 기준선과 동일 (본문 안 겹침 무변동) |

두 원장이 무증감이라는 것은 이 변경이 **다른 문서의 조판을 건드리지 않았다**는 뜻입니다.
대체가 일어나는 것은 확장 바탕쪽이 실제로 있는 소수 문서뿐입니다.

바탕쪽끼리 겹침(현재 samples 전수 15 건)의 감소는 이 브랜치에서 잴 수 없습니다 — 그
판정에는 #6322 의 본문 밖 후보 수집이 필요한데 이 브랜치에는 없습니다. #6322 가 병합되면
그 래칫에서 드러납니다.

## 시험이 결함을 실제로 잡는지 확인했습니다

`src/parser/body_text.rs` 만 되돌리고 같은 시험을 다시 돌렸습니다.

```
test hwp5_extension_master_matches_hancom_oracle_text ... FAILED
test hwp5_extension_master_does_not_stack_on_base ... FAILED

기본 짝수 바탕쪽의 쪽번호 '31' 은 정답지에 없다 — 덧그리기로 되돌아갔다:
  ["31", "32", "32", "32", "*", "확인 사항", …]
```

회귀 시험은 "바탕쪽이 1 겹" 만 보지 않고 **정답지에 없는 `31` 이 그려지지 않는지**도
단언합니다 — 잘못된 한 겹이 남아도 통과하는 것을 막기 위해서입니다.

## PR #6329 와의 관계

같은 형상의 **HWPX** 경로는 #6329 입니다. 두 PR 은 서로 다른 파일을 만지므로
(`parser/body_text.rs` vs `parser/hwpx/section.rs` + `serializer/hwpx/master_page.rs`)
독립적으로 병합할 수 있습니다. 적층이 아닙니다.

## 관련 이슈

closes #6334

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, Cargo generated test target을 포함하지 않음
- [x] `src/**`의 `#[cfg(test)]` 변경 없음 — `rust-unit-test-tiers --check --base-ref f6a6bee8f3` 통과 (4221)
- [x] `cargo test` 통과 — 신규 2종, `overflow_cell_baseline`, `visual_roundtrip_baseline` 전부 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] 관련 샘플 파일로 SVG 내보내기 확인 — `export-render-tree` 로 바탕쪽 겹 수와 글자를 전후 비교했습니다(위 표)
- [ ] 웹(WASM) 렌더링 확인 — 파서 변경이라 렌더 백엔드 무관
- [ ] rhwp-studio 변경 — 해당 없음
- [ ] 작업 증빙 캡슐 — 파서 수정이라 해당 없음. 실측 로그 원문을 위에 실었습니다
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 — 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: 없음. 파싱 시 상수 대입이 변수 대입으로 바뀌었을 뿐이고, 오히려 덧그리던
  바탕쪽 하나가 줄어 해당 쪽의 렌더 노드가 감소합니다.
- 재현·측정: `overflow_cell_baseline` 945 문서 전수 230.48s 로 기존과 같은 자릿수입니다.
