### PR TITLE
docs(pr_review): 조판 원장이 무엇을 지키고 무엇을 안 지키는지 §4.3.2 로 정리한다

### DIFF
--- a/mydocs/manual/pr_review/local_validation.md
+++ b/mydocs/manual/pr_review/local_validation.md
@@ -277,6 +277,41 @@ remote push, PR 생성, ready 전환, merge 승인과는 별개다.
 | CI workflow | [GitHub 저장소 운영 매뉴얼](../github_operations.md)의 변경 등급에 따른 workflow 구문·정책 테스트·required check 영향·최신 GitHub Actions 결과 |
 | 기존 golden/baseline/fixture | 관련 focused test, snapshot 결정성, 최신 PR head CI |
 
+### 4.3.2 조판 원장(baseline ratchet) — 무엇이 자동으로 지켜지나
+
+renderer·layout·pagination 을 건드리면 아래 원장들이 `Build & Test` 안에서 함께 돈다.
+**따로 실행할 필요는 없지만, 무엇이 지켜지고 무엇이 안 지켜지는지는 알고 있어야 한다** —
+어느 것도 걸리지 않았다고 해서 조판이 안 바뀐 것은 아니다.
+
+| 원장 | 무엇을 고정하나 | 판정 |
+| --- | --- | --- |
+| `tests/overflow_cell_baseline.rs` | 셀 줄이 쪽 하단 밖으로 나가 소실되는 것 | 문서별 줄 수 래칫 (`tests/fixtures/overflow_cell_baseline.tsv`) |
+| `tests/visual_roundtrip_baseline.rs` | parse → serialize → reparse 자기 정합성 | 전수 — `VISUAL_XFAIL`·`EXCLUDED` 외 전 샘플, 신규 샘플 자동 포함 |
+| `tests/ir_field_sweep_baseline.rs` | IR 필드 스윕 | 래칫 (`tests/fixtures/ir_field_sweep_baseline.tsv`) |
+| `tests/hwp5_roundtrip_baseline.rs`·`hwpx_roundtrip_baseline.rs` | 형식별 왕복 | 래칫 |
+
+원장이 실패하면 **수치를 올려 통과시키지 않는다.** 원인 정정이 원칙이고, 의도된 변화만
+기준선에 반영하며 그 근거를 PR 에 남긴다(§4.3.1).
+
+특히 `visual_roundtrip_baseline` 의 `VISUAL_XFAIL` 은 **현재 비어 있다**(주석에 남은 것은
+전부 PASS 로 승격돼 제거된 이력이다). 거기에 항목을 넣는 것은 지금 완전히 깨끗한 게이트를
+처음으로 무르게 만드는 일이므로, 내 변경이 만든 회귀를 받아주려고 등재하지 않는다.
+
+#### 원장이 보지 않는 것
+
+원장이 초록이어도 아래는 걸리지 않는다. renderer 변경의 시각 증적을 원장으로 대체할 수
+없는 이유다.
+
+- **본문 여백 초과**(`layout-anomaly` overflow) — 정상 조판에서도 어울림 개체·바탕쪽이
+  여백에 걸치므로 그 자체로는 결함이 아니다. 컨테이너 단위 판정이라 쪽 하단으로 몇 px
+  넘긴 것은 거의 보이지 않는다.
+- **한글과의 조판 일치** — 원장은 rhwp 의 **자기 무회귀**를 볼 뿐 한컴과 같은지는 보지
+  않는다. 원장이 전부 초록이어도 처음부터 한컴과 다르게 조판하고 있으면 그대로 통과한다.
+  그 축은 [한글 페이지 충실도 오라클](../verification/hangul_page_oracle.md) 이 맡는데
+  한컴오피스 설치본이 필요하다.
+- **조판의 환경 의존성** — 같은 문서·같은 커밋인데 로컬과 CI 의 조판이 갈리는 사례가
+  있다. 원장의 기준선은 어느 환경에서 뽑았는지에 따라 값이 달라질 수 있다.
+
 archive label 또는 trusted post-merge reuse topology를 바꾸면, 일반 workflow 계약 검사에 더해
 아래 두 묶음을 PR 전에 모두 실행한다. Studio E2E나 OS resource-limit처럼 이 변경 범위와
 무관한 Node 테스트까지 glob으로 섞지 않는다.


### PR DESCRIPTION
## 변경 요약

`local_validation.md` 에 **§4.3.2 조판 원장** 절을 추가했습니다. renderer·layout 을 건드릴 때
`Build & Test` 안에서 자동으로 도는 원장들이 **무엇을 지키고 무엇을 안 지키는지** 정리합니다.

`mydocs` 만 변경합니다. 기존 원장의 동작을 서술할 뿐 **정책을 바꾸지 않습니다.**

## 왜

원장 네 종이 이미 CI 에서 돌고 있는데, `local_validation.md` §4.3 표에는 "focused test,
release-test 전체" 라고만 적혀 있어 **기여자가 무엇이 자동으로 지켜지는지 알 수 없습니다.**

더 중요한 것은 반대쪽입니다 — **원장이 전부 초록이어도 안 걸리는 것**이 무엇인지 모르면,
"원장 통과했으니 조판 안 바뀜" 으로 오해하고 시각 증적을 생략하게 됩니다.

## 담은 것

| 원장 | 무엇을 고정하나 | 판정 |
| --- | --- | --- |
| `tests/overflow_cell_baseline.rs` | 셀 줄이 쪽 하단 밖으로 나가 소실되는 것 | 문서별 래칫 |
| `tests/visual_roundtrip_baseline.rs` | parse → serialize → reparse 자기 정합성 | 전수 (신규 샘플 자동 포함) |
| `tests/ir_field_sweep_baseline.rs` | IR 필드 스윕 | 래칫 |
| `tests/hwp5_roundtrip_baseline.rs`·`hwpx_roundtrip_baseline.rs` | 형식별 왕복 | 래칫 |

### `VISUAL_XFAIL` 이 비어 있다는 사실을 명시했습니다

`visual_roundtrip_baseline` 의 `VISUAL_XFAIL` 은 **현재 비어 있습니다.** 주석에 남은 것은
전부 PASS 로 승격돼 제거된 이력입니다. 거기 항목을 넣는 것은 **지금 완전히 깨끗한 게이트를
처음으로 무르게 만드는 일**이므로 별도 판단이 필요하다고 적었습니다.

제가 실제로 그 유혹을 겪었습니다 — PR #6329 에서 이 원장이 제 변경의 회귀를 잡았을 때,
`exam_kor.hwpx` 를 XFAIL 에 넣으면 즉시 초록이 됐습니다. 그러지 않고 원인(직렬화기 비대칭)을
고쳤습니다. 다음 사람이 같은 갈림길에서 같은 판단을 하도록 문서에 남깁니다.

### "원장이 보지 않는 것" — 이 절이 핵심입니다

원장이 초록이어도 아래는 걸리지 않습니다.

- **본문 여백 초과** — 정상 조판에서도 어울림 개체·바탕쪽이 여백에 걸치므로 그 자체로는
  결함이 아닙니다. 컨테이너 단위 판정이라 쪽 하단으로 몇 px 넘긴 것은 거의 안 보입니다.
- **한글과의 조판 일치** — 원장은 rhwp 의 **자기 무회귀**만 봅니다. 처음부터 한컴과 다르게
  조판하고 있으면 그대로 통과합니다. 그 축은 `hangul_page_oracle` 이 맡는데 한컴오피스
  설치본이 필요합니다.
- **조판의 환경 의존성** — 같은 문서·같은 커밋인데 로컬과 CI 의 조판이 갈리는 사례가
  있습니다. 원장 기준선의 값이 어느 환경에서 뽑았는지에 따라 달라질 수 있습니다.

renderer 변경의 시각 증적을 원장으로 대체할 수 없는 이유가 이 절입니다.

## 사실 확인

문서에 적은 것은 전부 `devel` `f6a6bee8f3` 에서 확인했습니다.

- 원장 파일 5 개 존재 확인
- `VISUAL_XFAIL` 배열이 비어 있음 확인(`tests/visual_roundtrip_baseline.rs:32`)
- 초안에 `clipping_baseline` 을 넣었다가 **해당 시험이 없어 뺐습니다**(픽스처 TSV 만 있고
  이를 읽는 `tests/**` 시험을 찾지 못했습니다). 없는 게이트를 있다고 쓰지 않았습니다.

## 테스트

- [ ] `cargo fmt --all -- --check` — **해당 없음**(`mydocs` 만 변경). Rust 코드 변경 없음
- [x] `git diff --check` 통과
- [x] 문서 링크 확인 — 참조하는 `hangul_page_oracle.md` 는 존재합니다. 아직 병합되지 않은
      문서(PR #6343)로는 **링크하지 않았습니다** — 끊어진 링크를 만들지 않기 위해서입니다
- [ ] 나머지 항목 — Rust·studio·WASM 변경이 없어 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: 없음 (문서 전용)
