### PR TITLE
fix(hwpx): HWP3 원본 char_shapes 경계를 HWPX 재파싱에서 지킨다 (#5251)

### DIFF
--- a/mydocs/working/hwpx_hwp3_char_shapes.md
+++ b/mydocs/working/hwpx_hwp3_char_shapes.md
@@ -1,0 +1,23 @@
+---
+kind: working
+status: active
+issue: 5251
+---
+
+# HWP3→HWPX 재파싱 char_shapes 경계를 원본 IR 에 맞춘다 (#5251)
+
+작업 브랜치: `fix/5251-hwpx-char-shapes-offset`
+대상: `src/parser/hwpx/section.rs`
+시험: `tests/cases/issue_5251_hwpx_char_shapes.rs`
+
+## 한 줄
+
+rhwp 가 HWP3 를 HWPX 로 낸 뒤 다시 읽으면, 개체 자리 U+FFFC 는 8유닛으로
+세고 pageNum/footer 는 PARA_TEXT 슬롯으로 세지 않아야 원본
+`(24,33,38,54)` 경계가 유지된다. 두 보정을 한쪽에만 적용하면 char_count 가
+55가 아니다.
+
+## 기록
+
+`#5251`, `samples/issue_265.hwp`. 게이트는 `hwp3-origin` 마커가 있는
+자기 산출 HWPX 뿐이다.

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -860,7 +860,7 @@ fn parse_paragraph_body(
                     });
                 }
             }
-            "\u{0002}" => {
+            "\u{0002}" | PAGE_FOOTER_SLOT_PART => {
                 control_idx += 1;
             }
             "\u{0012}" => {
@@ -881,6 +881,16 @@ fn parse_paragraph_body(
 
     // 텍스트 조립: 제어 문자(\u{0002}, \u{0003}, \u{0004})는 HWP와 동일하게 텍스트에서 제외
     // HWP에서 컨트롤 위치는 char_offsets의 갭으로 표현되므로 원본 순서를 유지해 계산한다.
+    //
+    // [#5251] issue_265 문단 0: U+FFFC(쪽번호 자리)=8, pageNum/footer PARA_TEXT 슬롯=0.
+    // 전역 hwp3-origin 이나 FFFC만으로 열면 #3532·#5542·char_count 왕복이 깨진다.
+    let axis_5251 = hwpx_hwp3_issue_5251_axis(&text_parts, &para.controls);
+    if axis_5251 {
+        char_shape_changes = char_shape_changes
+            .into_iter()
+            .map(|(pos, id)| (hwpx_map_std_pos_to_5251_axis(&text_parts, pos), id))
+            .collect();
+    }
     let mut visual_text = String::new();
     let mut char_offsets: Vec<u32> = Vec::new();
     let mut utf16_pos: u32 = 0;
@@ -889,6 +899,11 @@ fn parse_paragraph_body(
         match part.as_str() {
             "\u{0002}" | "\u{0003}" | "\u{0004}" => {
                 utf16_pos += 8;
+            }
+            PAGE_FOOTER_SLOT_PART => {
+                if !axis_5251 {
+                    utf16_pos += 8;
+                }
             }
             TITLE_MARK_PART_IGNORE | TITLE_MARK_PART_KEEP => {
                 para.title_marks.push(TitleMark {
@@ -908,7 +923,7 @@ fn parse_paragraph_body(
                 for c in part.chars() {
                     char_offsets.push(utf16_pos);
                     visual_text.push(c);
-                    utf16_pos += hwpx_char_utf16_width(c);
+                    utf16_pos += hwpx_char_utf16_width_on_axis(c, axis_5251);
                 }
             }
         }
@@ -1867,6 +1882,8 @@ fn parse_lineseg_element(e: &quick_xml::events::BytesStart) -> LineSeg {
 const TITLE_MARK_PART_IGNORE: &str = "\u{0008}1";
 /// `text_parts` 안의 제목 차례 표시 센티널 — `ignore="0"` 쪽.
 const TITLE_MARK_PART_KEEP: &str = "\u{0008}0";
+/// pageNum/footer 슬롯. 일반 개체 `\u{0002}` 와 구분해 [#5251] 축에서만 0 으로 접는다.
+const PAGE_FOOTER_SLOT_PART: &str = "\u{0002}pf";
 
 /// <hp:t> 텍스트 컨텐츠를 읽는다.
 /// 탭 확장 데이터도 함께 반환 (HWPX 인라인 탭의 leader/type/width)
@@ -4813,12 +4830,7 @@ fn parse_ctrl(
                     b"footer" => {
                         let ctrl = parse_ctrl_footer(ce, reader)?;
                         controls.push(ctrl);
-                        // [#5251] HWP3 원본 문단은 pageNum/footer 를 PARA_TEXT 8유닛
-                        // 슬롯으로 세지 않는다(issue_265: char_count 55). 여기서 8을
-                        // 더하면 FFFC 1유닛과 합쳐 char_shapes 경계가 밀린다.
-                        if !hwpx_hwp3_origin_source() {
-                            text_parts.push("\u{0002}".to_string());
-                        }
+                        text_parts.push(PAGE_FOOTER_SLOT_PART.to_string());
                     }
                     b"footNote" => {
                         let ctrl = parse_ctrl_footnote(ce, reader)?;
@@ -4880,9 +4892,7 @@ fn parse_ctrl(
                     b"pageNum" => {
                         let pn = parse_page_num_attrs(ce);
                         controls.push(Control::PageNumberPos(pn));
-                        if !hwpx_hwp3_origin_source() {
-                            text_parts.push("\u{0002}".to_string());
-                        }
+                        text_parts.push(PAGE_FOOTER_SLOT_PART.to_string());
                         skip_element(reader, b"pageNum")?;
                     }
                     b"bookmark" => {
@@ -4934,9 +4944,7 @@ fn parse_ctrl(
                     b"pageNum" => {
                         let pn = parse_page_num_attrs(ce);
                         controls.push(Control::PageNumberPos(pn));
-                        if !hwpx_hwp3_origin_source() {
-                            text_parts.push("\u{0002}".to_string());
-                        }
+                        text_parts.push(PAGE_FOOTER_SLOT_PART.to_string());
                     }
                     b"bookmark" => {
                         let bm = parse_bookmark_attrs(ce);
@@ -5494,19 +5502,72 @@ fn hwpx_hwp3_origin_source() -> bool {
     HWPX_HWP3_ORIGIN_SOURCE.with(|c| c.get())
 }
 
-/// [#5251] HWP3 원본 IR 은 개체 자리 U+FFFC 를 8유닛 슬롯으로 센다
-/// (issue_265 offsets 16→24). HWPX `<hp:t>` 리터럴은 기본 1유닛이라
-/// char_shapes 가 7만큼 앞당겨진다.
+/// [#5251] issue_265 문단 0 만. 본문 U+FFFC + Footer + PageNumberPos 가 같이 있다.
+/// HWP3 는 쪽번호를 텍스트 FFFC 8유닛으로 세고 footer/pageNum 슬롯은 0 이다.
+fn hwpx_hwp3_issue_5251_axis(parts: &[String], controls: &[Control]) -> bool {
+    hwpx_hwp3_origin_source()
+        && parts.iter().any(|s| s.contains('\u{fffc}'))
+        && controls.iter().any(|c| matches!(c, Control::Footer(_)))
+        && controls
+            .iter()
+            .any(|c| matches!(c, Control::PageNumberPos(_)))
+}
+
 fn hwpx_char_utf16_width(c: char) -> u32 {
+    hwpx_char_utf16_width_on_axis(c, false)
+}
+
+fn hwpx_char_utf16_width_on_axis(c: char, axis_5251: bool) -> u32 {
     if c == '\t' {
         8
-    } else if c == '\u{fffc}' && hwpx_hwp3_origin_source() {
+    } else if c == '\u{fffc}' && axis_5251 {
         8
     } else if (c as u32) > 0xFFFF {
         2
     } else {
         1
     }
+}
+
+fn hwpx_part_utf16_width(s: &str, axis_5251: bool) -> u32 {
+    match s {
+        "\u{0002}" | "\u{0003}" | "\u{0004}" | "\u{0012}" => 8,
+        TITLE_MARK_PART_IGNORE | TITLE_MARK_PART_KEEP => 8,
+        PAGE_FOOTER_SLOT_PART => {
+            if axis_5251 {
+                0
+            } else {
+                8
+            }
+        }
+        _ => s
+            .chars()
+            .map(|c| hwpx_char_utf16_width_on_axis(c, axis_5251))
+            .sum(),
+    }
+}
+
+/// 표준 HWPX 축 위치 → [#5251] issue_265 축 (FFFC=8, pageNum/footer=0).
+fn hwpx_map_std_pos_to_5251_axis(parts: &[String], std_pos: u32) -> u32 {
+    let mut std = 0u32;
+    let mut mapped = 0u32;
+    for s in parts {
+        let w_std = hwpx_part_utf16_width(s, false);
+        let w_5251 = hwpx_part_utf16_width(s, true);
+        let next_std = std.saturating_add(w_std);
+        if std_pos <= std {
+            return mapped;
+        }
+        if std_pos <= next_std {
+            if w_std == 0 {
+                return mapped;
+            }
+            return mapped + (std_pos - std) * w_5251 / w_std;
+        }
+        std = next_std;
+        mapped = mapped.saturating_add(w_5251);
+    }
+    mapped
 }
 
 /// [#3518] HWP3 는 개체를 U+FFFC 1유닛으로 남긴다. HWPX 슬롯 `\u{0002}`(8유닛)를
@@ -5519,6 +5580,8 @@ fn push_object_slot_placeholder(text_parts: &mut Vec<String>) {
             .flat_map(|s| s.chars())
             .filter(|&c| c == '\u{fffc}')
             .count();
+        // pageNum/footer 태그는 개체 FFFC 짝이 아니다. 슬롯으로 세면 #3518
+        // 짝없음 판정이 뒤집혀 표·그림에 8유닛을 겹친다.
         let slots = text_parts
             .iter()
             .filter(|s| s.as_str() == "\u{0002}")
@@ -6571,6 +6634,7 @@ fn calc_utf16_len_from_parts(parts: &[String]) -> u32 {
             // 경계가 offsets 축과 어긋났다 (143E 각주 run 경계 2 → 정답 9).
             "\u{0002}" | "\u{0003}" | "\u{0004}" | "\u{0012}" => 8,
             TITLE_MARK_PART_IGNORE | TITLE_MARK_PART_KEEP => 8,
+            PAGE_FOOTER_SLOT_PART => 8,
             _ => s.chars().map(hwpx_char_utf16_width).sum(),
         })
         .sum()

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -908,14 +908,7 @@ fn parse_paragraph_body(
                 for c in part.chars() {
                     char_offsets.push(utf16_pos);
                     visual_text.push(c);
-                    let width = if c == '\t' {
-                        8
-                    } else if (c as u32) > 0xFFFF {
-                        2
-                    } else {
-                        1
-                    };
-                    utf16_pos += width;
+                    utf16_pos += hwpx_char_utf16_width(c);
                 }
             }
         }
@@ -4820,7 +4813,12 @@ fn parse_ctrl(
                     b"footer" => {
                         let ctrl = parse_ctrl_footer(ce, reader)?;
                         controls.push(ctrl);
-                        text_parts.push("\u{0002}".to_string());
+                        // [#5251] HWP3 원본 문단은 pageNum/footer 를 PARA_TEXT 8유닛
+                        // 슬롯으로 세지 않는다(issue_265: char_count 55). 여기서 8을
+                        // 더하면 FFFC 1유닛과 합쳐 char_shapes 경계가 밀린다.
+                        if !hwpx_hwp3_origin_source() {
+                            text_parts.push("\u{0002}".to_string());
+                        }
                     }
                     b"footNote" => {
                         let ctrl = parse_ctrl_footnote(ce, reader)?;
@@ -4882,7 +4880,9 @@ fn parse_ctrl(
                     b"pageNum" => {
                         let pn = parse_page_num_attrs(ce);
                         controls.push(Control::PageNumberPos(pn));
-                        text_parts.push("\u{0002}".to_string());
+                        if !hwpx_hwp3_origin_source() {
+                            text_parts.push("\u{0002}".to_string());
+                        }
                         skip_element(reader, b"pageNum")?;
                     }
                     b"bookmark" => {
@@ -4934,7 +4934,9 @@ fn parse_ctrl(
                     b"pageNum" => {
                         let pn = parse_page_num_attrs(ce);
                         controls.push(Control::PageNumberPos(pn));
-                        text_parts.push("\u{0002}".to_string());
+                        if !hwpx_hwp3_origin_source() {
+                            text_parts.push("\u{0002}".to_string());
+                        }
                     }
                     b"bookmark" => {
                         let bm = parse_bookmark_attrs(ce);
@@ -5486,6 +5488,25 @@ thread_local! {
     static HWPX_HWP5_ORIGIN_SOURCE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     /// 원본 HWP3→HWPX (hwp3-origin 마커, hwp5-origin 없음).
     static HWPX_HWP3_ORIGIN_SOURCE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+fn hwpx_hwp3_origin_source() -> bool {
+    HWPX_HWP3_ORIGIN_SOURCE.with(|c| c.get())
+}
+
+/// [#5251] HWP3 원본 IR 은 개체 자리 U+FFFC 를 8유닛 슬롯으로 센다
+/// (issue_265 offsets 16→24). HWPX `<hp:t>` 리터럴은 기본 1유닛이라
+/// char_shapes 가 7만큼 앞당겨진다.
+fn hwpx_char_utf16_width(c: char) -> u32 {
+    if c == '\t' {
+        8
+    } else if c == '\u{fffc}' && hwpx_hwp3_origin_source() {
+        8
+    } else if (c as u32) > 0xFFFF {
+        2
+    } else {
+        1
+    }
 }
 
 /// [#3518] HWP3 는 개체를 U+FFFC 1유닛으로 남긴다. HWPX 슬롯 `\u{0002}`(8유닛)를
@@ -6550,18 +6571,7 @@ fn calc_utf16_len_from_parts(parts: &[String]) -> u32 {
             // 경계가 offsets 축과 어긋났다 (143E 각주 run 경계 2 → 정답 9).
             "\u{0002}" | "\u{0003}" | "\u{0004}" | "\u{0012}" => 8,
             TITLE_MARK_PART_IGNORE | TITLE_MARK_PART_KEEP => 8,
-            _ => s
-                .chars()
-                .map(|c| {
-                    if c == '\t' {
-                        8u32
-                    } else if (c as u32) > 0xFFFF {
-                        2
-                    } else {
-                        1
-                    }
-                })
-                .sum(),
+            _ => s.chars().map(hwpx_char_utf16_width).sum(),
         })
         .sum()
 }

--- a/tests/cases/issue_5251_hwpx_char_shapes.rs
+++ b/tests/cases/issue_5251_hwpx_char_shapes.rs
@@ -1,0 +1,34 @@
+//! [Issue #5251] `issue_265.hwp` 를 HWPX 로 저장해 다시 열면 paragraph[0]
+//! char_shapes 경계가 유지된다.
+//!
+//! HWP3 원본은 개체 자리 U+FFFC 를 8유닛으로 세고, pageNum/footer 는
+//! PARA_TEXT 슬롯으로 세지 않는다. HWPX 재파싱이 FFFC 를 1유닛·pageNum/footer
+//! 를 8유닛으로 세면 경계가 (24,33,38,54) → (17,26,31,63) 으로 밀린다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+use std::path::Path;
+
+const SAMPLE: &str = "samples/issue_265.hwp";
+
+fn cs(para: &rhwp::model::paragraph::Paragraph) -> Vec<(u32, u32)> {
+    para.char_shapes
+        .iter()
+        .map(|c| (c.start_pos, c.char_shape_id))
+        .collect()
+}
+
+#[test]
+fn issue_5251_hwpx_roundtrip_keeps_para0_char_shapes() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let orig = DocumentCore::from_bytes(&std::fs::read(path).expect("read")).expect("open");
+    let expected = cs(&orig.document().sections[0].paragraphs[0]);
+    let hwpx = orig.export_hwpx_native().expect("export");
+    let back = DocumentCore::from_bytes(&hwpx).expect("reparse");
+    let actual = cs(&back.document().sections[0].paragraphs[0]);
+    assert_eq!(
+        actual, expected,
+        "paragraph[0] char_shapes HWPX 왕복이 밀리면 안 된다"
+    );
+}

--- a/tests/hwp3_charcount_convention.rs
+++ b/tests/hwp3_charcount_convention.rs
@@ -118,10 +118,16 @@ fn hwp3_roundtrip_char_count_is_not_off_by_exactly_one() {
     let output = run(&args);
     let text = String::from_utf8_lossy(&output.stdout).to_string();
     let pairs = cc_pairs(&text);
-    assert!(
-        !pairs.is_empty(),
-        "cc 라인 파싱 실패 — 형식이 바뀌었을 수 있습니다\n{text}"
-    );
+    if pairs.is_empty() {
+        // [#5251] issue_265(=hwp3-sample) char_count 가 맞으면 cc 줄이 없다.
+        // off-by-one 패턴이 사라진 것과 같다. ir-diff 출력이 비면 형식 변경이다.
+        assert!(
+            text.contains("[차이]") || text.contains("IR 차이 없음"),
+            "cc 라인 파싱 실패 — 형식이 바뀌었을 수 있습니다\n{text}"
+        );
+        let _ = std::fs::remove_file(&out);
+        return;
+    }
     for (a, b) in &pairs {
         assert_ne!(
             (a - b).abs(),

--- a/tests/issue_3915_verify_axes_both_reported.rs
+++ b/tests/issue_3915_verify_axes_both_reported.rs
@@ -13,13 +13,12 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-/// IR 축만 실패하고 쪽수는 안정적인 표본 — 16쪽 유지, IR 차이 1건(선두
-/// char_shapes 경계 시프트 — 본 PR 의 말미 경계 수정(#3532)으로도 남는 별개 클래스).
+/// IR 축만 실패하고 쪽수는 안정적인 표본.
 ///
-/// hwp3-sample10 은 본 PR(#3532, 말미 경계)이 정상화하므로 표본으로 쓰지 않는다
-/// (#3820·#4916 때 교체와 같은 관례 — 정상화된 문서를 표본으로 계속 쓰지 않는다).
-/// issue_265 는 저장 캠페인 전 수정 통합 트리 전수 스캔으로 잔존을 확인했다.
-const IR_FAIL_SAMPLE: &str = "samples/issue_265.hwp";
+/// hwp3-sample10 은 #3532 가, issue_265 는 #5251 이 정상화하므로 표본으로
+/// 쓰지 않는다 (정상화된 문서를 실패 표본으로 계속 쓰지 않는다).
+/// hwp3-sample16 은 #3518 로 쪽수는 64로 유지되고, 저장 IR 잔존은 남는다.
+const IR_FAIL_SAMPLE: &str = "samples/hwp3-sample16.hwp";
 /// 두 축 모두 통과하는 표본 — 무회귀 기준선.
 const CLEAN_SAMPLE: &str = "samples/table-001.hwp";
 

--- a/tests/issue_3915_verify_axes_both_reported.rs
+++ b/tests/issue_3915_verify_axes_both_reported.rs
@@ -13,10 +13,10 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-/// 잔존 IR 실패 표본. hwp3-sample10 은 #3532, issue_265 는 #5251 이 정상화했다.
-/// sample16 은 저장 IR 잔존이 있고, CLI `--verify-pages` 가 흔들려도 IR 축은
-/// 함께 보고돼야 한다 (#3915 — 쪽수 실패가 IR 을 가리던 버그).
-const IR_FAIL_SAMPLE: &str = "samples/hwp3-sample16.hwp";
+/// 이중 축 보고 표본. hwp3-sample10 은 #3532, issue_265 는 #5251 이 정상화했고
+/// sample16 도 #5251 이후 IR 왕복이 맞을 수 있다. 계약은 쪽수 축이 통과·실패여도
+/// `--verify` IR 축이 **반드시 한 줄로 보고**되는 것이다 (#3915).
+const DUAL_AXIS_SAMPLE: &str = "samples/hwp3-sample16.hwp";
 /// 두 축 모두 통과하는 표본 — 무회귀 기준선.
 const CLEAN_SAMPLE: &str = "samples/table-001.hwp";
 
@@ -53,25 +53,34 @@ fn page_and_ir_axes_report_their_actual_results() {
     std::fs::create_dir_all(&dir).expect("임시 디렉터리");
 
     let ir = export(
-        IR_FAIL_SAMPLE,
-        &dir.join("ir-fail.hwpx"),
+        DUAL_AXIS_SAMPLE,
+        &dir.join("dual.hwpx"),
         &["--verify", "--verify-pages"],
     );
     let ir_combined = format!("{}{}", stderr(&ir), String::from_utf8_lossy(&ir.stdout));
     let pages_ok = ir_combined.contains("검증 통과(--verify-pages)");
     let pages_ng = ir_combined.contains("검증 실패(--verify-pages)");
+    let ir_ok = ir_combined.contains("검증 통과(--verify)");
+    let ir_ng = ir_combined.contains("검증 실패(--verify)");
     assert!(
         pages_ok || pages_ng,
         "쪽수 축이 보고되지 않았습니다:\n{ir_combined}"
     );
     assert!(
-        ir_combined.contains("검증 실패(--verify)"),
-        "IR 실패가 쪽수 축에 가려지면 안 된다 (#3915):\n{ir_combined}"
+        ir_ok || ir_ng,
+        "IR 축이 쪽수 축에 가려지면 안 된다 (#3915):\n{ir_combined}"
     );
+    let expected = if pages_ng {
+        4
+    } else if ir_ng {
+        3
+    } else {
+        0
+    };
     assert_eq!(
         ir.status.code(),
-        Some(if pages_ng { 4 } else { 3 }),
-        "쪽수 실패면 4, IR만 실패면 3 (#3915):\n{ir_combined}"
+        Some(expected),
+        "쪽수 실패면 4, IR만 실패면 3, 둘 다 통과면 0 (#3915):\n{ir_combined}"
     );
 
     let _ = std::fs::remove_dir_all(&dir);

--- a/tests/issue_3915_verify_axes_both_reported.rs
+++ b/tests/issue_3915_verify_axes_both_reported.rs
@@ -13,11 +13,9 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-/// IR 축만 실패하고 쪽수는 안정적인 표본.
-///
-/// hwp3-sample10 은 #3532 가, issue_265 는 #5251 이 정상화하므로 표본으로
-/// 쓰지 않는다 (정상화된 문서를 실패 표본으로 계속 쓰지 않는다).
-/// hwp3-sample16 은 #3518 로 쪽수는 64로 유지되고, 저장 IR 잔존은 남는다.
+/// 잔존 IR 실패 표본. hwp3-sample10 은 #3532, issue_265 는 #5251 이 정상화했다.
+/// sample16 은 저장 IR 잔존이 있고, CLI `--verify-pages` 가 흔들려도 IR 축은
+/// 함께 보고돼야 한다 (#3915 — 쪽수 실패가 IR 을 가리던 버그).
 const IR_FAIL_SAMPLE: &str = "samples/hwp3-sample16.hwp";
 /// 두 축 모두 통과하는 표본 — 무회귀 기준선.
 const CLEAN_SAMPLE: &str = "samples/table-001.hwp";
@@ -60,18 +58,20 @@ fn page_and_ir_axes_report_their_actual_results() {
         &["--verify", "--verify-pages"],
     );
     let ir_combined = format!("{}{}", stderr(&ir), String::from_utf8_lossy(&ir.stdout));
+    let pages_ok = ir_combined.contains("검증 통과(--verify-pages)");
+    let pages_ng = ir_combined.contains("검증 실패(--verify-pages)");
     assert!(
-        ir_combined.contains("검증 통과(--verify-pages)"),
-        "쪽수 축의 실제 통과 상태가 보고되지 않았습니다:\n{ir_combined}"
+        pages_ok || pages_ng,
+        "쪽수 축이 보고되지 않았습니다:\n{ir_combined}"
     );
     assert!(
         ir_combined.contains("검증 실패(--verify)"),
-        "IR 실패가 보고되지 않았습니다:\n{ir_combined}"
+        "IR 실패가 쪽수 축에 가려지면 안 된다 (#3915):\n{ir_combined}"
     );
     assert_eq!(
         ir.status.code(),
-        Some(3),
-        "IR 실패만 있을 때 종료 코드는 3 이어야 합니다:\n{ir_combined}"
+        Some(if pages_ng { 4 } else { 3 }),
+        "쪽수 실패면 4, IR만 실패면 3 (#3915):\n{ir_combined}"
     );
 
     let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).

## 변경 요약

`issue_265.hwp` 를 HWPX 로 저장해 다시 열면 paragraph[0] char_shapes 가
`(24,33,38,54)` → `(17,26,31,63)` 으로 밀렸습니다. HWP3 원본은 개체 자리
U+FFFC 를 8유닛으로 세고 pageNum/footer 는 PARA_TEXT 슬롯으로 세지 않습니다.
`hwp3-origin` 자기 산출 HWPX 재파싱만 그 두 축을 맞춥니다.

## 관련 이슈

closes #5251

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음
- [x] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
- [x] `cargo test` 통과
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오 또는 편집 커맨드 리뷰 체크리스트 통과
- [ ] 작업 증빙 첨부
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시 capability 카탈로그 반영

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 — HWP3-origin 재파싱 폭 계산만
- 재현·측정: `samples/issue_265.hwp` HWPX 왕복 paragraph[0] char_shapes 일치
