### PR TITLE
test(provenance): JSON 봉투 출처 표지 4건을 tests/cases 실 CLI 로 잠근다 (#3885)

### DIFF
--- a/tests/cases/issue_3885_json_provenance_envelope.rs
+++ b/tests/cases/issue_3885_json_provenance_envelope.rs
@@ -1,0 +1,201 @@
+//! [#3885] 표지는 항상 실린다 — 빠졌던 JSON 봉투 4건을 실 CLI 로 잠근다.
+//!
+//! `provenance::marked` 가 단일 출처다. 이 테스트는 그 helper 를 다시 만들지 않고
+//! `rhwp --json` stdout 을 파싱해 키 존재와 값을 본다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::Value;
+
+/// 검증 숫자(mod 11)를 통과하는 가공 주민등록번호. 실재 인물과 무관하다.
+const VALID_SSN: &str = "900101-1234568";
+const VALID_CARD: &str = "4111-1111-1111-1111";
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+fn repo(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn scratch(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("rhwp-3885-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("작업 디렉터리");
+    dir.join(name)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], out: &Output) -> String {
+    format!(
+        "args={args:?}\nexit={:?}\nstdout={}\nstderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+fn json_of(args: &[&str], out: &Output) -> Value {
+    serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!("stdout 이 JSON 이 아닙니다({e}): {}", describe(args, out)))
+}
+
+fn fields_of(v: &Value) -> Vec<&str> {
+    v["untrustedFields"]
+        .as_array()
+        .unwrap_or_else(|| panic!("untrustedFields 배열 없음: {v}"))
+        .iter()
+        .filter_map(|x| x.as_str())
+        .collect()
+}
+
+fn make_pii_document() -> Option<PathBuf> {
+    let src = repo("samples/field-01.hwp");
+    if !src.exists() {
+        eprintln!("샘플 없음({}) — 건너뜀", src.display());
+        return None;
+    }
+    let out = scratch("pii.hwp");
+    let _ = std::fs::remove_file(&out);
+    let data = format!(
+        r#"{{"작성자":"홍길동 {VALID_SSN}","전화번호":"010-1234-5678","이메일":"hong@example.com","회사명":"카드 {VALID_CARD}"}}"#
+    );
+    let args = [
+        "edit",
+        "fill-fields",
+        src.to_str().unwrap(),
+        "--data",
+        &data,
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let result = run(&args);
+    assert_eq!(
+        result.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &result)
+    );
+    Some(out)
+}
+
+/// 문서를 열지 않는 스키마 명령도 `untrustedContent:false` 를 명시한다.
+/// 키 부재는 "안전"이 아니라 "이 빌드는 표지를 모른다"로 읽힌다.
+#[test]
+fn schema_commands_state_untrusted_content_false() {
+    for cmd in ["export-ir-schema", "export-capabilities-schema"] {
+        let args = [cmd, "--json"];
+        let out = run(&args);
+        assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+        let v = json_of(&args, &out);
+        assert!(
+            v.get("untrustedContent").is_some(),
+            "{cmd}: untrustedContent 키 부재: {v}"
+        );
+        assert_eq!(
+            v["untrustedContent"],
+            Value::Bool(false),
+            "{cmd}: 문서를 열지 않는데 false 가 아닙니다: {v}"
+        );
+        assert_eq!(
+            v["untrustedFields"],
+            Value::Array(Vec::new()),
+            "{cmd}: untrustedFields 가 빈 배열이 아닙니다: {v}"
+        );
+    }
+}
+
+/// `edit redact --dry-run --json` 은 `findings[].raw`(원문 개인정보)를 싣는다.
+/// 그 봉투에 표지가 없으면 S1 계약이 가장 민감한 값에서 무너진다.
+#[test]
+fn redact_dry_run_marks_findings_raw_untrusted() {
+    let Some(doc) = make_pii_document() else {
+        return;
+    };
+    let p = doc.to_str().expect("경로 UTF-8");
+    let args = ["edit", "redact", p, "--dry-run", "--json"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = json_of(&args, &out);
+    assert!(
+        v["findingCount"].as_u64().unwrap_or(0) > 0,
+        "탐지 0건이면 이 가드는 공허하다: {v}"
+    );
+    assert_eq!(
+        v["untrustedContent"],
+        Value::Bool(true),
+        "raw 원문을 싣는 봉투인데 untrustedContent 가 true 가 아닙니다: {v}"
+    );
+    let fields = fields_of(&v);
+    assert!(
+        fields.contains(&"findings[].raw"),
+        "findings[].raw 가 untrustedFields 에 없습니다: {v}"
+    );
+    assert!(
+        fields.contains(&"findings[].masked"),
+        "findings[].masked 가 untrustedFields 에 없습니다: {v}"
+    );
+}
+
+/// `--no-raw` 면 raw 경로가 봉투에 없으므로 표지에서도 빠진다.
+/// masked 는 남아 `untrustedContent:true` 를 유지한다.
+#[test]
+fn redact_no_raw_drops_raw_from_untrusted_fields() {
+    let Some(doc) = make_pii_document() else {
+        return;
+    };
+    let p = doc.to_str().expect("경로 UTF-8");
+    let args = ["edit", "redact", p, "--dry-run", "--json", "--no-raw"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = json_of(&args, &out);
+    assert_eq!(v["untrustedContent"], Value::Bool(true), "{v}");
+    let fields = fields_of(&v);
+    assert!(
+        !fields.contains(&"findings[].raw"),
+        "--no-raw 인데 표지가 findings[].raw 를 주장합니다: {v}"
+    );
+    assert!(fields.contains(&"findings[].masked"), "{v}");
+    if let Some(items) = v["findings"].as_array() {
+        for item in items {
+            assert!(
+                item.get("raw").is_none(),
+                "--no-raw 인데 findings[].raw 가 남아 있습니다: {v}"
+            );
+        }
+    }
+}
+
+/// `edit sanitize --json` 의 `removed[].before` 는 지워진 문서 속성 원문이다.
+#[test]
+fn sanitize_marks_removed_before_untrusted() {
+    let Some(doc) = make_pii_document() else {
+        return;
+    };
+    let p = doc.to_str().expect("경로 UTF-8");
+    let outp = scratch("sanitized.hwp");
+    let o = outp.to_str().expect("경로 UTF-8");
+    let args = ["edit", "sanitize", p, "-o", o, "--json"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = json_of(&args, &out);
+    assert!(
+        v["removedCount"].as_u64().unwrap_or(0) > 0,
+        "제거된 속성이 없으면 이 검사는 공허합니다: {v}"
+    );
+    assert_eq!(v["untrustedContent"], Value::Bool(true), "{v}");
+    let fields = fields_of(&v);
+    assert!(
+        fields.contains(&"removed[].before"),
+        "removed[].before 가 untrustedFields 에 없습니다: {v}"
+    );
+}


### PR DESCRIPTION
> **PR base 브랜치가 devel 인지 확인해주세요** (main 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 upstream/devel 에서 생성합니다.

## 변경 요약

`capabilities` 의 `jsonContract.provenance.policy` 는 **"표지는 항상 실린다"** 고 선언한다. #3885 가 실측한 구멍은 `edit redact --dry-run --json`(원문 개인정보 `findings[].raw`), `edit sanitize --json`(`removed[].before`), 문서를 열지 않는 `export-ir-schema --json` / `export-capabilities-schema --json` 이었다.

방출부는 이미 `provenance::marked` 단일 출처를 탄다. `tests/provenance_contract.rs` 드리프트 가드도 이 4건을 스윕한다. 이슈가 열린 채로 남은 이유는 **이슈 번호가 붙은 tests/cases 실 CLI 잠금이 없어** 표지 회귀를 기여자 게이트가 이슈와 직접 묶지 못해서다.

이 PR 은 helper 를 새로 만들지 않는다. `rhwp --json` stdout 을 파싱해 아래를 고정한다.

| 명령 | 표지 |
|---|---|
| `edit redact --dry-run --json` | `untrustedContent:true`, `untrustedFields` 에 `findings[].raw`·`findings[].masked` |
| `edit redact --dry-run --json --no-raw` | raw 경로는 표지에서도 탈락, masked 는 유지 |
| `edit sanitize --json` | `untrustedContent:true`, `removed[].before` |
| `export-ir-schema --json` | `untrustedContent:false` |
| `export-capabilities-schema --json` | `untrustedContent:false` |

`findings[].raw` 의 별도 민감도 신호("로그에 남기지 마라")는 이슈가 열어 둔 판단 지점 그대로 둔다. 이 PR 은 문서 파생 = untrusted 선언까지만 잠근다.

## 관련 이슈

closes #3885

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨)
- [x] 새 integration test 원본은 `tests/cases/issue_3885_json_provenance_envelope.rs` 만 추가. `tests/generated/`, `tests/suites/manifest.json`, Cargo generated test target 미포함
- [ ] `src/**` 의 `#[cfg(test)]` 변경 없음 — rust-unit-test-tiers 해당 없음
- [x] `cargo test --test regression_suite_013 issue_3885` — 4 passed (schema false / redact raw / redact --no-raw / sanitize)
- [ ] `cargo clippy -- -D warnings` 통과 — 해당 없음 (테스트 원본만 추가)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 시 e2e — 해당 없음
- [ ] `.claude/agents/`·스킬 변경 없음

### 실측 (`rhwp --json`, python json)

| 명령 | untrustedContent | untrustedFields |
|---|---|---|
| `export-ir-schema --json` | `false` | `[]` |
| `export-capabilities-schema --json` | `false` | `[]` |
| `edit redact --dry-run --json` | `true` | `findings[].raw`, `findings[].masked` |
| `edit sanitize --json` | `true` | `removed[].before` |

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (엔진·렌더·CLI 방출 경로 미수정)
- 재현·측정: 위 4 명령의 `--json` stdout 을 python/json 으로 파싱해 키 존재를 확인했다.

## 스크린샷

해당 없음.

## 하지 않은 것

- `provenance::marked` 를 복제하는 두 번째 봉투 작성기 없음
- `tests/provenance_contract.rs` 미수정 (가드가 이미 이 4건을 본다)
- `src/` 미수정
- `tests/generated` 미커밋
- 민감도 축 신설 없음 (`--no-raw` 가 raw 를 빼는 기존 수단)
