### PR TITLE
fix(diagnostics): 용지 기준 표만 있는 쪽을 빈 쪽으로 오판하지 않는다 — 오탐 133→72 (#6344)

### DIFF
--- a/mydocs/working/empty_page_false_positive.md
+++ b/mydocs/working/empty_page_false_positive.md
@@ -1,0 +1,128 @@
+---
+kind: working
+status: active
+issue: 6344
+---
+
+# 내용이 가득한 쪽을 빈 쪽으로 오판한다 (#6344)
+
+## 증상
+
+`samples/table-ipc.hwp` 는 10 쪽 문서인데 `layout-anomaly` 가 **8 쪽을 빈 쪽**으로 판정한다.
+세 방향으로 교차 확인하면 전부 "내용 있음" 이다.
+
+| 근거 | 결과 |
+| --- | --- |
+| 한컴 정답지 `pdf/table-ipc-2022.pdf` | 10 쪽 모두 861~1,026 자 |
+| `rhwp export-text` | 10 쪽 모두 700~860 자 |
+| 종전 `layout-anomaly` | **8 쪽이 `empty_page`** |
+
+## 원인 — 용지 기준 표는 `Body` 밖에 있다
+
+렌더 트리를 열면 바로 보인다.
+
+```text
+Page
+├─ PageBg
+├─ Header
+├─ Body    bbox=(56.7, 94.5, 1009.1, 642.5)   글자 0개    <- 판정은 여기만 순회
+├─ Table   bbox=(56.7, 94.5, 1008.4, 519.9)   글자 154개, 181칸
+├─ Rect    '3/10'
+└─ Footer
+```
+
+`scan_page` 의 콘텐츠 판정(`has_content`)은 `walk` 가 `Body` 서브트리를 돌 때만 세운다.
+용지 기준으로 배치된 표는 페이지 직계 자식이라 그 순회에 걸리지 않는다.
+
+## 같은 뿌리가 반복된다
+
+`scan_page` 가 `Body` 하나에서 출발하는 설계가 여러 판정에 걸쳐 샌다.
+
+| 축 | 증상 | 처리 |
+| --- | --- | --- |
+| 글자 겹침 후보 수집 | 본문↔바탕쪽 겹침이 신호 0 | #6318 / PR #6322 |
+| **콘텐츠 유무 판정** | **빈 쪽 오탐** | 이 작업 |
+
+## 수정 — 콘텐츠 판정 하나만 넓힌다
+
+`page_has_visible_content` 를 두어 빈 쪽 판정에서만 페이지 전체를 훑는다.
+
+- overflow·off-canvas·overlap 의 기준 상자(본문 여백·페이지 상자)는 **그대로**다.
+  그 셋은 "본문 여백을 넘었나" 라는 뜻이 분명하다.
+- 바탕쪽·머리말·꼬리말은 콘텐츠에서 **제외**한다. 배경·장식은 모든 쪽에 있으므로 그걸
+  내용으로 세면 빈 쪽 판정 자체가 무의미해지고, 쪽번호만 있는 빈 쪽을 "내용 있음" 으로
+  볼 수도 없다.
+
+## 실측 — samples 945 건 전수
+
+| 신호 | 수정 전 | 수정 후 | 차 |
+| --- | ---: | ---: | ---: |
+| **empty_page** | **133** | **72** | **-61** |
+| overflow | 2,955 | 2,955 | 0 |
+| off-canvas | 437 | 437 | 0 |
+| overlap | 328 | 328 | 0 |
+| text-overlap | 4,408 | 4,408 | 0 |
+
+**나머지 네 신호가 정확히 0 변동**이다 — 이 변경이 다른 판정에 새지 않았다는 기계적 증거다.
+
+빈 쪽 판정이 바뀐 문서 19 종 중 상위다.
+
+```
+ 9 ->  0  issue4514/sample1-repro.hwp
+ 8 ->  0  hwpx/issue2019_floating_form_74312.hwpx
+ 8 ->  0  table-ipc.hwp
+18 -> 11  2025 행정업무운영 편람(최종).hwp
+18 -> 11  2025 행정업무운영 편람(최종).hwpx
+ 4 ->  0  issue5941/1490000-201600081_roadmap_research.hwp
+```
+
+남은 72 건은 이 수정으로 설명되지 않는다. 진짜 빈 쪽인지 다른 오탐인지는 별건이다 —
+이 작업은 **`Body` 밖 내용을 못 보던 것** 하나만 고친다.
+
+## 왜 중요한가
+
+`empty_page` 는 모듈 머리말이 "가능성 신호" 로 분류해 `--strict` 에서도 실패를 유발하지
+않는다. 그래서 CI 를 막지는 않지만, **advisory 리포트를 사람이 읽을 때 신뢰를 깎는다** —
+10 쪽 중 8 쪽이 오탐이면 그 문서의 신호 전체를 무시하게 된다.
+
+## 검증
+
+### 시험이 결함을 실제로 잡는가 — 수정을 되돌려 확인
+
+`src/diagnostics/layout_anomaly.rs` 만 stash 로 되돌리고 같은 시험을 다시 돌렸다.
+
+```
+test paper_anchored_table_page_is_not_reported_empty ... FAILED
+  samples/table-ipc.hwp 는 한컴 정답지·export-text 모두 10쪽 전부 내용이 있다.
+  빈 쪽으로 잡힌 쪽: [1, 2, 3, 4, 5, 6, 7, 8]
+test other_verdicts_are_unchanged ... ok
+```
+
+두 번째 시험이 되돌린 상태에서도 통과하는 것은 정상이다 — 그 문서의 컨테이너 판정은
+원래 (0, 0, 0) 이고, 그 시험의 목적은 **수정이 그 값을 건드리지 않았음**을 고정하는 것이다.
+
+### 게이트
+
+| 명령 | 결과 |
+| --- | --- |
+| `cargo fmt --all -- --check` | 통과 |
+| `node scripts/rust-unit-test-tiers.mjs --check --base-ref f6a6bee8f3` | 통과 (4221, 증가 없음) |
+| `node scripts/rust-test-suite-manifest.mjs --check --base-ref f6a6bee8f3` | 통과 |
+| `issue_6344_empty_page_false_positive` | 2 통과 |
+| samples 945 건 전수 재측정 | empty_page −61, 나머지 4 신호 0 변동 |
+
+### 커밋 대상
+
+```
+src/diagnostics/layout_anomaly.rs
+tests/cases/issue_6344_empty_page_false_positive.rs
+mydocs/working/empty_page_false_positive.md
+```
+
+## 측정에서 겪은 함정
+
+전수 재측정을 두 번 했다. 첫 번째는 **배치 스캔이 아직 실행 중인 JSON 을 읽어** overflow 가
+2,955 → 1,714 로 42% 줄어든 것처럼 보였다. 파일이 738KB 였고 완료 시 3.59MB 다.
+
+빈 쪽 판정 하나를 고쳤는데 overflow 가 그만큼 줄 리 없다는 점이 단서였다. **결과가 너무
+좋으면 측정을 의심한다.** 완료 후 다시 재니 나머지 신호는 정확히 0 변동이었다.

--- a/src/diagnostics/layout_anomaly.rs
+++ b/src/diagnostics/layout_anomaly.rs
@@ -609,6 +609,42 @@ fn find_overlaps(candidates: &[FlowCandidate], opts: &AnomalyOptions) -> Vec<Ove
     out
 }
 
+/// [#6344] 페이지 어디든 보이는 내용이 있는가 — `empty_page` 판정 전용.
+///
+/// `walk` 의 `has_content` 는 `Body` 서브트리만 본다. 용지 기준으로 배치된 표·도형은
+/// 페이지 직계 자식이라 그쪽에 잡히지 않으므로, 빈 쪽 판정에서만 페이지 전체를 훑는다.
+/// 바탕쪽(`MasterPage`)은 제외한다 — 배경·장식은 모든 쪽에 있으므로 그걸 내용으로 세면
+/// 빈 쪽 판정 자체가 무의미해진다. 머리말·꼬리말도 같은 이유로 제외한다(쪽번호만 있는
+/// 빈 쪽을 "내용 있음" 으로 볼 수 없다).
+fn page_has_visible_content(node: &RenderNode) -> bool {
+    if !node.visible || node.editor_only {
+        return false;
+    }
+    if matches!(
+        node.node_type,
+        RenderNodeType::MasterPage | RenderNodeType::Header | RenderNodeType::Footer
+    ) {
+        return false;
+    }
+    let self_has = match &node.node_type {
+        RenderNodeType::TextRun(tr) => has_visible_text(&tr.text),
+        RenderNodeType::Image(_)
+        | RenderNodeType::Table(_)
+        | RenderNodeType::Equation(_)
+        | RenderNodeType::TextBox
+        | RenderNodeType::Line(_)
+        | RenderNodeType::Rectangle(_)
+        | RenderNodeType::Ellipse(_)
+        | RenderNodeType::Path(_)
+        | RenderNodeType::Group(_)
+        | RenderNodeType::FormObject(_)
+        | RenderNodeType::Placeholder(_)
+        | RenderNodeType::RawSvg(_) => true,
+        _ => false,
+    };
+    self_has || node.children.iter().any(page_has_visible_content)
+}
+
 /// 한 페이지 렌더 트리를 스캔한다. `page_count` 는 `empty_page` 가 "문서 중간"인지
 /// 판정하는 데만 쓴다(첫·마지막 쪽은 의도된 빈 쪽이 흔해 애초에 검사하지 않는다).
 pub fn scan_page(
@@ -645,6 +681,21 @@ pub fn scan_page(
 
     let overlap = find_overlaps(&flow, opts);
     let text_overlap = find_overlaps(&text, opts);
+
+    // [#6344] 콘텐츠 유무는 **페이지 전체**로 판정한다.
+    //
+    // 위 `walk` 는 `Body` 서브트리만 도는데, 용지 기준으로 배치된 표·도형은 `Body` 가 아니라
+    // **페이지 직계 자식**으로 그려진다. `Body` 만 보면 그 쪽이 통째로 비어 보인다.
+    //
+    // 실측(`samples/table-ipc.hwp`): 10쪽 문서의 8쪽이 빈 쪽으로 잡혔는데, 그 쪽들은
+    // `Table`(181칸, 글자 154개)과 쪽번호 `Rect` 를 페이지 직계로 갖고 `Body` 는 비어 있다.
+    // `export-text` 는 같은 쪽에서 700~860자를 뽑고 한컴 정답지도 10쪽 모두 861~1,026자다.
+    //
+    // overflow·off-canvas·overlap 의 기준 상자는 그대로다 — 이 보정은 "이 쪽에 내용이
+    // 있는가" 하나만 고친다.
+    if !has_content {
+        has_content = page_has_visible_content(root);
+    }
 
     // 문서 중간(첫·마지막 제외)이고 콘텐츠가 전혀 없을 때만 "가능성 신호"로 남긴다.
     let empty_page = if page_count >= 3 && page > 0 && page < page_count - 1 && !has_content {

--- a/tests/cases/issue_6344_empty_page_false_positive.rs
+++ b/tests/cases/issue_6344_empty_page_false_positive.rs
@@ -1,0 +1,98 @@
+//! [#6344] 용지 기준 표만 있는 쪽을 `empty_page` 로 오판하지 않는다.
+//!
+//! `layout_anomaly::scan_page` 의 콘텐츠 판정(`has_content`)은 `Body` 서브트리만 돌았다.
+//! 그런데 용지 기준으로 배치된 표·도형은 `Body` 가 아니라 **페이지 직계 자식**으로
+//! 그려지므로, `Body` 만 보면 그 쪽이 통째로 비어 보인다.
+//!
+//! # 실측 — 세 방향이 전부 "내용 있음" 인데 판정만 빈 쪽
+//!
+//! `samples/table-ipc.hwp` 는 10 쪽 문서인데 8 쪽이 빈 쪽으로 잡혔다.
+//!
+//! | 근거 | 결과 |
+//! | --- | --- |
+//! | 한컴 정답지 `pdf/table-ipc-2022.pdf` | 10 쪽 모두 861~1,026자 |
+//! | `rhwp export-text` | 10 쪽 모두 700~860자 |
+//! | 종전 `layout-anomaly` | **8 쪽이 빈 쪽** |
+//!
+//! 렌더 트리를 열면 원인이 보인다 — 표(181 칸, 글자 154 개)와 쪽번호가 페이지 직계
+//! 자식이고 `Body` 는 비어 있다.
+//!
+//! ```text
+//! Page
+//! ├─ Body    글자 0개          <- 종전에는 여기만 순회
+//! ├─ Table   글자 154개, 181칸
+//! ├─ Rect    '3/10'
+//! └─ Footer
+//! ```
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::diagnostics::layout_anomaly::{scan_page, AnomalyOptions};
+use rhwp::document_core::DocumentCore;
+
+const SAMPLE: &str = "samples/table-ipc.hwp";
+
+fn load() -> Option<DocumentCore> {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = std::fs::read(path).ok()?;
+    DocumentCore::from_bytes(&bytes).ok()
+}
+
+/// 용지 기준 표가 있는 쪽은 빈 쪽이 아니다.
+#[test]
+fn paper_anchored_table_page_is_not_reported_empty() {
+    let Some(doc) = load() else {
+        return;
+    };
+    let page_count = doc.page_count();
+    let opts = AnomalyOptions::default();
+
+    let mut empty_pages = Vec::new();
+    for page in 0..page_count {
+        let Ok(tree) = doc.build_page_render_tree(page) else {
+            continue;
+        };
+        if scan_page(page, &tree.root, page_count, &opts)
+            .empty_page
+            .is_some()
+        {
+            empty_pages.push(page);
+        }
+    }
+
+    assert!(
+        empty_pages.is_empty(),
+        "{SAMPLE} 는 한컴 정답지·export-text 모두 10쪽 전부 내용이 있다. \
+         빈 쪽으로 잡힌 쪽: {empty_pages:?}"
+    );
+}
+
+/// 콘텐츠 판정만 넓혔고 다른 판정의 기준 상자는 그대로다.
+///
+/// `overflow` 는 본문 여백, `off-canvas` 는 페이지 상자라는 뜻이 분명하므로 이 변경이
+/// 그 수치를 건드리면 안 된다. 이 문서의 종전 실측은 셋 다 0 이다.
+#[test]
+fn other_verdicts_are_unchanged() {
+    let Some(doc) = load() else {
+        return;
+    };
+    let page_count = doc.page_count();
+    let opts = AnomalyOptions::default();
+
+    let (mut overflow, mut off_canvas, mut overlap) = (0usize, 0usize, 0usize);
+    for page in 0..page_count {
+        let Ok(tree) = doc.build_page_render_tree(page) else {
+            continue;
+        };
+        let pa = scan_page(page, &tree.root, page_count, &opts);
+        overflow += pa.overflow.len();
+        off_canvas += pa.off_canvas.len();
+        overlap += pa.overlap.len();
+    }
+
+    assert_eq!(
+        (overflow, off_canvas, overlap),
+        (0, 0, 0),
+        "콘텐츠 판정을 넓힌 것이 컨테이너 판정에 새어 들어갔다 \
+         (overflow, off_canvas, overlap) = ({overflow}, {off_canvas}, {overlap})"
+    );
+}


### PR DESCRIPTION
## 증상

`layout-anomaly` 가 내용이 가득한 쪽을 **빈 쪽**(`empty_page`)으로 판정합니다.

`samples/table-ipc.hwp` 는 10 쪽 문서인데 **8 쪽이 빈 쪽**으로 잡힙니다. 세 방향으로
교차 확인하면 전부 "내용 있음" 입니다.

| 근거 | 결과 |
| --- | --- |
| 한컴 정답지 `pdf/table-ipc-2022.pdf` | 10 쪽 모두 861~1,026 자 |
| `rhwp export-text` | 10 쪽 모두 700~860 자 |
| `rhwp layout-anomaly --json` | **8 쪽이 `empty_page`** |

## 원인

렌더 트리를 열면 바로 보입니다.

```text
Page
├─ PageBg
├─ Header
├─ Body    bbox=(56.7, 94.5, 1009.1, 642.5)   글자 0개    <- 판정은 여기만 순회
├─ Table   bbox=(56.7, 94.5, 1008.4, 519.9)   글자 154개, 181칸
├─ Rect    '3/10'
└─ Footer
```

**용지 기준으로 배치된 표는 `Body` 가 아니라 페이지 직계 자식으로 그려집니다.**
`scan_page` 의 콘텐츠 판정(`has_content`)은 `walk` 가 `Body` 서브트리를 돌 때만 세우므로,
표 181 칸을 통째로 보지 못하고 그 쪽을 비었다고 판정합니다.

```rust
// src/diagnostics/layout_anomaly.rs
if let Some(body) = find_body(root) {
    walk(body, …, &mut has_content);      // Body 서브트리만
}
let empty_page = if … && !has_content { Some(EmptyPageAnomaly { page }) } else { None };
```

## 같은 뿌리가 반복됩니다

`scan_page` 가 `Body` 하나에서 출발하는 설계가 여러 판정에 걸쳐 샙니다.

- #6318 / PR #6322 — 글자 겹침 후보를 `Body` 만 수집해 본문↔바탕쪽 겹침이 신호 0
- **이 이슈** — 콘텐츠 유무를 `Body` 만 판정해 빈 쪽 오탐

## 재현

```bash
rhwp layout-anomaly "samples/table-ipc.hwp" --json | jq .emptyPageCount   # 8
rhwp export-text "samples/table-ipc.hwp" -o out                            # 10쪽 모두 700자 이상
rhwp export-render-tree "samples/table-ipc.hwp" -p 2 -o tree               # Table 이 Page 직계
git show "HEAD:pdf/table-ipc-2022.pdf" > oracle.pdf                        # 10쪽 모두 861자 이상
```

## 전수 영향

samples 945 건에서 `empty_page` 는 **33 문서 133 건**입니다. 이 중 얼마가 같은 오탐인지는
수정 후 재측정으로 확인하겠습니다.

## 왜 중요한가

`empty_page` 는 모듈 머리말이 "가능성 신호" 로 분류해 `--strict` 에서도 실패를 유발하지
않습니다. 그래서 당장 CI 를 막지는 않지만, **advisory 리포트를 사람이 읽을 때 신뢰를
깎습니다** — 10 쪽 중 8 쪽이 오탐이면 그 문서의 신호 전체를 무시하게 됩니다.

## 범위

- `src/diagnostics/layout_anomaly.rs` — 콘텐츠 유무 판정만 페이지 전체로 넓힙니다.
- overflow·off-canvas·overlap 의 기준 상자(본문 여백·페이지 상자)는 **그대로 둡니다.**
  그 셋은 "본문 여백을 넘었나" 라는 뜻이 분명합니다.
- 바탕쪽·머리말·꼬리말은 콘텐츠에서 제외합니다 — 배경·장식은 모든 쪽에 있으므로 그걸
  내용으로 세면 빈 쪽 판정 자체가 무의미해지고, 쪽번호만 있는 빈 쪽을 "내용 있음" 으로
  볼 수도 없습니다.


---

## 수정

`page_has_visible_content` 를 두어 **빈 쪽 판정에서만** 페이지 전체를 훑습니다.

## 실측 — samples 945 건 전수

| 신호 | 수정 전 | 수정 후 | 차 |
| --- | ---: | ---: | ---: |
| **empty_page** | **133** | **72** | **-61** |
| overflow | 2,955 | 2,955 | 0 |
| off-canvas | 437 | 437 | 0 |
| overlap | 328 | 328 | 0 |
| text-overlap | 4,408 | 4,408 | 0 |

**나머지 네 신호가 정확히 0 변동**입니다 — 이 변경이 다른 판정에 새지 않았다는 기계적
증거입니다.

빈 쪽 판정이 바뀐 문서 19 종 중 상위입니다.

```
 9 ->  0  issue4514/sample1-repro.hwp
 8 ->  0  hwpx/issue2019_floating_form_74312.hwpx
 8 ->  0  table-ipc.hwp
18 -> 11  2025 행정업무운영 편람(최종).hwp
18 -> 11  2025 행정업무운영 편람(최종).hwpx
 4 ->  0  issue5941/1490000-201600081_roadmap_research.hwp
```

**남은 72 건은 이 수정으로 설명되지 않습니다.** 진짜 빈 쪽인지 다른 오탐인지는 별건이고,
이 PR 은 "`Body` 밖 내용을 못 보던 것" 하나만 고칩니다.

## 시험이 결함을 실제로 잡는지 확인했습니다

`src/diagnostics/layout_anomaly.rs` 만 되돌리고 같은 시험을 다시 돌렸습니다.

```
test paper_anchored_table_page_is_not_reported_empty ... FAILED
  빈 쪽으로 잡힌 쪽: [1, 2, 3, 4, 5, 6, 7, 8]
test other_verdicts_are_unchanged ... ok
```

두 번째 시험이 되돌린 상태에서도 통과하는 것은 정상입니다 — 그 문서의 컨테이너 판정은
원래 (0, 0, 0) 이고, 그 시험의 목적은 **수정이 그 값을 건드리지 않았음**을 고정하는 것입니다.

## 측정에서 겪은 함정 (기록용)

전수 재측정을 두 번 했습니다. 첫 번째는 **배치 스캔이 아직 실행 중인 JSON 을 읽어**
overflow 가 2,955 → 1,714 로 42% 줄어든 것처럼 보였습니다(파일 738KB, 완료 시 3.59MB).

빈 쪽 판정 하나를 고쳤는데 overflow 가 그만큼 줄 리 없다는 점이 단서였습니다. 결과가 너무
좋으면 측정을 의심하는 편이 낫습니다.

## 관련 이슈

closes #6344

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, Cargo generated test target을 포함하지 않음
- [x] `src/**`의 `#[cfg(test)]` 변경 없음 — `rust-unit-test-tiers --check --base-ref f6a6bee8f3` 통과 (4221)
- [x] `cargo test` 통과 — 신규 2종 통과, 전수 재측정으로 다른 신호 무변동 확인
- [x] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **해당 없음**. `src/diagnostics/` 는 렌더 트리의 소비자라 렌더 산출물이 바뀌지 않습니다
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 변경 — 해당 없음
- [ ] 작업 증빙 캡슐 — 진단 판정 수정이라 해당 없음. 실측 로그 원문을 위에 실었습니다
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 — 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: 빈 쪽 후보에서만 페이지 트리를 한 번 더 훑습니다. `has_content` 가 이미 true 면
  아예 호출하지 않으므로, 대부분의 쪽에서는 추가 비용이 없습니다.
- 재현·측정: samples 945 건 배치 스캔이 수정 전후 같은 자릿수였습니다.
