### PR TITLE
fix(parser): HWP3 쪽 테두리 여백 ×4 가 i16 을 넘어도 패닉하지 않는다 (#5196)

### DIFF
--- a/mydocs/working/hwp3_border_margin_overflow.md
+++ b/mydocs/working/hwp3_border_margin_overflow.md
@@ -1,0 +1,21 @@
+---
+kind: working
+status: active
+issue: 5196
+---
+
+# HWP3 쪽 테두리 여백 ×4 가 i16 을 넘어도 패닉하지 않는다 (#5196)
+
+작업 브랜치: `fix/5196-hwp3-border-margin-overflow`
+대상: `src/parser/hwp3/mod.rs`
+
+## 한 줄
+
+`border_margin: u16` 을 `as i16 * 4` 하면 퍼징 입력에서 debug overflow 로
+죽는다. `i32` 로 곱한 뒤 i16 범위에 붙인다.
+
+## 기록
+
+`#5196`, 크래시 `parse_hwp3.rs` / `hwp3/mod.rs:138`.
+새 `#[test]` 를 넣지 않고 기존 `test_hwp3_page_border_fill_is_always_page_basis`
+에 포화 단언만 더했다 (unit-test-tier 총량 동결).

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -124,6 +124,14 @@ fn apply_hwp3_compressed_flag(
     }
 }
 
+/// HWP3 `border_margin` 은 u16 이고 HWP5 간격은 i16 HU(×4)다.
+/// 퍼징 입력(#5196)처럼 여백이 크면 `as i16 * 4` 가 debug overflow 로 패닉한다.
+fn hwp3_border_spacing_hu(margin: u16) -> i16 {
+    i32::from(margin)
+        .saturating_mul(4)
+        .clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16
+}
+
 fn hwp3_page_border_fill(
     doc_info: &Hwp3DocInfo,
     border_fill_id: u16,
@@ -133,10 +141,10 @@ fn hwp3_page_border_fill(
     // Page/BodyBased로 정규화한다. (Task #1129 Stage 24)
     crate::model::page::PageBorderFill {
         attr: 0x01,
-        spacing_left: (doc_info.border_margin_left as i16) * 4,
-        spacing_right: (doc_info.border_margin_right as i16) * 4,
-        spacing_top: (doc_info.border_margin_top as i16) * 4,
-        spacing_bottom: (doc_info.border_margin_bottom as i16) * 4,
+        spacing_left: hwp3_border_spacing_hu(doc_info.border_margin_left),
+        spacing_right: hwp3_border_spacing_hu(doc_info.border_margin_right),
+        spacing_top: hwp3_border_spacing_hu(doc_info.border_margin_top),
+        spacing_bottom: hwp3_border_spacing_hu(doc_info.border_margin_bottom),
         border_fill_id,
         basis: crate::model::page::PageBorderBasis::BodyBased,
         ui_basis: crate::model::page::PageBorderUiBasis::Page,
@@ -5760,6 +5768,20 @@ mod tests {
         assert_eq!(pbf.spacing_bottom, 160);
         assert_eq!(pbf.basis, PageBorderBasis::BodyBased);
         assert_eq!(pbf.ui_basis, PageBorderUiBasis::Page);
+
+        // [#5196] u16 여백 ×4 가 i16 을 넘어도 패닉하지 않는다.
+        let huge = Hwp3DocInfo {
+            border_margin_left: u16::MAX,
+            border_margin_right: u16::MAX,
+            border_margin_top: u16::MAX,
+            border_margin_bottom: u16::MAX,
+            ..Default::default()
+        };
+        let huge_pbf = hwp3_page_border_fill(&huge, 1);
+        assert_eq!(huge_pbf.spacing_left, i16::MAX);
+        assert_eq!(huge_pbf.spacing_right, i16::MAX);
+        assert_eq!(huge_pbf.spacing_top, i16::MAX);
+        assert_eq!(huge_pbf.spacing_bottom, i16::MAX);
     }
 
     #[test]


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).

## 변경 요약

HWP3 `border_margin`(u16)을 HWP5 간격(i16 HU, ×4)으로 바꿀 때 debug overflow 로
패닉했습니다 (`parse_hwp3` 퍼징, #5196). `i32` 로 곱한 뒤 i16 범위에 붙입니다.

## 관련 이슈

closes #5196

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음
- [x] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
- [x] `cargo test` 통과
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오 또는 편집 커맨드 리뷰 체크리스트 통과
- [ ] 작업 증빙 첨부
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시 capability 카탈로그 반영

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음
- 재현·측정: 기존 `test_hwp3_page_border_fill_is_always_page_basis` 에 u16::MAX 포화 단언
