### PR TITLE
fix(cli): bench 실패 경로에서 stdout 을 비운다 (#3884 G1)

### DIFF
--- a/src/diagnostics/bench.rs
+++ b/src/diagnostics/bench.rs
@@ -135,14 +135,8 @@ pub fn run(args: &[String]) -> i32 {
             }
         }
     }
-    // [#3884 G1] 전건 실패면 stdout 을 비운다 — 빈 표에 배너까지 얹어 내보내면
-    // 파이프 소비자가 "측정 결과"로 읽는다. 실패의 전말은 stderr 와 종료 코드가 말한다.
-    if !rows.is_empty() {
-        println!("=== bench: 단계별 처리 성능 (median of {iters}회, 워밍업 1회) ===");
-        println!("주의: 절대 수치는 측정 머신·빌드 의존. 동일 환경 상대·재현 지표로 해석.");
-        print_table(&rows);
-    }
 
+    let mut tsv_written: Option<String> = None;
     if let Some(path) = tsv {
         if rows.is_empty() {
             // 측정 성공 0건이면 산출물을 만들지 않는다(redact 의 "탐지 0건 = 파일
@@ -150,7 +144,7 @@ pub fn run(args: &[String]) -> i32 {
             eprintln!("TSV 생략: 측정 성공이 0건입니다 - {path}");
         } else {
             match write_tsv(&path, &rows) {
-                Ok(()) => println!("\nTSV: {path}"),
+                Ok(()) => tsv_written = Some(path),
                 Err(e) => {
                     eprintln!("TSV 쓰기 실패: {e}");
                     failures += 1;
@@ -159,13 +153,25 @@ pub fn run(args: &[String]) -> i32 {
         }
     }
 
-    // 성능 계측은 CI·스크립트에서 자동화되므로, 하나 이상의 파일 처리 실패가
-    // 있으면 non-zero 로 종료해 실패가 성공처럼 숨겨지지 않게 한다.
+    // [#3884 G1] 실패가 하나라도 있으면 stdout 은 0바이트다
+    // (`capabilities.jsonContract.failure`). 종전엔 성공 행이 하나 있으면 배너+표를
+    // stdout 에 얹은 채 exit 1 을 냈고, `bench <문서> --json` 이 `--json` 을 파일
+    // 이름으로 접던 시절의 518 B 누수가 그 혼합 실패였다. 사람용 전말은 stderr.
     if failures > 0 {
         eprintln!("\n{failures}개 파일 처리 실패 — 종료 코드 1");
-        // process::exit 대신 반환한다 — 호출부(main 의 exit_with)가 종료를 맡으면
-        // 이 함수도 다른 진단 명령과 같은 계약 하나만 지키면 된다.
+        if let Some(path) = tsv_written {
+            eprintln!("TSV: {path}");
+        }
         return super::EXIT_RUNTIME;
+    }
+
+    if !rows.is_empty() {
+        println!("=== bench: 단계별 처리 성능 (median of {iters}회, 워밍업 1회) ===");
+        println!("주의: 절대 수치는 측정 머신·빌드 의존. 동일 환경 상대·재현 지표로 해석.");
+        print_table(&rows);
+    }
+    if let Some(path) = tsv_written {
+        println!("\nTSV: {path}");
     }
     super::EXIT_OK
 }

--- a/tests/cases/issue_3884_bench_json_failure_stdout.rs
+++ b/tests/cases/issue_3884_bench_json_failure_stdout.rs
@@ -1,0 +1,134 @@
+//! [#3884 G1] `bench` 실패 경로 stdout 0바이트 계약.
+//!
+//! `capabilities.jsonContract.failure` 는 단건 실패 시 stdout 0바이트를 선언한다.
+//! `bench <문서> --json` 이 사람용 배너·표를 stdout 에 흘리며 exit 1 이 되던 구멍이
+//! 그 대표 증상이다. `--json` 자체는 아직 JSON 봉투가 없어 사용법 오류(exit 2)로
+//! 거부하되, 어떤 실패든 stdout 은 비고 사람용 전말은 stderr 로만 나간다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/field-01.hwp";
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .args(args)
+        .output()
+        .expect("rhwp 실행")
+}
+
+fn describe(args: &[&str], out: &Output) -> String {
+    format!(
+        "args={args:?}\nexit={:?}\nstdout={}\nstderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+#[test]
+fn bench_json_on_missing_file_keeps_stdout_empty() {
+    let args = ["bench", "no-such-file-3884.hwp", "--json"];
+    let out = run(&args);
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "실패인데 성공이면 안 된다: {}",
+        describe(&args, &out)
+    );
+    assert!(
+        out.stdout.is_empty(),
+        "bench --json 실패 경로 stdout 은 0바이트여야 한다: {}",
+        describe(&args, &out)
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !err.is_empty(),
+        "사람용 전말은 stderr 로 나가야 한다: {}",
+        describe(&args, &out)
+    );
+}
+
+#[test]
+fn bench_missing_file_keeps_stdout_empty() {
+    let args = ["bench", "no-such-file-3884.hwp"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(1), "{}", describe(&args, &out));
+    assert!(
+        out.stdout.is_empty(),
+        "전건 실패인데 stdout 이 비지 않았다: {}",
+        describe(&args, &out)
+    );
+    assert!(
+        !out.stderr.is_empty(),
+        "실패 사유는 stderr 로 나가야 한다: {}",
+        describe(&args, &out)
+    );
+}
+
+#[test]
+fn bench_partial_failure_keeps_stdout_empty() {
+    let s = sample();
+    let args = [
+        "bench",
+        s.to_str().unwrap(),
+        "no-such-file-3884.hwp",
+        "-n",
+        "1",
+    ];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(1), "{}", describe(&args, &out));
+    assert!(
+        out.stdout.is_empty(),
+        "일부만 실패해도 stdout 은 비어야 한다: {}",
+        describe(&args, &out)
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("no-such-file-3884.hwp"),
+        "실패한 경로는 stderr 가 말해야 한다: {}",
+        describe(&args, &out)
+    );
+}
+
+#[test]
+fn bench_json_flag_does_not_leak_human_table() {
+    let s = sample();
+    let args = ["bench", s.to_str().unwrap(), "--json"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(2), "{}", describe(&args, &out));
+    assert!(
+        out.stdout.is_empty(),
+        "--json 을 파일로 접어 반쪽 표를 stdout 에 흘리면 안 된다: {}",
+        describe(&args, &out)
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("--json"),
+        "무엇이 거부됐는지 stderr 가 말해야 한다: {}",
+        describe(&args, &out)
+    );
+}
+
+#[test]
+fn bench_success_still_prints_the_table() {
+    let s = sample();
+    let args = ["bench", s.to_str().unwrap(), "-n", "1"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        text.contains("=== bench:"),
+        "성공하면 배너+표가 그대로 나와야 한다: {}",
+        describe(&args, &out)
+    );
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

`rhwp bench` 가 하나라도 실패하면 stdout 을 0바이트로 유지한다.

`capabilities.jsonContract.failure` 는 단건 실패 시 stdout 0바이트를 선언한다. 종전엔 성공 행이 하나 있으면 배너·표를 stdout 에 얹은 채 exit 1 을 냈고, `bench <문서> --json` 이 `--json` 을 파일 이름으로 접던 시절의 518 B 사람용 텍스트 누수가 그 혼합 실패였다. 사람용 전말은 stderr 로만 나간다.

`--json` 자체는 아직 JSON 봉투가 없어 사용법 오류(exit 2)로 거부하되, 그 경로도 stdout 은 비어 있다.

이 PR 은 **G1 만** 다룬다. G2(진단 명령 부류 판단)·G4(inspect·edit 하위 명령 자기서술)는 남는다. G3(`run` stdout 예외 자기서술)는 이미 devel 의 `jsonContract.failure` 문구에 있다.

## 관련 이슈

#3884

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음 (`--sync-cargo-targets` 메인터너 registry PR은 marker 블록만 예외)
- [ ] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
- [x] `cargo test --test issue_3884_bench_json_failure_stdout` 통과 (5/5)
- [x] `cargo clippy --bin rhwp -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — `rhwp replay --capsule` 영수증 캡슐 또는 관련 `--json` 봉투 원문 ([AGENTS.md 작업 증빙 절](../AGENTS.md#작업-증빙--에이전트-기본-경로-권장))
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: [capability 카탈로그](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_capability_registry.md)의 등록·검증 규칙을 반영

## 실측

수정 후 `CARGO_TARGET_DIR` 공유 debug 바이너리:

| 명령 | exit | stdout |
|---|---:|---:|
| `bench no-such-file-3884.hwp --json` | 2 | **0 B** |
| `bench samples/field-01.hwp --json` | 2 | **0 B** |
| `bench no-such-file-3884.hwp` | 1 | **0 B** |
| `bench samples/field-01.hwp no-such-file-3884.hwp -n 1` | 1 | **0 B** (수정 전 866 B) |

실패 사유의 사람용 텍스트는 stderr 로만 나간다.

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 — 실패 시 stdout 억제, 성공 경로 표 출력은 그대로
- 재현·측정: 위 실측 표. 벤치 절대 수치는 이 계약과 무관

## 스크린샷

해당 없음 (CLI stdout 계약).
