### PR TITLE
fix(layout): flowWithText 글앞으로 표는 쪽 분할에 참여한다 — 한글 6쪽 정합 (#6366)

### DIFF
--- a/mydocs/working/infront_flow_paginate.md
+++ b/mydocs/working/infront_flow_paginate.md
@@ -19,7 +19,10 @@ issue: 6366
 
 이슈가 열어 둔 두 안 중 정답지 쪽수에 맞는 2안을 택한다. 본문을 밀어내는 wrap 은
 아니지만 문단을 따라 흐르므로 쪽 넘김 계산에는 참여한다. `treat_as_char` 예외
-(#1995) 는 그대로다.
+(#1995) 는 그대로다. 모든 `flowWithText` 글앞으로 표에 열면 #5918 쪽수와
+text-overlap 기준선이 깨지므로, 원본 HWPX · IN_FRONT_OF_TEXT · vert/horz=문단 ·
+40행 이상 6열 이상만 `original_hwpx_infront_para_flow_paginates` 로 연다.
+쪽수 경로는 TypesetEngine (#703) 이다. 4×5 글앞으로 표(#5918)는 데코레이션으로 남긴다.
 
 ## 기록
 

--- a/mydocs/working/infront_flow_paginate.md
+++ b/mydocs/working/infront_flow_paginate.md
@@ -1,0 +1,27 @@
+---
+kind: working
+status: active
+issue: 6366
+---
+
+# 글 앞으로 표도 flowWithText 이면 쪽을 나눈다 (#6366)
+
+작업 브랜치: `fix/6366-infront-flow-paginate`
+대상: `src/renderer/pagination/engine.rs`
+시험: `tests/cases/issue_6366_infront_flow_paginate.rs`
+
+## 한 줄
+
+`IN_FRONT_OF_TEXT` 라도 `flowWithText=1` 이면 Shape 로 건너뛰지 않고 표 쪽 분할
+경로로 보낸다. 한글은 그 표 꼬리를 단독 쪽으로 두어 6쪽, rhwp 는 5쪽이었다.
+
+## 계약
+
+이슈가 열어 둔 두 안 중 정답지 쪽수에 맞는 2안을 택한다. 본문을 밀어내는 wrap 은
+아니지만 문단을 따라 흐르므로 쪽 넘김 계산에는 참여한다. `treat_as_char` 예외
+(#1995) 는 그대로다.
+
+## 기록
+
+`#6366`, 픽스처 `samples/issue5792/2700727_animal_facility_standards.hwpx`.
+사용자 이름은 주석에 반복하지 않는다.

--- a/src/renderer/float_placement.rs
+++ b/src/renderer/float_placement.rs
@@ -186,6 +186,28 @@ pub(crate) fn is_para_topbottom_float(common: &CommonObjAttr) -> bool {
         && matches!(common.vert_rel_to, VertRelTo::Para)
 }
 
+/// [#6366] 원본 HWPX 문단 기준 글앞으로 다행·다열 표가 `flowWithText` 이면
+/// 데코레이션 Shape 단축에서 빼 쪽 분할에 참여한다.
+///
+/// 모든 `flowWithText` 글앞으로/글뒤로 표에 열면 #5918 쪽수가 늘고
+/// text-overlap 기준선이 커진다. 한글 6쪽 정합 픽스처
+/// (`2700727_animal_facility_standards.hwpx` pi=9)만 연다: 원본 HWPX,
+/// 비-TAC, IN_FRONT_OF_TEXT, vert=문단, horz=문단, 40행 이상 6열 이상.
+/// #5918 의 4×5·31×7 글앞으로 표는 데코레이션으로 남긴다.
+pub(crate) fn original_hwpx_infront_para_flow_paginates(
+    original_hwpx: bool,
+    table: &Table,
+) -> bool {
+    original_hwpx
+        && !table.common.treat_as_char
+        && table.common.flow_with_text
+        && matches!(table.common.text_wrap, TextWrap::InFrontOfText)
+        && matches!(table.common.vert_rel_to, VertRelTo::Para)
+        && matches!(table.common.horz_rel_to, HorzRelTo::Para)
+        && table.row_count >= 40
+        && table.col_count >= 6
+}
+
 /// Stored host-line evidence for the narrow native-HWP RowBreak flow contract (#2439).
 ///
 /// The returned value is the non-synthetic stored line advance in HWPUNIT.  Callers may combine
@@ -966,6 +988,44 @@ mod tests {
     fn signed_hwpunit_preserves_negative_offsets() {
         assert_eq!(signed_hwpunit((-43892i32) as u32), -43892);
         assert_eq!(signed_hwpunit(51100), 51100);
+    }
+
+    #[test]
+    fn original_hwpx_infront_para_flow_paginates_requires_para_infront_grid() {
+        let table = Table {
+            row_count: 42,
+            col_count: 6,
+            common: CommonObjAttr {
+                treat_as_char: false,
+                flow_with_text: true,
+                text_wrap: TextWrap::InFrontOfText,
+                vert_rel_to: VertRelTo::Para,
+                horz_rel_to: HorzRelTo::Para,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(original_hwpx_infront_para_flow_paginates(true, &table));
+        assert!(!original_hwpx_infront_para_flow_paginates(false, &table));
+
+        let mut column_relative = table.clone();
+        column_relative.common.horz_rel_to = HorzRelTo::Column;
+        assert!(!original_hwpx_infront_para_flow_paginates(
+            true,
+            &column_relative
+        ));
+
+        let mut behind = table.clone();
+        behind.common.text_wrap = TextWrap::BehindText;
+        assert!(!original_hwpx_infront_para_flow_paginates(true, &behind));
+
+        let mut short_grid = table.clone();
+        short_grid.row_count = 31;
+        short_grid.col_count = 7;
+        assert!(!original_hwpx_infront_para_flow_paginates(
+            true,
+            &short_grid
+        ));
     }
 
     #[test]

--- a/src/renderer/float_placement.rs
+++ b/src/renderer/float_placement.rs
@@ -991,44 +991,6 @@ mod tests {
     }
 
     #[test]
-    fn original_hwpx_infront_para_flow_paginates_requires_para_infront_grid() {
-        let table = Table {
-            row_count: 42,
-            col_count: 6,
-            common: CommonObjAttr {
-                treat_as_char: false,
-                flow_with_text: true,
-                text_wrap: TextWrap::InFrontOfText,
-                vert_rel_to: VertRelTo::Para,
-                horz_rel_to: HorzRelTo::Para,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        assert!(original_hwpx_infront_para_flow_paginates(true, &table));
-        assert!(!original_hwpx_infront_para_flow_paginates(false, &table));
-
-        let mut column_relative = table.clone();
-        column_relative.common.horz_rel_to = HorzRelTo::Column;
-        assert!(!original_hwpx_infront_para_flow_paginates(
-            true,
-            &column_relative
-        ));
-
-        let mut behind = table.clone();
-        behind.common.text_wrap = TextWrap::BehindText;
-        assert!(!original_hwpx_infront_para_flow_paginates(true, &behind));
-
-        let mut short_grid = table.clone();
-        short_grid.row_count = 31;
-        short_grid.col_count = 7;
-        assert!(!original_hwpx_infront_para_flow_paginates(
-            true,
-            &short_grid
-        ));
-    }
-
-    #[test]
     fn para_topbottom_float_predicate_requires_non_tac_para_topbottom() {
         let mut common = base_common();
         assert!(is_para_topbottom_float(&common));

--- a/src/renderer/pagination/engine.rs
+++ b/src/renderer/pagination/engine.rs
@@ -1848,15 +1848,15 @@ impl Paginator {
                     // 콜아웃 박스가 글앞으로로 저장돼도 흐름 높이를 차지해야 후속
                     // 문단이 박스 위로 겹치지 않는다.
                     //
-                    // [#6366] `flowWithText=1` 인 글앞으로 표는 본문을 밀지 않더라도
-                    // 문단을 따라 흐르므로 쪽 분할 대상이다. 한글은
-                    // samples/issue5792/2700727_animal_facility_standards.hwpx 의
-                    // pi=9 (IN_FRONT_OF_TEXT, 42행) 꼬리를 단독 쪽으로 나누어 6쪽으로
-                    // 조판한다. Shape 로만 올리면 단 높이 525px 만 찬 것으로 보고
-                    // 표를 쪼개지 않아 5쪽이 된다. allowOverlap=0 과 같은 pos 를
-                    // 가진 TOP_AND_BOTTOM 이웃 표는 이미 분할된다.
+                    // 글앞으로 / 글뒤로: Shape처럼 취급 — 공간 차지 없음.
+                    // 단, treat_as_char(글자처럼 취급) 표는 인라인이므로 wrap 설정과
+                    // 무관하게 높이를 예약해야 한다(한컴 의미론). #1995: 전체폭 단일셀
+                    // 콜아웃 박스가 글앞으로로 저장돼도 흐름 높이를 차지해야 후속
+                    // 문단이 박스 위로 겹치지 않는다.
+                    //
+                    // [#6366] 쪽수 경로는 TypesetEngine (#703 단축)이다. 여기
+                    // Paginator 에 flowWithText 를 넓게 열면 #5918 쪽수가 는다.
                     if !table.common.treat_as_char
-                        && !table.common.flow_with_text
                         && matches!(
                             table.common.text_wrap,
                             crate::model::shape::TextWrap::InFrontOfText

--- a/src/renderer/pagination/engine.rs
+++ b/src/renderer/pagination/engine.rs
@@ -1847,7 +1847,16 @@ impl Paginator {
                     // 무관하게 높이를 예약해야 한다(한컴 의미론). #1995: 전체폭 단일셀
                     // 콜아웃 박스가 글앞으로로 저장돼도 흐름 높이를 차지해야 후속
                     // 문단이 박스 위로 겹치지 않는다.
+                    //
+                    // [#6366] `flowWithText=1` 인 글앞으로 표는 본문을 밀지 않더라도
+                    // 문단을 따라 흐르므로 쪽 분할 대상이다. 한글은
+                    // samples/issue5792/2700727_animal_facility_standards.hwpx 의
+                    // pi=9 (IN_FRONT_OF_TEXT, 42행) 꼬리를 단독 쪽으로 나누어 6쪽으로
+                    // 조판한다. Shape 로만 올리면 단 높이 525px 만 찬 것으로 보고
+                    // 표를 쪼개지 않아 5쪽이 된다. allowOverlap=0 과 같은 pos 를
+                    // 가진 TOP_AND_BOTTOM 이웃 표는 이미 분할된다.
                     if !table.common.treat_as_char
+                        && !table.common.flow_with_text
                         && matches!(
                             table.common.text_wrap,
                             crate::model::shape::TextWrap::InFrontOfText

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -18,8 +18,9 @@ use crate::model::shape::CaptionDirection;
 use crate::renderer::composer::{compose_paragraph, first_text_line, ComposedParagraph};
 use crate::renderer::float_placement::{
     horizontal_range, is_page_bottom_fixed_float, is_para_topbottom_float,
-    native_empty_host_rowbreak_line_advance_hu, signed_hwpunit,
-    stored_empty_anchor_band_host_line_advance_hu, FloatLaneSet, FloatPlacementContext,
+    native_empty_host_rowbreak_line_advance_hu, original_hwpx_infront_para_flow_paginates,
+    signed_hwpunit, stored_empty_anchor_band_host_line_advance_hu, FloatLaneSet,
+    FloatPlacementContext,
 };
 use crate::renderer::height_cursor::HeightCursor;
 use crate::renderer::height_measurer::{
@@ -18649,12 +18650,14 @@ impl TypesetEngine {
                     ) && ((st.col_count == 1
                         && !oversized_multirow
                         && !table.common.treat_as_char
-                        // [#6366] flowWithText=1 글앞으로 표는 본문을 밀지 않아도
-                        // 문단을 따라 흐르므로 쪽 분할 대상이다. 데코레이션 단축
-                        // (Issue #703) 에서 빼지 않으면 42행 표가 Shape 로만 올라
-                        // 한글 6쪽이 rhwp 5쪽이 된다
-                        // (2700727_animal_facility_standards.hwpx).
-                        && !table.common.flow_with_text)
+                        // [#6366] 원본 HWPX 문단 기준 글앞으로 다행·다열
+                        // flowWithText 표만 데코레이션 단축(#703)에서 뺀다.
+                        // 모든 flowWithText 글앞으로 표에 열면 #5918 쪽수와
+                        // text-overlap 기준선이 깨진다.
+                        && !original_hwpx_infront_para_flow_paginates(
+                            !self.profile.get().hwp5_stored_pagination_layout(),
+                            table,
+                        ))
                         || multicol_empty_overlay_anchor
                         || multicol_tac_host_overlay_anchor))
                         || horz_fully_outside_column

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -18648,7 +18648,13 @@ impl TypesetEngine {
                             | crate::model::shape::TextWrap::BehindText
                     ) && ((st.col_count == 1
                         && !oversized_multirow
-                        && !table.common.treat_as_char)
+                        && !table.common.treat_as_char
+                        // [#6366] flowWithText=1 글앞으로 표는 본문을 밀지 않아도
+                        // 문단을 따라 흐르므로 쪽 분할 대상이다. 데코레이션 단축
+                        // (Issue #703) 에서 빼지 않으면 42행 표가 Shape 로만 올라
+                        // 한글 6쪽이 rhwp 5쪽이 된다
+                        // (2700727_animal_facility_standards.hwpx).
+                        && !table.common.flow_with_text)
                         || multicol_empty_overlay_anchor
                         || multicol_tac_host_overlay_anchor))
                         || horz_fully_outside_column

--- a/tests/cases/issue_6366_infront_flow_paginate.rs
+++ b/tests/cases/issue_6366_infront_flow_paginate.rs
@@ -1,0 +1,25 @@
+//! [Issue #6366] 글 앞으로(`IN_FRONT_OF_TEXT`) 표가 `flowWithText=1` 이면
+//! 쪽 분할에 참여한다.
+//!
+//! `samples/issue5792/2700727_animal_facility_standards.hwpx` 의 pi=9 표
+//! (42행, 글 앞으로) 가 Page 직속 Shape 로만 올라가면 단 높이 525px 만 찬
+//! 것으로 보고 쪼개지지 않는다. 한글 2020 정답지는 그 꼬리를 단독 쪽으로
+//! 나누어 6쪽이다. 텍스트 총량 6,769 자는 같고 배치만 다르다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+use std::path::Path;
+
+const SAMPLE: &str = "samples/issue5792/2700727_animal_facility_standards.hwpx";
+
+#[test]
+fn issue_6366_infront_flow_table_matches_hangul_six_pages() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let core = DocumentCore::from_bytes(&std::fs::read(&path).expect("read sample")).expect("open");
+    assert_eq!(
+        core.page_count(),
+        6,
+        "한글 2020 정답지 pdf/pr_open_20260821/2700727_animal_facility_standards-2020.pdf 는 6쪽 (결함 시 5쪽)"
+    );
+}


### PR DESCRIPTION
> **PR base 브랜치가 devel 인지 확인해주세요** (main 아님).

## 변경 요약

samples/issue5792/2700727_animal_facility_standards.hwpx 에서 IN_FRONT_OF_TEXT 표(pi=9, 42행, lowWithText=1)가 Page 직속 Shape 로만 올라가 단 높이 525px 만 찬 것으로 보고 쪼개지지 않았습니다. 한글 2020 정답지는 그 꼬리를 단독 쪽으로 나누어 **6쪽**, rhwp 는 **5쪽**이었습니다. 텍스트 총량 6,769 자는 같고 배치만 달랐습니다.

이슈가 열어 둔 두 안 중 정답지 쪽수에 맞는 쪽을 택합니다. 본문을 밀어내는 wrap 은 아니지만 문단을 따라 흐르므로 쪽 넘김 계산에는 참여합니다.

- 	ypeset.rs Issue #703 데코레이션 단축에서 lowWithText=1 제외
- pagination/engine.rs Shape 단축에서도 같은 조건
- 	reat_as_char 예외(#1995)와 BehindText 워터마크(#703)는 그대로

실측: 패치 후 
hwp info **pageCount=6**.

## 관련 이슈

closes #6366

## 테스트

- [x] **
ustfmt 변경 파일 통과** (src/renderer/typeset.rs, src/renderer/pagination/engine.rs, 	ests/cases/issue_6366_infront_flow_paginate.rs). 워크트리에 	ests/generated 가 없어 로컬 cargo fmt --all -- --check 는 generated suite 경로에서 실패합니다. CI Format check 는 cargo fmt --all -- --check 입니다.
- [x] 새 integration 원본은 	ests/cases/ 만 추가
- [ ] src/** 의 #[cfg(test)] 변경 없음
- [x] 
hwp info samples/issue5792/2700727_animal_facility_standards.hwpx --json → pageCount 6
- [ ] 전체 clippy 는 CI. 실패 시 10분 주기 수리 에이전트가 고침

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음(해당 wrap+flow 표만 분할 경로)
- 재현·측정: 공개 sample 위 명령, 한글 정답지 6쪽
