### PR TITLE
fix(parser/hwp3): samples 실측으로 남은 사적 문자 소실을 막는다 (#6380)

### DIFF
--- a/src/parser/hwp3/johab.rs
+++ b/src/parser/hwp3/johab.rs
@@ -461,15 +461,6 @@ mod tests {
     }
 
     #[test]
-    fn araea_with_filler_leading_keeps_the_bare_jamo() {
-        // [#6380] hwp3-sample16 의 0x87C1 — 초성 '채움'(인덱스 1) + 아래아 + 받침 없음.
-        // 한컴 변환본은 같은 자리를 `석ᆞ박사급` 처럼 U+119E 한 글자로 보존한다.
-        assert_eq!(decode_johab_araea_jamo(0x87C1), Some((None, 'ᆞ', None)));
-        // 무효 초성(인덱스 0)은 종전대로 None.
-        assert_eq!(decode_johab_araea_jamo(0x83C1), None);
-    }
-
-    #[test]
     fn hancom_tilde_variant_matches_hangul() {
         // KS X 1001 0xA1AD 는 표준 매핑이 U+223C(∼)지만 한글은 U+FF5E(～)를 쓴다.
         // 실측 80건 — 보정하지 않으면 되살린 문자가 다른 글자가 된다.

--- a/src/parser/hwp3/johab.rs
+++ b/src/parser/hwp3/johab.rs
@@ -10,7 +10,7 @@ use crate::parser::hwp3::johab_map;
 /// HWP3은 이 음절을 한 개 hchar로 저장하지만, HWP5/HWPX 변환본은
 /// 초성·아래아·종성 자모열로 보존한다. `decode_johab`의 완성형 반환 계약을
 /// 바꾸지 않기 위해, 가변 길이 텍스트가 필요한 호출자만 이 함수를 사용한다.
-pub fn decode_johab_araea_jamo(ch: u16) -> Option<(char, char, Option<char>)> {
+pub fn decode_johab_araea_jamo(ch: u16) -> Option<(Option<char>, char, Option<char>)> {
     if ch < 0x8000 {
         return None;
     }
@@ -32,11 +32,24 @@ pub fn decode_johab_araea_jamo(ch: u16) -> Option<(char, char, Option<char>)> {
     ];
     let cho = *cho_map.get(cho_idx)?;
     let jong = *jong_map.get(jong_idx)?;
-    if cho < 0 || jong < 0 {
+    if jong < 0 {
         return None;
     }
 
-    let leading = char::from_u32(0x1100 + cho as u32)?;
+    // [#6380] 초성 인덱스 1 은 '채움'(초성 없음)이라 무효가 아니다. cho_map 이 이를
+    // -1 로 내는 바람에 채움 + 아래아 음절이 통째로 버려졌다 — hwp3-sample16 의
+    // 0x87C1 이 그 경우로, 한컴 변환본은 같은 자리를 `석ᆞ박사급` 처럼 U+119E 한
+    // 글자로 보존한다. 그 밖의 무효 초성(0·21~31)은 종전대로 None 이다.
+    const CHO_FILL_INDEX: usize = 1;
+    if cho < 0 && cho_idx != CHO_FILL_INDEX {
+        return None;
+    }
+
+    let leading = if cho < 0 {
+        None
+    } else {
+        Some(char::from_u32(0x1100 + cho as u32)?)
+    };
     let araea = char::from_u32(0x119E)?;
     let trailing = if jong == 0 {
         None
@@ -271,6 +284,57 @@ fn decode_hwp3_extra(ch: u16) -> Option<char> {
         0x309D => 0xFF63, // ｣  07615(7)
         // 한컴 사설 영역 기호는 평면 15 PUA 로 보존한다 — 렌더러의 공통 한컴 PUA 표가
         // 표시 문자열을 담당한다(0x37C0..0x37C5·0x3366 과 같은 계약).
+        // [#6380] 아래는 저장소 `samples/` 의 HWP3 원본을 같은 문서의 한컴 변환본과
+        // 문자 멀티셋·문맥으로 대조해 얻은 값이다. 코드 출현 횟수가 변환본의 해당
+        // 문자 개수와 정확히 맞는 것만 싣는다.
+        //
+        // 텍스트 다이어그램 괘선 조각 — 0x301C(→F080F) 와 같은 묶음이고 상수
+        // 오프셋(0xC07F3)으로 이어진다. 렌더러 검증표가 ┌┬┐└┘│ 로 편다.
+        // sample11 개수: 3·1·10·6·9·17 ↔ 변환본 F0806·F0807·F0808·F080C·F080E·F0810 동수.
+        0x3013 => 0xF0806,
+        0x3014 => 0xF0807,
+        0x3015 => 0xF0808,
+        0x3019 => 0xF080C,
+        0x301B => 0xF080E,
+        0x301D => 0xF0810,
+        // 겹줄. 기호 좌표 규칙으로는 가타카나 `ネ` 가 되는 사적 graphic 코드다.
+        // sample10(42) · sample11(12) 의 변환본이 같은 자리에 리터럴 U+2550 을 동수로
+        // 갖는다 — 0x3048(→F0832) 과 달리 PUA 가 아니라 표준 문자로 저장된다.
+        0x37ED => 0x2550,
+        // 원문자·괄호문자 계열 (sample11).
+        //   0x2E01~0x2E07 은 표준 ①~⑦ 로 저장되고(7코드 연속 문맥 일치),
+        //   0x2E00·0x2E0A~0x2E12 는 hancom_pua.rs 가 근거로 적어 둔 p23 NVRAM 라벨 줄의
+        //   별도 글리프(F0288~F0291)다. 두 계열이 같은 문서에서 함께 쓰인다.
+        0x2E01 => 0x2460,
+        0x2E02 => 0x2461,
+        0x2E03 => 0x2462,
+        0x2E04 => 0x2463,
+        0x2E05 => 0x2464,
+        0x2E06 => 0x2465,
+        0x2E07 => 0x2466,
+        0x2E00 => 0xF0288,
+        0x2E0A => 0xF0289,
+        0x2E0B => 0xF028A,
+        0x2E0D => 0xF028C,
+        0x2E0E => 0xF028D,
+        0x2E0F => 0xF028E,
+        0x2E10 => 0xF028F,
+        0x2E11 => 0xF0290,
+        0x2E12 => 0xF0291,
+        // 0x2E0C(→F028B=③)는 근거 문서가 그 자리에 리터럴 ③ 을 써서 관측되지 않았다.
+        0x2C21 => 0x24D0, // ⓐ  sample11 개수 1·1·2·2·2·3 ↔ 변환본 ⓐ~ⓕ 동수
+        0x2C22 => 0x24D1,
+        0x2C23 => 0x24D2,
+        0x2C24 => 0x24D3,
+        0x2C25 => 0x24D4,
+        0x2C26 => 0x24D5,
+        0x2C40 => 0x3260, // ㉠  sample11 각 1건
+        0x2C41 => 0x3261,
+        0x2C42 => 0x3262,
+        // 글머리표·장식.
+        0x2022 => 0x2022,  // •  sample(4) — 유니코드 값 그대로 담은 자리
+        0x2F17 => 0x2022,  // •  sample10(3)
+        0x2F06 => 0x25A0,  // ■  sample10 "제목차례" 좌우 장식(2)
         0x25F5 => 0xF0099, // 04759(1)
         // 관인·서명란 도장 기호. 00460·00465·04442·04640·04845·05428·05755 (7문서 8회).
         0x2BCE => 0xF012B,
@@ -291,6 +355,9 @@ fn hancom_variant(c: char) -> char {
     match c {
         // 0xA1AD: 표준 U+223C(∼) ↔ 한컴 U+FF5E(～). 실측 80건.
         '\u{223C}' => '\u{FF5E}',
+        // [#6380] 0xA2C1: 표준 U+2299(⊙) ↔ 한컴 U+25C9(◉).
+        // hwp3-sample11 ↔ hwp3-sample11-hwpx 문맥 정렬 2건.
+        '\u{2299}' => '\u{25C9}',
         other => other,
     }
 }
@@ -313,7 +380,10 @@ mod tests {
     #[test]
     fn decode_johab_araea_preserves_legacy_jamo_sequence() {
         // HWP3 fixture의 첫 글자. 한컴 HWPX 변환본은 "ᄒᆞᆫ"으로 보존한다.
-        assert_eq!(decode_johab_araea_jamo(0xD3C5), Some(('ᄒ', 'ᆞ', Some('ᆫ'))));
+        assert_eq!(
+            decode_johab_araea_jamo(0xD3C5),
+            Some((Some('ᄒ'), 'ᆞ', Some('ᆫ')))
+        );
     }
 
     #[test]
@@ -388,6 +458,15 @@ mod tests {
                 "0x{ch:04X} 는 근거 없이 매핑하면 안 된다"
             );
         }
+    }
+
+    #[test]
+    fn araea_with_filler_leading_keeps_the_bare_jamo() {
+        // [#6380] hwp3-sample16 의 0x87C1 — 초성 '채움'(인덱스 1) + 아래아 + 받침 없음.
+        // 한컴 변환본은 같은 자리를 `석ᆞ박사급` 처럼 U+119E 한 글자로 보존한다.
+        assert_eq!(decode_johab_araea_jamo(0x87C1), Some((None, 'ᆞ', None)));
+        // 무효 초성(인덱스 0)은 종전대로 None.
+        assert_eq!(decode_johab_araea_jamo(0x83C1), None);
     }
 
     #[test]

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -2932,7 +2932,7 @@ pub(crate) fn parse_paragraph_list(
                     // char_offsets는 출력 문자마다 하나여야 하고, source hchar 위치는
                     // 이미 loop 시작에서 hwp3_char_to_utf16_pos에 기록했으므로 둘을
                     // 각각 갱신해 글자 모양·줄 시작 오프셋도 뒤따르게 한다.
-                    for decoded in [Some(leading), Some(araea), trailing].into_iter().flatten() {
+                    for decoded in [leading, Some(araea), trailing].into_iter().flatten() {
                         char_offsets.push(utf16_len);
                         utf16_len += decoded.len_utf16() as u32;
                         text_string.push(decoded);

--- a/tests/cases/issue_6380_hwp3_samples_symbol_map.rs
+++ b/tests/cases/issue_6380_hwp3_samples_symbol_map.rs
@@ -1,0 +1,99 @@
+//! Issue #6380: samples 실측으로 남아 있던 HWP3 사적 문자 소실.
+//!
+//! `decode_johab` 이 매핑을 못 찾아 `'?'` 를 돌려주면 HWP3 파서가 그 문자를 건너뛴다
+//! (`src/parser/hwp3/mod.rs` 의 `s == '?' && ch >= 0x0080` 분기). #5860 이 10k 코퍼스
+//! 실측으로 표를 채웠지만, 저장소 `samples/` 의 HWP3 원본만으로도 아직 버려지는 코드가
+//! 남아 있었다.
+//!
+//! 각 값은 `samples/hwp3-sampleNN.hwp` 를 같은 문서의 한컴 변환본(`-hwpx.hwpx`·
+//! `-hwp5.hwpx`)과 문자 멀티셋·문맥으로 대조해 얻었고, **코드 출현 횟수가 변환본의 해당
+//! 문자 개수와 정확히 맞는 것만** 실었다.
+
+use rhwp::parser::hwp3::johab::{decode_johab, decode_johab_araea_jamo};
+
+/// 텍스트 다이어그램 괘선 조각 — `0x301C`(→F080F) 와 같은 묶음이고 상수 오프셋으로
+/// 이어진다. sample11 코드 개수 3·1·10·6·9·17 이 변환본 PUA 개수와 그대로 맞는다.
+#[test]
+fn diagram_rule_fragments_decode_to_the_hancom_pua() {
+    let measured: &[(u16, char)] = &[
+        (0x3013, '\u{F0806}'),
+        (0x3014, '\u{F0807}'),
+        (0x3015, '\u{F0808}'),
+        (0x3019, '\u{F080C}'),
+        (0x301B, '\u{F080E}'),
+        (0x301D, '\u{F0810}'),
+    ];
+    for &(code, expected) in measured {
+        assert_eq!(
+            decode_johab(code),
+            expected,
+            "0x{code:04X} 가 다시 버려진다"
+        );
+    }
+}
+
+/// 겹줄 `0x37ED` — 기호 좌표 규칙으로는 가타카나 `ネ` 가 되는 사적 graphic 코드다.
+/// sample10(42건)·sample11(12건) 의 변환본이 같은 자리에 리터럴 `═` 를 동수로 갖는다.
+#[test]
+fn double_rule_fragment_is_a_literal_not_a_pua() {
+    assert_eq!(decode_johab(0x37ED), '═');
+}
+
+/// 원문자·괄호문자 계열 (sample11). 표준 문자로 저장된 계열과 별도 글리프(PUA) 계열이
+/// 같은 문서에서 함께 쓰인다 — 후자는 `hancom_pua.rs` 가 근거로 적어 둔 p23 NVRAM 라벨 줄이다.
+#[test]
+fn circled_and_parenthesized_series_decode() {
+    let measured: &[(u16, char)] = &[
+        (0x2E01, '①'),
+        (0x2E07, '⑦'),
+        (0x2E00, '\u{F0288}'),
+        (0x2E0A, '\u{F0289}'),
+        (0x2E12, '\u{F0291}'),
+        (0x2C21, 'ⓐ'),
+        (0x2C26, 'ⓕ'),
+        (0x2C40, '㉠'),
+        (0x2C42, '㉢'),
+    ];
+    for &(code, expected) in measured {
+        assert_eq!(
+            decode_johab(code),
+            expected,
+            "0x{code:04X} 가 다시 버려진다"
+        );
+    }
+    // 0x2E0C(→F028B=③)는 근거 문서가 그 자리에 리터럴 ③ 을 써서 관측되지 않았다.
+    assert_eq!(decode_johab(0x2E0C), '?');
+}
+
+/// 글머리표·장식 (sample·sample10).
+#[test]
+fn bullet_and_ornament_codes_decode() {
+    assert_eq!(decode_johab(0x2022), '•');
+    assert_eq!(decode_johab(0x2F17), '•');
+    assert_eq!(decode_johab(0x2F06), '■');
+}
+
+/// `0xA2C1` 의 표준 매핑은 U+2299(`⊙`)지만 한글은 U+25C9(`◉`)를 쓴다.
+/// `∼`→`～` 와 같은 성격의 한컴 표기 차이다 (sample11 문맥 정렬 2건).
+#[test]
+fn hancom_circled_dot_variant_matches_hangul() {
+    assert_eq!(decode_johab(0x3481), '◉');
+}
+
+/// 초성 '채움'(인덱스 1) + 아래아 음절. 종전에는 무효 초성으로 보고 통째로 버렸다 —
+/// hwp3-sample16 의 `0x87C1` 이 그 경우로, 한컴 변환본은 `석ᆞ박사급` 처럼 U+119E
+/// 한 글자로 보존한다.
+#[test]
+fn araea_with_filler_leading_survives() {
+    assert_eq!(decode_johab_araea_jamo(0x87C1), Some((None, 'ᆞ', None)));
+    // 채움이 아닌 무효 초성은 종전대로 None — 없는 음절을 지어내지 않는다.
+    assert_eq!(decode_johab_araea_jamo(0x83C1), None);
+}
+
+/// 실측 근거가 없는 이웃 코드는 여전히 매핑하지 않는다.
+#[test]
+fn unmeasured_neighbours_stay_unmapped() {
+    for code in [0x2C27_u16, 0x2C43, 0x3016] {
+        assert_eq!(decode_johab(code), '?', "0x{code:04X} 는 실측 근거가 없다");
+    }
+}


### PR DESCRIPTION
#6380 대응.

`decode_johab` 이 매핑을 못 찾아 `'?'` 를 돌려주면 HWP3 파서가 그 문자를 건너뛴다(`mod.rs` 의 `s == '?' && ch >= 0x0080`). #5860 이 10k 코퍼스 실측으로 표를 채웠지만, **저장소 `samples/` 의 HWP3 원본만으로도** 아직 버려지는 코드가 남아 있었습니다.

## 근거

각 값은 `samples/hwp3-sampleNN.hwp` 를 같은 문서의 한컴 변환본(`-hwpx.hwpx`·`-hwp5.hwpx`)과 문자 멀티셋·문맥으로 대조해 얻었습니다. **코드 출현 횟수가 변환본의 해당 문자 개수와 정확히 맞는 것만** 실었고, 구간 통과는 하지 않았습니다.

### 1. 텍스트 다이어그램 괘선 조각 6종 (sample11)

이미 표에 있던 `0x301C`(→F080F) 와 같은 묶음이고 상수 오프셋(0xC07F3)으로 이어집니다. 렌더러 검증표가 이미 표시 문자를 갖고 있습니다.

| HWP3 | 변환본 | 개수 | 표시 |
|------|--------|------|------|
| 0x3013 | U+F0806 | 3 ↔ 3 | ┌ |
| 0x3014 | U+F0807 | 1 ↔ 1 | ┬ |
| 0x3015 | U+F0808 | 10 ↔ 10 | ┐ |
| 0x3019 | U+F080C | 6 ↔ 6 | └ |
| 0x301B | U+F080E | 9 ↔ 9 | ┘ |
| 0x301D | U+F0810 | 17 ↔ 17 | │ |

### 2. 겹줄 0x37ED → U+2550

기호 좌표 규칙으로는 가타카나 `ネ` 가 되는 사적 graphic 코드입니다. sample10(42건)·sample11(12건) 의 변환본이 같은 자리에 **리터럴 `═`** 를 동수로 갖습니다 — `0x3048`(→U+F0832) 과 달리 PUA 가 아닙니다.

### 3. 원문자·괄호문자 계열 (sample11)

같은 문서에서 표준 문자 계열과 별도 글리프(PUA) 계열이 함께 쓰입니다.

- `0x2E01~0x2E07` → ①~⑦ (7코드 연속 문맥 일치)
- `0x2E00` → U+F0288(2↔2), `0x2E0A~0x2E12` → U+F0289~U+F0291 — `hancom_pua.rs` 가 근거로 적어 둔 p23 NVRAM 라벨 줄("F0288 F0289 F028A ③(리터럴) F028C…F0291 ⓐ ⓑ")의 HWP3 원시 코드가 이 값들입니다. `0x2E0C`(→F028B=③)는 그 문서가 리터럴 ③ 을 써서 관측되지 않아 넣지 않았습니다
- `0x2C21~0x2C26` → ⓐ~ⓕ (개수 1·1·2·2·2·3 ↔ 변환본 동수)
- `0x2C40~0x2C42` → ㉠~㉢ (각 1↔1)

### 4. 글머리표·장식

`0x2022`(항등 `•`, sample 4건) · `0x2F17`(→`•`, sample10 3건) · `0x2F06`(→`■`, sample10 "제목차례" 좌우 2건).

### 5. `hancom_variant` — ⊙ vs ◉

`0xA2C1` 의 표준 매핑은 U+2299(`⊙`)지만 sample11 변환본은 U+25C9(`◉`)를 씁니다(문맥 정렬 2건). 기존 `∼`→`～` 와 같은 성격입니다.

### 6. 초성 '채움' 아래아 음절 (sample16)

`decode_johab_araea_jamo` 는 초성 인덱스가 `cho_map` 에서 -1 이면 `None` 을 돌려주는데, **조합형 초성 인덱스 1 은 '채움'(초성 없음)** 이라 무효가 아닙니다. `0x87C1`(채움 + 아래아 + 받침없음)이 이 경로로 버려지고, 한컴 변환본은 같은 자리를 `석ᆞ박사급` 처럼 U+119E 한 글자로 보존합니다.

반환 타입의 초성을 `Option<char>` 로 바꾸고 호출부 한 곳(`mod.rs` 의 `[Some(leading), …]` → `[leading, …]`)을 맞췄습니다. 채움이 아닌 무효 초성(인덱스 0·21~31)은 종전대로 `None` 입니다.

## 검증

```
cargo fmt --all && cargo fmt --all -- --check     # OK
cargo clippy --lib                                 # 경고 0
cargo test --lib                                   # 3,890 passed / 0 failed
cargo test --test regression_suite_030 issue_6380  # 7 passed
node scripts/rust-unit-test-tiers.mjs --check      # 확인 완료
```

- `tests/cases/issue_6380_hwp3_samples_symbol_map.rs` 원본만 포함했습니다(파생 harness·manifest 미포함).
- `cargo clippy --lib --all-features` 는 `vello` 0.9 와 0.10 이 그래프에 함께 올라 `src/renderer/gpu.rs:193` 에서 먼저 깨집니다 — 이 PR 이 건드리지 않은 기존 상태라 그대로 두었습니다.
- `cargo nextest` 미설치 환경이라 release-test 전체 매트릭스는 CI 에 맡깁니다.

## 참고

이 실측은 rhwp 파서를 포팅해 쓰는 kordoc 쪽에서 같은 결함을 추적하다 나왔습니다. 그쪽에서는 완성형 좌표 규칙(`decode_hwp3_ksc_symbol`·`decode_hwp3_ksc_hanja`) 자체가 포팅에서 누락돼 있었고, 규칙을 이식한 뒤 남은 잔여가 위 코드들이었습니다.
