### PR TITLE
fix(hwpx): HWP3 빈 셀 저장 vertsize=1000 을 TAC 표 높이로 덮지 않는다 (#5184)

### DIFF
--- a/mydocs/working/hwp3_empty_cell_vertsize.md
+++ b/mydocs/working/hwp3_empty_cell_vertsize.md
@@ -1,0 +1,22 @@
+---
+kind: working
+status: active
+issue: 5184
+---
+
+# HWP3 빈 셀 vertsize=1000 을 HWPX 왕복에서 지킨다 (#5184)
+
+작업 브랜치: `fix/5184-hwp3-empty-cell-ir`
+대상: `src/document_core/commands/document.rs` TAC host LINE_SEG 확대
+시험: `tests/cases/issue_5184_hwp3_empty_cell_vertsize.rs`
+
+## 한 줄
+
+HWPX 로드 시 TAC 표 높이로 host `line_height` 를 키우는 보정은 **기본
+lh≤100 합성 seg** 에만 적용한다. HWP3 빈 셀의 저장 1000 을 표 높이로
+덮으면 `--verify` 가 실패한다.
+
+## 기록
+
+`#5184`, `samples/hwp3-empty-cell.hwp`. char_shapes 차이는 이 패치 전에
+이미 닫혀 있었고, 남은 축은 paragraph 5·7 vertsize 다.

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -448,7 +448,15 @@ impl DocumentCore {
                             para.line_segs.iter().any(|s| s.line_height >= max_tac_h);
                         if !already_covered {
                             if let Some(seg) = para.line_segs.first_mut() {
-                                if seg.line_height < max_tac_h {
+                                // 주석 계약: linesegarray 가 없어 기본 lh=100 단일
+                                // seg 만 있는 경우에만 확대한다. HWP3 빈 셀 문단은
+                                // 저장 vertsize=1000 을 갖는데 (#5184
+                                // hwp3-empty-cell), 여기까지 확대하면 HWPX 재파싱
+                                // IR 이 표 높이(23476/29096)로 바뀐다.
+                                if seg.line_height > 0
+                                    && seg.line_height <= 100
+                                    && seg.line_height < max_tac_h
+                                {
                                     seg.line_height = max_tac_h;
                                     body_line_seg_changed = true;
                                 }

--- a/tests/cases/issue_5184_hwp3_empty_cell_vertsize.rs
+++ b/tests/cases/issue_5184_hwp3_empty_cell_vertsize.rs
@@ -1,0 +1,33 @@
+//! [Issue #5184] HWP3 빈 셀 문단의 저장 `vertsize=1000` 은 HWPX 왕복에서
+//! 표 높이로 바뀌면 안 된다.
+//!
+//! `samples/hwp3-empty-cell.hwp` 를 HWPX 로 저장해 다시 열면
+//! `paragraph[5].linesegs[0].vertsize` 가 1000→23476,
+//! `paragraph[7]` 이 1000→29096 이 됐다. TAC host LINE_SEG 확대는
+//! 기본 lh=100 합성 seg 에만 적용한다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+use std::path::Path;
+
+const SAMPLE: &str = "samples/hwp3-empty-cell.hwp";
+
+#[test]
+fn issue_5184_hwpx_roundtrip_keeps_hwp3_empty_cell_vertsize() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let orig = DocumentCore::from_bytes(&std::fs::read(path).expect("read sample")).expect("open");
+    let hwpx = orig.export_hwpx_native().expect("export hwpx");
+    let back = DocumentCore::from_bytes(&hwpx).expect("reparse hwpx");
+
+    let orig_sec = &orig.document().sections[0];
+    let back_sec = &back.document().sections[0];
+    for pi in [5usize, 7] {
+        let expected = orig_sec.paragraphs[pi].line_segs[0].line_height;
+        let actual = back_sec.paragraphs[pi].line_segs[0].line_height;
+        assert_eq!(
+            actual, expected,
+            "paragraph[{pi}] linesegs[0].vertsize HWPX 왕복이 표 높이로 바뀌면 안 된다"
+        );
+    }
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).

## 변경 요약

`hwp3-empty-cell.hwp` 를 HWPX 로 저장해 다시 열면 빈 셀 host 문단의 저장
`vertsize=1000` 이 표 높이(23476/29096)로 바뀌었습니다. TAC host LINE_SEG 확대는
주석 계약대로 **기본 lh≤100 합성 seg** 에만 적용합니다.

## 관련 이슈

closes #5184

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음
- [x] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
- [x] `cargo test` 통과
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오 또는 편집 커맨드 리뷰 체크리스트 통과
- [ ] 작업 증빙 첨부
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시 capability 카탈로그 반영

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음
- 재현·측정: `samples/hwp3-empty-cell.hwp` HWPX 왕복 paragraph 5·7 vertsize 1000 유지
