### PR TITLE
docs: PR 전 Rust lint gate를 명확히 한다

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,14 +41,26 @@
 
 ## 문서와 검증
 
-- **모든 PR·push 직전 필수 (건너뛰면 CI Lint Format check 실패)**:
+- **Rust source 또는 Rust test/baseline helper를 바꾼 모든 PR·push 직전 필수**: 포맷만 확인하고
+  Clippy를 CI에 넘기지 않는다. PR review worktree에서 파생 integration suite를 준비한 뒤 아래
+  Rust lint 묶음을 **순차로** 모두 통과시킨다. `cargo clippy -- -D warnings`만으로는
+  WASM 전용 cfg와 workspace member·integration target을 놓치므로 CI `Lint (fmt, clippy, WASM
+  check)`의 세 Clippy 단계를 각각 확인한다.
   ```
+  node scripts/rust-test-suite-manifest.mjs --prepare
   cargo fmt --all
   cargo fmt --all -- --check
+  cargo clippy --locked --target-dir target/pr-review -- -D warnings
+  cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown \
+    --target-dir target/pr-review -- -D warnings
+  cargo build --locked --workspace --target-dir target/pr-review
+  cargo clippy --locked --workspace --all-targets --target-dir target/pr-review -- -D warnings
+  node scripts/rust-test-suite-manifest.mjs --check
   ```
-  CI Format check 는 `cargo fmt --all -- --check` 이다. `cargo fmt --check` 만으로는
-  부족하다. 테스트만 고친 커밋도 다시 돌려야 한다. `--check` 가 실패하면
-  `cargo fmt --all` 후 다시 `--check` 가 통과하기 전에는 push 하지 않는다.
+  새 integration test source를 추가한 경우 `--prepare`가 만든 파생 파일은 검증 뒤 review
+  worktree에서만 복원하고 PR에 stage하지 않는다. 한 단계라도 실패하면 수정·재실행 전에는 push 또는
+  PR을 만들지 않는다. 세부 범위와 예외는 `mydocs/manual/pr_review/local_validation.md`의 4.3을
+  따른다.
 - **source-side test 변경 시 추가**: `src/**`의 `#[cfg(test)]`를 변경하면
   `node scripts/rust-unit-test-tiers.mjs --check`를 실행한다. 이 검사는 source와 정책만 읽고
   파생 inventory를 만들지 않는다. 진단용 `--generate` 결과는 `tests/generated/unit-test-tiers.json`에

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,22 @@
 # Contributing to rhwp
 
 > **PR·push 차단 게이트 — 하나라도 실패하면 `gh pr create` / `git push` 하지 마세요.**
-> 테스트만 고친 뒤에도 `cargo fmt --all -- --check` 를 다시 돌리세요. 일반 기여자의 source PR
-> checkout에서는 generated suite를 준비하지 않습니다.
+> 테스트·baseline만 고친 뒤에도 포맷과 Clippy를 다시 확인하세요. 일반 기여자의 source PR
+> checkout에서는 generated suite를 준비하지 않으며, maintainer review worktree의 전체 lint gate는
+> [로컬 사전 검증](mydocs/manual/pr_review/local_validation.md#43-변경-범위별-기본-검증)을 따릅니다.
 >
 > ```bash
 > cargo fmt --all
 > cargo fmt --all -- --check
+> cargo clippy --locked -- -D warnings
+> cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown -- -D warnings
+> cargo build --locked --workspace --target-dir target/pr-review
+> cargo clippy --locked --workspace --all-targets --target-dir target/pr-review -- -D warnings
 > ```
 >
-> CI Lint job 의 Format check 는 `cargo fmt --all -- --check` 입니다.
-> `cargo fmt --check` 만으로는 부족합니다. 실패하면 `cargo fmt --all` 로 고친 뒤
-> `--check` 가 통과할 때까지 PR 을 만들지 마세요.
+> CI Lint job은 Format check 외에도 native·WASM32·workspace Clippy를 실행합니다. `cargo fmt --check`
+> 또는 native Clippy 하나만으로는 충분하지 않습니다. 실패하면 수정 후 같은 명령을 다시 통과시킨 뒤
+> PR을 만드세요.
 > `src/**`의 `#[cfg(test)]`를 바꾼 경우에는 추가로
 > `node scripts/rust-unit-test-tiers.mjs --check`를 실행하세요. 이 검사는 source와 추적 정책만
 > 읽으며 파생 inventory를 만들거나 stage하지 않습니다. 반면
@@ -156,6 +161,10 @@ HWP 파일이 한컴과 다르게 렌더링되면 알려주세요:
 cargo install cargo-nextest --locked             # 최초 1회
 cargo fmt --all                                  # 로컬 포맷 적용
 cargo fmt --all -- --check                       # CI와 같은 포맷 검증 — PR 전 필수
+cargo clippy --locked -- -D warnings              # native root lint
+cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown -- -D warnings # WASM cfg lint
+cargo build --locked --workspace --target-dir target/pr-review
+cargo clippy --locked --workspace --all-targets --target-dir target/pr-review -- -D warnings
 node --test scripts/tests/rust-test-suite-manifest.test.mjs
 # `src/**`의 `#[cfg(test)]`를 변경한 경우에만 실행한다. 파생 파일은 생성하지 않는다.
 node scripts/rust-unit-test-tiers.mjs --check
@@ -167,8 +176,8 @@ cargo clippy --all-targets --target-dir target/pr-review -- -D warnings # 린트
 ```
 
 `cargo fmt --all -- --check` 가 실패하면 PR을 만들지 마세요. `cargo fmt --check`
-만으로는 CI `Lint (fmt, clippy, WASM check)` 와 같지 않습니다. 포맷이 깨졌으면
-`cargo fmt --all` 로 고친 뒤 다시 `--check` 가 통과한 다음에만 PR을 생성해주세요.
+만으로는 CI `Lint (fmt, clippy, WASM check)` 와 같지 않습니다. 포맷이 깨졌거나 native/WASM
+Clippy가 경고를 내면 수정 뒤 해당 lint를 다시 통과한 다음에만 PR을 생성해주세요.
 
 새 통합 테스트는 `tests/cases/` 에만 둡니다. `tests/suites/suite-policy.json`,
 `tests/suites/unit-test-tier-policy.json`은 추적하는 정책이고, `tests/generated/`, `tests/suites/manifest.json`,

--- a/mydocs/manual/pr_review/local_validation.md
+++ b/mydocs/manual/pr_review/local_validation.md
@@ -2,7 +2,7 @@
 kind: guide
 status: active
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-08-10
+last_verified: 2026-08-30
 ---
 
 # 로컬 사전 검증
@@ -250,17 +250,38 @@ devel 위에 PR head를 합친 결과 tree와 conflict를 확인한다. conflict
 
 ## 4.3 변경 범위별 기본 검증
 
-**Rust 를 한 줄이라도 바꾼 PR 은 아래가 실패하면 생성하지 않는다.**
+**Rust source 또는 Rust test/baseline helper를 한 줄이라도 바꾼 PR은 아래 lint 묶음이 실패하면 생성하지
+않는다.** 테스트 전용 변경이나 기존 baseline 분할도 예외가 아니다. #6390처럼 test/baseline만
+바꾼 경우에 `fmt`와 focused nextest만 실행하고 Clippy를 GitHub CI에 넘기는 해석이 가능했던 것이
+기존 절차의 결함이었다.
 
 ```bash
+# PR review worktree에서만 실행: 파생 suite는 검증 뒤 stage하지 않는다.
+node scripts/rust-test-suite-manifest.mjs --prepare
 cargo fmt --all
 cargo fmt --all -- --check
+cargo clippy --locked --target-dir target/pr-review -- -D warnings
+cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown \
+  --target-dir target/pr-review -- -D warnings
+cargo build --locked --workspace --target-dir target/pr-review
+cargo clippy --locked --workspace --all-targets --target-dir target/pr-review -- -D warnings
 node scripts/rust-test-suite-manifest.mjs --check
+```
+
+이 묶음은 CI `Lint (fmt, clippy, WASM check)`의 Format check, native root Clippy, WASM32
+Clippy, workspace all-target Clippy와 대응한다. CI에만 있는 Node/Python 계약 검사는 변경 범위가
+해당할 때 아래 표와 workflow 전용 절차에 따라 추가한다. `cargo fmt --check` 또는 native
+`cargo clippy` 하나만 실행하면 각각 Format check 또는 WASM·workspace lint 오류를 놓친다.
+
+`src/**` 또는 `crates/*/src/**`의 `#[cfg(test)]`를 변경했을 때만 다음 policy 검사를 위 묶음 뒤에
+추가한다. 이 검사는 파생 파일을 만들지 않는다.
+
+```bash
 node scripts/rust-unit-test-tiers.mjs --check
 ```
 
-CI `Lint (fmt, clippy, WASM check)` 의 Format check 단계는
-`cargo fmt --all -- --check` 이다. `cargo fmt --check` 만 실행하면 CI 가 실패한다.
+`--prepare`가 만든 `tests/generated/`와 `tests/suites/manifest.json`은 검증 증적일 뿐 source PR에
+stage하지 않는다. 검증 뒤 review worktree에서만 복원한다.
 
 `PR 준비` 지시는 이 절에서 해당 변경 범위에 지정한 검증을 실제로 실행하는 승인이다. PR 본문 초안,
 review 문서, 오늘할일만 작성하고 이 표의 필수 회귀 게이트를 남겨 두면 준비 완료로 보고하지 않는다.
@@ -270,12 +291,13 @@ remote push, PR 생성, ready 전환, merge 승인과는 별개다.
 | 변경 범위 | 기본 검증 |
 | --- | --- |
 | mydocs만 변경 | git diff --check, 문서 경로·링크·변경 범위 확인. Cargo 생략 |
-| Rust parser/model/CLI | focused test, release-test 전체, fmt, clippy. 단, 4.3.0의 검토 재사용 조건이면 focused test와 GitHub 전체 CI 근거 |
+| Rust parser/model/CLI | 모든 Rust lint 묶음, focused test, release-test 전체. 단, 4.3.0의 검토 재사용 조건이면 focused test와 GitHub 전체 CI 근거 |
 | renderer/layout/typeset/WASM | focused test, release-test 전체, Native Skia 3종, wasm-pack build, 시각 증적. 단, 4.3.0의 검토 재사용 조건이면 focused test, WASM·시각 증적과 GitHub 전체 CI 근거 |
 | rhwp-studio만 변경 | TypeScript 검사, npm test, 실제 browser 동작 |
 | npm/editor public API·transport·type | 아래 package 검증 |
 | CI workflow | [GitHub 저장소 운영 매뉴얼](../github_operations.md)의 변경 등급에 따른 workflow 구문·정책 테스트·required check 영향·최신 GitHub Actions 결과 |
-| 기존 golden/baseline/fixture | 관련 focused test, snapshot 결정성, 최신 PR head CI |
+| Rust test/baseline helper | 모든 Rust lint 묶음, 관련 focused test, snapshot 결정성, 최신 PR head CI |
+| 기존 golden/baseline/fixture data만 변경 | 관련 focused test, snapshot 결정성, 최신 PR head CI. Rust helper도 함께 바꾸면 바로 위 행의 lint 묶음을 추가 |
 
 archive label 또는 trusted post-merge reuse topology를 바꾸면, 일반 workflow 계약 검사에 더해
 아래 두 묶음을 PR 전에 모두 실행한다. Studio E2E나 OS resource-limit처럼 이 변경 범위와
@@ -304,6 +326,9 @@ GitHub Full CI가 완료된 code head를 maintainer가 재검토할 때는
 
 - 이 예외는 source·test·fixture·workflow·baseline·asset 보정이 전혀 없고, current-base merge가
   clean 또는 `mydocs/` 한정 bridge인 경우에만 사용한다.
+- maintainer가 Rust source·test·baseline helper 보정을 새 code head에 추가한 경우에는 이전 녹색 CI를
+  lint 생략 근거로 재사용하지 않는다. 위 Rust lint 묶음과 변경 범위 검증을 새 head에서 먼저
+  끝내고 PR을 만든다.
 - focused test, `git diff --check`, 변경 문서 링크 검사, renderer의 실제 WASM/브라우저 시각 검증은
   생략하지 않는다.
 - Docker 등 표준 실행 환경이 없어서 host fallback을 썼다면, 표준 경로를 통과했다고 쓰지 않고

--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -2,7 +2,7 @@
 kind: canonical
 status: active
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-08-16
+last_verified: 2026-08-30
 ---
 
 # PR 리뷰 · 통합 워크플로우 매뉴얼
@@ -28,6 +28,12 @@ rhwp의 PR 처리는 외부 contributor PR, collaborator self PR, collaborator�
 소스, 테스트, CI workflow, golden/baseline, 기존 샘플 변경은 maintainer라도 일반 PR과 최신 CI를
 기본으로 한다. GitHub review, comment, push, ready 전환, merge, close는 각각 작업지시자의 명시 승인을
 받은 뒤에만 수행한다.
+
+Rust source 또는 Rust test/baseline helper가 바뀐 PR은 `local_validation.md` 4.3의 Rust lint 묶음
+(format, native Clippy, WASM32 Clippy, workspace all-target Clippy)을 **PR 생성 전에** 통과해야 한다.
+focused test 또는 과거 녹색 CI는 이 선행 lint gate를 대체하지 않는다. GitHub Full CI 재사용은 정확한
+기존 code head를 재검토할 때의 광범위 회귀 생략 규칙일 뿐, maintainer 보정이나 새 code/test/baseline
+commit의 lint 생략 규칙이 아니다.
 
 ### 1.1 PR 번호 채번과 review 기록
 

--- a/mydocs/orders/20260830.md
+++ b/mydocs/orders/20260830.md
@@ -17,8 +17,17 @@ date: 2026-08-30
   render-tree 집계도 기존 TSV와 diff가 없었다.
 - [x] 상세 self-review와 CI artifact 측정값을
   [PR #6390 검토 문서](../pr/archives/pr_6390_review.md)에 보관했다.
-- [ ] trailing 문서 head의 CI와 mergeability를 재확인한 뒤 작업지시자 승인에 따라 squash merge하고,
-  merge 후 duration refresh의 trusted PR artifact 재사용을 검증한다.
+- [x] trailing 문서 head의 CI와 mergeability를 확인해 squash merge했다. merge commit
+  `067a8134bc5c6a39c614536fc6f769f94fdf17ea`의 devel CI와 trusted PR artifact duration refresh가
+  성공했고, [#6360](https://github.com/edwardkim/rhwp/issues/6360)을 완료로 종료했다.
+
+## PR 전 Rust lint gate 명확화
+
+- [x] focused test·format만 실행하고 Rust test/baseline helper의 Clippy를 CI에 넘길 수 있었던 절차
+  공백을 분석했다. native, WASM32, workspace all-target Clippy를 PR 생성 전 순차 gate로 명시했다.
+- [x] [PR #6393](https://github.com/edwardkim/rhwp/pull/6393)의 self-review 기록을
+  [archive 문서](../pr/archives/pr_6393_review.md)에 보관했다. 문서 4개만 변경한 review-only PR이므로
+  최신 head의 fast-pass aggregate와 mergeability를 확인한 뒤 작업지시자 승인에 따라 squash merge한다.
 
 ## HWP 2024 MCP 무인 스크립트 사전 차단 가이드
 

--- a/mydocs/pr/archives/pr_6393_review.md
+++ b/mydocs/pr/archives/pr_6393_review.md
@@ -1,0 +1,58 @@
+---
+kind: pr-review
+status: pending-ci
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-30
+pr: 6393
+author: jangster77
+---
+
+# PR #6393 review - PR 전 Rust lint gate 명확화
+
+## 라우팅과 metadata
+
+- PR: [#6393](https://github.com/edwardkim/rhwp/pull/6393), base: `devel`.
+- base route: `collaborator_self_merge.md`; modifiers: `intake_and_review.md`,
+  `local_validation.md`, `review_only_fast_pass.md`.
+- 작성자·self-review: `jangster77`; collaborator 본인 PR이므로 reviewer request는 등록하지 않았다.
+- 작성 시점 참고값: code candidate `4baba2a50eb21a71fc04ac36e846cd90647f110e`, Open non-draft,
+  `MERGEABLE`, 4 files, `+70/-18`. CI 결과와 mergeability는 merge 직전에 다시 확인한다.
+
+## 변경 범위와 원인
+
+- 이전 절차는 Rust parser/model/CLI 행에만 `clippy`를 명시하고, Rust test/baseline 변경 행에는
+  focused test와 최신 CI만 기록했다. 따라서 test/baseline helper 변경에서 format만 확인하고
+  Clippy를 GitHub CI에 맡길 수 있는 공백이 있었다.
+- `AGENTS.md`, `CONTRIBUTING.md`, `local_validation.md`, `pr_review_workflow.md`를 같은 규칙으로
+  정렬했다. Rust source 또는 Rust test/baseline helper 변경은 PR 생성 전에 format, native Clippy,
+  WASM32 Clippy, workspace all-target Clippy를 순차로 통과해야 한다.
+- HWP/HWPX/PDF 같은 fixture data만 바꾼 경우와 Rust helper 변경을 분리했다. data-only 변경에는
+  불필요한 Cargo lint를 강제하지 않지만, helper가 같이 바뀌면 Rust lint gate를 적용한다.
+- 이 PR에는 Rust source, test, baseline, fixture data, workflow가 포함되지 않아 review-only fast-pass
+  범위다.
+
+## 로컬 검증
+
+- `git diff --check`: 통과.
+- `python3 scripts/check_markdown_links.py AGENTS.md CONTRIBUTING.md
+  mydocs/manual/pr_review/local_validation.md mydocs/manual/pr_review_workflow.md`: 4개 문서의 내부
+  Markdown 상대 링크 이상 없음.
+- 현재 `ci.yml` Lint job의 format, native Clippy, WASM32 Clippy, workspace all-target Clippy 명령을
+  대조했다. 문서에 적은 `--locked`, `target/pr-review`은 로컬 검토 target·lockfile 보호를 위한
+  동등한 제약이며, 검사 범위를 줄이지 않는다.
+- 변경 파일 목록에 classifier를 적용한 결과:
+
+  ```json
+  {"rust_required":"false","frontend_mode":"none","render_required":"false",+  "native_skia_required":"false","codeql_languages":"none",+  "classification_status":"classified","reason":"classified:review-only"}
+  ```
+
+- 문서 전용 변경이므로 Cargo lint·nextest는 실행하지 않았다. 새 규칙의 실제 Cargo 실행은 이후 Rust
+  변경 PR에서 해당 변경 범위의 필수 gate로 수행한다.
+
+## 최종 권고와 후속 조건
+
+**조건부 수용.** 원인인 범위 표의 빈틈과 CI lint와의 대응 관계가 모두 문서화됐다.
+
+- trailing 문서 commit 뒤 최신 head의 preflight와 Build & Test aggregate가 review-only fast-pass로
+  성공하는지 확인한다.
+- 최신 head가 `MERGEABLE/CLEAN`이고 required check가 성공하면 작업지시자 승인에 따라 squash merge한다.


### PR DESCRIPTION
## 배경

Rust test/baseline helper 변경에서 focused test와 format만 실행하고 Clippy를 GitHub CI에 맡길 수 있었던 문서 공백을 제거합니다.

## 변경

- AGENTS와 PR review workflow에 PR 생성 전 Rust lint gate를 명시했습니다.
- local validation에 native, WASM32, workspace all-target Clippy와 manifest 준비 순서를 추가했습니다.
- CONTRIBUTING 체크리스트를 같은 방향으로 보강했습니다.
- 기존 HWP/PDF fixture data만 바꾼 경우와 Rust helper 변경을 구분했습니다.

## 검증

- git diff --check
- python3 scripts/check_markdown_links.py AGENTS.md CONTRIBUTING.md mydocs/manual/pr_review/local_validation.md mydocs/manual/pr_review_workflow.md
- CI impact classifier: classified:review-only