### PR TITLE
문서: HWP5 무인 스크립트 사전 차단 안내

### DIFF
--- a/mydocs/manual/mcp_hwp2024Convert_usage.md
+++ b/mydocs/manual/mcp_hwp2024Convert_usage.md
@@ -2,7 +2,7 @@
 kind: guide
 status: active
 canonical: mydocs/manual/mcp_hwp2024Convert_usage.md
-last_verified: 2026-08-28
+last_verified: 2026-08-30
 ---
 
 # HWP 2024 변환 MCP client 사용법
@@ -461,17 +461,39 @@ server process 전체에서 하나씩 직렬 실행한다. 비동기 요청은 �
 많은 문서·거대 표·중첩 표는 1800초를 권장한다. client의 동기 HTTP request는 변환 timeout에 120초
 여유를 더해 기다린다.
 
-## 손상 HWP 입력
+## HWP5 입력 사전 차단
 
-HWP5 구조 사전 검증에서 손상으로 판정되면 비동기 job은 `failed`로 끝나고 다음과 같은 오류를 반환한다.
+service는 한컴 runtime을 시작하기 전에 HWP5 입력을 검사한다. 암호 HWP5는 비밀번호 전처리가 만든
+평문 CFB에도 같은 검사를 다시 적용한다. 사전 차단되면 비동기 job은 `terminal: true`, `status: failed`,
+`phase: failed`, `output_bytes: 0`으로 끝나고 result blob이나 local output을 만들지 않는다. 따라서
+`succeeded`가 아니면 `download`를 호출해서는 안 된다.
+
+### 손상 HWP
+
+HWP5 구조 사전 검증에서 손상으로 판정되면 다음과 같은 오류를 반환한다.
 
 ```text
 input preflight rejected the document: corrupt HWP document: <손상 원인>
 ```
 
-이 경우 한컴 worker와 PDF/HWPX 변환은 시작되지 않으며 결과 blob도 만들지 않는다. `timeout_seconds`를
-늘리거나 다른 engine으로 재시도하지 말고, `status` 오류를 기록한 뒤 원본 파일을 다시 받거나 복구한다.
-`succeeded`가 아니므로 `download`를 호출해서는 안 된다.
+이 경우 한컴 worker와 PDF/HWPX 변환은 시작되지 않는다. `timeout_seconds`를 늘리거나 다른 engine으로
+재시도하지 말고, `status` 오류를 기록한 뒤 원본 파일을 다시 받거나 복구한다.
+
+### 문서 열기 스크립트
+
+HWP5의 `Scripts/DefaultJScript`에 `function OnDocument_Open(...)`가 있으면 한컴의 스크립트 실행 승인
+모달이 무인 service를 멈출 수 있다. service는 문서 코드를 실행하거나 승인하지 않고, 한컴 DLL과 문서
+open 전에 다음 오류로 차단한다.
+
+```text
+input preflight rejected the document: script-enabled HWP with an OnDocument_Open handler cannot be converted unattended
+```
+
+암호 HWP5는 비밀번호 전처리 뒤 같은 handler가 발견되면 오류 접두어가
+`input preflight rejected the prepared password document:`가 될 수 있다. `Scripts` storage 자체나
+`OnDocument_New`만 있는 문서는 이 정책으로 차단하지 않는다. 이 오류는 파일 구조 손상을 뜻하지 않는다.
+`timeout_seconds`나 engine을 바꿔 재시도하거나 script 실행을 승인하지 말고, 원본 제공자에게 스크립트 없는
+사본을 요청하거나 보안 검토가 가능한 별도 대화형 환경에서 문서 코드를 확인한다.
 
 ## 성공 확인
 
@@ -548,6 +570,11 @@ HWP→PDF와 HWP→HWPX job 모두 즉시 terminal `failed`가 되었고, 각각
 `input preflight rejected the document: corrupt HWP document: DocumentProperties section count does not match BodyText streams`
 오류를 반환했다. 두 요청 모두 한컴 direct worker를 시작하지 않았고 result blob을 만들지 않았다.
 
+2026-08-29 배포 server에서 `OnDocument_Open` handler를 포함한 HWP5 fixture를 비동기
+`start → status`로 검증했다. `engine: 2020`, `target: pdf` 요청은 1초 뒤 terminal `failed`,
+`output_bytes: 0`으로 끝났고, 위의 script-enabled preflight 오류를 반환했다. 한컴 open과 스크립트
+승인 모달은 시작되지 않았으며 result blob도 만들지 않았다.
+
 ## 문제 해결
 
 - `HWP2024_MCP_AUTH_TOKEN or --auth-token is required`
@@ -561,9 +588,14 @@ HWP→PDF와 HWP→HWPX job 모두 즉시 terminal `failed`가 되었고, 각각
 - `unsupported target 'hwpx' for .hwpx input`
   - `.hwpx` 입력은 `pdf` 또는 `hwp`로 변환한다.
 - `input preflight rejected the document: corrupt HWP document: ...`
-  - HWP5 구조 사전 검증이 입력을 손상 문서로 판정한 것이다. 변환은 시작되지 않았고 output도 없다.
-    timeout 또는 engine을 바꿔 재시도하지 말고, 원본을 다시 받거나 복구한다. `succeeded`가 아니므로
-    download하지 않는다.
+   - HWP5 구조 사전 검증이 입력을 손상 문서로 판정한 것이다. 변환은 시작되지 않았고 output도 없다.
+     timeout 또는 engine을 바꿔 재시도하지 말고, 원본을 다시 받거나 복구한다. `succeeded`가 아니므로
+     download하지 않는다.
+- `input preflight rejected the document: script-enabled HWP with an OnDocument_Open handler cannot be converted unattended`
+  - HWP5 문서 열기 스크립트가 무인 실행에 안전하지 않아 한컴을 시작하기 전에 차단된 것이다. 스크립트를
+    실행하거나 승인하지 말고, 스크립트 없는 사본을 받거나 별도 대화형 보안 검토 환경에서 문서 코드를 확인한다.
+    암호 HWP5는 `prepared password document` 접두어가 붙을 수 있다. `succeeded`가 아니므로 download하지
+    않는다.
 - 기존 파일 오류
   - client는 output을 덮어쓰지 않는다. 다른 `output_filename`을 사용하거나 기존 파일을 별도 보관한 뒤 재시도한다.
 - 큰 문서 timeout

--- a/mydocs/orders/20260830.md
+++ b/mydocs/orders/20260830.md
@@ -1,0 +1,16 @@
+---
+kind: daily-order
+status: active
+date: 2026-08-30
+---
+
+# 오늘 할 일 - 2026년 8월 30일
+
+## HWP 2024 MCP 무인 스크립트 사전 차단 가이드
+
+- [x] 최신 `upstream/devel@97c4d7155` 위에서 [PR #6386](https://github.com/edwardkim/rhwp/pull/6386)을
+  생성했다. HWP5 구조 손상과 `OnDocument_Open` 문서 열기 스크립트의 무인 사전 차단을 사용자 가이드에서
+  구분하고, 암호 HWP5 재검사·비동기 `failed`·결과물 없음·download 금지를 반영했다.
+- [x] 단일 사용자 가이드의 링크 검사·문서 메타데이터 검사와 `cargo fmt --all -- --check`를 통과했다.
+- [x] self-review 기록을 [PR #6386 검토 문서](../pr/archives/pr_6386_review.md)에 보관했다. 문서 전용
+  fast-pass의 최신 head CI와 병합 가능 상태를 다시 확인한 뒤 user 승인에 따라 squash merge한다.

--- a/mydocs/pr/archives/pr_6386_review.md
+++ b/mydocs/pr/archives/pr_6386_review.md
@@ -1,0 +1,50 @@
+---
+kind: pr-review
+status: accepted
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-30
+pr: 6386
+issue: null
+author: jangster77
+---
+
+# PR #6386 review - HWP5 무인 스크립트 사전 차단 안내
+
+## 라우팅
+
+- PR: [#6386](https://github.com/edwardkim/rhwp/pull/6386)
+- 작성자·self-review: `jangster77`; collaborator 본인 PR이므로 reviewer request는 등록하지 않았다.
+- base: `devel`, 기준: `upstream/devel@97c4d7155`.
+- code candidate: `3387bac7182d7792fe8e2b1590dc53dad018cd52`.
+- 범위: `mydocs/manual/mcp_hwp2024Convert_usage.md` 사용자 가이드 한 파일만 변경한 review-only PR이다.
+- 관련 issue: 없음. 배포된 HWP 2024 MCP의 `OnDocument_Open` 무인 사전 차단 동작을 사용자 가이드에 반영한다.
+- 적용 절차: `AGENTS.md`, `mydocs/manual/pr_review_workflow.md`,
+  `mydocs/manual/pr_review/intake_and_review.md`,
+  `mydocs/manual/pr_review/collaborator_self_merge.md`,
+  `mydocs/manual/pr_review/review_only_fast_pass.md`,
+  `mydocs/manual/pr_review/post_merge.md`.
+
+## 검토 판단
+
+**수용 및 squash merge 권고.** 기존 가이드는 HWP5 구조 손상만 즉시 실패로 설명해, 문서 열기 스크립트가
+무인 service에서 실행·승인되지 않는 별도 사유를 사용자가 구분할 수 없었다. 변경은 이를 손상과 분리하고,
+암호 HWP5의 전처리 후 재검사, terminal `failed`, 결과물 없음, download 금지를 실제 service 계약에 맞게
+설명한다. client artifact·server 설정·변환 source는 바꾸지 않는다.
+
+## 검증과 위험 판정
+
+- `venv\Scripts\python.exe scripts\check_markdown_links.py mydocs\manual\mcp_hwp2024Convert_usage.md`: 통과.
+- `venv\Scripts\python.exe scripts\check_document_metadata.py`: 통과.
+- `cargo fmt --all`, `cargo fmt --all -- --check`, `git diff --check`: 통과.
+- PR 작성 시점의 code candidate는 review-only fast-pass로 CI preflight와 Build & Test aggregate가 성공했고,
+  CodeQL·Adapter inter-diff·Proptest roundtrip의 preflight도 성공했다. heavy worker의 skipped는 문서 전용
+  범위에 따른 정상 결과다.
+- renderer, parser, sample, 기준 PDF, workflow를 변경하지 않는다. 사용자 화면·출력 산출물 주장을 하지 않으므로
+  visual sweep은 적용 대상이 아니다.
+- 최종 merge 전에는 이 trailing review 기록이 포함된 최신 PR head의 fast-pass CI와 mergeable 상태를 다시
+  확인한다.
+
+## 후속 처리
+
+- user 승인에 따라 최신 head가 녹색이면 squash merge한다.
+- merge 뒤에는 `upstream/devel` fast-forward와 이번 작업 브랜치 정리를 수행한다.


### PR DESCRIPTION
## 변경 요약

- HWP5 입력 사전 차단을 손상 문서와 `OnDocument_Open` 문서 열기 스크립트로 구분했습니다.
- 비동기 `failed` 상태, 결과물 없음, 암호 HWP5 재검사와 안전한 후속 조치를 안내했습니다.
- 실제 배포 MCP의 1초 내 사전 차단 검증 결과를 기록했습니다.

## 검증

- `venv\Scripts\python.exe scripts\check_markdown_links.py mydocs\manual\mcp_hwp2024Convert_usage.md`
- `venv\Scripts\python.exe scripts\check_document_metadata.py`
- `cargo fmt --all`
- `cargo fmt --all -- --check`

## 범위

- `mydocs/manual/mcp_hwp2024Convert_usage.md` 한 파일만 변경했습니다.
