### PR TITLE
Task #6373: 회전 편집의 flip bit19·rotate_image 강제를 제거한다

### DIFF
--- a/src/document_core/commands/object_ops/picture.rs
+++ b/src/document_core/commands/object_ops/picture.rs
@@ -291,8 +291,16 @@ impl DocumentCore {
 
         pic.shape_attr.rotation_center.x = (pic.common.width / 2) as i32;
         pic.shape_attr.rotation_center.y = (pic.common.height / 2) as i32;
-        pic.shape_attr.rotate_image = true;
-        pic.shape_attr.flip |= 0x0008_0000;
+        // `rotate_image` 와 `flip` bit19(0x0008_0000)는 **여기서 건드리지 않는다.**
+        // 종전에는 각도와 무관하게 둘을 세웠고, 회전을 0 으로 되돌려도 남아 되돌릴 경로가
+        // 없었다. 한컴 오라클(`tools/hangul_rotation_oracle/EVIDENCE.md`)이 잰 결과 둘은
+        // 회전 상태의 함수가 아니다:
+        //   - 한컴 저장본 5660개 개체에서 bit19 는 회전 개체 569건 중 559건이 **꺼져** 있고
+        //     비회전 개체 5091건 중 4416건이 **켜져** 있다(회전과 반대 방향).
+        //   - 한글 2024 는 회전 0 그림의 bit19 를 그대로 켜 두고, 34° 회전 그림의
+        //     `rotateimage` 를 0 으로 둔다.
+        // 세우는 것도 지우는 것도 근거가 없으므로 파싱된 값을 보존한다. HWP5 저장에는
+        // `flip` 만 나가고 `rotate_image` 는 HWPX `rotateimage` 의 원천이다.
     }
     fn apply_picture_display_width(pic: &mut crate::model::image::Picture, width: u32) {
         let old_common_width = pic.common.width;

--- a/tests/cases/issue_6373_picture_rotation_storage_bits.rs
+++ b/tests/cases/issue_6373_picture_rotation_storage_bits.rs
@@ -1,0 +1,120 @@
+//! [#6373] 회전 편집은 `flip` 저장 워드와 `rotate_image` 를 건드리지 않는다.
+//!
+//! 종전 `refresh_picture_rotation_layout_for_save` 는 각도와 무관하게
+//! `rotate_image = true` 와 `flip |= 0x0008_0000`(bit19) 을 세웠다. 회전을 0 으로 되돌려도
+//! 남아 되돌릴 경로가 없었다.
+//!
+//! 두 값은 회전 상태의 함수가 아니다 — `tools/hangul_rotation_oracle/EVIDENCE.md` 실측:
+//! 한컴 저장본 5660개 개체에서 bit19 는 회전 개체 569건 중 559건이 꺼져 있고 비회전 개체
+//! 5091건 중 4416건이 켜져 있다. 한글 2024 는 회전 0 그림의 bit19 를 켜 두고 34° 회전
+//! 그림의 `rotateimage` 를 0 으로 둔다. 그래서 세우는 것도 지우는 것도 근거가 없다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::model::image::Picture;
+
+/// 한컴이 만든 34° 회전 그림 — 표 셀 안.
+/// `tests/issue_1279_picture_rotation_save.rs` 가 같은 샘플로 회전 행렬 계약을 고정한다.
+const SAMPLE: &str = "samples/ta-pic-001-r.hwp";
+const CELL_PATH: &str = r#"[{"controlIdx":2,"cellIdx":2,"cellParaIdx":0}]"#;
+const ROTATE_IMAGE_BIT: u32 = 0x0008_0000;
+
+fn read_fixture(path: &str) -> Vec<u8> {
+    std::fs::read(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(path))
+        .unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+fn cell_picture(core: &DocumentCore) -> &Picture {
+    let table = match &core.document().sections[0].paragraphs[0].controls[2] {
+        Control::Table(table) => table,
+        other => panic!("샘플 좌표가 표가 아니다: {other:?}"),
+    };
+    table.cells[2].paragraphs[0]
+        .controls
+        .iter()
+        .find_map(|ctrl| match ctrl {
+            Control::Picture(pic) => Some(&**pic),
+            _ => None,
+        })
+        .expect("셀에 그림이 없다")
+}
+
+fn set_rotation(core: &mut DocumentCore, degrees: i32) {
+    core.set_cell_picture_properties_by_path_native(
+        0,
+        0,
+        CELL_PATH,
+        0,
+        &format!(r#"{{"rotationAngle":{degrees}}}"#),
+    )
+    .unwrap_or_else(|e| panic!("회전 {degrees} 적용: {e}"));
+}
+
+/// 회전 제거·복귀 왕복에서 두 값이 보존된다.
+#[test]
+fn issue_6373_rotation_edit_preserves_storage_flip_and_rotate_image() {
+    let mut core = DocumentCore::from_bytes(&read_fixture(SAMPLE)).expect("파싱");
+
+    let (flip, rotate_image, angle) = {
+        let pic = cell_picture(&core);
+        (
+            pic.shape_attr.flip,
+            pic.shape_attr.rotate_image,
+            pic.shape_attr.rotation_angle,
+        )
+    };
+    assert_eq!(angle, 34, "전제: 한컴 원본은 34° 회전");
+    assert_ne!(
+        flip & ROTATE_IMAGE_BIT,
+        0,
+        "전제: 원본에 bit19 가 켜져 있다"
+    );
+    assert!(
+        !rotate_image,
+        "전제: 한컴은 회전 그림에도 rotateImage=0 을 쓴다"
+    );
+
+    // 회전 제거 — 종전에는 이 시점에 rotate_image=true 가 되고 bit19 가 세워졌다.
+    set_rotation(&mut core, 0);
+    {
+        let pic = cell_picture(&core);
+        assert_eq!(pic.shape_attr.rotation_angle, 0, "회전이 제거됐다");
+        assert_eq!(
+            pic.shape_attr.flip, flip,
+            "회전 편집이 flip 저장 워드를 바꾸지 말아야 한다"
+        );
+        assert_eq!(
+            pic.shape_attr.rotate_image, rotate_image,
+            "회전 편집이 rotate_image 를 바꾸지 말아야 한다"
+        );
+    }
+
+    // 되돌리기도 성립한다.
+    set_rotation(&mut core, 34);
+    let pic = cell_picture(&core);
+    assert_eq!(pic.shape_attr.rotation_angle, 34);
+    assert_eq!(pic.shape_attr.flip, flip, "왕복 후에도 flip 이 보존된다");
+    assert_eq!(pic.shape_attr.rotate_image, rotate_image);
+}
+
+/// 저장·재파싱에서도 보존된다 — HWP5 저장에 나가는 것은 `flip` 워드다.
+#[test]
+fn issue_6373_preserved_bits_survive_save_and_reparse() {
+    let mut core = DocumentCore::from_bytes(&read_fixture(SAMPLE)).expect("파싱");
+    let flip = cell_picture(&core).shape_attr.flip;
+
+    set_rotation(&mut core, 0);
+    let saved = core.export_hwp_native().expect("저장");
+
+    let reparsed = DocumentCore::from_bytes(&saved).expect("재파싱");
+    let pic = cell_picture(&reparsed);
+    assert_eq!(
+        pic.shape_attr.rotation_angle, 0,
+        "회전 제거가 저장에 반영됐다"
+    );
+    assert_eq!(
+        pic.shape_attr.flip, flip,
+        "회전 제거가 flip 저장 워드를 바꾸지 말아야 한다"
+    );
+}


### PR DESCRIPTION
관련 이슈: #6373

## 문제
그림 회전 편집이 `rotate_image = true` 와 `flip |= 0x0008_0000`(bit19) 을 각도와 무관하게
세운다. 한컴은 두 값을 회전 상태의 함수로 쓰지 않으므로 근거가 없고, 회전을 0 으로 되돌려도
남아 되돌릴 경로가 없다.

## 원인
`refresh_picture_rotation_layout_for_save`
(`src/document_core/commands/object_ops/picture.rs:294-295`) 의 마지막 두 줄이 각도를 보지 않고
무조건 실행된다. 두 값이 "회전됨" 을 뜻한다는 전제가 실측과 어긋난다 — 아래 검증 참조.

## 변경
회전 편집이 `rotate_image` 와 `flip` 을 건드리지 않는다. 파싱된 값을 보존하므로 회전 왕복이
성립한다. 위치·크기·회전 중심 재계산은 그대로다.

측정 근거를 주석에 남긴다 — 왜 "0 에서 내린다" 가 아니라 "건드리지 않는다" 인지가 이 변경의
핵심이고, 근거 없이 되면 다음 사람이 반대 방향으로 되돌리기 쉽다.

추가 테스트 `tests/cases/issue_6373_picture_rotation_storage_bits.rs`:

- `issue_6373_rotation_edit_preserves_storage_flip_and_rotate_image` — 34→0→34 왕복 보존
- `issue_6373_preserved_bits_survive_save_and_reparse` — 저장·재파싱 후에도 보존

## 검증
devel `b54f20e39` 기준. 측정 도구와 원자료는 #6372 가 들여오는
`tools/hangul_rotation_oracle/` 이다.

- **수정 전 실패 증명**: `samples/ta-pic-001-r.hwp` 표 셀 그림(34° 회전)에서 회전을 0 으로
  바꾸면 `rotate_image` 가 `false`→`true`, 회전을 34 로 되돌려도 `true` 로 남았다.
  수정 후 두 값 모두 보존.
- **두 값이 회전의 함수가 아님** (오라클 실측):
  - 한컴 저장본 `samples/**/*.hwp` 529개, 변환 정보를 가진 개체 5660건에서 bit19 는 회전
    개체 569건 중 **559건이 꺼져** 있고 비회전 개체 5091건 중 **4416건이 켜져** 있다.
    회전 상태와 정확히 일치하는 비트는 없다.
  - `ta-pic-001-r.hwp` 한 파일 안에서 34° 그림(`flip=0x26080000`)과 0° 그림
    (`flip=0x24080000`)이 둘 다 bit19 가 켜져 있다. 차이는 bit25 다.
  - 한글 2024(COM `Version=13,0,0,645`) 재저장 시 회전 0 그림의 bit19 는 켜진 채 유지되고
    34° 그림의 `rotateimage` 는 0 으로 유지된다. 한글이 바꾼 것은 bit16 뿐이고 회전 여부와
    무관하게 양쪽 모두 세웠다.
- 회전 계약 스위트 그린 — `issue_1279_picture_rotation_save` 143 passed, 0 failed.
  이 파일이 `flip & 0x0008_0000` 보존과 HWPX→HWP 회전 계약을 고정하고 있어 이 변경의 주
  감시선이다. `issue_1282_rotated_cell_picture_resize` 포함 149 passed(1 ignored), 0 failed.
- HWP5 왕복 기준선 포함 스위트 140 passed, 0 failed.
- `cargo test --release --lib` — 3889 passed / 0 failed / 13 ignored.
- `cargo fmt --all -- --check` 클린, `cargo clippy --workspace --all-targets -- -D warnings` 클린.
- `node scripts/rust-unit-test-tiers.mjs --check --base-ref origin/devel` 통과
  (4221 tests / 299 modules, src `#[cfg(test)]` 무변경).

## 범위 외
- 한글이 저장 시 `flip` bit16 을 세우는 것(회전 무관, 실측). rhwp 는 따라가지 않는다.
- bit25 가 회전 개체에서만 나타나는(569건 중 7건) 이유 — 표본이 적어 판정하지 않는다.
- 같은 함수의 위치 재중심화. 참고: #6355
