### PR TITLE
Task #6388: 표 CTRL_HEADER raw 캐시의 0 확장을 없앤다

### DIFF
--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -10,6 +10,24 @@ use crate::model::event::DocumentEvent;
 use crate::model::path::{path_from_flat, PathSegment};
 use crate::model::shape::common_obj_offsets;
 
+/// [#6388] 표 CTRL_HEADER raw 캐시의 한 필드를 제자리에 덧쓴다 — **raw 를 늘리지 않는다.**
+///
+/// 표는 `raw_ctrl_data` 가 정본이라(`serializer/control.rs::serialize_table`) raw 가 비어
+/// 있으면 저장기가 `common` 합성 경로로 간다 — HWPX 파스본·신설 표를 위해 #1916 이 세운
+/// 계약이다. 종전에는 `while len < 필요길이 { push(0) }` 으로 raw 를 늘렸는데, 그러면
+/// **빈 raw 가 "있는" raw 로 바뀌어** 합성 경로가 끊기고 12바이트짜리 CTRL_HEADER 가
+/// 방출됐다. offset 12 이후의 width(12..16)·height(16..20)·여백(24..32)·instance_id(32..36)
+/// 가 그 순간 사라진다(실측: HWPX 파스본 표를 옮겨 저장하면 45152x58826 → 0x0).
+///
+/// 길이가 모자라면 조용히 건너뛴다. 그래도 값을 잃지 않는다 — 호출자가 `common` 을 함께
+/// 갱신하고 그쪽이 합성 원천이기 때문이다. `Table::update_ctrl_dimensions` 가 이미 쓰는
+/// 가드와 같은 규칙이다.
+fn patch_raw_ctrl_field(raw: &mut [u8], range: std::ops::Range<usize>, bytes: &[u8]) {
+    if raw.len() >= range.end {
+        raw[range].copy_from_slice(bytes);
+    }
+}
+
 impl DocumentCore {
     pub(crate) fn get_table_mut(
         &mut self,
@@ -2644,42 +2662,37 @@ impl DocumentCore {
     ) -> Result<String, HwpError> {
         let table = self.get_table_mut(section_idx, parent_para_idx, control_idx)?;
 
-        // CommonObjAttr 바이트 레이아웃: flags/v_offset/h_offset
-        while table.raw_ctrl_data.len() < common_obj_offsets::H_OFFSET.end {
-            table.raw_ctrl_data.push(0);
-        }
-
         let is_treat_as_char = (table.attr & 0x01) != 0;
+
+        // [#6388] 현재 오프셋은 `common` 에서 읽는다 — 종전에는 raw 에서 읽어서 raw 가 빈
+        // 표(HWPX 파스본)를 다루려면 0 확장이 필요했고, 그 확장이 저장 경로를 파괴했다.
+        // `common` 이 정본으로 안전한 근거: 파스본 표 6708개에서 raw V/H_OFFSET 과
+        // `common.vertical_offset`/`horizontal_offset` 불일치가 0건이다(실측).
+        // 쓰기는 `common` 에 하고 raw 에는 길이가 허락할 때만 덧쓴다(dual-write 유지).
 
         // vertical_offset: CommonObjAttr::V_OFFSET (i32 LE)
         let mut new_v = if delta_v != 0 {
-            let cur_v = i32::from_le_bytes(
-                table.raw_ctrl_data[common_obj_offsets::V_OFFSET]
-                    .try_into()
-                    .unwrap(),
-            );
-            let nv = cur_v.wrapping_add(delta_v);
-            table.raw_ctrl_data[common_obj_offsets::V_OFFSET].copy_from_slice(&nv.to_le_bytes());
+            let nv = (table.common.vertical_offset as i32).wrapping_add(delta_v);
             table.common.vertical_offset = nv as u32;
+            patch_raw_ctrl_field(
+                &mut table.raw_ctrl_data,
+                common_obj_offsets::V_OFFSET,
+                &nv.to_le_bytes(),
+            );
             nv
         } else {
-            i32::from_le_bytes(
-                table.raw_ctrl_data[common_obj_offsets::V_OFFSET]
-                    .try_into()
-                    .unwrap(),
-            )
+            table.common.vertical_offset as i32
         };
 
         // horizontal_offset: CommonObjAttr::H_OFFSET (i32 LE)
         if delta_h != 0 {
-            let cur_h = i32::from_le_bytes(
-                table.raw_ctrl_data[common_obj_offsets::H_OFFSET]
-                    .try_into()
-                    .unwrap(),
-            );
-            let new_h = cur_h.wrapping_add(delta_h);
-            table.raw_ctrl_data[common_obj_offsets::H_OFFSET].copy_from_slice(&new_h.to_le_bytes());
+            let new_h = (table.common.horizontal_offset as i32).wrapping_add(delta_h);
             table.common.horizontal_offset = new_h as u32;
+            patch_raw_ctrl_field(
+                &mut table.raw_ctrl_data,
+                common_obj_offsets::H_OFFSET,
+                &new_h.to_le_bytes(),
+            );
         }
 
         // treat_as_char 표: 문단 경계를 넘으면 문단 이동 (다중 경계 루프)
@@ -2721,9 +2734,12 @@ impl DocumentCore {
             // 최종 v_offset 갱신
             if result_ppi != parent_para_idx {
                 let tbl = self.get_table_mut(section_idx, result_ppi, control_idx)?;
-                tbl.raw_ctrl_data[common_obj_offsets::V_OFFSET]
-                    .copy_from_slice(&new_v.to_le_bytes());
                 tbl.common.vertical_offset = new_v as u32;
+                patch_raw_ctrl_field(
+                    &mut tbl.raw_ctrl_data,
+                    common_obj_offsets::V_OFFSET,
+                    &new_v.to_le_bytes(),
+                );
             }
         }
 
@@ -3044,16 +3060,23 @@ impl DocumentCore {
         }
         table.common.attr = table.attr;
         // 위치 오프셋: CommonObjAttr [0..4]=flags, [4..8]=v_offset, [8..12]=h_offset
-        while table.raw_ctrl_data.len() < common_obj_offsets::H_OFFSET.end {
-            table.raw_ctrl_data.push(0);
-        }
+        // [#6388] raw 를 0 확장하지 않는다 — `common` 이 합성 원천이고 raw 는 길이가
+        // 허락할 때만 덧쓴다.
         if let Some(v) = json_i32(json, "vertOffset") {
-            table.raw_ctrl_data[common_obj_offsets::V_OFFSET].copy_from_slice(&v.to_le_bytes());
             table.common.vertical_offset = v as u32;
+            patch_raw_ctrl_field(
+                &mut table.raw_ctrl_data,
+                common_obj_offsets::V_OFFSET,
+                &v.to_le_bytes(),
+            );
         }
         if let Some(v) = json_i32(json, "horzOffset") {
-            table.raw_ctrl_data[common_obj_offsets::H_OFFSET].copy_from_slice(&v.to_le_bytes());
             table.common.horizontal_offset = v as u32;
+            patch_raw_ctrl_field(
+                &mut table.raw_ctrl_data,
+                common_obj_offsets::H_OFFSET,
+                &v.to_le_bytes(),
+            );
         }
         // restrictInPage → attr bit 13
         if let Some(v) = json_bool(json, "restrictInPage") {
@@ -3083,17 +3106,23 @@ impl DocumentCore {
         // 저장 파일에서 통째로 유실되고 재로드 시 원복된다. V_OFFSET/H_OFFSET/
         // PREVENT_PAGE_BREAK/MARGIN_* 패치와 동일 규칙 (미변경 시에는 파싱
         // 원본 attr 를 그대로 다시 쓰는 항등 연산이라 무해).
-        table.raw_ctrl_data[common_obj_offsets::FLAGS].copy_from_slice(&table.attr.to_le_bytes());
+        // [#6388] raw 가 빌 수 있으므로(HWPX 파스본) 가드를 거친다. 종전에는 바로 위
+        // 위치 오프셋 블록의 0 확장이 길이 4 를 보장해 무조건 색인해도 됐다.
+        patch_raw_ctrl_field(
+            &mut table.raw_ctrl_data,
+            common_obj_offsets::FLAGS,
+            &table.attr.to_le_bytes(),
+        );
         // keepWithAnchor → prevent_page_break
         // CommonObjAttr::PREVENT_PAGE_BREAK (parse_common_obj_attr 정합)
         if let Some(v) = json_bool(json, "keepWithAnchor") {
-            while table.raw_ctrl_data.len() < common_obj_offsets::PREVENT_PAGE_BREAK.end {
-                table.raw_ctrl_data.push(0);
-            }
             let val: i32 = if v { 1 } else { 0 };
-            table.raw_ctrl_data[common_obj_offsets::PREVENT_PAGE_BREAK]
-                .copy_from_slice(&val.to_le_bytes());
             table.common.prevent_page_break = val;
+            patch_raw_ctrl_field(
+                &mut table.raw_ctrl_data,
+                common_obj_offsets::PREVENT_PAGE_BREAK,
+                &val.to_le_bytes(),
+            );
         }
 
         // 바깥 여백 (CommonObjAttr margin ranges, parse_common_obj_attr 정합)

--- a/tests/cases/issue_6388_table_raw_zero_extension.rs
+++ b/tests/cases/issue_6388_table_raw_zero_extension.rs
@@ -1,0 +1,230 @@
+//! [#6388] 표 위치 편집이 `raw_ctrl_data` 를 0 확장해 표 기하를 저장에서 파괴하는 문제.
+//!
+//! 표는 `raw_ctrl_data` 가 정본이라(`serializer/control.rs::serialize_table`) raw 가 비어
+//! 있으면 저장기가 `common` 합성 경로로 간다 — HWPX 파스본·신설 표를 위해 #1916 이 세운
+//! 계약이다. 종전 `while len < 필요길이 { push(0) }` 은 **빈 raw 를 "있는" raw 로 바꿔** 그
+//! 계약을 끊고 12바이트짜리 CTRL_HEADER 를 방출했다. offset 12 이후의 width·height·여백·
+//! z-order·instance_id 가 그 순간 사라진다.
+//!
+//! 발동 집합은 raw 가 빈 표다 — `samples/**/*.hwp` 529개 표 6719개의 길이 분포는
+//! `{0: 11, 40: 541, 42: 4716, 44: 1449, 48: 2}` 로 1~39바이트가 없고, HWPX 파서는 표
+//! `raw_ctrl_data` 를 채우지 않으므로 HWPX 파스본 표는 전부 해당한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::model::table::Table;
+
+/// 표 4개 전부 `raw_ctrl_data` 가 비어 있는 HWP5 표본.
+const EMPTY_RAW_SAMPLE: &str = "samples/hwp5-tbl-attr-1916.hwp";
+/// HWPX 파스본 — 표 raw 가 항상 비어 있는 실물 경로.
+const HWPX_SAMPLES: [&str; 2] = [
+    "samples/hwpx/basic-table-01.hwpx",
+    "samples/hwpx/business_overview.hwpx",
+];
+
+fn read_fixture(path: &str) -> Vec<u8> {
+    std::fs::read(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(path))
+        .unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+fn first_table_coord(core: &DocumentCore) -> (usize, usize, usize) {
+    for (si, s) in core.document().sections.iter().enumerate() {
+        for (pi, p) in s.paragraphs.iter().enumerate() {
+            for (ci, c) in p.controls.iter().enumerate() {
+                if matches!(c, Control::Table(_)) {
+                    return (si, pi, ci);
+                }
+            }
+        }
+    }
+    panic!("표가 없다");
+}
+
+fn table_at(core: &DocumentCore, c: (usize, usize, usize)) -> &Table {
+    match &core.document().sections[c.0].paragraphs[c.1].controls[c.2] {
+        Control::Table(t) => t,
+        other => panic!("표가 아니다: {other:?}"),
+    }
+}
+
+/// 빈 raw 표를 옮겨도 raw 가 비어 있어야 한다 — 그래야 저장기가 `common` 합성 경로를 쓴다.
+#[test]
+fn issue_6388_moving_empty_raw_table_does_not_grow_raw() {
+    let mut core = DocumentCore::from_bytes(&read_fixture(EMPTY_RAW_SAMPLE)).expect("파싱");
+    let c = first_table_coord(&core);
+    assert!(
+        table_at(&core, c).raw_ctrl_data.is_empty(),
+        "전제: 이 표본의 표는 raw 가 비어 있다"
+    );
+
+    core.move_table_offset_native(c.0, c.1, c.2, 1000, 1000)
+        .expect("표 이동");
+
+    assert!(
+        table_at(&core, c).raw_ctrl_data.is_empty(),
+        "빈 raw 를 0 확장하면 저장기가 12바이트 CTRL_HEADER 를 방출한다 (#6388)"
+    );
+}
+
+/// 이동이 표의 크기·여백을 저장에서 파괴하지 않는다.
+///
+/// 수정 전에는 45152x58826 → 0x0 이 되고 여백도 전부 0 이 됐다(파일 63488 → 62976 B).
+#[test]
+fn issue_6388_moving_empty_raw_table_preserves_geometry_through_save() {
+    let mut core = DocumentCore::from_bytes(&read_fixture(EMPTY_RAW_SAMPLE)).expect("파싱");
+    let c = first_table_coord(&core);
+    let (w, h, margin) = {
+        let t = table_at(&core, c);
+        (t.common.width, t.common.height, t.common.margin.clone())
+    };
+    assert!(w > 0 && h > 0, "전제: 표에 크기가 있다");
+
+    core.move_table_offset_native(c.0, c.1, c.2, 1000, 1000)
+        .expect("표 이동");
+    let saved = core.export_hwp_native().expect("저장");
+
+    let reparsed = DocumentCore::from_bytes(&saved).expect("재파싱");
+    let rc = first_table_coord(&reparsed);
+    let t = table_at(&reparsed, rc);
+    assert_eq!(
+        (t.common.width, t.common.height),
+        (w, h),
+        "이동 후 저장·재파싱에서 표 크기가 사라졌다 (#6388)"
+    );
+    assert_eq!(
+        (
+            t.common.margin.left,
+            t.common.margin.right,
+            t.common.margin.top,
+            t.common.margin.bottom
+        ),
+        (margin.left, margin.right, margin.top, margin.bottom),
+        "이동 후 저장·재파싱에서 표 여백이 사라졌다 (#6388)"
+    );
+}
+
+/// 이동 자체는 계속 반영된다 — 파괴만 막고 기능은 유지한다.
+#[test]
+fn issue_6388_move_still_applies_offsets_without_raw() {
+    let mut core = DocumentCore::from_bytes(&read_fixture(EMPTY_RAW_SAMPLE)).expect("파싱");
+    let c = first_table_coord(&core);
+    let (v0, h0) = {
+        let t = table_at(&core, c);
+        (
+            t.common.vertical_offset as i32,
+            t.common.horizontal_offset as i32,
+        )
+    };
+
+    core.move_table_offset_native(c.0, c.1, c.2, 700, 0)
+        .expect("가로 이동");
+
+    let t = table_at(&core, c);
+    assert_eq!(
+        t.common.horizontal_offset as i32,
+        h0 + 700,
+        "가로 오프셋이 적용돼야 한다"
+    );
+    assert_eq!(
+        t.common.vertical_offset as i32, v0,
+        "세로 오프셋은 그대로여야 한다"
+    );
+}
+
+/// HWPX 파스본 표도 같다 — 실제 사용 경로의 회귀 가드.
+#[test]
+fn issue_6388_hwpx_tables_survive_move_and_save() {
+    for sample in HWPX_SAMPLES {
+        let mut core = DocumentCore::from_bytes(&read_fixture(sample)).expect("파싱");
+        let c = first_table_coord(&core);
+        let (w, h) = {
+            let t = table_at(&core, c);
+            assert!(
+                t.raw_ctrl_data.is_empty(),
+                "{sample}: 전제 — HWPX 파스본 표는 raw 가 비어 있다"
+            );
+            (t.common.width, t.common.height)
+        };
+        assert!(w > 0 && h > 0, "{sample}: 전제 — 표에 크기가 있다");
+
+        core.move_table_offset_native(c.0, c.1, c.2, 1000, 1000)
+            .expect("표 이동");
+        let saved = core.export_hwp_native().expect("저장");
+
+        let reparsed = DocumentCore::from_bytes(&saved).expect("재파싱");
+        let rc = first_table_coord(&reparsed);
+        let t = table_at(&reparsed, rc);
+        assert_eq!(
+            (t.common.width, t.common.height),
+            (w, h),
+            "{sample}: 이동 후 저장·재파싱에서 표 크기가 사라졌다 (#6388)"
+        );
+    }
+}
+
+/// 위치 속성 setter 도 같은 계약이다 — `vertOffset`/`horzOffset` 경로의 0 확장.
+#[test]
+fn issue_6388_position_props_do_not_grow_empty_raw() {
+    let mut core = DocumentCore::from_bytes(&read_fixture(EMPTY_RAW_SAMPLE)).expect("파싱");
+    let c = first_table_coord(&core);
+    let (w, h) = {
+        let t = table_at(&core, c);
+        (t.common.width, t.common.height)
+    };
+
+    core.set_table_properties_native(c.0, c.1, c.2, r#"{"vertOffset":2000,"horzOffset":1500}"#)
+        .expect("위치 속성 설정");
+
+    {
+        let t = table_at(&core, c);
+        assert!(
+            t.raw_ctrl_data.is_empty(),
+            "위치 속성 setter 가 빈 raw 를 0 확장하면 안 된다 (#6388)"
+        );
+        assert_eq!(t.common.vertical_offset, 2000, "세로 오프셋 반영");
+        assert_eq!(t.common.horizontal_offset, 1500, "가로 오프셋 반영");
+    }
+
+    let saved = core.export_hwp_native().expect("저장");
+    let reparsed = DocumentCore::from_bytes(&saved).expect("재파싱");
+    let rc = first_table_coord(&reparsed);
+    let t = table_at(&reparsed, rc);
+    assert_eq!(
+        (t.common.width, t.common.height),
+        (w, h),
+        "위치 속성 변경 후 저장·재파싱에서 표 크기가 사라졌다 (#6388)"
+    );
+    assert_eq!(t.common.vertical_offset, 2000, "세로 오프셋이 저장에 반영됐다");
+    assert_eq!(
+        t.common.horizontal_offset, 1500,
+        "가로 오프셋이 저장에 반영됐다"
+    );
+}
+
+/// raw 가 있는 표(한컴 파스본)의 dual-write 는 종전대로 유지된다.
+#[test]
+fn issue_6388_populated_raw_still_dual_written() {
+    const SAMPLE: &str = "samples/ta-pic-001-r.hwp";
+    let mut core = DocumentCore::from_bytes(&read_fixture(SAMPLE)).expect("파싱");
+    let c = first_table_coord(&core);
+    let raw_len = {
+        let t = table_at(&core, c);
+        assert!(
+            t.raw_ctrl_data.len() >= 20,
+            "전제: 한컴 파스본 표는 raw 를 가진다"
+        );
+        t.raw_ctrl_data.len()
+    };
+
+    core.move_table_offset_native(c.0, c.1, c.2, 500, 300)
+        .expect("표 이동");
+
+    let t = table_at(&core, c);
+    assert_eq!(t.raw_ctrl_data.len(), raw_len, "raw 길이는 변하지 않는다");
+    let raw_h = i32::from_le_bytes(t.raw_ctrl_data[8..12].try_into().unwrap());
+    assert_eq!(
+        raw_h, t.common.horizontal_offset as i32,
+        "raw 와 common 이 함께 갱신돼야 한다(dual-write 유지)"
+    );
+}

--- a/tests/cases/issue_6388_table_raw_zero_extension.rs
+++ b/tests/cases/issue_6388_table_raw_zero_extension.rs
@@ -195,7 +195,10 @@ fn issue_6388_position_props_do_not_grow_empty_raw() {
         (w, h),
         "위치 속성 변경 후 저장·재파싱에서 표 크기가 사라졌다 (#6388)"
     );
-    assert_eq!(t.common.vertical_offset, 2000, "세로 오프셋이 저장에 반영됐다");
+    assert_eq!(
+        t.common.vertical_offset, 2000,
+        "세로 오프셋이 저장에 반영됐다"
+    );
     assert_eq!(
         t.common.horizontal_offset, 1500,
         "가로 오프셋이 저장에 반영됐다"


### PR DESCRIPTION
관련 이슈: #6388

## 문제
표 위치를 옮기거나 위치 속성을 바꾸면 `raw_ctrl_data` 가 0 으로 확장돼, raw 가 없던 표
(HWPX 파스본 전부)의 크기·여백·z-order·instance_id 가 저장에서 사라진다.

## 원인
표는 `raw_ctrl_data` 가 **정본**이다(`serializer/control.rs::serialize_table`). raw 가 비어
있으면 저장기가 `common` 합성 경로로 가는데, 이는 HWPX 파스본·신설 표를 위해 #1916 이 세운
계약이다.

`table_ops.rs` 세 곳이 `while len < 필요길이 { push(0) }` 로 raw 를 늘렸다.

- `move_table_offset_native`(`:2648`) → `H_OFFSET.end`(12)까지
- 위치 속성 setter 의 `vertOffset`/`horzOffset`(`:3047`) → 12까지
- `keepWithAnchor`(`:3090`) → `PREVENT_PAGE_BREAK.end`(40)까지

그 확장이 **빈 raw 를 "있는" raw 로 바꾸는 순간** 합성 경로가 끊기고 12바이트짜리
CTRL_HEADER 가 방출된다. offset 12 이후의 WIDTH(12..16)·HEIGHT(16..20)·MARGIN(24..32)·
INSTANCE_ID(32..36) 가 사라진다.

같은 파일의 다른 dual-write(`update_ctrl_dimensions`·`sync_ctrl_height`·여백 기록)는
`if raw.len() >= <필요 길이>` 가드로 짧으면 건너뛴다. 0 확장 세 곳만 그 관습을 벗어났다.

## 변경
- `patch_raw_ctrl_field` — 가드된 제자리 덧쓰기 헬퍼. 길이가 모자라면 건너뛴다.
  **raw 를 늘리지 않는다.** 값은 잃지 않는다 — 호출자가 `common` 을 함께 갱신하고 그쪽이
  합성 원천이다(`serialize_common_obj_attr` 가 오프셋·여백·`prevent_page_break` 까지 방출).
- `move_table_offset_native` 이 현재 오프셋을 raw 대신 **`common` 에서 읽는다.** 종전에는
  raw 에서 읽었기 때문에 raw 가 빈 표를 다루려면 0 확장이 필요했다.
- 위치 속성 setter 의 `vertOffset`/`horzOffset`, `keepWithAnchor` 도 같은 규칙으로 전환.
- FLAGS 덧쓰기도 가드한다 — 종전에는 바로 위 0 확장이 길이 4 를 보장해 무조건 색인했다.

추가 테스트 `tests/cases/issue_6388_table_raw_zero_extension.rs` 6건:

- `issue_6388_moving_empty_raw_table_does_not_grow_raw`
- `issue_6388_moving_empty_raw_table_preserves_geometry_through_save` — 크기·여백 왕복
- `issue_6388_move_still_applies_offsets_without_raw` — 기능 유지
- `issue_6388_hwpx_tables_survive_move_and_save` — 실제 사용 경로(HWPX 2종)
- `issue_6388_position_props_do_not_grow_empty_raw` — 위치 속성 setter 경로
- `issue_6388_populated_raw_still_dual_written` — raw 가 있는 표의 dual-write 유지

## 검증
devel `067a8134b` 기준(게이트는 `f54408110` 에서 실행, rebase 후 관련 파일 변경 없음).

- **수정 전 실패 증명**: `samples/hwp5-tbl-attr-1916.hwp`(표 4개 전부 raw 없음)에서 표를
  옮기고 저장·재파싱하면 `common` 이 45152x58826 → **0x0**, 여백 전부 0. 파일도
  63488 → 62976 B. HWPX 실물 2종(`basic-table-01.hwpx`, `business_overview.hwpx`)도 동일하게
  크기 손실. 수정 후 세 경로 모두 보존.
- **`common` 을 읽기 원천으로 삼는 근거**: 파스본 표 **6708개**에서 raw V/H_OFFSET 과
  `common.vertical_offset`/`horizontal_offset` 불일치가 **0건**(실측). 같은 조사에서
  `table.attr` 과 raw FLAGS 불일치도 6719개 중 0건이었다.
- **발동 집합 확인**: `samples/**/*.hwp` 529개 표 6719개의 raw 길이 분포는
  `{0: 11, 40: 541, 42: 4716, 44: 1449, 48: 2}` — 1~39바이트가 없다. 즉 0 확장은 오직
  빈 raw 에서만 발동했고, HWPX 파서는 표 raw 를 채우지 않으므로 HWPX 파스본은 전부 해당.
- 계약 스위트 그린, 0 failed —
  `issue_1916_tbl_common_attr`(빈 raw → `common` 합성 계약) 포함 126 passed,
  `issue_2724_passthrough_invalidation_guard` 포함 136 passed,
  `hwp5_roundtrip_baseline` 포함 155 passed,
  `issue_1916` 포함 136 passed(3 ignored), `issue_1282_rotated_cell_picture_resize` 포함 140 passed.
- `cargo test --release --lib` — 3889 passed / 0 failed / 13 ignored.
- 신규 스위트 150 passed / 0 failed.
- `cargo fmt --all -- --check` 클린, `cargo clippy --workspace --all-targets -- -D warnings` 클린.
- `node scripts/rust-unit-test-tiers.mjs --check --base-ref origin/devel` 통과
  (4221 tests / 299 modules, src `#[cfg(test)]` 무변경).

## 범위 외
- raw 가 비어 있지 않은 표의 제자리 덧쓰기. 길이 가드가 있고 해당 필드 범위만 건드려
  미해석 바이트를 해치지 않는다 — 의도된 dual-write 이고 이 PR 이 유지한다.
- 여백 기록이 `raw.len() >= MARGIN_BOTTOM.end` 로 가드돼 짧은 raw 에서 생략되는 것.
  위 분포에서 그 길이의 표가 실재하지 않아 이번 범위에서 제외한다.
- 참고: #5890 (setter 순수화 표 행. 수식·그림 행은 #6350·#6355·#6373 으로 종결)
