### PR TITLE
Task #6350: 수식 속성 setter 순수화 — 봉인 기반 raw 판정과 명시 크기 존중

### DIFF
--- a/src/document_core/commands/object_ops/equation.rs
+++ b/src/document_core/commands/object_ops/equation.rs
@@ -523,26 +523,16 @@ impl DocumentCore {
 #[cfg(test)]
 mod tests {
     use crate::document_core::DocumentCore;
-    use crate::model::control::{Control, Equation};
-    use crate::model::raw_provenance::record_digest;
-
-    fn sealed_equation() -> Equation {
-        let mut eq = Equation {
-            script: "1 over 2".to_string(),
-            font_size: 1000,
-            raw_ctrl_data: vec![0xAB; 16],
-            ..Default::default()
-        };
-        eq.common.width = 5000;
-        eq.common.height = 4000;
-        // 파서(seal_body_raw_provenance)가 서는 봉인과 같은 계약.
-        eq.raw_ctrl_seal = Some(record_digest(&eq.common));
-        eq
-    }
+    use crate::model::control::Equation;
 
     /// 봉인이 없는 raw(파서를 거치지 않은 합성 IR·어댑터 산출)는 저장기가 원본
     /// CTRL_HEADER 를 무조건 방출하므로, 판정 근거가 없어 종전대로 비워야 한다.
     /// 비우지 않으면 크기/위치 편집이 저장에서 원복된다.
+    ///
+    /// 봉인이 **있는** 경우의 계약(파괴하지 않음·되돌리기 성립·명시 크기 존중)은
+    /// 인크레이트 접근이 필요 없어 통합 테스트에 둔다 —
+    /// `tests/cases/issue_6350_equation_setter_purity.rs`.
+    /// 이 모듈은 `pub(crate)` 진입점과 합성 IR 이 필요한 한 가지만 남긴다.
     #[test]
     fn apply_equation_properties_clears_unsealed_raw_ctrl_data() {
         let mut eq = Equation {
@@ -557,180 +547,5 @@ mod tests {
             eq.raw_ctrl_data.is_empty(),
             "봉인 없는 raw_ctrl_data 는 비워져야 편집이 .hwp 저장에 반영된다"
         );
-    }
-
-    /// [#5890] 봉인된 raw 는 setter 가 파괴하지 않는다 — #4495 봉인이 `common` 변경을
-    /// 감지해 저장기를 IR 합성으로 내리므로 지울 이유가 없고, 지우지 않으면 되돌릴 때
-    /// 원본 바이트가 살아난다.
-    #[test]
-    fn apply_equation_properties_keeps_sealed_raw_ctrl_data() {
-        let mut eq = sealed_equation();
-        DocumentCore::apply_equation_properties(&mut eq, 96.0, r#"{"script":"1 over 3"}"#);
-        assert_eq!(
-            eq.raw_ctrl_data,
-            vec![0xAB; 16],
-            "봉인된 raw_ctrl_data 는 setter 가 지우지 않는다 (#5890)"
-        );
-        assert_ne!(
-            eq.raw_ctrl_seal,
-            Some(record_digest(&eq.common)),
-            "자동 크기 재계산으로 common 이 바뀌었으면 봉인이 어긋나 저장기가 IR 로 합성한다"
-        );
-    }
-
-    /// [#5890] 파괴하지 않으므로 되돌리기가 성립한다 — `common` 을 원상복구하면 봉인이
-    /// 다시 맞아 저장기가 원본 CTRL_HEADER 바이트를 그대로 방출한다.
-    #[test]
-    fn sealed_equation_raw_revives_when_common_restored() {
-        let mut eq = sealed_equation();
-        let sealed = eq.raw_ctrl_seal.expect("픽스처는 봉인돼 있다");
-        let before = eq.common.clone();
-
-        DocumentCore::apply_equation_properties(&mut eq, 96.0, r#"{"script":"1 over 3"}"#);
-        assert_ne!(
-            record_digest(&eq.common),
-            record_digest(&before),
-            "편집이 common 을 바꿨다"
-        );
-
-        eq.script = "1 over 2".to_string();
-        eq.common = before;
-        assert_eq!(
-            eq.raw_ctrl_seal,
-            Some(sealed),
-            "setter 는 봉인 자체를 건드리지 않는다"
-        );
-        assert_eq!(
-            sealed,
-            record_digest(&eq.common),
-            "common 원상복구 후 봉인이 다시 맞아 저장기가 원본 raw 를 승인한다 (#5890)"
-        );
-        assert_eq!(eq.raw_ctrl_data, vec![0xAB; 16], "원본 바이트가 남아 있다");
-    }
-
-    /// [#5890] 자동 크기 파생은 봉지가 지정하지 않은 축에만 적용한다 — 종전에는
-    /// 무조건 덧써서 명시된 width/height 가 조용히 무시됐다.
-    #[test]
-    fn apply_equation_properties_honors_explicit_size() {
-        let mut eq = Equation {
-            script: "1 over 2".to_string(),
-            font_size: 1000,
-            ..Default::default()
-        };
-        let (intrinsic_w, intrinsic_h) =
-            crate::renderer::equation::intrinsic_size_hwp(&eq.script, eq.font_size);
-
-        DocumentCore::apply_equation_properties(&mut eq, 96.0, r#"{"width":5000,"height":4000}"#);
-        assert_eq!((eq.common.width, eq.common.height), (5000, 4000));
-
-        // 한 축만 지정하면 나머지 축은 파생값을 받는다.
-        let mut half = Equation {
-            script: "1 over 2".to_string(),
-            font_size: 1000,
-            ..Default::default()
-        };
-        DocumentCore::apply_equation_properties(&mut half, 96.0, r#"{"width":5000}"#);
-        assert_eq!((half.common.width, half.common.height), (5000, intrinsic_h));
-
-        // 크기를 담지 않은 부분 봉지(UI 다이얼로그 계약)는 두 축 모두 파생값.
-        let mut auto = Equation {
-            script: "1 over 2".to_string(),
-            font_size: 1000,
-            ..Default::default()
-        };
-        DocumentCore::apply_equation_properties(&mut auto, 96.0, r#"{"color":255}"#);
-        assert_eq!(
-            (auto.common.width, auto.common.height),
-            (intrinsic_w, intrinsic_h)
-        );
-    }
-
-    fn find_equation_coord(core: &DocumentCore) -> (usize, usize, usize) {
-        for (si, section) in core.document.sections.iter().enumerate() {
-            for (pi, para) in section.paragraphs.iter().enumerate() {
-                for (ci, ctrl) in para.controls.iter().enumerate() {
-                    if matches!(ctrl, Control::Equation(_)) {
-                        return (si, pi, ci);
-                    }
-                }
-            }
-        }
-        panic!("샘플에 수식 컨트롤이 없다");
-    }
-
-    /// [#5890] 한컴 원본 3종에서 getter 가 낸 속성 봉지를 그대로 setter 에 먹이면
-    /// 저장 바이트가 편집 전과 같아야 한다(get∘set = 항등).
-    ///
-    /// 기준선도 구역 패스스루(`raw_stream`)를 비워 setter 와 같은 조건에서 비교한다 —
-    /// 판정 대상은 수식 CTRL_HEADER 이고, 구역 스트림 봉인은 #4488 이 따로 다룬다.
-    ///
-    /// 수정 전에는 세 샘플 모두 불일치했다: setter 가 `raw_ctrl_data` 를 파괴하고
-    /// 자동 크기로 `common.width/height` 를 덧썼다(equation-lim 9096x2715 → 9327x2684,
-    /// atop-equation-01 1235x2362 → 1075x2640, issue-505 9096x2715 → 13466x3025).
-    #[test]
-    fn setter_roundtrip_is_byte_identical_on_hancom_samples() {
-        for sample in [
-            "samples/equation-lim.hwp",
-            "samples/atop-equation-01.hwp",
-            "samples/issue-505-equations.hwp",
-        ] {
-            let bytes = std::fs::read(sample).unwrap_or_else(|e| panic!("{sample}: {e}"));
-
-            let mut base = DocumentCore::from_bytes(&bytes).expect("파싱");
-            let (si, pi, ci) = find_equation_coord(&base);
-            {
-                let eq = base
-                    .find_equation_ref(si, pi, ci, None, None)
-                    .expect("수식 참조");
-                assert!(
-                    !eq.raw_ctrl_data.is_empty() && eq.raw_ctrl_seal.is_some(),
-                    "{sample}: 파스본 수식은 봉인된 raw 를 가진다 (전제)"
-                );
-            }
-            let bag = base
-                .get_equation_properties_native(si, pi, ci, None, None)
-                .expect("getter");
-            base.document.sections[si].raw_stream = None;
-            let baseline = base.export_hwp_native().expect("기준 저장");
-
-            let mut edited = DocumentCore::from_bytes(&bytes).expect("파싱");
-            edited
-                .set_equation_properties_native(si, pi, ci, None, None, &bag)
-                .expect("setter");
-            let roundtripped = edited.export_hwp_native().expect("편집 저장");
-
-            assert_eq!(
-                baseline, roundtripped,
-                "{sample}: getter 봉지를 그대로 먹인 뒤 저장 바이트가 달라졌다 (#5890)"
-            );
-
-            // 종전 `raw_ctrl_data.clear()` 가 지키던 계약은 그대로다 — 실제 편집은 봉인
-            // 불일치로 저장기를 IR 합성으로 내려 저장·재파싱에서 살아남는다.
-            let mut resized = DocumentCore::from_bytes(&bytes).expect("파싱");
-            resized
-                .set_equation_properties_native(
-                    si,
-                    pi,
-                    ci,
-                    None,
-                    None,
-                    r#"{"width":5000,"height":4000}"#,
-                )
-                .expect("setter");
-            let resaved = resized.export_hwp_native().expect("편집 저장");
-            assert_ne!(
-                baseline, resaved,
-                "{sample}: 크기 편집이 저장 바이트에 반영되지 않았다"
-            );
-            let reparsed = DocumentCore::from_bytes(&resaved).expect("재파싱");
-            let eq = reparsed
-                .find_equation_ref(si, pi, ci, None, None)
-                .expect("수식 참조");
-            assert_eq!(
-                (eq.common.width, eq.common.height),
-                (5000, 4000),
-                "{sample}: 크기 편집이 저장·재파싱에서 살아남지 않았다"
-            );
-        }
     }
 }

--- a/src/document_core/commands/object_ops/equation.rs
+++ b/src/document_core/commands/object_ops/equation.rs
@@ -165,16 +165,37 @@ impl DocumentCore {
         }
         Self::apply_common_obj_attr_from_json(&mut eq.common, props_json);
 
-        let (width, height) =
-            crate::renderer::equation::intrinsic_size_hwp(&eq.script, eq.font_size);
-        eq.common.width = width;
-        eq.common.height = height;
+        // [#5890] 파생(자동 크기)은 봉지가 크기를 지정하지 않은 축에만 적용한다.
+        // 종전에는 무조건 덧써서 getter 가 낸 봉지를 그대로 먹여도 크기가 바뀌었다
+        // (get∘set ≠ 항등) — 속성 봉지만으로 되돌릴 수 없는 조작이 되고,
+        // apply_common_obj_attr_from_json 이 방금 반영한 width/height 도 조용히 무시됐다.
+        // UI 다이얼로그는 변경된 키만 담은 부분 봉지를 보내므로(width/height 미포함)
+        // 스크립트·글자크기 편집의 자동 크기 재계산은 종전대로 동작한다.
+        let explicit_width = json_u32(props_json, "width").is_some();
+        let explicit_height = json_u32(props_json, "height").is_some();
+        if !explicit_width || !explicit_height {
+            let (width, height) =
+                crate::renderer::equation::intrinsic_size_hwp(&eq.script, eq.font_size);
+            if !explicit_width {
+                eq.common.width = width;
+            }
+            if !explicit_height {
+                eq.common.height = height;
+            }
+        }
 
-        // raw_ctrl_data 무효화: serialize_equation_control 은 raw_ctrl_data 가 비어있지 않으면
-        // 원본 CTRL_HEADER 바이트를 그대로 방출한다. 편집한 eq.common(크기/위치/treat_as_char)이
-        // .hwp 저장에 반영되도록 원본 passthrough 를 비운다(table_ops 셀 편집 가드, adapt_equation
-        // 의 hwpx→hwp 변환과 동형). EQEDIT 자식 레코드(script/font)는 IR 로 재생성되므로 무관.
-        eq.raw_ctrl_data.clear();
+        // [#5890] raw 패스스루 무효화는 파괴가 아니라 판정으로 한다.
+        // serialize_equation_control 은 raw_ctrl_data 가 비어있지 않으면 원본 CTRL_HEADER
+        // 바이트를 방출하지만, #4495 봉인이 서 있으면 `common` 변경만으로 봉인이 어긋나
+        // 저장기가 IR 합성으로 내려간다 — 원본 바이트를 지우지 않아도 편집(크기/위치/
+        // treat_as_char)은 .hwp 저장에 반영된다. 지우지 않으면 `common` 을 되돌렸을 때
+        // 봉인이 다시 맞아 원본 바이트가 그대로 살아난다(속성 봉지만으로 되돌리는 참 역연산).
+        // 봉인이 없는 raw(파서를 거치지 않은 합성 IR·어댑터 산출)는 판정 근거가 없어
+        // 종전대로 비운다(table_ops 셀 편집 가드, adapt_equation 의 hwpx→hwp 변환과 동형).
+        // EQEDIT 자식 레코드(script/font)는 어느 쪽이든 IR 로 재생성되므로 무관.
+        if eq.raw_ctrl_seal.is_none() {
+            eq.raw_ctrl_data.clear();
+        }
     }
     pub fn get_equation_properties_native(
         &self,
@@ -502,23 +523,214 @@ impl DocumentCore {
 #[cfg(test)]
 mod tests {
     use crate::document_core::DocumentCore;
-    use crate::model::control::Equation;
+    use crate::model::control::{Control, Equation};
+    use crate::model::raw_provenance::record_digest;
 
-    /// .hwp 저장 시 serialize_equation_control 은 raw_ctrl_data 가 비어있지 않으면 원본
-    /// CTRL_HEADER 를 그대로 방출한다. 속성 편집 후 raw_ctrl_data 가 비워지지 않으면
-    /// 크기/위치 편집이 저장에서 원복된다.
-    #[test]
-    fn apply_equation_properties_clears_raw_ctrl_data() {
+    fn sealed_equation() -> Equation {
         let mut eq = Equation {
             script: "1 over 2".to_string(),
             font_size: 1000,
             raw_ctrl_data: vec![0xAB; 16],
             ..Default::default()
         };
+        eq.common.width = 5000;
+        eq.common.height = 4000;
+        // 파서(seal_body_raw_provenance)가 서는 봉인과 같은 계약.
+        eq.raw_ctrl_seal = Some(record_digest(&eq.common));
+        eq
+    }
+
+    /// 봉인이 없는 raw(파서를 거치지 않은 합성 IR·어댑터 산출)는 저장기가 원본
+    /// CTRL_HEADER 를 무조건 방출하므로, 판정 근거가 없어 종전대로 비워야 한다.
+    /// 비우지 않으면 크기/위치 편집이 저장에서 원복된다.
+    #[test]
+    fn apply_equation_properties_clears_unsealed_raw_ctrl_data() {
+        let mut eq = Equation {
+            script: "1 over 2".to_string(),
+            font_size: 1000,
+            raw_ctrl_data: vec![0xAB; 16],
+            ..Default::default()
+        };
+        assert!(eq.raw_ctrl_seal.is_none(), "합성 IR 은 봉인이 없다");
         DocumentCore::apply_equation_properties(&mut eq, 96.0, r#"{"width":5000,"height":4000}"#);
         assert!(
             eq.raw_ctrl_data.is_empty(),
-            "apply_equation_properties 후 raw_ctrl_data 가 비워져야 편집이 .hwp 저장에 반영된다"
+            "봉인 없는 raw_ctrl_data 는 비워져야 편집이 .hwp 저장에 반영된다"
         );
+    }
+
+    /// [#5890] 봉인된 raw 는 setter 가 파괴하지 않는다 — #4495 봉인이 `common` 변경을
+    /// 감지해 저장기를 IR 합성으로 내리므로 지울 이유가 없고, 지우지 않으면 되돌릴 때
+    /// 원본 바이트가 살아난다.
+    #[test]
+    fn apply_equation_properties_keeps_sealed_raw_ctrl_data() {
+        let mut eq = sealed_equation();
+        DocumentCore::apply_equation_properties(&mut eq, 96.0, r#"{"script":"1 over 3"}"#);
+        assert_eq!(
+            eq.raw_ctrl_data,
+            vec![0xAB; 16],
+            "봉인된 raw_ctrl_data 는 setter 가 지우지 않는다 (#5890)"
+        );
+        assert_ne!(
+            eq.raw_ctrl_seal,
+            Some(record_digest(&eq.common)),
+            "자동 크기 재계산으로 common 이 바뀌었으면 봉인이 어긋나 저장기가 IR 로 합성한다"
+        );
+    }
+
+    /// [#5890] 파괴하지 않으므로 되돌리기가 성립한다 — `common` 을 원상복구하면 봉인이
+    /// 다시 맞아 저장기가 원본 CTRL_HEADER 바이트를 그대로 방출한다.
+    #[test]
+    fn sealed_equation_raw_revives_when_common_restored() {
+        let mut eq = sealed_equation();
+        let sealed = eq.raw_ctrl_seal.expect("픽스처는 봉인돼 있다");
+        let before = eq.common.clone();
+
+        DocumentCore::apply_equation_properties(&mut eq, 96.0, r#"{"script":"1 over 3"}"#);
+        assert_ne!(
+            record_digest(&eq.common),
+            record_digest(&before),
+            "편집이 common 을 바꿨다"
+        );
+
+        eq.script = "1 over 2".to_string();
+        eq.common = before;
+        assert_eq!(
+            eq.raw_ctrl_seal,
+            Some(sealed),
+            "setter 는 봉인 자체를 건드리지 않는다"
+        );
+        assert_eq!(
+            sealed,
+            record_digest(&eq.common),
+            "common 원상복구 후 봉인이 다시 맞아 저장기가 원본 raw 를 승인한다 (#5890)"
+        );
+        assert_eq!(eq.raw_ctrl_data, vec![0xAB; 16], "원본 바이트가 남아 있다");
+    }
+
+    /// [#5890] 자동 크기 파생은 봉지가 지정하지 않은 축에만 적용한다 — 종전에는
+    /// 무조건 덧써서 명시된 width/height 가 조용히 무시됐다.
+    #[test]
+    fn apply_equation_properties_honors_explicit_size() {
+        let mut eq = Equation {
+            script: "1 over 2".to_string(),
+            font_size: 1000,
+            ..Default::default()
+        };
+        let (intrinsic_w, intrinsic_h) =
+            crate::renderer::equation::intrinsic_size_hwp(&eq.script, eq.font_size);
+
+        DocumentCore::apply_equation_properties(&mut eq, 96.0, r#"{"width":5000,"height":4000}"#);
+        assert_eq!((eq.common.width, eq.common.height), (5000, 4000));
+
+        // 한 축만 지정하면 나머지 축은 파생값을 받는다.
+        let mut half = Equation {
+            script: "1 over 2".to_string(),
+            font_size: 1000,
+            ..Default::default()
+        };
+        DocumentCore::apply_equation_properties(&mut half, 96.0, r#"{"width":5000}"#);
+        assert_eq!((half.common.width, half.common.height), (5000, intrinsic_h));
+
+        // 크기를 담지 않은 부분 봉지(UI 다이얼로그 계약)는 두 축 모두 파생값.
+        let mut auto = Equation {
+            script: "1 over 2".to_string(),
+            font_size: 1000,
+            ..Default::default()
+        };
+        DocumentCore::apply_equation_properties(&mut auto, 96.0, r#"{"color":255}"#);
+        assert_eq!(
+            (auto.common.width, auto.common.height),
+            (intrinsic_w, intrinsic_h)
+        );
+    }
+
+    fn find_equation_coord(core: &DocumentCore) -> (usize, usize, usize) {
+        for (si, section) in core.document.sections.iter().enumerate() {
+            for (pi, para) in section.paragraphs.iter().enumerate() {
+                for (ci, ctrl) in para.controls.iter().enumerate() {
+                    if matches!(ctrl, Control::Equation(_)) {
+                        return (si, pi, ci);
+                    }
+                }
+            }
+        }
+        panic!("샘플에 수식 컨트롤이 없다");
+    }
+
+    /// [#5890] 한컴 원본 3종에서 getter 가 낸 속성 봉지를 그대로 setter 에 먹이면
+    /// 저장 바이트가 편집 전과 같아야 한다(get∘set = 항등).
+    ///
+    /// 기준선도 구역 패스스루(`raw_stream`)를 비워 setter 와 같은 조건에서 비교한다 —
+    /// 판정 대상은 수식 CTRL_HEADER 이고, 구역 스트림 봉인은 #4488 이 따로 다룬다.
+    ///
+    /// 수정 전에는 세 샘플 모두 불일치했다: setter 가 `raw_ctrl_data` 를 파괴하고
+    /// 자동 크기로 `common.width/height` 를 덧썼다(equation-lim 9096x2715 → 9327x2684,
+    /// atop-equation-01 1235x2362 → 1075x2640, issue-505 9096x2715 → 13466x3025).
+    #[test]
+    fn setter_roundtrip_is_byte_identical_on_hancom_samples() {
+        for sample in [
+            "samples/equation-lim.hwp",
+            "samples/atop-equation-01.hwp",
+            "samples/issue-505-equations.hwp",
+        ] {
+            let bytes = std::fs::read(sample).unwrap_or_else(|e| panic!("{sample}: {e}"));
+
+            let mut base = DocumentCore::from_bytes(&bytes).expect("파싱");
+            let (si, pi, ci) = find_equation_coord(&base);
+            {
+                let eq = base
+                    .find_equation_ref(si, pi, ci, None, None)
+                    .expect("수식 참조");
+                assert!(
+                    !eq.raw_ctrl_data.is_empty() && eq.raw_ctrl_seal.is_some(),
+                    "{sample}: 파스본 수식은 봉인된 raw 를 가진다 (전제)"
+                );
+            }
+            let bag = base
+                .get_equation_properties_native(si, pi, ci, None, None)
+                .expect("getter");
+            base.document.sections[si].raw_stream = None;
+            let baseline = base.export_hwp_native().expect("기준 저장");
+
+            let mut edited = DocumentCore::from_bytes(&bytes).expect("파싱");
+            edited
+                .set_equation_properties_native(si, pi, ci, None, None, &bag)
+                .expect("setter");
+            let roundtripped = edited.export_hwp_native().expect("편집 저장");
+
+            assert_eq!(
+                baseline, roundtripped,
+                "{sample}: getter 봉지를 그대로 먹인 뒤 저장 바이트가 달라졌다 (#5890)"
+            );
+
+            // 종전 `raw_ctrl_data.clear()` 가 지키던 계약은 그대로다 — 실제 편집은 봉인
+            // 불일치로 저장기를 IR 합성으로 내려 저장·재파싱에서 살아남는다.
+            let mut resized = DocumentCore::from_bytes(&bytes).expect("파싱");
+            resized
+                .set_equation_properties_native(
+                    si,
+                    pi,
+                    ci,
+                    None,
+                    None,
+                    r#"{"width":5000,"height":4000}"#,
+                )
+                .expect("setter");
+            let resaved = resized.export_hwp_native().expect("편집 저장");
+            assert_ne!(
+                baseline, resaved,
+                "{sample}: 크기 편집이 저장 바이트에 반영되지 않았다"
+            );
+            let reparsed = DocumentCore::from_bytes(&resaved).expect("재파싱");
+            let eq = reparsed
+                .find_equation_ref(si, pi, ci, None, None)
+                .expect("수식 참조");
+            assert_eq!(
+                (eq.common.width, eq.common.height),
+                (5000, 4000),
+                "{sample}: 크기 편집이 저장·재파싱에서 살아남지 않았다"
+            );
+        }
     }
 }

--- a/tests/cases/issue_6350_equation_setter_purity.rs
+++ b/tests/cases/issue_6350_equation_setter_purity.rs
@@ -1,0 +1,190 @@
+//! [#6350] 수식 속성 setter 순수화 — getter 봉지 재적용이 저장 바이트에 항등인가.
+//!
+//! 종전 setter 는 봉지 반영 뒤 두 가지를 무조건 했다.
+//!
+//! - 자동 크기(`intrinsic_size_hwp`)를 `common.width/height` 에 덧써 명시 크기를 무시했다.
+//! - `raw_ctrl_data.clear()` 로 원본 CTRL_HEADER 를 파괴했다. #4495 봉인이 들어온 뒤로는
+//!   중복이다 — 저장기가 `common` 봉인 불일치를 보고 이미 IR 합성으로 내려간다.
+//!
+//! 결과로 값을 하나도 바꾸지 않은 재적용조차 저장 바이트를 바꿨고, 속성 봉지만으로
+//! 되돌릴 수 없었다. 여기서는 **공개 API 만으로** 그 계약을 고정한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+
+/// 한컴 편집기가 만든 수식 문서들. 저장 크기와 rhwp 자동 계산 크기가 서로 다르므로
+/// (예: equation-lim 9096x2715 vs 9327x2684) 자동 크기 덧쓰기가 곧 손실로 드러난다.
+const SAMPLES: [&str; 3] = [
+    "samples/equation-lim.hwp",
+    "samples/atop-equation-01.hwp",
+    "samples/issue-505-equations.hwp",
+];
+
+fn read_fixture(path: &str) -> Vec<u8> {
+    std::fs::read(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(path))
+        .unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+fn find_equation(core: &DocumentCore) -> (usize, usize, usize) {
+    for (si, section) in core.document().sections.iter().enumerate() {
+        for (pi, para) in section.paragraphs.iter().enumerate() {
+            for (ci, ctrl) in para.controls.iter().enumerate() {
+                if matches!(ctrl, Control::Equation(_)) {
+                    return (si, pi, ci);
+                }
+            }
+        }
+    }
+    panic!("샘플에 수식 컨트롤이 없다");
+}
+
+fn equation_at(
+    core: &DocumentCore,
+    si: usize,
+    pi: usize,
+    ci: usize,
+) -> &rhwp::model::control::Equation {
+    match &core.document().sections[si].paragraphs[pi].controls[ci] {
+        Control::Equation(eq) => eq,
+        other => panic!("수식이 아니다: {other:?}"),
+    }
+}
+
+/// getter 가 낸 봉지를 값 변경 없이 그대로 먹이면 저장 바이트가 같아야 한다(get∘set = 항등).
+///
+/// 기준선도 구역 패스스루(`raw_stream`)를 비워 setter 와 같은 조건에서 비교한다 — 판정
+/// 대상은 수식 CTRL_HEADER 이고 구역 스트림 봉인은 #4488 이 따로 다룬다.
+///
+/// 수정 전에는 세 샘플 모두 불일치했다: `raw_ctrl_data`(48/54/48B)가 0B 로 파괴되고
+/// 자동 크기가 `common.width/height` 를 덧썼다.
+#[test]
+fn getter_bag_reapplied_keeps_saved_bytes_identical() {
+    for sample in SAMPLES {
+        let bytes = read_fixture(sample);
+
+        let mut base = DocumentCore::from_bytes(&bytes).expect("파싱");
+        let (si, pi, ci) = find_equation(&base);
+        {
+            let eq = equation_at(&base, si, pi, ci);
+            assert!(
+                !eq.raw_ctrl_data.is_empty() && eq.raw_ctrl_seal.is_some(),
+                "{sample}: 전제 — 파스본 수식은 봉인된 raw 를 가진다"
+            );
+        }
+        let bag = base
+            .get_equation_properties_native(si, pi, ci, None, None)
+            .expect("getter");
+        base.document_mut().sections[si].raw_stream = None;
+        let baseline = base.export_hwp_native().expect("기준 저장");
+
+        let mut edited = DocumentCore::from_bytes(&bytes).expect("파싱");
+        edited
+            .set_equation_properties_native(si, pi, ci, None, None, &bag)
+            .expect("setter");
+        let roundtripped = edited.export_hwp_native().expect("편집 저장");
+
+        assert_eq!(
+            baseline, roundtripped,
+            "{sample}: getter 봉지를 그대로 먹인 뒤 저장 바이트가 달라졌다"
+        );
+    }
+}
+
+/// 봉인된 raw 는 setter 가 파괴하지 않는다 — 저장기가 봉인 불일치로 IR 합성에 내려가므로
+/// 지울 이유가 없고, 지우지 않으면 되돌릴 때 원본 바이트가 살아난다.
+#[test]
+fn script_edit_keeps_sealed_raw_ctrl_data() {
+    for sample in SAMPLES {
+        let bytes = read_fixture(sample);
+        let mut core = DocumentCore::from_bytes(&bytes).expect("파싱");
+        let (si, pi, ci) = find_equation(&core);
+        let original_raw = equation_at(&core, si, pi, ci).raw_ctrl_data.clone();
+
+        core.set_equation_properties_native(si, pi, ci, None, None, r#"{"script":"x^2 + 1"}"#)
+            .expect("스크립트 편집");
+
+        let eq = equation_at(&core, si, pi, ci);
+        assert_eq!(eq.script, "x^2 + 1", "{sample}: 편집이 반영됐다");
+        assert_eq!(
+            eq.raw_ctrl_data, original_raw,
+            "{sample}: 봉인된 raw_ctrl_data 를 setter 가 지우지 말아야 한다"
+        );
+    }
+}
+
+/// 종전 `raw_ctrl_data.clear()` 가 지키던 계약은 그대로다 — 실제 크기 편집은 봉인
+/// 불일치로 저장기를 IR 합성으로 내려 저장·재파싱에서 살아남는다.
+#[test]
+fn size_edit_survives_save_and_reparse() {
+    for sample in SAMPLES {
+        let bytes = read_fixture(sample);
+        let mut core = DocumentCore::from_bytes(&bytes).expect("파싱");
+        let (si, pi, ci) = find_equation(&core);
+
+        core.set_equation_properties_native(
+            si,
+            pi,
+            ci,
+            None,
+            None,
+            r#"{"width":5000,"height":4000}"#,
+        )
+        .expect("크기 편집");
+        let saved = core.export_hwp_native().expect("저장");
+
+        let reparsed = DocumentCore::from_bytes(&saved).expect("재파싱");
+        let eq = equation_at(&reparsed, si, pi, ci);
+        assert_eq!(
+            (eq.common.width, eq.common.height),
+            (5000, 4000),
+            "{sample}: 크기 편집이 저장·재파싱에서 살아남지 않았다"
+        );
+    }
+}
+
+/// 자동 크기 파생은 봉지가 지정하지 않은 축에만 적용한다.
+///
+/// 종전에는 무조건 덧써서 명시된 width/height 가 조용히 무시됐다. 변경 키만 담는 부분
+/// 봉지(스튜디오 다이얼로그 계약)는 두 축 모두 파생값을 받아 종전대로 동작한다.
+#[test]
+fn explicit_size_wins_over_intrinsic_derivation() {
+    let bytes = read_fixture(SAMPLES[0]);
+
+    // 양축 명시 — 파생이 덧쓰지 않는다.
+    let mut both = DocumentCore::from_bytes(&bytes).expect("파싱");
+    let (si, pi, ci) = find_equation(&both);
+    both.set_equation_properties_native(
+        si,
+        pi,
+        ci,
+        None,
+        None,
+        r#"{"script":"x","width":5000,"height":4000}"#,
+    )
+    .expect("양축 명시");
+    let eq = equation_at(&both, si, pi, ci);
+    assert_eq!((eq.common.width, eq.common.height), (5000, 4000));
+
+    // 크기를 담지 않은 부분 봉지 — 두 축 모두 파생값을 받는다.
+    let mut auto = DocumentCore::from_bytes(&bytes).expect("파싱");
+    auto.set_equation_properties_native(si, pi, ci, None, None, r#"{"script":"x"}"#)
+        .expect("부분 봉지");
+    let derived = {
+        let eq = equation_at(&auto, si, pi, ci);
+        (eq.common.width, eq.common.height)
+    };
+    assert_ne!(
+        derived,
+        (5000, 4000),
+        "크기를 지정하지 않으면 스크립트에서 파생된 크기가 와야 한다"
+    );
+
+    // 한 축만 지정 — 지정한 축은 그대로, 나머지는 파생값.
+    let mut half = DocumentCore::from_bytes(&bytes).expect("파싱");
+    half.set_equation_properties_native(si, pi, ci, None, None, r#"{"script":"x","width":5000}"#)
+        .expect("한 축 명시");
+    let eq = equation_at(&half, si, pi, ci);
+    assert_eq!(eq.common.width, 5000, "명시한 축은 유지된다");
+    assert_eq!(eq.common.height, derived.1, "나머지 축은 파생값을 받는다");
+}


### PR DESCRIPTION
관련 이슈: #6350

## 문제
수식 속성 setter 가 원본 CTRL_HEADER 를 지우고 자동 크기를 무조건 덧써서, getter 가 낸 속성
봉지를 값 변경 없이 재적용해도 저장 바이트가 달라진다(get∘set ≠ 항등).

## 원인
`apply_equation_properties`(`src/document_core/commands/object_ops/equation.rs:144`):

- `:168-171` — 자동 크기를 무조건 덧써 `apply_common_obj_attr_from_json` 이 방금 반영한
  명시 크기를 무시한다.
- `:177` — `raw_ctrl_data.clear()`. #4495 봉인 도입 뒤로는 중복이다. 저장기
  (`src/serializer/control.rs:2904-2911`)가 `common` 봉인 불일치를 보고 이미 IR 합성으로
  내려가고, 파스본 수식은 항상 봉인돼 있다(`src/model/raw_provenance.rs:390-393`).
  지우면 되돌릴 원본이 남지 않는다.

## 변경
setter 를 mutate/derive 로 가른다.

- 자동 크기 파생을 **봉지가 크기를 지정하지 않은 축에만** 적용한다. 변경된 키만 담는 부분
  봉지를 보내는 UI 다이얼로그(`rhwp-studio/src/ui/equation-props-dialog.ts`,
  `equation-editor-dialog.ts` 는 width/height 를 보내지 않는다)의 자동 크기 동작은 그대로다.
- raw 무효화를 파괴에서 판정으로 바꾼다. 봉인이 있으면 지우지 않고(저장기가 봉인 불일치로
  IR 합성해 편집이 그대로 저장에 반영된다), 봉인이 없는 raw(파서를 거치지 않은 합성 IR·
  어댑터 산출)만 종전대로 비운다. `common` 을 되돌리면 봉인이 다시 맞아 원본 바이트가 살아난다.

추가·갱신 테스트(`src/document_core/commands/object_ops/equation.rs`):

- `setter_roundtrip_is_byte_identical_on_hancom_samples` — 한컴 원본 3종에서 getter 봉지
  재적용 후 저장 바이트 동일 + **실제 크기 편집은 저장·재파싱에서 살아남음**(종전
  `clear()` 가 지키던 계약의 회귀 가드)
- `apply_equation_properties_keeps_sealed_raw_ctrl_data`
- `sealed_equation_raw_revives_when_common_restored` — `common` 원상복구 시 봉인 재일치
- `apply_equation_properties_honors_explicit_size` — 양축·한축·무지정 3경우
- 기존 `apply_equation_properties_clears_raw_ctrl_data` → `..._clears_unsealed_raw_ctrl_data`
  로 이름과 근거를 봉인 없는 경우로 명시(종전 계약 유지 증명)

## 검증
devel `f6a6bee8f` 기준.

- **수정 전 실패 증명**: 세 샘플 모두 get∘set 재적용 뒤 저장 바이트 불일치.
  `equation-lim.hwp` 9096x2715 → 9327x2684, `atop-equation-01.hwp` 1235x2362 → 1075x2640,
  `issue-505-equations.hwp` 9096x2715 → 13466x3025, `raw_ctrl_data` 48/54/48B → 0B.
  세 샘플 모두 파스 직후 `raw_ctrl_seal` 이 서 있음을 테스트가 전제로 확인한다.
  수정 후 세 샘플 모두 저장 바이트 동일.
- `cargo test --release --lib` — 3893 passed / 0 failed / 13 ignored (신규 5건 포함).
- 수식·저장 경로가 걸린 통합 스위트 4종 그린 — 135 / 156 / 146 / 121 passed, 0 failed:
  `hml_serializer`(set_equation_properties_native 경유 HML 왕복),
  `issue_2727_equation_line_mode`, `cases/set_equation_properties_contract`(CLI 계약),
  `issue_2724_passthrough_invalidation_guard`.
- #2724 패스스루 가드 통과 — `set_equation_properties_native` 의 `section.raw_stream = None`
  은 그대로다. 이 PR 이 바꾸는 것은 수식 컨트롤 하위 raw 판정뿐이다.
- `cargo fmt --all -- --check` 클린, `cargo clippy -- -D warnings` ·
  `cargo clippy --workspace --all-targets -- -D warnings` 클린.
- `node scripts/rust-unit-test-tiers.mjs --check` 통과(4225 tests / 299 modules).

## 범위 외
- 그림·표의 같은 계열 setter 파괴(#5890 표의 나머지 두 줄).
- undo 라우팅을 스냅샷에서 역연산으로 바꾸는 예산 회수 — 이 PR 은 전제만 만든다.
