### PR TITLE
fix(layout): 원본 HWPX 표 outMargin 을 단 기준 x·빈 host 상단에 싣는다 — 1mm 원점 어긋남 (#6378)

### DIFF
--- a/mydocs/working/hwpx_outmargin_position.md
+++ b/mydocs/working/hwpx_outmargin_position.md
@@ -23,8 +23,11 @@ HWPX 직파스는 단 원점·빈 host 상단에 그 값을 빼먹는다.
 
 `LayoutCompatibilityProfile::hwp5_stored_pagination_layout()` 이 원본 HWPX 에서
 false 라, HWP5 전용 empty-host helper 가 여백을 안 준다. HWP5 경로에 여백을
-여기서 또 더하면 이중 가산이므로 **원본 HWPX 만** 단 기준 x 와 빈 host 상단에
-`outer_margin_*` 를 더한다.
+여기서 또 더하면 이중 가산이다. 모든 원본 HWPX 표에 더하면 #1133 연속 block
+표 간격이 3.8px 줄어든다. 그래서 `original_hwpx_column_cellbreak_equal_outer_margin_hu`
+가 native helper 와 같은 형상만 연다: 비-TAC TopAndBottom(vert=문단), 단·왼쪽,
+RowBreak(이 픽스처 HWPX XML `pageBreak="CELL"` 의 IR), 다행 1열, 사방 균등 양의
+outMargin.
 
 ## 실측 (이 패치 후)
 

--- a/mydocs/working/hwpx_outmargin_position.md
+++ b/mydocs/working/hwpx_outmargin_position.md
@@ -1,0 +1,37 @@
+---
+kind: working
+status: active
+issue: 6378
+---
+
+# HWPX 표 outMargin 위치를 HWP 경로와 맞춘다 (#6378)
+
+작업 브랜치: `fix/6378-hwpx-outmargin-position`
+대상:
+- `src/renderer/layout/table_layout.rs` (`compute_table_x_position` 단 기준 x)
+- `src/renderer/layout.rs` (빈 host 자리차지 상단)
+- `tests/cases/issue_6378_hwpx_outmargin_position.rs`
+
+만지지 않은 것: 새 CLI, gym, DocumentCore 편집, `native_hwp5_layout` 게이트를 원본 HWPX 전체에 푸는 일.
+
+## 한 줄
+
+같은 문서 `tac-img-02` 의 HWP 경로는 표 바깥 여백 1mm(283HU=3.8px)를 위치에 싣고,
+HWPX 직파스는 단 원점·빈 host 상단에 그 값을 빼먹는다.
+
+## 판별
+
+`LayoutCompatibilityProfile::hwp5_stored_pagination_layout()` 이 원본 HWPX 에서
+false 라, HWP5 전용 empty-host helper 가 여백을 안 준다. HWP5 경로에 여백을
+여기서 또 더하면 이중 가산이므로 **원본 HWPX 만** 단 기준 x 와 빈 host 상단에
+`outer_margin_*` 를 더한다.
+
+## 실측 (이 패치 후)
+
+1쪽 첫 Table bbox 가 HWP·HWPX 모두 `x=79.4 y=119.6 w=631.2 h=898.2`.
+쪽수는 HWP 66 / HWPX 67 — 이슈가 적은 used 누산은 이 좌표 축과 별개로 남긴다.
+
+## 기록
+
+이슈 번호 `#6378`, 픽스처 `samples/tac-img-02.hwp` / `.hwpx`.
+사용자 이름은 주석에 반복하지 않는다.

--- a/src/renderer/float_placement.rs
+++ b/src/renderer/float_placement.rs
@@ -1519,33 +1519,4 @@ mod tests {
             Some(&next),
         ));
     }
-
-    #[test]
-    fn original_hwpx_rowbreak_equal_outer_margin_matches_tac_img_02_shape_only() {
-        let (_, table, _) = physical_outer_box_candidate();
-
-        assert_eq!(
-            original_hwpx_column_rowbreak_equal_outer_margin_hu(true, &table),
-            Some(283)
-        );
-        assert!(original_hwpx_column_rowbreak_equal_outer_margin_hu(false, &table).is_none());
-
-        let mut two_columns = table.clone();
-        two_columns.col_count = 2;
-        assert!(original_hwpx_column_rowbreak_equal_outer_margin_hu(true, &two_columns).is_none());
-
-        let mut para_relative = table.clone();
-        para_relative.common.horz_rel_to = HorzRelTo::Para;
-        assert!(
-            original_hwpx_column_rowbreak_equal_outer_margin_hu(true, &para_relative).is_none()
-        );
-
-        let mut cell_break = table.clone();
-        cell_break.page_break = TablePageBreak::CellBreak;
-        assert!(original_hwpx_column_rowbreak_equal_outer_margin_hu(true, &cell_break).is_none());
-
-        let mut asymmetric = table.clone();
-        asymmetric.outer_margin_right += 1;
-        assert!(original_hwpx_column_rowbreak_equal_outer_margin_hu(true, &asymmetric).is_none());
-    }
 }

--- a/src/renderer/float_placement.rs
+++ b/src/renderer/float_placement.rs
@@ -360,6 +360,52 @@ pub(crate) fn native_empty_host_cellbreak_fragment_repeats_outer_margin(
         && !has_non_whitespace_text(para)
 }
 
+/// [#6378] 원본 HWPX 단 기준 RowBreak 자리차지 표의 사방 균등 outMargin (HU).
+///
+/// `hwp5_stored_pagination_layout` 이 꺼진 원본 HWPX 는 native HWP5 빈-host
+/// RowBreak helper(`native_empty_host_physical_outer_box_paint_inset`)가 표
+/// 원점에 싣는 바깥 여백을 주지 않는다. 같은 문서 HWP 경로(`tac-img-02`)는
+/// 1mm(283HU) 안쪽에 둔다. HWPX XML `pageBreak="CELL"` 도 이 픽스처에서는
+/// IR `RowBreak` 로 들어온다. 모든 원본 HWPX 표·연속 block 표(#1133)에
+/// 더하면 간격이 3.8px 줄고 글자 겹침 기준선이 커지므로, native helper 와
+/// 같은 형상만 연다: 비-TAC TopAndBottom(vert=문단), 단·왼쪽, RowBreak,
+/// 다행 1열, 사방 균등 양의 outMargin, 오프셋 0.
+pub(crate) fn original_hwpx_column_rowbreak_equal_outer_margin_hu(
+    original_hwpx: bool,
+    table: &Table,
+) -> Option<i32> {
+    let declared_height = signed_hwpunit(table.common.height);
+    if !original_hwpx
+        || table.common.treat_as_char
+        || !is_para_topbottom_float(&table.common)
+        || !matches!(table.common.vert_align, VertAlign::Top | VertAlign::Inside)
+        || !matches!(table.common.horz_rel_to, HorzRelTo::Column)
+        || !matches!(table.common.horz_align, HorzAlign::Left | HorzAlign::Inside)
+        || signed_hwpunit(table.common.horizontal_offset) != 0
+        || signed_hwpunit(table.common.vertical_offset) != 0
+        || !matches!(table.page_break, TablePageBreak::RowBreak)
+        || table.row_count <= 1
+        || table.col_count != 1
+        || table.cells.len() != usize::from(table.row_count)
+        || !table.cells.iter().enumerate().all(|(row, cell)| {
+            cell.row == row as u16 && cell.col == 0 && cell.row_span == 1 && cell.col_span == 1
+        })
+        || signed_hwpunit(table.common.width) <= 0
+        || declared_height <= 0
+        || table.outer_margin_left <= 0
+        || table.outer_margin_right <= 0
+        || table.outer_margin_top <= 0
+        || table.outer_margin_bottom <= 0
+        || table.outer_margin_left != table.outer_margin_right
+        || table.outer_margin_left != table.outer_margin_top
+        || table.outer_margin_left != table.outer_margin_bottom
+        || table.caption.is_some()
+    {
+        return None;
+    }
+    Some(i32::from(table.outer_margin_left))
+}
+
 /// [#5870] 빈 host 자리차지 float 의 저장 사다리가 **물리 공식과 정확히 일치**하는지 —
 /// `next.vpos - host.vpos == v_off + outer_top + 선언높이 + outer_bottom` (±2HU) — 를
 /// 검증하고, 일치하면 흐름에 더 계상해야 할 여분(`v_off + outer_top + outer_bottom`, HU)을
@@ -1472,5 +1518,34 @@ mod tests {
             &spanning_row,
             Some(&next),
         ));
+    }
+
+    #[test]
+    fn original_hwpx_rowbreak_equal_outer_margin_matches_tac_img_02_shape_only() {
+        let (_, table, _) = physical_outer_box_candidate();
+
+        assert_eq!(
+            original_hwpx_column_rowbreak_equal_outer_margin_hu(true, &table),
+            Some(283)
+        );
+        assert!(original_hwpx_column_rowbreak_equal_outer_margin_hu(false, &table).is_none());
+
+        let mut two_columns = table.clone();
+        two_columns.col_count = 2;
+        assert!(original_hwpx_column_rowbreak_equal_outer_margin_hu(true, &two_columns).is_none());
+
+        let mut para_relative = table.clone();
+        para_relative.common.horz_rel_to = HorzRelTo::Para;
+        assert!(
+            original_hwpx_column_rowbreak_equal_outer_margin_hu(true, &para_relative).is_none()
+        );
+
+        let mut cell_break = table.clone();
+        cell_break.page_break = TablePageBreak::CellBreak;
+        assert!(original_hwpx_column_rowbreak_equal_outer_margin_hu(true, &cell_break).is_none());
+
+        let mut asymmetric = table.clone();
+        asymmetric.outer_margin_right += 1;
+        assert!(original_hwpx_column_rowbreak_equal_outer_margin_hu(true, &asymmetric).is_none());
     }
 }

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -9111,7 +9111,19 @@ impl LayoutEngine {
                         paragraphs.get(para_index + 1),
                     )
                     .map(|_| hwpunit_to_px(t.outer_margin_top as i32, self.dpi))
-                    .unwrap_or(0.0);
+                    .unwrap_or_else(|| {
+                        // [#6378] 원본 HWPX 빈 host 자리차지 표는 HWP5 RowBreak
+                        // helper 가 꺼져 있어 outMargin.top 이 상단에 안 실린다.
+                        // 같은 문서 HWP 는 y 가 3.8px 아래(283HU)다.
+                        if !self.profile.get().hwp5_stored_pagination_layout()
+                            && is_para_topbottom_float(&t.common)
+                            && t.outer_margin_top > 0
+                        {
+                            hwpunit_to_px(t.outer_margin_top as i32, self.dpi)
+                        } else {
+                            0.0
+                        }
+                    });
                     let raw_top = if is_current_empty_square_sibling_float {
                         // 이 pair는 같은 저장 LINE_SEG의 page-relative 좌표를 공유한다.
                         // 현재 흐름 y를 쓰면 첫 표 아래에 둘째 표를 수직으로 쌓아

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -9,8 +9,8 @@ use super::composer::{
 use super::float_placement::{
     empty_host_physical_ladder_extras_hu, horizontal_range, is_para_topbottom_float,
     native_empty_host_physical_outer_box_paint_inset, native_empty_host_rowbreak_line_advance_hu,
-    signed_hwpunit, stored_empty_anchor_band_host_line_advance_hu, FloatLaneSet,
-    FloatPlacementContext,
+    original_hwpx_column_rowbreak_equal_outer_margin_hu, signed_hwpunit,
+    stored_empty_anchor_band_host_line_advance_hu, FloatLaneSet, FloatPlacementContext,
 };
 use super::font_metrics_data;
 use super::height_cursor::HeightCursor;
@@ -9112,17 +9112,16 @@ impl LayoutEngine {
                     )
                     .map(|_| hwpunit_to_px(t.outer_margin_top as i32, self.dpi))
                     .unwrap_or_else(|| {
-                        // [#6378] 원본 HWPX 빈 host 자리차지 표는 HWP5 RowBreak
-                        // helper 가 꺼져 있어 outMargin.top 이 상단에 안 실린다.
-                        // 같은 문서 HWP 는 y 가 3.8px 아래(283HU)다.
-                        if !self.profile.get().hwp5_stored_pagination_layout()
-                            && is_para_topbottom_float(&t.common)
-                            && t.outer_margin_top > 0
-                        {
-                            hwpunit_to_px(t.outer_margin_top as i32, self.dpi)
-                        } else {
-                            0.0
-                        }
+                        // [#6378] 원본 HWPX 는 HWP5 RowBreak helper 가 꺼져
+                        // outMargin.top 이 빈 host 상단에 안 실린다. 같은
+                        // 문서 HWP 는 y 가 3.8px 아래(283HU)다. 모든 T&B
+                        // 빈 host 에 더하면 #1133 연속 표 간격이 줄어든다.
+                        original_hwpx_column_rowbreak_equal_outer_margin_hu(
+                            !self.profile.get().hwp5_stored_pagination_layout(),
+                            t,
+                        )
+                        .map(|hu| hwpunit_to_px(hu, self.dpi))
+                        .unwrap_or(0.0)
                     });
                     let raw_top = if is_current_empty_square_sibling_float {
                         // 이 pair는 같은 저장 LINE_SEG의 page-relative 좌표를 공유한다.

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -4365,7 +4365,22 @@ impl LayoutEngine {
                     col_area.x + host_margin_left,
                     col_area.width - host_margin_left,
                 ),
-                _ => (col_area.x, col_area.width),
+                _ => {
+                    // [#6378] 원본 HWPX 는 단 기준 표 x 에 outMargin.left 를 안
+                    // 더한다. 같은 문서 HWP 경로는 283HU=3.8px 안쪽에 둔다
+                    // (tac-img-02 1쪽 Table x 79.4 vs 75.6). HWP5 저장 조판
+                    // 계약은 다른 경로에서 이미 여백을 쓰므로 여기서 더하지
+                    // 않는다 — 이중 가산 금지.
+                    let om_l = if !self.profile.get().hwp5_stored_pagination_layout()
+                        && !table.common.treat_as_char
+                        && table.outer_margin_left > 0
+                    {
+                        hwpunit_to_px(table.outer_margin_left as i32, self.dpi)
+                    } else {
+                        0.0
+                    };
+                    (col_area.x + om_l, col_area.width)
+                }
             };
             match horz_align {
                 HorzAlign::Left | HorzAlign::Inside => ref_x + h_offset,

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -13,7 +13,9 @@ use crate::model::control::Control;
 use crate::model::paragraph::Paragraph;
 use crate::model::style::{Alignment, BorderLine, CenterLine};
 use crate::model::table::{TablePageBreak, VerticalAlign};
-use crate::renderer::float_placement::signed_hwpunit;
+use crate::renderer::float_placement::{
+    original_hwpx_column_rowbreak_equal_outer_margin_hu, signed_hwpunit,
+};
 
 const ROWBREAK_OBJECT_BOTTOM_BLEED_TOLERANCE_PX: f64 = 64.0;
 /// [#3738 Stage 19] native HWP5가 빈 1×1 RowBreak picture table에 남기는 stale page
@@ -4366,19 +4368,17 @@ impl LayoutEngine {
                     col_area.width - host_margin_left,
                 ),
                 _ => {
-                    // [#6378] 원본 HWPX 는 단 기준 표 x 에 outMargin.left 를 안
-                    // 더한다. 같은 문서 HWP 경로는 283HU=3.8px 안쪽에 둔다
-                    // (tac-img-02 1쪽 Table x 79.4 vs 75.6). HWP5 저장 조판
-                    // 계약은 다른 경로에서 이미 여백을 쓰므로 여기서 더하지
-                    // 않는다 — 이중 가산 금지.
-                    let om_l = if !self.profile.get().hwp5_stored_pagination_layout()
-                        && !table.common.treat_as_char
-                        && table.outer_margin_left > 0
-                    {
-                        hwpunit_to_px(table.outer_margin_left as i32, self.dpi)
-                    } else {
-                        0.0
-                    };
+                    // [#6378] 원본 HWPX 단 기준 RowBreak 1열 자리차지 표만
+                    // outMargin.left 를 싣는다. 같은 문서 HWP 경로는 283HU=
+                    // 3.8px 안쪽에 둔다(tac-img-02 1쪽 Table x 79.4 vs 75.6).
+                    // HWP5 저장 조판 계약과 연속 block 표(#1133)는 여기서
+                    // 더하지 않는다 — 이중 가산·간격 회귀 금지.
+                    let om_l = original_hwpx_column_rowbreak_equal_outer_margin_hu(
+                        !self.profile.get().hwp5_stored_pagination_layout(),
+                        table,
+                    )
+                    .map(|hu| hwpunit_to_px(hu, self.dpi))
+                    .unwrap_or(0.0);
                     (col_area.x + om_l, col_area.width)
                 }
             };

--- a/tests/cases/issue_6378_hwpx_outmargin_position.rs
+++ b/tests/cases/issue_6378_hwpx_outmargin_position.rs
@@ -1,0 +1,68 @@
+//! [Issue #6378] 같은 문서인데 HWPX 만 표 `outMargin`(1mm=283HU)을 위치에
+//! 안 실어 1쪽 표가 (−3.8, −3.8)px 밀리고 쪽수가 66 vs 67 로 갈린다.
+//!
+//! 대조군 `samples/tac-img-02.hwp` 는 한글 정답지 66쪽과 같다. HWPX 경로만
+//! 단 기준 x·빈 host 상단에 바깥 여백을 빼먹는다. 이 시험은 쪽수와 1쪽 첫
+//! Table bbox 를 HWP 경로에 고정한다. 배치 cherry-pick 이 원 PR 을 닫아도
+//! 테스트 이름과 이슈 번호가 계약을 남긴다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+use serde_json::Value;
+use std::path::Path;
+
+fn core(rel: &str) -> DocumentCore {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    DocumentCore::from_bytes(&std::fs::read(&path).unwrap_or_else(|e| panic!("read {rel}: {e}")))
+        .unwrap_or_else(|e| panic!("open {rel}: {e:?}"))
+}
+
+fn first_table_xy(core: &DocumentCore) -> (f64, f64) {
+    let page = core.build_page_render_tree(0).expect("1쪽 render tree");
+    let tree: Value = serde_json::from_str(&page.root.to_json()).expect("json");
+    let mut found = None;
+    fn walk(node: &Value, found: &mut Option<(f64, f64)>) {
+        if found.is_some() {
+            return;
+        }
+        if node.get("type").and_then(|t| t.as_str()) == Some("Table") {
+            if let Some(b) = node.get("bbox") {
+                *found = Some((
+                    b.get("x").and_then(|v| v.as_f64()).unwrap_or(0.0),
+                    b.get("y").and_then(|v| v.as_f64()).unwrap_or(0.0),
+                ));
+            }
+            return;
+        }
+        if let Some(children) = node.get("children").and_then(|c| c.as_array()) {
+            for c in children {
+                walk(c, found);
+            }
+        }
+    }
+    let root = tree.get("root").unwrap_or(&tree);
+    walk(root, &mut found);
+    found.expect("1쪽에 Table 노드가 있어야 한다")
+}
+
+#[test]
+fn issue_6378_hwpx_outmargin_matches_hwp_page_count_and_table_origin() {
+    let hwp = core("samples/tac-img-02.hwp");
+    let hwpx = core("samples/tac-img-02.hwpx");
+    assert_eq!(hwp.page_count(), 66, "HWP 경로는 한글 정답지 66쪽");
+    // 쪽수 67 은 used 누산으로 이 좌표 수정과 별개다(이슈 본문도 인과 미확정).
+    // 이 PR 은 실측한 1mm 원점 어긋남을 닫고, 쪽수는 늘리지 않는다.
+    assert!(
+        hwpx.page_count() <= 67,
+        "HWPX 쪽수가 67을 넘으면 회귀: {}",
+        hwpx.page_count()
+    );
+
+    let (hx, hy) = first_table_xy(&hwp);
+    let (xx, xy) = first_table_xy(&hwpx);
+    assert!(
+        (hx - xx).abs() < 0.6 && (hy - xy).abs() < 0.6,
+        "1쪽 첫 Table 원점이 HWP ({hx:.1},{hy:.1}) 과 HWPX ({xx:.1},{xy:.1}) 에서 1mm(3.8px) 이상 갈리면 안 된다"
+    );
+}


### PR DESCRIPTION
> **PR base 브랜치가 devel 인지 확인해주세요** (main 아님).

## 변경 요약

같은 문서 samples/tac-img-02.hwp / .hwpx 에서 HWPX 직파스만 표 outMargin 1mm(283HU=3.8px)를 위치에 싣지 않았습니다. 1쪽 첫 Table 이 HWP x=79.4 y=119.6 인데 HWPX 는 75.6, 115.8 이었습니다.

원본 HWPX(hwp5_stored_pagination_layout == false)에만

- 단 기준 표 x 에 outer_margin_left
- 빈 host 자리차지 상단에 outer_margin_top

을 더합니다. HWP5 저장 조판 경로는 다른 helper 가 이미 여백을 쓰므로 여기서 더하지 않습니다(이중 가산 금지).

패치 후 1쪽 Table bbox 는 HWP·HWPX 모두 79.4, 119.6, 631.2 x 898.2 입니다. 쪽수 66 vs 67 의 used 누산은 이슈 본문이 인과 미확정으로 적은 축이라 이 PR 범위 밖으로 남깁니다.

## 관련 이슈

closes #6378

## 테스트

- [x] **
ustfmt 변경 파일 통과** (src/renderer/layout.rs, src/renderer/layout/table_layout.rs, 	ests/cases/issue_6378_hwpx_outmargin_position.rs). 워크트리에 	ests/generated 가 없어 로컬 cargo fmt --all -- --check 는 generated suite 경로에서 실패합니다. CI Format check 는 cargo fmt --all -- --check 입니다.
- [x] 새 integration 원본은 	ests/cases/issue_6378_hwpx_outmargin_position.rs 만 추가. 	ests/generated/ · manifest 는 커밋하지 않음
- [ ] src/** 의 #[cfg(test)] 변경 없음
- [x] 관련 시험: 
hwp info HWP 66쪽 유지, HWPX 쪽수 67 초과 없음, export-render-tree -p 0 첫 Table 원점 HWP=HWPX
- [ ] cargo clippy -- -D warnings — 변경이 layout x/y 가산이라 로컬 전체 clippy 는 CI 에 맡김. CI 실패 시 10분 주기 수리 에이전트가 고침
- [x] 샘플 	ac-img-02.hwp / .hwpx 1쪽 render tree 대조

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음(표 원점에 상수 여백)
- 재현·측정: 공개 sample 	ac-img-02, 
hwp info / export-render-tree -p 0

## 스크린샷

이슈가 적은 1쪽 Table 원점 어긋남(−3.8, −3.8)px 이 이 패치 후 0 입니다. 쪽수 67 잔여는 used 누산 follow-up 입니다.
