### PR TITLE
tools(fidelity_compare): samples 와 pdf/ 정답지를 자동으로 짝지어 준다 — 등록 6쌍에서 566쌍으로

### DIFF
--- a/tools/fidelity_compare/README.md
+++ b/tools/fidelity_compare/README.md
@@ -248,6 +248,43 @@ border의 stroke interval이 ancestor `body-clip-*` 또는 `cell-clip-*`과 만�
 이슈로 승격한다. 문자 멀티셋도 후보 검출용이다. PDF 텍스트층에 없는 path 글리프,
 숨김 텍스트, 추출기 문자 매핑 차이가 있으므로 최종 시각 판정을 대신하지 않는다.
 
+## 등록되지 않은 문서와 짝짓기 — `oracle_pair_index.py`
+
+`REG` 에는 6 쌍이 등록돼 있는데 `pdf/` 에는 정답지가 **573 장** 있다. 나머지를 쓰려면
+`--source`·`--reference-pdf` 로 직접 지정해야 하고, 그때마다 짝을 손으로 찾아야 한다.
+
+`oracle_pair_index.py` 가 그 짝짓기를 자동화한다.
+
+```bash
+# 짝지어진 566개 목록 (TSV)
+python tools/fidelity_compare/oracle_pair_index.py --list
+
+# 한 문서의 인자쌍을 바로 얻는다
+python tools/fidelity_compare/oracle_pair_index.py --args "samples/basic/sungeo.hwp"
+#   --source "samples/basic/sungeo.hwp" --reference-pdf "pdf/basic/sungeo-2022.pdf" --label sungeo
+```
+
+### 짝짓기는 디렉터리까지 본다
+
+이름만 맞추면 **같은 이름의 다른 문서**를 집는다. 저장소에는 그런 문서가 44 종 있다.
+
+```
+samples/KTX.hwp        27쪽  「AI-반도체 해외실증 지원 사업 공모 안내서」
+samples/basic/KTX.hwp   1쪽  실제 KTX 노선도
+```
+
+둘은 `pdf/KTX-2022.pdf`(27 쪽)와 `pdf/basic/KTX-2022.pdf`(1 쪽)를 함께 후보로 갖는다.
+잘못 짝지으면 대조 결과 전체가 무의미해진다. 같은 디렉터리의 정답지가 있으면 그것만 쓰고,
+없으면 이름 후보를 그대로 쓰되 `--list` 의 3 열에 후보 수를 적어 사람이 판단하게 한다.
+566 개 중 **96 개가 디렉터리로 좁혀진다.**
+
+### 모아 찍기 문서는 쪽 단위로 견주지 않는다
+
+`print_method` 가 모아 찍기(4·5)면 한글이 한 장에 여러 쪽을 실어 뽑아 쪽수·용지 방향이
+rhwp 와 다르다. `--rhwp <바이너리>` 를 주면 `--list` 4 열에 `nup` 으로 표시한다(566 개 중
+10 개). 그 문서는 쪽 좌표를 그대로 견주면 오판한다 —
+`model::document::print_method_implies_nup` 주석의 실측표를 참고한다.
+
 ## 등록 쌍과 기준 등급
 
 `REG`는 한글 경로 인코딩·NFC/NFD 함정을 피하려고 ASCII 글롭을 사용한다. `pdf/` 아래의

--- a/tools/fidelity_compare/oracle_pair_index.py
+++ b/tools/fidelity_compare/oracle_pair_index.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""`samples/` 문서와 `pdf/` 한컴 정답지를 자동으로 짝지어 목록을 낸다.
+
+`fidelity_compare.py` 는 비교할 쌍을 `REG` 에 손으로 등록하거나 `--source`·`--reference-pdf`
+로 직접 지정해야 한다. 등록된 것은 6 개인데 `pdf/` 에는 정답지가 **573 장** 있다. 나머지를
+쓰려면 매번 짝을 찾아 손으로 적어야 한다.
+
+이 도구는 그 짝짓기를 자동화한다. 산출은 `fidelity_compare.py` 에 그대로 넣을 수 있는
+`--source`/`--reference-pdf` 인자쌍이거나 TSV 목록이다.
+
+    python tools/fidelity_compare/oracle_pair_index.py --list
+    python tools/fidelity_compare/oracle_pair_index.py --args "samples/basic/sungeo.hwp"
+
+## 짝짓기 규칙 — 디렉터리까지 본다
+
+정답지 파일명은 `<이름>[-접미사].pdf` 이고 접미사는 한글 버전·폰트 조건이다
+(`-2022`, `-2020-kopub`, `-no-ttf` 등). 이름만 맞추면 **같은 이름의 다른 문서**를 집는다.
+
+    samples/KTX.hwp        27쪽  「AI-반도체 해외실증 지원 사업 공모 안내서」
+    samples/basic/KTX.hwp   1쪽  실제 KTX 노선도
+
+이 둘은 `pdf/KTX-2022.pdf`(27 쪽)와 `pdf/basic/KTX-2022.pdf`(1 쪽)를 함께 후보로 갖는다.
+잘못 짝지으면 대조 결과 전체가 무의미해진다 — 실제로 이 함정에 걸려 "글자 93.8% 손실" 이라는
+가짜 결함을 만들 뻔했다. 저장소에는 같은 이름의 서로 다른 문서가 **44 종** 있다.
+
+그래서 **같은 디렉터리의 정답지가 있으면 그것만** 쓴다. 없으면 이름 후보를 그대로 쓰되
+`--list` 출력에 후보 수를 함께 적어 사람이 판단할 수 있게 한다.
+
+## 모아 찍기 문서는 표시한다
+
+`print_method` 가 모아 찍기(4·5)면 한글이 한 장에 여러 쪽을 실어 뽑으므로 쪽수·용지 방향이
+rhwp 와 다르다(`model::document::print_method_implies_nup`). 쪽 단위로 견주면 오판하므로
+`--list` 에 `nup` 으로 표시한다. `--rhwp` 를 주면 그 판정을 채운다.
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+SUFFIX = re.compile(r'-(20\d\d|hwp|hwpx|kopub|no-ttf|current)+$', re.I)
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def stem(path):
+    name = re.sub(r'\.(pdf|hwp|hwpx)$', '', os.path.basename(path), flags=re.I)
+    prev = None
+    while prev != name:
+        prev = name
+        name = SUFFIX.sub('', name)
+    return name
+
+
+def subdir(path, root):
+    d = os.path.dirname(path).replace(os.sep, '/')
+    return d[len(root):].lstrip('/') if d.startswith(root) else d
+
+
+def git_pdfs():
+    """`pdf/` 는 sparse-checkout 대상이 아니라 작업 트리에 없을 수 있다 — git 으로 읽는다."""
+    out = subprocess.run(
+        ['git', '-c', 'core.quotePath=false', 'ls-tree', '-r', 'HEAD', '--name-only', 'pdf/'],
+        capture_output=True, text=True, encoding='utf-8', errors='replace', cwd=REPO).stdout
+    return [p.strip() for p in out.split('\n') if p.strip().lower().endswith('.pdf')]
+
+
+def samples():
+    found = []
+    root = os.path.join(REPO, 'samples')
+    for dirpath, _, files in os.walk(root):
+        for f in files:
+            if f.lower().endswith(('.hwp', '.hwpx')):
+                p = os.path.join(dirpath, f).replace(os.sep, '/')
+                found.append('samples/' + p[len(root.replace(os.sep, '/')) + 1:])
+    return sorted(found)
+
+
+def build_index():
+    by_name = {}
+    for p in git_pdfs():
+        by_name.setdefault(stem(p), []).append(p)
+
+    index = {}
+    for s in samples():
+        cands = by_name.get(stem(s))
+        if not cands:
+            continue
+        same_dir = [p for p in cands if subdir(p, 'pdf') == subdir(s, 'samples')]
+        chosen = same_dir if same_dir else cands
+        index[s] = (sorted(chosen), len(cands))
+    return index
+
+
+def nup_flag(rhwp, sample):
+    r = subprocess.run([rhwp, 'info', os.path.join(REPO, sample), '--json'],
+                       capture_output=True, text=True, encoding='utf-8', errors='replace')
+    if r.returncode != 0:
+        return None
+    try:
+        return bool(json.loads(r.stdout).get('printMethodImpliesNup'))
+    except Exception:
+        return None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--list', action='store_true', help='짝지어진 목록을 TSV 로 낸다')
+    ap.add_argument('--args', metavar='SAMPLE',
+                    help='그 문서의 fidelity_compare 인자쌍을 낸다')
+    ap.add_argument('--rhwp', help='모아 찍기 판정을 채울 rhwp 바이너리 경로')
+    args = ap.parse_args()
+
+    index = build_index()
+
+    if args.args:
+        key = args.args.replace(os.sep, '/')
+        if key not in index:
+            print(f'짝지어진 정답지가 없다: {key}', file=sys.stderr)
+            return 1
+        chosen, _ = index[key]
+        print('--source "%s" --reference-pdf "%s" --label %s'
+              % (key, chosen[0], re.sub(r'[^A-Za-z0-9]+', '-', stem(key)).strip('-') or 'doc'))
+        if len(chosen) > 1:
+            print('# 정답지 후보 %d개 — 한글 버전·폰트 조건이 다르다:' % len(chosen),
+                  file=sys.stderr)
+            for p in chosen:
+                print('#   %s' % p, file=sys.stderr)
+        return 0
+
+    if not args.list:
+        ap.print_help()
+        return 2
+
+    print('# 문서\t정답지(쉼표구분)\t이름후보수\t모아찍기')
+    nup_count = 0
+    for s, (chosen, n_all) in sorted(index.items()):
+        nup = ''
+        if args.rhwp:
+            f = nup_flag(args.rhwp, s)
+            if f:
+                nup = 'nup'
+                nup_count += 1
+        print('%s\t%s\t%d\t%s' % (s, ','.join(chosen), n_all, nup))
+    narrowed = sum(1 for _, (c, n) in index.items() if len(c) < n)
+    print('# 짝지어진 문서 %d개 / 디렉터리로 좁혀진 것 %d개%s'
+          % (len(index), narrowed, ' / 모아찍기 %d개' % nup_count if args.rhwp else ''),
+          file=sys.stderr)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## 변경 요약

`samples/` 문서와 `pdf/` 한컴 정답지를 **자동으로 짝지어 주는** 도구를 추가했습니다.

- `tools/fidelity_compare/oracle_pair_index.py` (신규)
- `tools/fidelity_compare/README.md` 에 사용법·함정 등재

`fidelity_compare.py` 본체는 건드리지 않습니다.

## 왜

`fidelity_compare` 는 비교할 쌍을 `REG` 에 손으로 등록하거나 `--source`·`--reference-pdf`
로 직접 지정해야 합니다. **등록된 것은 6 쌍인데 `pdf/` 에는 정답지가 573 장 있습니다.**
나머지를 쓰려면 매번 짝을 손으로 찾아야 했습니다.

```bash
python tools/fidelity_compare/oracle_pair_index.py --list          # 566문서 TSV
python tools/fidelity_compare/oracle_pair_index.py --args "samples/basic/sungeo.hwp"
#   --source "samples/basic/sungeo.hwp" --reference-pdf "pdf/basic/sungeo-2022.pdf" --label sungeo
```

**566 문서**가 짝지어집니다.

## 핵심 — 디렉터리까지 봐야 한다

이름만 맞추면 **같은 이름의 다른 문서**를 집습니다. 저장소에 그런 문서가 **44 종** 있습니다.

```
samples/KTX.hwp        27쪽  「AI-반도체 해외실증 지원 사업 공모 안내서」
samples/basic/KTX.hwp   1쪽  실제 KTX 노선도
```

둘이 `pdf/KTX-2022.pdf`(27 쪽)와 `pdf/basic/KTX-2022.pdf`(1 쪽)를 **함께** 후보로 갖습니다.
잘못 짝지으면 대조 결과 전체가 무의미해집니다.

**실제로 이 함정에 걸렸습니다.** 정답지 텍스트 대조 스윕에서 `KTX.hwp` 가 "글자 93.8% 손실"
로 나와 심각한 결함인 줄 알았는데, 정답지를 직접 열어보니 27 쪽짜리 **다른 문서**였습니다.
결함을 신고하려다 도구의 결함을 찾았습니다.

같은 디렉터리의 정답지가 있으면 그것만 쓰고, 없으면 이름 후보를 그대로 쓰되 `--list` 의
3 열에 후보 수를 적어 사람이 판단하게 합니다. **566 개 중 96 개가 디렉터리로 좁혀집니다.**

## 모아 찍기 표시

`print_method` 가 모아 찍기(4·5)면 한글이 한 장에 여러 쪽을 실어 뽑아 쪽수·용지 방향이
rhwp 와 다릅니다. `--rhwp <바이너리>` 를 주면 `--list` 4 열에 `nup` 으로 표시합니다
(566 개 중 **10 개**). 그 문서는 쪽 좌표를 그대로 견주면 오판합니다 —
`model::document::print_method_implies_nup` 주석의 실측표가 근거입니다.

## 검증

| 항목 | 결과 |
| --- | --- |
| `--list` | 566 문서 / 디렉터리로 좁혀진 것 96 개 / 모아찍기 10 개 |
| `--args "samples/basic/sungeo.hwp"` | `pdf/basic/sungeo-2022.pdf` 를 고름 |
| KTX 두 문서 | 각자 올바른 정답지로 짝지어짐 |
| `git diff --check` | 통과 |

`pdf/` 는 sparse-checkout 대상이 아니라 작업 트리에 없을 수 있으므로 `git ls-tree` 로
읽습니다 — sparse 설정을 건드릴 필요가 없습니다.

## 관련

같은 짝짓기 규칙을 쓰는 것이 PR #6338(정답지 쪽수 원장)이고, 방법론은 PR #6343 에
정리했습니다. 이 PR 은 그 규칙을 기존 시각 대조 하네스에서도 쓸 수 있게 합니다.
세 PR 은 서로 독립이라 병합 순서에 제약이 없습니다.

## 테스트

- [ ] `cargo fmt --all -- --check` — **해당 없음**(Python 도구·README 만 변경)
- [x] `git diff --check` 통과
- [x] 도구 실행 확인 — 위 검증 표
- [x] 문서 링크 확인 — README 안 상대 참조만 씁니다
- [ ] 나머지 항목 — Rust·studio·WASM 변경이 없어 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: 없음 (CI 에서 실행되지 않는 보조 도구)
- `--list` 는 `git ls-tree` 한 번과 `samples/` 순회로 즉시 끝납니다. `--rhwp` 를 주면
  문서마다 `rhwp info` 를 한 번씩 부르므로 566 문서에서 수 분이 걸립니다.
