### PR TITLE
ci: 개별 회귀 시간 기반 nextest suite 배분

### DIFF
--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -180,11 +180,17 @@ jobs:
                 echo 'duration_policy_source=fallback:no-pinned-policy'
               fi
 
+              # `regression_suite_NNN`는 고정 workload 이름이 아니다. 현재 source 구성에
+              # 대응하는 개별 testcase 측정값으로 harness를 다시 pack한 뒤 archive를 만든다.
+              node scripts/rust-test-suite-manifest.mjs \
+                --rebalance-by-duration "${duration_policy}"
+
               mapfile -t selected_targets < <(
                 cargo metadata --no-deps --format-version 1 \
                   | node scripts/select-nextest-archive-targets.mjs \
                     --group "${{ inputs.target_group }}" \
-                    --policy "${duration_policy}"
+                    --policy "${duration_policy}" \
+                    --manifest tests/suites/manifest.json
               )
               if (( ${#selected_targets[@]} == 0 )); then
                 echo "::error::integration target group selected no targets: ${{ inputs.target_group }}"

--- a/mydocs/working/task_m100_6360_stage1_individual_regression_duration_model.md
+++ b/mydocs/working/task_m100_6360_stage1_individual_regression_duration_model.md
@@ -1,0 +1,37 @@
+# #6360 Stage 1: 개별 회귀 테스트 시간 기반 suite 및 archive 배분
+
+## 문제
+
+`regression_suite_NNN`은 파생 harness 이름일 뿐 고정된 실행 workload가 아니다. 기존 정책은
+target 이름에 과거 총 시간을 연결했으므로, source가 다른 suite로 이동한 뒤에도 오래된 target
+시간을 적용했다. 2026-08-29 devel run `33239619089`에서 B/C/D 예상시간은 약 888초였지만
+C의 JUnit 누적은 약 2,503초로 확인됐다.
+
+## 설계
+
+- B/C/D JUnit artifact는 target 합계와 `target::module::test` 개별 시간을 함께 보관한다.
+- 정책 v2는 개별 시간을 source module 단위로 합산한 `cases`와 원본 `test_cases`를 함께
+  보관한다. 정책 갱신은 성공한 동일 devel run의 B/C/D 측정값만 사용한다.
+- archive build는 현재 checkout의 source 목록과 `cases`를 사용해 32개 generated suite를
+  다시 LPT 배정한다. 측정값이 없는 source는 `#[test]` 또는 `#[case]` 수당 60초의 보수적
+  fallback을 쓴다.
+- B/C/D 선택은 현재 생성된 `tests/suites/manifest.json`에서 suite별 source 시간 합계를 다시
+  계산한다. 과거 `regression_suite_NNN` 이름에 붙은 시간은 v2에서 사용하지 않는다.
+- v1 metrics ref는 migration 동안 읽을 수 있지만 suite 이름 기반 시간은 재배정에 쓰지 않는다.
+  첫 성공 devel full lane이 v2 측정 artifact를 올리면 이후 CI부터 개별 측정값을 쓴다.
+- 기존 green PR의 trusted review-tail post-merge artifact가 v1이면 재사용 판정과 artifact
+  provenance는 그대로 인정하되, policy refresh는 v2 정책을 변경하지 않고 성공한다. 따라서
+  #6297의 Render Diff merge-bridge 재사용 경로를 막거나 구형 suite 이름 측정을 되살리지 않는다.
+
+## 검증 범위
+
+- Node 계약 테스트는 JUnit 개별 시간 수집, source 합산, 현재 manifest 기반 suite 추정을 확인한다.
+- Rust suite manifest 계약 테스트는 개별 source 시간으로 32-suite LPT 배정이 바뀌는지 확인한다.
+- workflow 계약 테스트는 archive builder가 metrics policy를 받은 뒤 duration rebalance와
+  current manifest selector를 실행하는지 확인한다.
+
+## 한계와 다음 관찰
+
+개별 테스트의 실제 실행시간 자체가 코드 변경으로 급증하는 첫 PR은 과거 측정값만으로 예측할 수
+없다. 이 변경은 mutable suite 이름 때문에 발생한 잘못된 귀속을 제거한다. 첫 v2 devel full lane
+후 B/C/D 실제시간과 새 policy의 예측값을 비교해 fallback과 장기 테스트 격리 필요성을 재평가한다.

--- a/scripts/collect-nextest-target-durations.mjs
+++ b/scripts/collect-nextest-target-durations.mjs
@@ -66,6 +66,57 @@ export function collectTargetDurations(junitXml) {
   return Object.fromEntries([...durations.entries()].sort(([left], [right]) => left.localeCompare(right)));
 }
 
+function targetForClassName(className) {
+  const separator = className.indexOf("::");
+  return separator === -1 ? className : className.slice(separator + 2);
+}
+
+function caseNameForTest(target, testName) {
+  if (!target.startsWith("regression_suite_")) {
+    return target;
+  }
+  const separator = testName.indexOf("::");
+  if (separator <= 0) {
+    fail(`grouped target testcase must include its source module: ${target}::${testName}`);
+  }
+  return testName.slice(0, separator);
+}
+
+export function collectDurationMeasurement(junitXml) {
+  const targets = new Map();
+  const cases = new Map();
+  const testCases = new Map();
+  for (const match of junitXml.matchAll(/<testcase\b([^>]*)>/g)) {
+    const attributes = parseAttributes(match[1]);
+    const className = attributes.get("classname");
+    const testName = attributes.get("name");
+    const seconds = Number(attributes.get("time"));
+    if (
+      !className
+      || !testName
+      || className.startsWith("@setup-script:")
+      || !Number.isFinite(seconds)
+      || seconds < 0
+    ) {
+      continue;
+    }
+    const target = targetForClassName(className);
+    if (!target) {
+      continue;
+    }
+    const caseName = caseNameForTest(target, testName);
+    const testCase = `${target}::${testName}`;
+    targets.set(target, (targets.get(target) ?? 0) + seconds);
+    cases.set(caseName, (cases.get(caseName) ?? 0) + seconds);
+    testCases.set(testCase, (testCases.get(testCase) ?? 0) + seconds);
+  }
+  return {
+    targets: Object.fromEntries([...targets.entries()].sort(([left], [right]) => left.localeCompare(right))),
+    cases: Object.fromEntries([...cases.entries()].sort(([left], [right]) => left.localeCompare(right))),
+    test_cases: Object.fromEntries([...testCases.entries()].sort(([left], [right]) => left.localeCompare(right))),
+  };
+}
+
 function main() {
   const options = parseArgs(process.argv.slice(2));
   if (options.help) {
@@ -76,22 +127,22 @@ function main() {
     fail("--archive-label b|c|d, --input, and --output are required");
   }
 
-  const targets = collectTargetDurations(fs.readFileSync(options.input, "utf8"));
-  if (Object.keys(targets).length === 0) {
+  const measurement = collectDurationMeasurement(fs.readFileSync(options.input, "utf8"));
+  if (Object.keys(measurement.targets).length === 0) {
     fail("JUnit report contains no target durations");
   }
   const report = {
-    schema_version: 1,
+    schema_version: 2,
     archive_label: options["archive-label"],
     run_id: process.env.GITHUB_RUN_ID ?? null,
     ref: process.env.GITHUB_REF ?? null,
     sha: process.env.GITHUB_SHA ?? null,
-    targets,
+    ...measurement,
   };
   fs.mkdirSync(path.dirname(options.output), { recursive: true });
   fs.writeFileSync(options.output, `${JSON.stringify(report, null, 2)}\n`);
   process.stderr.write(
-    `[NextestTargetDuration] archive=${report.archive_label} target_durations=${Object.keys(targets).length}\n`,
+    `[NextestTargetDuration] archive=${report.archive_label} target_durations=${Object.keys(report.targets).length} case_durations=${Object.keys(report.cases).length}\n`,
   );
 }
 

--- a/scripts/refresh-nextest-target-duration-policy.mjs
+++ b/scripts/refresh-nextest-target-duration-policy.mjs
@@ -35,6 +35,72 @@ function parseArgs(args) {
 }
 
 export function refreshDurationPolicy(policy, measurements) {
+  if (policy.schema_version === 2) {
+    if (
+      !Number.isFinite(policy.fallback_seconds_per_test)
+      || policy.fallback_seconds_per_test <= 0
+      || !policy.cases
+      || typeof policy.cases !== "object"
+      || Array.isArray(policy.cases)
+      || !policy.test_cases
+      || typeof policy.test_cases !== "object"
+      || Array.isArray(policy.test_cases)
+    ) {
+      fail("schema_version 2 policy requires fallback_seconds_per_test, cases, and test_cases");
+    }
+    // A trusted review-tail may have completed before this schema migration.
+    // Its artifact provenance is still valid for post-merge reuse, but it has
+    // no source-case detail. Keep the v2 policy unchanged rather than making
+    // post-merge processing fail or reviving mutable suite-name measurements.
+    if (measurements.every((measurement) => measurement?.schema_version === 1)) {
+      return policy;
+    }
+    const targets = {};
+    const cases = {};
+    const testCases = {};
+    const sourceKeys = new Set();
+    for (const measurement of measurements) {
+      if (!measurement || measurement.schema_version !== 2 || !["b", "c", "d"].includes(measurement.archive_label)) {
+        fail("measurement must be a B, C, or D schema_version 2 report");
+      }
+      for (const [field, destination] of [["targets", targets], ["cases", cases], ["test_cases", testCases]]) {
+        if (!measurement[field] || typeof measurement[field] !== "object" || Array.isArray(measurement[field])) {
+          fail(`measurement ${field} must be an object: ${measurement.archive_label}`);
+        }
+        for (const [name, seconds] of Object.entries(measurement[field])) {
+          if (!name || !Number.isFinite(seconds) || seconds <= 0) {
+            fail(`measurement ${field} must have a positive duration: ${name}`);
+          }
+          destination[name] = seconds;
+        }
+      }
+      if (Object.keys(measurement.targets).length === 0 || Object.keys(measurement.cases).length === 0) {
+        fail(`measurement must contain target and case durations: ${measurement.archive_label}`);
+      }
+      const source = [measurement.run_id, measurement.ref, measurement.sha];
+      if (!source.every((value) => typeof value === "string" && value.length > 0)) {
+        fail(`measurement must identify its run, ref, and sha: ${measurement.archive_label}`);
+      }
+      sourceKeys.add(JSON.stringify(source));
+    }
+    if (sourceKeys.size !== 1) {
+      fail("B, C, and D measurements must have identical run, ref, and sha provenance");
+    }
+    return {
+      schema_version: 2,
+      fallback_seconds_per_test: policy.fallback_seconds_per_test,
+      measurement_sources: Object.fromEntries(measurements
+        .map((measurement) => [measurement.archive_label, {
+          run_id: measurement.run_id,
+          ref: measurement.ref,
+          sha: measurement.sha,
+        }])
+        .sort(([left], [right]) => left.localeCompare(right))),
+      targets: Object.fromEntries(Object.entries(targets).sort(([left], [right]) => left.localeCompare(right))),
+      cases: Object.fromEntries(Object.entries(cases).sort(([left], [right]) => left.localeCompare(right))),
+      test_cases: Object.fromEntries(Object.entries(testCases).sort(([left], [right]) => left.localeCompare(right))),
+    };
+  }
   parseDurationPolicy(policy);
   const durations = { ...policy.targets };
   const sourceKeys = new Set();

--- a/scripts/rust-test-suite-manifest.mjs
+++ b/scripts/rust-test-suite-manifest.mjs
@@ -354,7 +354,7 @@ const MODULE_BLOCKERS = [
   ],
 ];
 
-export function sourceMetrics(source, manifest, root = ROOT) {
+export function sourceMetrics(source, manifest, root = ROOT, durationPolicy = null) {
   const text = readFileSync(path.join(root, source), 'utf8');
   const testAttributes = (text.match(TEST_ATTRIBUTE) ?? []).length;
   const caseAttributes = (text.match(CASE_ATTRIBUTE) ?? []).length;
@@ -368,7 +368,7 @@ export function sourceMetrics(source, manifest, root = ROOT) {
   const blockers = MODULE_BLOCKERS.filter(
     ([name, pattern]) => !allowedBlockers.has(name) && pattern.test(text),
   ).map(([name]) => name);
-  return {
+  const metric = {
     source,
     caseName: caseNameForSource(source),
     staticTests,
@@ -377,6 +377,36 @@ export function sourceMetrics(source, manifest, root = ROOT) {
       bytes + Math.max(1, staticTests) * manifest.sharding.testAttributeWeight,
     blockers,
   };
+  if (durationPolicy !== null) {
+    const measured = durationPolicy.cases.get(metric.caseName);
+    const fallback = Math.max(1, metric.staticTests) * durationPolicy.fallbackSecondsPerTest;
+    metric.durationSeconds = measured ?? fallback;
+    metric.weight = metric.durationSeconds;
+  }
+  return metric;
+}
+
+function readDurationPolicy(policyPath) {
+  const policy = JSON.parse(readFileSync(policyPath, 'utf8'));
+  if (policy.schema_version === 2) {
+    if (
+      !Number.isFinite(policy.fallback_seconds_per_test)
+      || policy.fallback_seconds_per_test <= 0
+      || !policy.cases
+      || typeof policy.cases !== 'object'
+      || Array.isArray(policy.cases)
+    ) {
+      throw new Error('duration policy v2 requires fallback_seconds_per_test and cases');
+    }
+    return {
+      fallbackSecondsPerTest: policy.fallback_seconds_per_test,
+      cases: new Map(Object.entries(policy.cases)),
+    };
+  }
+  if (policy.schema_version === 1) {
+    return { fallbackSecondsPerTest: 60, cases: new Map() };
+  }
+  throw new Error(`unsupported duration policy schema_version: ${policy.schema_version}`);
 }
 
 export function buildCaseIndex(manifest) {
@@ -449,9 +479,13 @@ function lightestSuite(records) {
   )[0];
 }
 
-export function rebalanceManifest(manifest, root = ROOT) {
+export function rebalanceManifest(
+  manifest,
+  root = ROOT,
+  { durationPolicy = null } = {},
+) {
   const sources = discoverSourceFiles(manifest, root);
-  const metrics = sources.map((source) => sourceMetrics(source, manifest, root));
+  const metrics = sources.map((source) => sourceMetrics(source, manifest, root, durationPolicy));
   const manualPaths = new Set(
     manifest.exceptions.filter((entry) => entry.manual).map((entry) => entry.path),
   );
@@ -1027,6 +1061,16 @@ if (process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH) {
       const manifest = prepareManifest(loadManifest());
       generateArtifacts(manifest);
       printValidation(validateRepository());
+    } else if (command === '--rebalance-by-duration') {
+      const policyPath = process.argv[3];
+      if (!policyPath || process.argv.length !== 4) {
+        throw new Error('--rebalance-by-duration requires exactly one duration policy path');
+      }
+      const manifest = rebalanceManifest(loadManifest(), ROOT, {
+        durationPolicy: readDurationPolicy(policyPath),
+      });
+      generateArtifacts(manifest);
+      printValidation(validateRepository());
     } else if (command === '--sync-cargo-targets') {
       const manifest = prepareManifest(loadManifest());
       generateArtifacts(manifest, ROOT, { syncCargoTargets: true });
@@ -1056,6 +1100,7 @@ if (process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH) {
       process.stderr.write(
         '사용법: node scripts/rust-test-suite-manifest.mjs ' +
         '--check [--base-ref <Git ref>]|--prepare|--generate|--sync|--rebalance|' +
+          '--rebalance-by-duration <policy.json>|' +
           '--adopt-new|--adopt <파일...>|--sync-cargo-targets\n',
       );
       process.exitCode = 2;

--- a/scripts/rust-test-suite-manifest.mjs
+++ b/scripts/rust-test-suite-manifest.mjs
@@ -982,6 +982,14 @@ export function validateRepository(
   }
 }
 
+export function validateManifest(
+  manifest,
+  root = ROOT,
+  { checkGenerated = true, checkCargo = true } = {},
+) {
+  return inspectRepository(manifest, root, { checkGenerated, checkCargo });
+}
+
 export function generateArtifacts(
   manifest,
   root = ROOT,
@@ -1070,7 +1078,9 @@ if (process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH) {
         durationPolicy: readDurationPolicy(policyPath),
       });
       generateArtifacts(manifest);
-      printValidation(validateRepository());
+      // CI에서는 현재 duration policy로 다시 pack한 harness를 빌드한다. 기본 정책에서
+      // 다시 derive하면 동적으로 생성한 harness와 비교해 false-positive drift가 된다.
+      printValidation(validateManifest(manifest));
     } else if (command === '--sync-cargo-targets') {
       const manifest = prepareManifest(loadManifest());
       generateArtifacts(manifest, ROOT, { syncCargoTargets: true });

--- a/scripts/select-nextest-archive-targets.mjs
+++ b/scripts/select-nextest-archive-targets.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import process from "node:process";
 
 const GROUPS = ["integration-b", "integration-c", "integration-d"];
+const TEST_ATTRIBUTE = /^\s*#\s*\[(?:test|case)\b/gm;
 
 function fail(message) {
   throw new Error(`[NextestTargetDuration] ${message}`);
@@ -18,7 +19,7 @@ function parseArgs(args) {
       options.help = true;
       continue;
     }
-    if (arg !== "--group" && arg !== "--policy") {
+    if (!["--group", "--policy", "--manifest"].includes(arg)) {
       fail(`unknown argument: ${arg}`);
     }
     const value = args[index + 1];
@@ -37,6 +38,7 @@ function usage() {
     "  node scripts/select-nextest-archive-targets.mjs",
     "    --group integration-b|integration-c|integration-d",
     "    --policy tests/suites/nextest-target-duration-policy.json",
+    "    [--manifest tests/suites/manifest.json]",
   ].join(" ");
 }
 
@@ -57,9 +59,36 @@ async function readStandardInput() {
   return source;
 }
 
+function parseDurations(entries, field) {
+  const durations = new Map();
+  for (const [name, seconds] of Object.entries(entries)) {
+    if (!name || !Number.isFinite(seconds) || seconds <= 0) {
+      fail(`duration policy ${field} must have a positive duration: ${name}`);
+    }
+    durations.set(name, seconds);
+  }
+  return durations;
+}
+
 export function parseDurationPolicy(policy) {
+  if (policy?.schema_version === 2) {
+    if (!Number.isFinite(policy.fallback_seconds_per_test) || policy.fallback_seconds_per_test <= 0) {
+      fail("duration policy fallback_seconds_per_test must be a positive number");
+    }
+    for (const field of ["targets", "cases", "test_cases"]) {
+      if (!policy[field] || typeof policy[field] !== "object" || Array.isArray(policy[field])) {
+        fail(`duration policy ${field} must be an object`);
+      }
+    }
+    return {
+      schemaVersion: 2,
+      fallbackSeconds: policy.fallback_seconds_per_test,
+      durations: parseDurations(policy.targets, "target"),
+      caseDurations: parseDurations(policy.cases, "case"),
+    };
+  }
   if (!policy || policy.schema_version !== 1) {
-    fail("duration policy schema_version must be 1");
+    fail("duration policy schema_version must be 1 or 2");
   }
   if (!Number.isFinite(policy.fallback_seconds) || policy.fallback_seconds <= 0) {
     fail("duration policy fallback_seconds must be a positive number");
@@ -67,18 +96,13 @@ export function parseDurationPolicy(policy) {
   if (!policy.targets || typeof policy.targets !== "object" || Array.isArray(policy.targets)) {
     fail("duration policy targets must be an object");
   }
-
-  const durations = new Map();
-  for (const [target, seconds] of Object.entries(policy.targets)) {
-    if (!target || !Number.isFinite(seconds) || seconds <= 0) {
-      fail(`duration policy target must have a positive duration: ${target}`);
-    }
-    durations.set(target, seconds);
-  }
-
   return {
+    schemaVersion: 1,
+    // The v1 selector remains byte-for-byte compatible until v2 measurements land.
+    // Mutable suite names are excluded by the current-manifest estimate path.
     fallbackSeconds: policy.fallback_seconds,
-    durations,
+    durations: parseDurations(policy.targets, "target"),
+    caseDurations: new Map(),
   };
 }
 
@@ -93,31 +117,56 @@ export function integrationTargetsFromMetadata(metadata, workspaceManifestPath) 
   if (!workspacePackage) {
     fail(`workspace package is missing: ${workspaceManifestPath}`);
   }
-
   const targets = workspacePackage.targets
     .filter((target) => Array.isArray(target.kind) && target.kind.includes("test"))
     .map((target) => target.name)
     .sort((left, right) => left.localeCompare(right));
-
   if (new Set(targets).size !== targets.length) {
     fail("cargo metadata contains duplicate integration target names");
   }
   return targets;
 }
 
-export function assignIntegrationTargets(targets, policy) {
-  const parsedPolicy = parseDurationPolicy(policy);
+function caseNameForSource(source) {
+  return path.basename(source, ".rs").replaceAll("-", "_");
+}
+
+function sourceEstimate(source, parsedPolicy, root) {
+  const measured = parsedPolicy.caseDurations.get(caseNameForSource(source));
+  if (measured !== undefined) {
+    return measured;
+  }
+  const text = fs.readFileSync(path.join(root, source), "utf8");
+  const tests = (text.match(TEST_ATTRIBUTE) ?? []).length;
+  return Math.max(1, tests) * parsedPolicy.fallbackSeconds;
+}
+
+export function estimateManifestTargetDurations(manifest, policy, root = process.cwd()) {
+  const parsedPolicy = policy?.caseDurations ? policy : parseDurationPolicy(policy);
+  const estimates = new Map();
+  for (const [target, sources] of Object.entries(manifest.suites ?? {})) {
+    estimates.set(target, sources.reduce(
+      (total, source) => total + sourceEstimate(source, parsedPolicy, root),
+      0,
+    ));
+  }
+  for (const exception of manifest.exceptions ?? []) {
+    estimates.set(exception.target, sourceEstimate(exception.path, parsedPolicy, root));
+  }
+  return estimates;
+}
+
+export function assignIntegrationTargets(targets, policy, targetEstimates = new Map()) {
+  const parsedPolicy = policy?.caseDurations ? policy : parseDurationPolicy(policy);
   const assignments = Object.fromEntries(
     GROUPS.map((group) => [group, { estimatedSeconds: 0, targets: [] }]),
   );
-
   const weightedTargets = [...new Set(targets)]
     .map((name) => ({
       name,
-      seconds: parsedPolicy.durations.get(name) ?? parsedPolicy.fallbackSeconds,
+      seconds: targetEstimates.get(name) ?? parsedPolicy.durations.get(name) ?? parsedPolicy.fallbackSeconds,
     }))
     .sort((left, right) => right.seconds - left.seconds || left.name.localeCompare(right.name));
-
   for (const target of weightedTargets) {
     const destination = GROUPS.reduce((shortest, group) => (
       assignments[group].estimatedSeconds < assignments[shortest].estimatedSeconds
@@ -131,7 +180,6 @@ export function assignIntegrationTargets(targets, policy) {
     assignments[destination].targets.push(target.name);
     assignments[destination].estimatedSeconds += target.seconds;
   }
-
   for (const assignment of Object.values(assignments)) {
     assignment.targets.sort((left, right) => left.localeCompare(right));
   }
@@ -147,17 +195,18 @@ async function main() {
   if (!GROUPS.includes(options.group) || !options.policy) {
     fail(usage());
   }
-
   const metadata = JSON.parse(await readStandardInput());
-  const policy = readJson(options.policy, "duration policy");
+  const policy = parseDurationPolicy(readJson(options.policy, "duration policy"));
   const targets = integrationTargetsFromMetadata(metadata, path.join(process.cwd(), "Cargo.toml"));
-  const assignments = assignIntegrationTargets(targets, policy);
-  const assignment = assignments[options.group];
-
+  const targetEstimates = options.manifest
+    ? estimateManifestTargetDurations(readJson(options.manifest, "derived suite manifest"), policy)
+    : new Map();
+  const assignment = assignIntegrationTargets(targets, policy, targetEstimates)[options.group];
   process.stderr.write(
     `[NextestTargetDuration] group=${options.group} integration_targets=${targets.length} `
       + `selected_targets=${assignment.targets.length} `
-      + `estimated_seconds=${assignment.estimatedSeconds.toFixed(3)}\n`,
+      + `estimated_seconds=${assignment.estimatedSeconds.toFixed(3)} `
+      + `duration_model=${options.manifest ? `current-manifest-v${policy.schemaVersion}` : `target-v${policy.schemaVersion}`}\n`,
   );
   process.stdout.write(`${assignment.targets.join("\n")}\n`);
 }

--- a/scripts/tests/nextest-target-duration-policy.test.mjs
+++ b/scripts/tests/nextest-target-duration-policy.test.mjs
@@ -111,6 +111,49 @@ test("JUnit collection aggregates testcase durations per binary and skips setup 
   assert.deepEqual(durations, { issue_1: 2, issue_2: 2 });
 });
 
+test("JUnit measurement retains individual testcase and source-case durations", async () => {
+  const { collectDurationMeasurement } = await import("../collect-nextest-target-durations.mjs");
+  const measurement = collectDurationMeasurement([
+    '<testcase name="security_corpus_regression::negative_sweep" classname="rhwp::regression_suite_015" time="9.25" />',
+    '<testcase name="security_corpus_regression::positive_sweep" classname="rhwp::regression_suite_015" time="0.75" />',
+    '<testcase name="standalone" classname="rhwp::issue_1" time="2.00" />',
+  ].join("\n"));
+
+  assert.deepEqual(measurement.targets, { issue_1: 2, regression_suite_015: 10 });
+  assert.deepEqual(measurement.cases, { issue_1: 2, security_corpus_regression: 10 });
+  assert.deepEqual(measurement.test_cases, {
+    "issue_1::standalone": 2,
+    "regression_suite_015::security_corpus_regression::negative_sweep": 9.25,
+    "regression_suite_015::security_corpus_regression::positive_sweep": 0.75,
+  });
+});
+
+test("v2 policy uses current suite source composition instead of a historical suite name", async () => {
+  const { estimateManifestTargetDurations } = await import("../select-nextest-archive-targets.mjs");
+  const fs = await import("node:fs");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "rhwp-duration-manifest-"));
+  try {
+    fs.mkdirSync(path.join(root, "tests", "cases"), { recursive: true });
+    fs.writeFileSync(path.join(root, "tests", "cases", "heavy.rs"), "#[test] fn one() {}\n");
+    fs.writeFileSync(path.join(root, "tests", "cases", "light.rs"), "#[test] fn one() {}\n");
+    const estimates = estimateManifestTargetDurations({
+      suites: { regression_suite_001: ["tests/cases/heavy.rs", "tests/cases/light.rs"] },
+      exceptions: [],
+    }, {
+      schema_version: 2,
+      fallback_seconds_per_test: 60,
+      targets: { regression_suite_001: 1 },
+      cases: { heavy: 800, light: 5 },
+      test_cases: {},
+    }, root);
+    assert.equal(estimates.get("regression_suite_001"), 805);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("policy refresh accepts one successful B, C, and D measurement", () => {
   const refreshed = refreshDurationPolicy({
     schema_version: 1,
@@ -128,6 +171,25 @@ test("policy refresh accepts one successful B, C, and D measurement", () => {
     c: { run_id: "10", ref: "refs/heads/devel", sha: "same-sha" },
     d: { run_id: "10", ref: "refs/heads/devel", sha: "same-sha" },
   });
+});
+
+test("v2 policy keeps its source-case model when a trusted v1 artifact is reused", () => {
+  const policy = {
+    schema_version: 2,
+    fallback_seconds_per_test: 60,
+    targets: {},
+    cases: {},
+    test_cases: {},
+  };
+  const measurements = ["b", "c", "d"].map((archive_label) => ({
+    schema_version: 1,
+    archive_label,
+    run_id: "10",
+    ref: "refs/heads/devel",
+    sha: "same-sha",
+    targets: { regression_suite_001: 4 },
+  }));
+  assert.deepEqual(refreshDurationPolicy(policy, measurements), policy);
 });
 
 test("policy refresh rejects empty or mismatched B/C/D measurements", () => {

--- a/scripts/tests/rust-test-suite-manifest.test.mjs
+++ b/scripts/tests/rust-test-suite-manifest.test.mjs
@@ -211,6 +211,31 @@ test('신규 source는 선택된 suite에 정확히 한 번만 배정한다', (t
   assert.equal(assigned.filter((source) => source === 'tests/second.rs').length, 1);
 });
 
+test('개별 testcase에서 합산한 source 시간으로 suite를 재배정한다', async (t) => {
+  const { rebalanceManifest } = await import('../rust-test-suite-manifest.mjs');
+  const root = mkdtempSync(path.join(os.tmpdir(), 'rhwp-duration-rebalance-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  mkdirSync(path.join(root, 'tests', 'cases'), { recursive: true });
+  mkdirSync(path.join(root, 'tests', 'suites'), { recursive: true });
+  writeFileSync(path.join(root, 'tests', 'cases', 'heavy.rs'), '#[test]\nfn heavy() {}\n');
+  writeFileSync(path.join(root, 'tests', 'cases', 'light.rs'), '#[test]\nfn light() {}\n');
+  const manifest = {
+    sharding: { suitePrefix: 'regression_suite_', suiteCount: 2, testAttributeWeight: 1 },
+    sourceRoots: [{ path: 'tests/cases', recursive: false }],
+    moduleIntegrationOverrides: [],
+    exceptions: [],
+    suites: {},
+  };
+  const rebalanced = rebalanceManifest(manifest, root, {
+    durationPolicy: {
+      fallbackSecondsPerTest: 60,
+      cases: new Map([['heavy', 800], ['light', 5]]),
+    },
+  });
+  assert.deepEqual(rebalanced.suites.regression_suite_001, ['tests/cases/heavy.rs']);
+  assert.deepEqual(rebalanced.suites.regression_suite_002, ['tests/cases/light.rs']);
+});
+
 test('PR base에 없던 integration source는 tests/cases 밖에서 거부한다', () => {
   const baseManifest = {
     exceptions: [{ path: 'tests/legacy.rs' }],

--- a/scripts/tests/rust-test-suite-manifest.test.mjs
+++ b/scripts/tests/rust-test-suite-manifest.test.mjs
@@ -212,7 +212,11 @@ test('신규 source는 선택된 suite에 정확히 한 번만 배정한다', (t
 });
 
 test('개별 testcase에서 합산한 source 시간으로 suite를 재배정한다', async (t) => {
-  const { rebalanceManifest } = await import('../rust-test-suite-manifest.mjs');
+  const {
+    generateArtifacts,
+    rebalanceManifest,
+    validateManifest,
+  } = await import('../rust-test-suite-manifest.mjs');
   const root = mkdtempSync(path.join(os.tmpdir(), 'rhwp-duration-rebalance-'));
   t.after(() => rmSync(root, { recursive: true, force: true }));
   mkdirSync(path.join(root, 'tests', 'cases'), { recursive: true });
@@ -220,7 +224,14 @@ test('개별 testcase에서 합산한 source 시간으로 suite를 재배정한�
   writeFileSync(path.join(root, 'tests', 'cases', 'heavy.rs'), '#[test]\nfn heavy() {}\n');
   writeFileSync(path.join(root, 'tests', 'cases', 'light.rs'), '#[test]\nfn light() {}\n');
   const manifest = {
-    sharding: { suitePrefix: 'regression_suite_', suiteCount: 2, testAttributeWeight: 1 },
+    sharding: {
+      suitePrefix: 'regression_suite_',
+      suiteCount: 2,
+      testAttributeWeight: 1,
+      maximumIntegrationTargets: 2,
+    },
+    minimumNextestCases: 1,
+    nextestPriorities: [],
     sourceRoots: [{ path: 'tests/cases', recursive: false }],
     moduleIntegrationOverrides: [],
     exceptions: [],
@@ -234,6 +245,11 @@ test('개별 testcase에서 합산한 source 시간으로 suite를 재배정한�
   });
   assert.deepEqual(rebalanced.suites.regression_suite_001, ['tests/cases/heavy.rs']);
   assert.deepEqual(rebalanced.suites.regression_suite_002, ['tests/cases/light.rs']);
+  generateArtifacts(rebalanced, root);
+  assert.deepEqual(
+    validateManifest(rebalanced, root, { checkCargo: false }).errors,
+    [],
+  );
 });
 
 test('PR base에 없던 integration source는 tests/cases 밖에서 거부한다', () => {

--- a/scripts/tests/test_nextest_archive_workflow.py
+++ b/scripts/tests/test_nextest_archive_workflow.py
@@ -135,6 +135,8 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
             builder,
         )
         self.assertIn('--policy "${duration_policy}"', builder)
+        self.assertIn('--manifest tests/suites/manifest.json', builder)
+        self.assertIn('--rebalance-by-duration "${duration_policy}"', builder)
         self.assertNotIn("index % 2", builder)
         self.assertIn("cargo_target_args+=(--lib)", builder)
         self.assertIn('cargo_target_args+=(--test "${target}")', builder)
@@ -153,8 +155,10 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         collector = (root / "scripts/collect-nextest-target-durations.mjs").read_text()
         refresh = (root / "scripts/refresh-nextest-target-duration-policy.mjs").read_text()
 
-        self.assertIn('"schema_version": 1', policy)
-        self.assertIn('"fallback_seconds": 1', policy)
+        self.assertIn('"schema_version": 2', policy)
+        self.assertIn('"fallback_seconds_per_test": 60', policy)
+        self.assertIn('"cases": {}', policy)
+        self.assertIn('"test_cases": {}', policy)
         self.assertIn("[profile.ci-duration-observation.junit]", config)
         self.assertIn("github.event_name == 'push'", runner)
         self.assertIn("github.ref == 'refs/heads/devel'", runner)
@@ -171,6 +175,8 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         self.assertIn("estimatedSeconds", selector)
         self.assertIn("<testcase", collector)
         self.assertIn("JUnit report contains no target durations", collector)
+        self.assertIn("collectDurationMeasurement", collector)
+        self.assertIn("case_durations", collector)
         self.assertIn("exactly one B, C, and D report", refresh)
         self.assertIn("identical run, ref, and sha provenance", refresh)
 

--- a/tests/suites/nextest-target-duration-policy.json
+++ b/tests/suites/nextest-target-duration-policy.json
@@ -1,5 +1,7 @@
 {
-  "schema_version": 1,
-  "fallback_seconds": 1,
-  "targets": {}
+  "schema_version": 2,
+  "fallback_seconds_per_test": 60,
+  "targets": {},
+  "cases": {},
+  "test_cases": {}
 }


### PR DESCRIPTION
## 배경

`regression_suite_NNN`은 생성 시 구성원이 달라지는 묶음 이름이므로, 과거 target 이름의 실행시간만으로는 B/C/D 균형을 안정적으로 맞출 수 없습니다.

Refs #6360

## 변경

- JUnit 측정 artifact를 schema v2로 확장해 source-case와 개별 test case 시간을 보관합니다.
- 현재 manifest 구성에 source-case 시간을 합산해 `regression_suite`를 재배분합니다.
- B/C/D 선택은 현재 manifest 기반 예상시간을 사용합니다.
- 기존 trusted v1 측정 artifact만 있는 post-merge 재사용은 v2 정책을 유지한 채 안전하게 통과시킵니다.
- Render Diff merge-bridge/review-tail reuse 정책(#6297)은 변경하지 않습니다.

## 사전 검증

- `node --test scripts/tests/nextest-target-duration-policy.test.mjs` (10 passed)
- `node --test scripts/tests/rust-test-suite-manifest.test.mjs` (19 passed)
- CI 영향 및 trusted post-merge reuse Node 계약 테스트 (78 passed)
- `python3 -m unittest discover -s scripts/tests -p 'test_*workflow.py'` (166 passed)
- `git diff --check`

옵션 B에 따라 PR 검토 문서와 오늘할일은 이 코드 PR의 CI 완료 뒤 별도 review-only PR로 제출합니다.