### PR TITLE
[cli] layout-anomaly -p 를 카운트·hasSignal·종료코드까지 적용

### DIFF
--- a/mydocs/working/anomaly_page_filter_scope.md
+++ b/mydocs/working/anomaly_page_filter_scope.md
@@ -1,0 +1,100 @@
+# layout-anomaly `-p` 의 적용 범위 (#6348)
+
+## 무엇이 문제였나
+
+`rhwp layout-anomaly <파일> -p N` 은 **`pages` 배열만** 걸러냈다. 카운트와
+`hasSignal`, 그리고 `--strict` 종료코드는 필터 이전의 **문서 전체** 값이 그대로
+나갔다. 그래서 한 봉투 안에서 서로 모순되는 값이 나온다.
+
+`samples/2025 행정업무운영 편람(최종).hwp` (384 쪽) 실측 — 수정 전:
+
+```
+-p 0   pages=0개  overflow=163 offCanvas=11 overlap=1 textOverlap=24 emptyPage=18
+       hasSignal=true   --strict 종료코드=3
+```
+
+0 쪽에는 신호가 하나도 없는데 `hasSignal: true` 가 나오고 `--strict` 는 3 을 냈다.
+`pages: []` 와 `overflowCount: 163` 이 같은 JSON 안에 함께 있으니, 이 출력으로는
+**"이 쪽이 깨끗한가"를 판정할 수 없다.** 쪽 단위로 좁혀 보는 것이 `-p` 의 유일한
+용도이므로 실질적으로 `-p` 는 사람이 눈으로 배열을 세는 용도 외에는 쓸 수 없었다.
+
+`--batch` 도 같았다. `fill_ok_row` 가 문서 전체 카운트로 `row.status` 를 정해,
+`-p 0` 을 줘도 그 쪽과 무관하게 `ANOMALY` 로 찍혔다.
+
+## 어떻게 고쳤나
+
+`src/diagnostics/layout_anomaly.rs` 에 `filtered_for_page()` 를 두고, `-p` 를
+**한 번만** 적용한 뒤 그 결과에서 카운트·`hasSignal`·종료코드를 모두 끌어낸다.
+
+- 단일 파일 경로(`run`): 범위 검사 직후 한 번 걸러 JSON·사람용 출력·종료코드가
+  같은 집합을 본다.
+- 배치 경로(`fill_ok_row`): 행 카운트와 `status`, 봉투가 같은 집합을 본다.
+- `envelope()` 안에서도 한 번 더 적용한다. 이미 걸러진 값을 받아도 무해하며
+  (idempotent), 호출자가 빠뜨렸을 때 봉투 안에서 배열과 카운트가 어긋나는 것을 막는다.
+- `page` 가 `None` 이면 `Cow::Borrowed` 라 종전 경로에 복사 비용이 없다.
+
+`pageCount` 는 그대로 문서 전체 쪽수다. 필터와 무관한 메타데이터이고,
+`pageFilter` 와 같이 읽으면 "전체 N 쪽 중 M 쪽" 이 된다.
+
+`hasSignal` 의 정의(=`empty_page` 는 확정 신호가 아니다)는 건드리지 않았다.
+좁힌 집합에 같은 정의를 적용할 뿐이다.
+
+## 검증 실측
+
+`samples/2025 행정업무운영 편람(최종).hwp` — 수정 후:
+
+| 실행 | pages | overflow | offCanvas | overlap | textOverlap | emptyPage | hasSignal | `--strict` |
+|------|------:|---------:|----------:|--------:|------------:|----------:|-----------|-----------:|
+| `-p 68` | 1 | 4 | 0 | 0 | 0 | 0 | true | 3 |
+| `-p 0` | 0 | 0 | 0 | 0 | 0 | 0 | false | 0 |
+| `-p 2` | 1 | 0 | 0 | 0 | 0 | 1 | false | 0 |
+| 필터 없음 | 149 | 163 | 11 | 1 | 24 | 18 | true | 3 |
+
+`-p 2` 는 `empty_page` 만 있는 쪽이다. 확정 신호가 아니므로 `hasSignal=false`,
+종료코드 0 — 문서 전체 실행에서의 정의와 같다. 필터 없는 실행 값은 수정 전과
+동일하다(회귀 없음).
+
+배치 — `table_giant_cell_overfill.hwpx`(신호는 18·39~44 쪽) 와
+`hwp3-sample.hwp` 한 폴더:
+
+```
+-p 0     [CLEAN]   overflow=0  table_giant_cell_overfill.hwpx
+필터 없음 [ANOMALY] overflow=3  table_giant_cell_overfill.hwpx
+```
+
+### 게이트
+
+```
+cargo fmt --all -- --check                                   통과
+cargo clippy --profile release-test --all-targets -- -D warnings   통과
+node scripts/rust-test-suite-manifest.mjs --check --base-ref upstream/devel   통과
+node scripts/rust-unit-test-tiers.mjs --check --base-ref upstream/devel       통과
+cargo test --test regression_suite_031   131 passed
+cargo test --test regression_suite_024   134 passed
+cargo test --test regression_suite_023   126 passed
+cargo test --test regression_suite_032   138 passed
+```
+
+## 회귀 테스트
+
+`tests/cases/layout_anomaly_contract.rs` 의
+`layout_anomaly_page_filter_scopes_counts_and_strict_exit`.
+
+쪽 번호를 상수로 박지 않는다. 필터 없는 실행의 `pages` 에서 overflow 가 있는 쪽과
+어느 목록에도 없는 쪽을 뽑아 쓴다. 조판이 바뀌어 신호가 다른 쪽으로 옮겨가도
+계약 자체는 계속 검사된다.
+
+수정 전 코드에서 이 테스트는 실패한다(실측):
+
+```
+left: Number(3)   right: 1
+```
+
+`-p <신호 있는 쪽>` 인데 `overflowCount` 가 문서 전체 값 3 으로 나오는 것을 잡는다.
+
+## 남는 것
+
+`--batch -p N` 에서 그 쪽 번호가 없는 문서는 종전처럼 `error` 행이 되고 종료코드
+1(측정 실패)이 된다. 쪽 수가 제각각인 폴더에 `-p` 를 주면 대부분이 error 가 되는데,
+이는 "전건을 재봤다고 말할 수 없으면 실패" 라는 기존 계약이라 이 변경에서 건드리지
+않았다.

--- a/src/diagnostics/layout_anomaly.rs
+++ b/src/diagnostics/layout_anomaly.rs
@@ -682,6 +682,7 @@ pub fn scan_document(core: &DocumentCore, opts: &AnomalyOptions) -> Result<DocAn
 // CLI: `rhwp layout-anomaly`
 // ─────────────────────────────────────────────────────────────────────────
 
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -862,13 +863,36 @@ fn types_json(opts: &CliOptions) -> Value {
     }
 }
 
+/// [#6348] `-p` 가 주어지면 그 쪽만 남긴 결과를 돌려준다.
+///
+/// 종전에는 `envelope` 이 `pages` 배열만 걸러내고 카운트·`hasSignal` 은 필터 이전의
+/// 문서 전체 값을 실었다. 그래서 신호가 0 인 쪽을 지정해도 `overflowCount: 163`,
+/// `hasSignal: true` 가 나오고 `--strict` 가 종료코드 3 을 냈다 — 배열과 카운트가 서로
+/// 모순되고, 쪽 단위 판정에 쓸 수 없었다.
+///
+/// `page_count` 는 문서 전체 쪽수라 필터와 무관한 메타데이터다. `pageFilter` 와 함께
+/// 읽으면 "전체 N 쪽 중 M 쪽" 이 되므로 그대로 둔다.
+fn filtered_for_page(doc: &DocAnomalies, page: Option<u32>) -> Cow<'_, DocAnomalies> {
+    let Some(want) = page else {
+        return Cow::Borrowed(doc);
+    };
+    Cow::Owned(DocAnomalies {
+        page_count: doc.page_count,
+        pages: doc
+            .pages
+            .iter()
+            .filter(|p| p.page == want)
+            .cloned()
+            .collect(),
+    })
+}
+
 fn envelope(source: &str, doc: &DocAnomalies, opts: &CliOptions) -> Value {
-    let pages: Vec<Value> = doc
-        .pages
-        .iter()
-        .filter(|p| opts.page.is_none_or(|want| p.page == want))
-        .map(page_json)
-        .collect();
+    // 카운트·hasSignal 과 pages 는 반드시 같은 집합에서 나와야 한다. 필터를 여기서
+    // 다시 적용하는 것은 이미 걸러진 값을 받아도 무해하며(idempotent), 호출자가
+    // 하나라도 빠뜨렸을 때 JSON 안에서 서로 모순되는 값이 나가는 것을 막는다.
+    let doc = &filtered_for_page(doc, opts.page);
+    let pages: Vec<Value> = doc.pages.iter().map(page_json).collect();
     crate::provenance::marked(
         json!({
             "schemaVersion": SCHEMA_VERSION,
@@ -944,6 +968,10 @@ fn run_single(opts: &CliOptions) -> i32 {
         }
     }
 
+    // -p 는 여기서 한 번만 적용한다. 이후의 카운트·hasSignal·종료코드는 모두
+    // 이 걸러진 집합에서 나오므로 출력끼리 서로 모순되지 않는다.
+    let doc = filtered_for_page(&doc, opts.page);
+
     if opts.json {
         println!("{}", envelope(&opts.path.display().to_string(), &doc, opts));
         return if opts.strict && doc.has_signal() {
@@ -953,11 +981,7 @@ fn run_single(opts: &CliOptions) -> i32 {
         };
     }
 
-    let shown: Vec<&PageAnomalies> = doc
-        .pages
-        .iter()
-        .filter(|p| opts.page.is_none_or(|want| p.page == want))
-        .collect();
+    let shown: Vec<&PageAnomalies> = doc.pages.iter().collect();
 
     println!(
         "쪽 수: {}  overflow: {}  off-canvas: {}  overlap: {}  text-overlap: {}  empty_page(가능성): {}",
@@ -1171,6 +1195,7 @@ fn run_batch(opts: &CliOptions) -> i32 {
 }
 
 fn fill_ok_row(row: &mut BatchRow, doc: &DocAnomalies, opts: &CliOptions) {
+    let doc = &filtered_for_page(doc, opts.page);
     row.overflow = doc.overflow_count();
     row.overlap = doc.overlap_count();
     row.empty_page = doc.empty_page_count();

--- a/tests/cases/layout_anomaly_contract.rs
+++ b/tests/cases/layout_anomaly_contract.rs
@@ -182,6 +182,89 @@ fn layout_anomaly_strict_clean_stays_zero() {
     assert_eq!(v["hasSignal"], false, "{v}");
 }
 
+/// [#6348] `-p` 는 `pages` 배열뿐 아니라 카운트·`hasSignal`·`--strict` 종료코드까지
+/// 그 쪽으로 좁힌다.
+///
+/// 종전에는 배열만 걸러 `pages: []` 인데 `overflowCount` 는 문서 전체 값이 실렸고,
+/// 신호가 하나도 없는 쪽을 지정해도 `--strict` 가 3 을 냈다. 그 값으로는
+/// "이 쪽이 깨끗한가"를 판정할 수 없다.
+///
+/// 쪽 번호는 필터 없는 실행에서 뽑는다. 조판이 바뀌어 신호가 다른 쪽으로 옮겨가도
+/// 이 계약 자체는 계속 검사된다.
+#[test]
+fn layout_anomaly_page_filter_scopes_counts_and_strict_exit() {
+    let src = sample(OVERFLOW);
+    let path = src.to_str().unwrap();
+
+    let all_args = ["layout-anomaly", path, "--json"];
+    let all_out = run(&all_args);
+    let all = parse_stdout_json(&all_args, &all_out);
+    let pages = all["pages"].as_array().unwrap();
+    let page_count = all["pageCount"].as_u64().unwrap();
+
+    // 확정 신호(overflow)가 있는 쪽 하나와, 신호가 아예 없는 쪽 하나.
+    let dirty = pages
+        .iter()
+        .find(|p| p["overflow"].as_array().is_some_and(|o| !o.is_empty()))
+        .map(|p| p["page"].as_u64().unwrap())
+        .unwrap_or_else(|| panic!("스캐폴딩 전제: overflow 있는 쪽이 있어야 한다\n{all}"));
+    let flagged: Vec<u64> = pages.iter().map(|p| p["page"].as_u64().unwrap()).collect();
+    let clean = (0..page_count)
+        .find(|p| !flagged.contains(p))
+        .unwrap_or_else(|| panic!("스캐폴딩 전제: 신호 없는 쪽이 있어야 한다\n{all}"));
+
+    let dirty_s = dirty.to_string();
+    let args = ["layout-anomaly", path, "-p", &dirty_s, "--json"];
+    let v = parse_stdout_json(&args, &run(&args));
+    assert_eq!(v["pages"].as_array().unwrap().len(), 1, "{v}");
+    assert_eq!(v["overflowCount"], 1, "그 쪽의 overflow 만 세야 한다\n{v}");
+    assert_eq!(v["hasSignal"], true, "{v}");
+    // pageCount 는 필터와 무관한 문서 메타데이터다.
+    assert_eq!(v["pageCount"], page_count, "{v}");
+    assert_eq!(v["pageFilter"], dirty, "{v}");
+
+    let clean_s = clean.to_string();
+    let args = ["layout-anomaly", path, "-p", &clean_s, "--json"];
+    let v = parse_stdout_json(&args, &run(&args));
+    assert!(v["pages"].as_array().unwrap().is_empty(), "{v}");
+    for key in [
+        "overflowCount",
+        "offCanvasCount",
+        "overlapCount",
+        "textOverlapCount",
+        "emptyPageCount",
+    ] {
+        assert_eq!(
+            v[key], 0,
+            "빈 pages 와 0 이 아닌 {key} 가 함께 나오면 안 된다\n{v}"
+        );
+    }
+    assert_eq!(v["hasSignal"], false, "{v}");
+
+    // 종료코드도 같은 집합에서 나온다.
+    let args = ["layout-anomaly", path, "-p", &clean_s, "--strict", "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "신호 없는 쪽만 봤으면 --strict 도 0 이다.\n{}",
+        describe(&args, &output)
+    );
+    let args = ["layout-anomaly", path, "-p", &dirty_s, "--strict", "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "그 쪽에 확정 신호가 있으면 3 이다.\n{}",
+        describe(&args, &output)
+    );
+
+    // 필터가 없으면 종전 그대로 문서 전체.
+    assert!(all["overflowCount"].as_u64().unwrap() >= 1, "{all}");
+    assert_eq!(all["hasSignal"], true, "{all}");
+    assert!(all["pageFilter"].is_null(), "{all}");
+}
+
 #[test]
 fn layout_anomaly_usage_errors_are_exit_two_with_silent_stdout() {
     let src = sample(CLEAN);


### PR DESCRIPTION
`rhwp layout-anomaly <파일> -p N` 이 `pages` 배열만 걸러내고, 카운트·`hasSignal`·
`--strict` 종료코드는 필터 이전의 **문서 전체** 값을 그대로 냈다.

closes #6348

## 문제

`samples/2025 행정업무운영 편람(최종).hwp` (384 쪽) — 수정 전:

```
-p 0   pages=0개  overflow=163 offCanvas=11 overlap=1 textOverlap=24 emptyPage=18
       hasSignal=true   --strict 종료코드=3
```

0 쪽에는 신호가 하나도 없는데 `hasSignal: true` 가 나오고 `--strict` 가 3 을 냈다.
`pages: []` 와 `overflowCount: 163` 이 같은 봉투 안에 있으니 이 출력으로는
**"이 쪽이 깨끗한가"를 판정할 수 없다.** 쪽 단위로 좁혀 보는 것이 `-p` 의 유일한
용도라, 사람이 배열을 눈으로 세는 것 외에는 쓸 수 없었다.

`--batch` 도 같다. `fill_ok_row` 가 문서 전체 카운트로 `status` 를 정해 `-p 0` 을
줘도 무관하게 `ANOMALY` 로 찍혔다.

## 변경

`filtered_for_page()` 로 `-p` 를 **한 번만** 적용하고, 이후 카운트·`hasSignal`·
종료코드를 모두 그 집합에서 끌어낸다.

- 단일 파일 경로(`run`): 범위 검사 직후 한 번 걸러 JSON·사람용 출력·종료코드가 같은 집합을 본다
- 배치 경로(`fill_ok_row`): 행 카운트·`status`·봉투가 같은 집합을 본다
- `envelope()` 안에서도 한 번 더 적용한다. 이미 걸러진 값을 받아도 idempotent 하며,
  호출자가 빠뜨렸을 때 봉투 안에서 배열과 카운트가 어긋나는 것을 막는다
- `page` 가 `None` 이면 `Cow::Borrowed` 라 종전 경로에 복사 비용이 없다

`pageCount` 는 그대로 문서 전체 쪽수다. 필터와 무관한 메타데이터이고 `pageFilter` 와
같이 읽으면 "전체 N 쪽 중 M 쪽" 이 된다. `hasSignal` 의 정의(`empty_page` 는 확정
신호가 아니다)도 그대로이며, 좁힌 집합에 같은 정의를 적용할 뿐이다.

## 실측 (수정 후)

| 실행 | pages | overflow | offCanvas | overlap | textOverlap | emptyPage | hasSignal | `--strict` |
|------|------:|---------:|----------:|--------:|------------:|----------:|-----------|-----------:|
| `-p 68` | 1 | 4 | 0 | 0 | 0 | 0 | true | 3 |
| `-p 0` | 0 | 0 | 0 | 0 | 0 | 0 | false | 0 |
| `-p 2` | 1 | 0 | 0 | 0 | 0 | 1 | false | 0 |
| 필터 없음 | 149 | 163 | 11 | 1 | 24 | 18 | true | 3 |

`-p 2` 는 `empty_page` 만 있는 쪽 — 확정 신호가 아니라 `hasSignal=false`, 종료코드 0.
문서 전체 실행에서의 정의와 같다. **필터 없는 실행 값은 수정 전과 동일하다(회귀 없음).**

배치 — `table_giant_cell_overfill.hwpx`(신호는 18·39~44 쪽)와 `hwp3-sample.hwp` 한 폴더:

```
-p 0      [CLEAN]   overflow=0  table_giant_cell_overfill.hwpx
필터 없음  [ANOMALY] overflow=3  table_giant_cell_overfill.hwpx
```

## 회귀 테스트

`tests/cases/layout_anomaly_contract.rs` 의
`layout_anomaly_page_filter_scopes_counts_and_strict_exit`.

쪽 번호를 상수로 박지 않는다. 필터 없는 실행의 `pages` 에서 overflow 가 있는 쪽과
어느 목록에도 없는 쪽을 뽑아 쓰므로, 조판이 바뀌어 신호가 다른 쪽으로 옮겨가도
계약 자체는 계속 검사된다.

수정 전 코드에서 이 테스트는 실패한다(실측):

```
panicked at tests/cases/layout_anomaly_contract.rs:220
  left: Number(3)   right: 1
```

## 검증

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --profile release-test --all-targets -- -D warnings`
- [x] `node scripts/rust-test-suite-manifest.mjs --check --base-ref upstream/devel`
- [x] `node scripts/rust-unit-test-tiers.mjs --check --base-ref upstream/devel`
- [x] `cargo test --test regression_suite_031` — 131 passed (본 계약 파일)
- [x] `cargo test --test regression_suite_024` — 134 passed (off-canvas 계약)
- [x] `cargo test --test regression_suite_023` — 126 passed (m02f)
- [x] `cargo test --test regression_suite_032` — 138 passed (text-overlap 계약)

렌더링·레이아웃 산출물을 바꾸지 않는 진단 CLI 보고 경로 변경이라 시각 근거는 해당 없다.

처리 결과: `mydocs/working/anomaly_page_filter_scope.md`

## 남는 것

`--batch -p N` 에서 그 쪽 번호가 없는 문서는 종전처럼 `error` 행이 되고 종료코드
1(측정 실패)이 된다. "전건을 재봤다고 말할 수 없으면 실패" 라는 기존 계약이라 이
변경에서 건드리지 않았다.
