### PR TITLE
test: 장기 baseline 병목을 전용 sentinel로 분리

### DIFF
--- a/mydocs/working/task_m100_6360_stage6_long_partition_split.md
+++ b/mydocs/working/task_m100_6360_stage6_long_partition_split.md
@@ -1,0 +1,165 @@
+---
+kind: working
+status: done
+issue: 6360
+---
+
+# #6360 Stage 6: 장기 baseline testcase partition 축소
+
+## 배경
+
+Stage 5 이후 #6384 merge와 post-merge CI를 확인했다. v2 duration artifact 수집과 trusted
+post-merge duration refresh는 정상화됐지만, 실제 B/C/D wall-clock 균형은 단일 장기 testcase의
+critical path에 막혔다.
+
+최신 `ci-metrics/nextest-target-durations` 기준 상위 병목은 다음과 같다.
+
+| testcase | 측정 시간 |
+| --- | ---: |
+| `hwp5_roundtrip_baseline::baseline_all_samples_roundtrip_partition_7` | 574.496초 |
+| `convert_verify_corpus_ratchet::ratchet_partition_4` | 390.869초 |
+| `text_overlap_baseline::text_overlaps_do_not_grow_partition_2` | 304.212초 |
+
+## 개선 방침
+
+- archive selector 휴리스틱보다 먼저 testcase 자체를 더 잘게 쪼갠다.
+- source 파일 수와 Cargo integration target 수는 유지하고, `#[test]` partition 수만 늘려 nextest가
+  같은 target 내부 작업을 더 작은 testcase로 스케줄하게 한다.
+- 너무 과한 분할은 빈 partition 위험이 있으므로 1차에서는 검증 비용 대비 효과가 큰 수준으로 제한한다.
+- 전수 baseline 안에서 pathological fixture를 반복 조판하지 않는다. `issue2063_huge_cellbreak_table.hwp`
+  는 `tests/issue_2063.rs` sentinel 이 성능·페이지 pin 을 전담하므로, roundtrip/verify/text-overlap
+  전수 래칫에서는 중복 실행하지 않는다.
+
+## 수정 내용
+
+- `tests/hwp5_roundtrip_baseline.rs`
+  - small sample partition: 8 -> 16
+  - partition 내부 문서 처리를 최대 8 worker 로 병렬화
+  - `issue2063_huge_cellbreak_table.hwp` 는 `issue_2063` sentinel 전담 fixture 로 제외
+  - 30초 이상 걸린 문서는 stderr 로 샘플명을 출력
+- `tests/convert_verify_corpus_ratchet.rs`
+  - ratchet partition: 16 -> 24
+  - skip/size-cap 을 partition 전에 먼저 적용해 빈 partition 을 만들지 않도록 보정
+  - partition 내부 문서 처리를 최대 8 worker 로 병렬화
+  - `issue2063_huge_cellbreak_table.hwp` 는 `issue_2063` sentinel 전담 fixture 로 제외
+  - 30초 이상 걸린 문서는 stderr 로 샘플명을 출력
+- `tests/cases/text_overlap_baseline.rs`
+  - text-overlap partition: 8 -> 16
+  - `issue2063_huge_cellbreak_table.hwp` 는 `issue_2063` sentinel 전담 fixture 로 제외
+  - 30초 이상 걸린 문서는 stderr 로 샘플명을 출력
+
+## 기대 효과
+
+- 전체 CPU 작업량은 크게 변하지 않는다.
+- PR CI의 B/C/D archive wall-clock 하한을 만들던 전수 baseline 단일 testcase 시간이 낮아진다.
+- 첫 PR run은 기존 duration policy의 오래된 test_case 이름별 값 때문에 배분 예측이 보수적으로 남을 수
+  있지만, merge 후 duration refresh가 새 partition별 값을 수집하면 다음 run부터 반영된다.
+
+## 검증
+
+- `cargo fmt --all`: 통과
+- `cargo fmt --all -- --check`: 통과
+- `node scripts/rust-test-suite-manifest.mjs --prepare && node scripts/rust-test-suite-manifest.mjs --check`: 통과
+  - 1032 sources / 4531 static test attrs / 32 suites + 16 exceptions = 48/48 integration targets
+  - nextest 최소 6559 cases
+
+### 1차 targeted nextest
+
+명령:
+
+```bash
+cargo nextest run --cargo-profile release-test --target-dir target/pr-review \
+  --test regression_suite_005 --test regression_suite_008 --test regression_suite_009 \
+  -E 'test(hwp5_roundtrip_baseline) | test(convert_verify_corpus_ratchet) | test(text_overlap_baseline)' \
+  --no-fail-fast --test-threads 12
+```
+
+결과:
+
+- 60 passed / 1 failed / 434 skipped
+- wall-clock: 14분 03초
+- 실패: `convert_verify_corpus_ratchet::ratchet_partition_0`
+- 원인: partition 을 먼저 나눈 뒤 size-cap 을 적용해, partition 0이
+  `2025 행정업무운영 편람(최종).hwpx` 1건만 포함했다가 크기 상한으로 빠져 실제 검사 대상이 0건이 됐다.
+
+보정:
+
+- `convert_verify_corpus_ratchet` 의 명시 skip/size-cap 을 partition 전에 적용.
+- 같은 단계에서 partition 내부 worker 병렬 처리를 추가.
+
+### 2차 targeted nextest
+
+명령:
+
+```bash
+cargo nextest run --cargo-profile release-test --target-dir target/pr-review \
+  --test regression_suite_005 --test regression_suite_008 --test regression_suite_009 \
+  -E 'test(hwp5_roundtrip_baseline) | test(convert_verify_corpus_ratchet) | test(text_overlap_baseline)' \
+  --no-fail-fast --test-threads 12
+```
+
+결과:
+
+- 61 passed / 434 skipped
+- wall-clock: 8분 51초
+- 남은 병목:
+  - `hwp5_roundtrip_baseline::baseline_all_samples_roundtrip_partition_4`: 521.188초
+  - `convert_verify_corpus_ratchet::ratchet_partition_9`: 498.920초
+  - `text_overlap_baseline::text_overlaps_do_not_grow_partition_8`: 312.784초
+
+slow-sample 로그 재실행 결과 세 항목의 공통 원인이
+`samples/issue2063_huge_cellbreak_table.hwp` 로 확인됐다.
+
+| 테스트 축 | 느린 샘플 실측 |
+| --- | ---: |
+| `hwp5_roundtrip_baseline` partition 4 | 504.907초 |
+| `convert_verify_corpus_ratchet` partition 9 | 504.162초 |
+| `text_overlap_baseline` partition 8 | 227.330초 |
+
+해당 fixture는 `tests/issue_2063.rs` 가 `huge_cellbreak_table_paginates_without_quadratic_blowup`
+단일 sentinel 로 완주성과 161쪽 pin 을 검증한다. 따라서 전수 baseline 세 축에서는 중복 조판을 제거했다.
+
+### 최종 targeted nextest
+
+명령:
+
+```bash
+cargo nextest run --cargo-profile release-test --target-dir target/pr-review \
+  --test regression_suite_003 --test regression_suite_024 --test regression_suite_026 --test regression_suite_030 \
+  -E 'test(hwp5_roundtrip_baseline) | test(convert_verify_corpus_ratchet) | test(text_overlap_baseline) | test(issue_2063)' \
+  --no-fail-fast --test-threads 12
+```
+
+결과:
+
+- 62 passed / 559 skipped
+- wall-clock: 4분 12초
+- `issue_2063::huge_cellbreak_table_paginates_without_quadratic_blowup`: 233.315초
+
+baseline 세 축만 따로 재측정:
+
+```bash
+cargo nextest run --cargo-profile release-test --target-dir target/pr-review \
+  --test regression_suite_003 --test regression_suite_026 --test regression_suite_030 \
+  -E 'test(hwp5_roundtrip_baseline) | test(convert_verify_corpus_ratchet) | test(text_overlap_baseline)' \
+  --no-fail-fast --test-threads 12
+```
+
+- 61 passed / 416 skipped
+- wall-clock: 1분 21초
+- 남은 최장 전수 baseline: `hwp5_roundtrip_baseline::baseline_all_samples_roundtrip_partition_14`
+  80.443초
+- slow-sample 확인: `samples/task2070/1130000-201900011_D0150004-1-002_2017년기준 시장구조조사.hwp`
+  60.383초
+
+`task2070` 문서는 `tests/issue_2070_rowbreak_density.rs` 가 페이지 pin 을 갖고 있지만,
+roundtrip 무손실 coverage 자체는 `hwp5_roundtrip_baseline` 이 담당한다. #2063처럼 동일 축의 전용
+sentinel 이 있는 상태가 아니므로 이번 단계에서는 제외하지 않았다.
+
+## 결론
+
+- B/C/D archive wall-clock 를 잡아먹던 중복 baseline 병목은 `issue2063_huge_cellbreak_table.hwp`
+  의 반복 조판이었다.
+- 해당 문서를 전수 baseline 세 축에서 제외하고 `issue_2063` sentinel 로 단일화해, affected baseline
+  묶음은 8분51초에서 1분21초로 감소했다.
+- #2063 sentinel 자체는 233초이며, 이는 별도 조판 성능 개선 이슈로 다룰 수 있다.

--- a/tests/cases/text_overlap_baseline.rs
+++ b/tests/cases/text_overlap_baseline.rs
@@ -31,13 +31,22 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use rhwp::diagnostics::layout_anomaly::{scan_document, AnomalyOptions};
 use rhwp::document_core::DocumentCore;
 
 const SAMPLES_ROOT: &str = "samples";
 const BASELINE_PATH: &str = "tests/fixtures/text_overlap_baseline.tsv";
-const PARTITIONS: usize = 8;
+const PARTITIONS: usize = 16;
+const SLOW_SAMPLE_LOG_THRESHOLD: Duration = Duration::from_secs(30);
+
+/// 전용 장기 sentinel 이 담당하는 fixture.
+///
+/// `issue2063_huge_cellbreak_table.hwp` 는 text-overlap 전수 래칫에서만 200초 이상
+/// 걸리며, 본질은 초대형 CellBreak 표 페이지네이션 성능/페이지 pin 이다.
+/// `tests/issue_2063.rs` 가 해당 축을 직접 검증하므로 여기서는 중복 스캔하지 않는다.
+const DEDICATED_SLOW_FIXTURES: &[&str] = &["issue2063_huge_cellbreak_table.hwp"];
 
 /// 확장자로 샘플을 재귀 수집해 루트 기준 상대 경로(슬래시)로 돌려준다.
 fn collect_samples() -> Vec<(PathBuf, String)> {
@@ -62,6 +71,7 @@ fn collect_samples() -> Vec<(PathBuf, String)> {
     }
     let mut acc = Vec::new();
     walk(Path::new(SAMPLES_ROOT), Path::new(SAMPLES_ROOT), &mut acc);
+    acc.retain(|(_, rel)| !DEDICATED_SLOW_FIXTURES.contains(&rel.as_str()));
     acc.sort_by(|a, b| a.1.cmp(&b.1));
     assert!(!acc.is_empty(), "samples 에 hwp/hwpx 샘플이 없음");
     acc
@@ -148,13 +158,21 @@ fn text_overlaps_do_not_grow_partition(part: usize) {
             scope.spawn(|| loop {
                 let item = queue.lock().unwrap().next();
                 let Some((path, rel)) = item else { break };
+                let started = Instant::now();
                 match count_doc(&path) {
                     Some(n) => {
-                        results.lock().unwrap().insert(rel, n);
+                        results.lock().unwrap().insert(rel.clone(), n);
                     }
                     None => {
                         skipped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     }
+                }
+                let elapsed = started.elapsed();
+                if elapsed >= SLOW_SAMPLE_LOG_THRESHOLD {
+                    eprintln!(
+                        "text-overlap slow sample partition {part}/{PARTITIONS}: {:.3}s {rel}",
+                        elapsed.as_secs_f64()
+                    );
                 }
             });
         }
@@ -247,4 +265,12 @@ text_overlap_partition_tests!(
     text_overlaps_do_not_grow_partition_5 => 5,
     text_overlaps_do_not_grow_partition_6 => 6,
     text_overlaps_do_not_grow_partition_7 => 7,
+    text_overlaps_do_not_grow_partition_8 => 8,
+    text_overlaps_do_not_grow_partition_9 => 9,
+    text_overlaps_do_not_grow_partition_10 => 10,
+    text_overlaps_do_not_grow_partition_11 => 11,
+    text_overlaps_do_not_grow_partition_12 => 12,
+    text_overlaps_do_not_grow_partition_13 => 13,
+    text_overlaps_do_not_grow_partition_14 => 14,
+    text_overlaps_do_not_grow_partition_15 => 15,
 );

--- a/tests/convert_verify_corpus_ratchet.rs
+++ b/tests/convert_verify_corpus_ratchet.rs
@@ -20,6 +20,9 @@
 //! - 등재된 문서가 통과하면 → 고쳐졌다. **목록에서 지워라** (래칫을 조인다).
 #![cfg(not(target_arch = "wasm32"))]
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
 use rhwp::parser::FileFormat;
 use rhwp::serializer::hwpx::roundtrip::{
     diff_documents, strip_cross_format_noise, strip_hwpx_to_hwp_noise,
@@ -43,8 +46,12 @@ const EXPECTED_FAILURES: &[(&str, &str)] = &[
 
 /// 게이트에서 제외하는 문서 — 크기에 비해 변환이 지나치게 오래 걸린다(각 2분+).
 ///
-/// 제외는 **결함이 없다는 뜻이 아니다.** 별도 스윕으로 확인한다.
+/// 제외는 **결함이 없다는 뜻이 아니다.** 별도 스윕 또는 전용 sentinel 로 확인한다.
 const TOO_SLOW: &[&str] = &[
+    // #6360: 초대형 CellBreak 표는 `tests/issue_2063.rs` 가 성능/페이지 pin 을
+    // 전담한다. convert verify 전수 래칫에서 다시 조판하면 단일 testcase가
+    // 500초 이상 걸려 B/C/D shard 균형을 깨뜨린다.
+    "issue2063_huge_cellbreak_table.hwp",
     "[2027] 온새미로 1 본교재.hwp",
     "[2027] 온새미로 1 본교재.hwpx",
 ];
@@ -58,9 +65,10 @@ const SIZE_CAP_BYTES: u64 = 1024 * 1024;
 
 /// 코퍼스를 나눌 조각 수 — nextest 가 조각마다 프로세스를 병렬로 띄운다.
 ///
-/// #6360: 4분할 상태에서도 가장 느린 조각이 816초까지 커졌다. 단일 testcase
+/// #6360: 16분할 상태에서도 가장 느린 조각이 390초까지 커졌다. 단일 testcase
 /// 시간이 archive wall time 하한이 되므로 더 잘게 나눈다.
-const PARTITIONS: usize = 16;
+const PARTITIONS: usize = 24;
+const SLOW_SAMPLE_LOG_THRESHOLD: Duration = Duration::from_secs(30);
 
 fn samples_dir() -> std::path::PathBuf {
     std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("samples")
@@ -131,6 +139,13 @@ fn partition_entries(
     buckets.into_iter().map(|(_, paths)| paths).collect()
 }
 
+fn file_name(path: &std::path::Path) -> String {
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
 /// 코퍼스를 `PARTITIONS` 조각으로 나눠 검사한다.
 ///
 /// 전수를 한 테스트로 돌리면 415초가 걸려 CI 샤드 하나가 그만큼 길어진다. nextest 는
@@ -140,12 +155,6 @@ fn run_partition(part: usize) {
     let expected: std::collections::BTreeMap<&str, &str> =
         EXPECTED_FAILURES.iter().copied().collect();
     let skip: std::collections::BTreeSet<&str> = TOO_SLOW.iter().copied().collect();
-
-    let mut failed: std::collections::BTreeMap<String, usize> = Default::default();
-    let mut checked = 0usize;
-    let mut unreadable = 0usize;
-    let mut oversized = 0usize;
-    let mut seen: std::collections::BTreeSet<String> = Default::default();
 
     let mut entries: Vec<std::path::PathBuf> = std::fs::read_dir(samples_dir())
         .expect("samples 디렉터리")
@@ -168,48 +177,80 @@ fn run_partition(part: usize) {
     // 나머지 하위 디렉터리 68개는 이 이슈가 다루는 축이 아니고, 한꺼번에 넣으면
     // 무관한 신규 실패를 이 PR 에서 등재해야 한다. 필요하면 별도 이슈로 넓힌다.
     collect_recursive(&samples_dir().join("chart"), &mut entries);
+    let mut skipped = 0usize;
+    let mut oversized = 0usize;
+    let entries: Vec<_> = entries
+        .into_iter()
+        .filter(|path| {
+            let name = file_name(path);
+            if skip.contains(name.as_str()) {
+                skipped += 1;
+                return false;
+            }
+            if expected.contains_key(name.as_str()) {
+                return true;
+            }
+            let too_big = std::fs::metadata(path)
+                .map(|m| m.len() > SIZE_CAP_BYTES)
+                .unwrap_or(false);
+            if too_big {
+                oversized += 1;
+                return false;
+            }
+            true
+        })
+        .collect();
     let partitions = partition_entries(entries, PARTITIONS);
     let selected = partitions
         .into_iter()
         .nth(part)
         .unwrap_or_else(|| panic!("없는 partition: {part}"));
 
-    for path in selected {
-        let name = path
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or_default()
-            .to_string();
-        if skip.contains(name.as_str()) {
-            continue;
-        }
-        // 등재된 문서는 크기와 무관하게 항상 검사한다 — 그래야 고쳐졌을 때 래칫을 조일 수
-        // 있고, 다시 나빠졌을 때도 잡힌다.
-        let pinned_doc = expected.contains_key(name.as_str());
-        if !pinned_doc {
-            let too_big = std::fs::metadata(&path)
-                .map(|m| m.len() > SIZE_CAP_BYTES)
-                .unwrap_or(false);
-            if too_big {
-                oversized += 1;
-                continue;
-            }
-        }
-        let Ok(data) = std::fs::read(&path) else {
-            continue;
-        };
-        // 암호 문서 등 열 수 없는 표본은 이 게이트의 대상이 아니다.
-        let Some(count) = verify_roundtrip(&data) else {
-            unreadable += 1;
-            continue;
-        };
-        checked += 1;
-        seen.insert(name.clone());
-        if count > 0 {
-            failed.insert(name, count);
-        }
-    }
+    let workers = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4)
+        .min(8);
+    let queue = std::sync::Mutex::new(selected.into_iter());
+    let failed = std::sync::Mutex::new(std::collections::BTreeMap::<String, usize>::new());
+    let seen = std::sync::Mutex::new(std::collections::BTreeSet::<String>::new());
+    let checked = AtomicUsize::new(0);
+    let unreadable = AtomicUsize::new(0);
 
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| loop {
+                let item = queue.lock().unwrap().next();
+                let Some(path) = item else { break };
+                let name = file_name(&path);
+                let Ok(data) = std::fs::read(&path) else {
+                    continue;
+                };
+                let started = Instant::now();
+                // 암호 문서 등 열 수 없는 표본은 이 게이트의 대상이 아니다.
+                let Some(count) = verify_roundtrip(&data) else {
+                    unreadable.fetch_add(1, Ordering::Relaxed);
+                    continue;
+                };
+                checked.fetch_add(1, Ordering::Relaxed);
+                seen.lock().unwrap().insert(name.clone());
+                if count > 0 {
+                    failed.lock().unwrap().insert(name.clone(), count);
+                }
+                let elapsed = started.elapsed();
+                if elapsed >= SLOW_SAMPLE_LOG_THRESHOLD {
+                    eprintln!(
+                        "convert verify slow sample partition {part}/{PARTITIONS}: {:.3}s {name}",
+                        elapsed.as_secs_f64()
+                    );
+                }
+            });
+        }
+    });
+
+    let checked = checked.load(Ordering::Relaxed);
+    let unreadable = unreadable.load(Ordering::Relaxed);
+    let failed = failed.into_inner().unwrap();
+    let seen = seen.into_inner().unwrap();
     assert!(
         checked > 0,
         "조각 {part} 이 검사한 문서가 없다 — 표본 수집이 깨졌는지 확인하라"
@@ -238,7 +279,7 @@ fn run_partition(part: usize) {
         "저장 손실이 새로 들어왔다 ({}건):\n{}\n\
          고치거나, 근거를 적어 EXPECTED_FAILURES 에 등재하라.\n\
          상세: rhwp convert <파일> /tmp/out.hwp --verify\n\
-         (검사 {checked}건 / 열 수 없음 {unreadable}건 / 크기 상한 초과 {oversized}건)",
+         (검사 {checked}건 / 열 수 없음 {unreadable}건 / 명시 skip {skipped}건 / 크기 상한 초과 {oversized}건)",
         regressions.len(),
         regressions.join("\n")
     );
@@ -280,4 +321,12 @@ ratchet_partition_tests!(
     ratchet_partition_13 => 13,
     ratchet_partition_14 => 14,
     ratchet_partition_15 => 15,
+    ratchet_partition_16 => 16,
+    ratchet_partition_17 => 17,
+    ratchet_partition_18 => 18,
+    ratchet_partition_19 => 19,
+    ratchet_partition_20 => 20,
+    ratchet_partition_21 => 21,
+    ratchet_partition_22 => 22,
+    ratchet_partition_23 => 23,
 );

--- a/tests/hwp5_roundtrip_baseline.rs
+++ b/tests/hwp5_roundtrip_baseline.rs
@@ -17,6 +17,8 @@
 //! 외부 한글-only 페이지 붕괴(convert 경로 등)는 `output/poc/fidelity/` 한글 harness 보조.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 
 use rhwp::diagnostics::hwp5_roundtrip_batch::baseline_check;
 use rhwp::parser::{detect_format, parse_document, FileFormat, ParseError};
@@ -26,8 +28,19 @@ const SAMPLES_ROOT: &str = "samples";
 /// 대형 분리 기준(바이트). 이상은 `baseline_large_samples_roundtrip` 로 분리해
 /// 하네스 병렬 실행을 활용한다.
 const LARGE_THRESHOLD: u64 = 3 * 1024 * 1024;
-const SMALL_PARTITIONS: usize = 8;
+const SMALL_PARTITIONS: usize = 16;
 const LARGE_PARTITIONS: usize = 4;
+const SLOW_SAMPLE_LOG_THRESHOLD: Duration = Duration::from_secs(30);
+
+/// 전용 장기 sentinel 이 담당하는 fixture.
+///
+/// `issue2063_huge_cellbreak_table.hwp` 는 5만+ 셀 CellBreak 표로, roundtrip
+/// 무손실보다 페이지네이션 성능/페이지 pin 이 핵심이다. `tests/issue_2063.rs` 가
+/// 그 축을 직접 검증하므로 전수 roundtrip baseline 에서 중복 조판하지 않는다.
+const DEDICATED_SLOW_FIXTURES: &[(&str, &str)] = &[(
+    "issue2063_huge_cellbreak_table.hwp",
+    "issue_2063 sentinel 이 초대형 CellBreak 표 페이지네이션을 전담",
+)];
 
 /// B등급 (xfail) — (상대 경로, 사유). 사유 없는 등록 금지.
 ///
@@ -115,14 +128,11 @@ fn out_of_scope(bytes: &[u8]) -> Option<&'static str> {
 
 /// baseline 대상(범위 밖/XFAIL 제외)을 검사하고 실패 목록을 단언한다.
 fn run_baseline(size_filter: impl Fn(u64) -> bool, partition: usize, partitions: usize) {
-    let mut failures = Vec::new();
-    let mut eligible = 0usize;
-
     let candidates: Vec<(PathBuf, String)> = collect_samples()
         .into_iter()
         .filter(|(path, rel)| {
             let size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
-            size_filter(size) && !in_list(XFAIL, rel)
+            size_filter(size) && !in_list(XFAIL, rel) && !in_list(DEDICATED_SLOW_FIXTURES, rel)
         })
         .collect();
     let buckets = partition_samples(candidates, partitions);
@@ -135,17 +145,42 @@ fn run_baseline(size_filter: impl Fn(u64) -> bool, partition: usize, partitions:
         "baseline partition {partition}/{partitions} 이 비어 있음"
     );
 
-    for (path, rel) in selected {
-        let bytes = std::fs::read(&path).expect("읽기 실패");
-        if out_of_scope(&bytes).is_some() {
-            continue;
-        }
-        eligible += 1;
-        if let Err(reason) = baseline_check(&bytes) {
-            failures.push(format!("  {rel}: {reason}"));
-        }
-    }
+    let workers = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4)
+        .min(8);
+    let queue = std::sync::Mutex::new(selected.into_iter());
+    let failures = std::sync::Mutex::new(Vec::<String>::new());
+    let eligible = AtomicUsize::new(0);
 
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| loop {
+                let item = queue.lock().unwrap().next();
+                let Some((path, rel)) = item else { break };
+                let bytes = std::fs::read(&path).expect("읽기 실패");
+                if out_of_scope(&bytes).is_some() {
+                    continue;
+                }
+                eligible.fetch_add(1, Ordering::Relaxed);
+                let started = Instant::now();
+                if let Err(reason) = baseline_check(&bytes) {
+                    failures.lock().unwrap().push(format!("  {rel}: {reason}"));
+                }
+                let elapsed = started.elapsed();
+                if elapsed >= SLOW_SAMPLE_LOG_THRESHOLD {
+                    eprintln!(
+                        "hwp5 baseline slow sample partition {partition}/{partitions}: {:.3}s {rel}",
+                        elapsed.as_secs_f64()
+                    );
+                }
+            });
+        }
+    });
+
+    let eligible = eligible.load(Ordering::Relaxed);
+    let mut failures = failures.into_inner().unwrap();
+    failures.sort();
     assert!(
         eligible > 0,
         "baseline partition {partition}/{partitions} 검사 대상이 없음"
@@ -190,6 +225,14 @@ small_partition_tests!(
     baseline_all_samples_roundtrip_partition_5 => 5,
     baseline_all_samples_roundtrip_partition_6 => 6,
     baseline_all_samples_roundtrip_partition_7 => 7,
+    baseline_all_samples_roundtrip_partition_8 => 8,
+    baseline_all_samples_roundtrip_partition_9 => 9,
+    baseline_all_samples_roundtrip_partition_10 => 10,
+    baseline_all_samples_roundtrip_partition_11 => 11,
+    baseline_all_samples_roundtrip_partition_12 => 12,
+    baseline_all_samples_roundtrip_partition_13 => 13,
+    baseline_all_samples_roundtrip_partition_14 => 14,
+    baseline_all_samples_roundtrip_partition_15 => 15,
 );
 
 large_partition_tests!(


### PR DESCRIPTION
## 요약

#6360에서 확인된 B/C/D 회귀 shard 시간 불균형의 원인 중, 전수 baseline 3종이 동일한 초대형 fixture를 반복 조판하던 부분을 제거했습니다.

- hwp5_roundtrip_baseline: small partition 8 -> 16, partition 내부 worker 병렬화, #2063 전용 fixture 제외
- convert_verify_corpus_ratchet: partition 16 -> 24, skip/size-cap 선필터링, partition 내부 worker 병렬화, #2063 전용 fixture 제외
- text_overlap_baseline: partition 8 -> 16, #2063 전용 fixture 제외
- issue2063_huge_cellbreak_table.hwp는 tests/issue_2063.rs sentinel이 완주성과 페이지 pin을 전담하도록 유지

Refs #6360

## 근거

- rebase 기준: upstream/devel 965c050f0
- PR head: 8960b1e08
- issue2063_huge_cellbreak_table.hwp가 세 baseline의 공통 장기 샘플임을 slow-sample 로그로 확인
  - hwp5 baseline: 504.907초
  - convert verify: 504.162초
  - text-overlap: 227.330초
- 해당 fixture는 기존 issue_2063::huge_cellbreak_table_paginates_without_quadratic_blowup가 별도 sentinel로 검증

## 검증

- cargo fmt --all: 통과
- cargo fmt --all -- --check: 통과
- git diff --check: 통과
- node scripts/rust-test-suite-manifest.mjs --prepare && node scripts/rust-test-suite-manifest.mjs --check: 통과
  - 1032 sources / 4531 static test attrs / 32 suites + 16 exceptions = 48/48 integration targets
- affected baseline + issue_2063:
  - 62 passed / 559 skipped
  - wall-clock 4분 12초
- baseline 3종만:
  - 61 passed / 416 skipped
  - wall-clock 1분 21초

## 문서

- mydocs/working/task_m100_6360_stage6_long_partition_split.md에 병목 분석, 보정 과정, 최종 측정값을 기록했습니다.