### PR TITLE
ci: exact kerning fixture generator의 Render Diff 선택 분류를 등록한다

### DIFF
--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -24,6 +24,7 @@ on:
       - 'scripts/ci-impact-classifier.cjs'
       - 'scripts/generate_font_glyph_payload_fixture.py'
       - 'scripts/generate_exact_face_collection_fixture.py'
+      - 'scripts/generate_exact_kerning_fixture.py'
       - 'scripts/generate_font_native_hwpx_fixture.py'
       - 'scripts/requirements-font-fixtures.txt'
       - 'samples/render-p35-font-native-bitmap.hwpx'

--- a/scripts/ci-impact-classifier.cjs
+++ b/scripts/ci-impact-classifier.cjs
@@ -71,6 +71,7 @@ const RENDER_TOOL_PATHS = new Set([
   'scripts/renderer_baseline_manifest.json',
   'scripts/generate_font_glyph_payload_fixture.py',
   'scripts/generate_exact_face_collection_fixture.py',
+  'scripts/generate_exact_kerning_fixture.py',
   'scripts/generate_font_native_hwpx_fixture.py',
   'scripts/requirements-font-fixtures.txt',
   'samples/render-p35-font-native-bitmap.hwpx',

--- a/scripts/ci-impact-policy.cjs
+++ b/scripts/ci-impact-policy.cjs
@@ -125,6 +125,7 @@ const RENDER_DIFF_PULL_REQUEST_PATHS = [
   'scripts/ci-impact-classifier.cjs',
   'scripts/generate_font_glyph_payload_fixture.py',
   'scripts/generate_exact_face_collection_fixture.py',
+  'scripts/generate_exact_kerning_fixture.py',
   'scripts/generate_font_native_hwpx_fixture.py',
   'scripts/requirements-font-fixtures.txt',
   'samples/render-p35-font-native-bitmap.hwpx',

--- a/scripts/tests/ci-impact-classifier.test.cjs
+++ b/scripts/tests/ci-impact-classifier.test.cjs
@@ -246,6 +246,7 @@ test('Native Skia integration test and support changes run Rust and Native Skia 
 test('Rust test input changes keep default Rust tests alongside render gates', () => {
   for (const filename of [
     'tests/fixtures/fonts/RHWPExactFaceSmoke.ttc',
+    'tests/fixtures/fonts/RHWPExactKerningSmoke.ttf',
     'ttfs/opensource/NotoSansKR-Regular.ttf',
     'samples/render-p35-font-native-bitmap.hwpx',
   ]) {
@@ -267,6 +268,7 @@ test('frontend font assets and render tooling do not over-enable the Rust lane',
   for (const filename of [
     'assets/fonts/NotoSansKR-Regular.woff2',
     'scripts/generate_exact_face_collection_fixture.py',
+    'scripts/generate_exact_kerning_fixture.py',
     'docs/text-ir-v2.md',
   ]) {
     const result = classifyChanges({

--- a/scripts/tests/ci-impact-policy.test.cjs
+++ b/scripts/tests/ci-impact-policy.test.cjs
@@ -486,6 +486,8 @@ test('mirrored trigger contracts match CI, CodeQL, and Render Diff workflows', (
   assert.equal(workflowRunExpected('CI', [{ filename: 'samples/new-reference.hwp' }]), true);
   assert.equal(workflowRunExpected('CodeQL', [{ filename: 'samples/new-reference.hwp' }]), true);
   assert.equal(workflowRunExpected('Render Diff', [{ filename: 'rhwp-studio/tests/a.ts' }]), true);
+  assert.equal(workflowRunExpected('Render Diff', [{ filename: 'scripts/generate_exact_face_collection_fixture.py' }]), true);
+  assert.equal(workflowRunExpected('Render Diff', [{ filename: 'scripts/generate_exact_kerning_fixture.py' }]), true);
   assert.equal(workflowRunExpected('Render Diff', [{ filename: 'src/cli/document_io.rs' }]), true);
   assert.equal(workflowRunExpected('Render Diff', [{ filename: 'src/cli/commands/caption_validation.rs' }]), false);
   assert.equal(workflowRunExpected('Render Diff', [{ filename: 'src/cli/outputs/mod.rs' }]), true);

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -590,6 +590,21 @@ class CiImpactWorkflowTests(unittest.TestCase):
         self.assertIn("pr-base-trusted", self.preflight)
         self.assertNotIn("pr-base-trusted-shadow", self.preflight)
 
+    def test_font_fixture_generators_are_registered_as_render_tools(self) -> None:
+        classifier = CLASSIFIER_PATH.read_text(encoding="utf-8")
+        tool_block = classifier.split("const RENDER_TOOL_PATHS = new Set([", maxsplit=1)[1].split(
+            "]);",
+            maxsplit=1,
+        )[0]
+        for expected in (
+            "scripts/generate_font_glyph_payload_fixture.py",
+            "scripts/generate_exact_face_collection_fixture.py",
+            "scripts/generate_exact_kerning_fixture.py",
+            "scripts/generate_font_native_hwpx_fixture.py",
+        ):
+            with self.subTest(path=expected):
+                self.assertIn(f"'{expected}'", tool_block)
+
     def test_missing_classifier_checkout_cannot_claim_trusted_authority(self) -> None:
         self.assertIn(
             "const classifierPath = path.join(\n"

--- a/scripts/tests/test_render_diff_workflow.py
+++ b/scripts/tests/test_render_diff_workflow.py
@@ -19,6 +19,8 @@ class RenderDiffTriggerPolicyTests(unittest.TestCase):
         self.assertIn("      - 'src/renderer/**'", pull_request_trigger)
         self.assertIn("      - 'rhwp-studio/**'", pull_request_trigger)
         self.assertIn("      - 'scripts/ci-impact-classifier.cjs'", pull_request_trigger)
+        self.assertIn("      - 'scripts/generate_exact_face_collection_fixture.py'", pull_request_trigger)
+        self.assertIn("      - 'scripts/generate_exact_kerning_fixture.py'", pull_request_trigger)
         self.assertNotIn("'mydocs/**'", pull_request_trigger)
 
     def test_canvas_uses_the_base_classifier_render_axis(self) -> None:

--- a/scripts/tests/test_review_only_fast_pass_workflows.py
+++ b/scripts/tests/test_review_only_fast_pass_workflows.py
@@ -65,6 +65,25 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
                 self.assertNotIn("filename.endsWith('.hwp')", sample_function)
                 self.assertNotIn("filename.endsWith('.hwpx')", sample_function)
 
+    def test_font_fixture_generators_are_not_review_only_or_enforcement_surface(self) -> None:
+        for name, workflow_path in WORKFLOWS.items():
+            with self.subTest(workflow=name):
+                workflow = workflow_path.read_text(encoding="utf-8")
+                execution = workflow.split(
+                    "function isCiExecutionPath(filename)", maxsplit=1
+                )[1].split("function latestRun", maxsplit=1)[0]
+                self.assertNotIn("generate_exact_kerning_fixture.py", execution)
+                self.assertNotIn("generate_exact_face_collection_fixture.py", execution)
+
+        pull_request_trigger = WORKFLOWS["render-diff"].read_text(encoding="utf-8").split(
+            "  workflow_dispatch:",
+            maxsplit=1,
+        )[0]
+        self.assertIn(
+            "      - 'scripts/generate_exact_kerning_fixture.py'",
+            pull_request_trigger,
+        )
+
     def test_base_advance_does_not_invalidate_a_trailing_review_record(self) -> None:
         for name, workflow_path in WORKFLOWS.items():
             with self.subTest(workflow=name):


### PR DESCRIPTION
## 변경 요약

PR #6214에서 제품 source와 함께 넣지 않았던 `scripts/generate_exact_kerning_fixture.py` Render Diff 선택 분류를 기존 font fixture generator와 같은 운영 경로에 등록합니다.

- classifier `RENDER_TOOL_PATHS`에 generator를 등록해 generator-only 변경이 Rust lane을 켜지 않고 Render Diff·Native Skia를 선택합니다.
- policy `RENDER_DIFF_PULL_REQUEST_PATHS`와 `.github/workflows/render-diff.yml` pull_request paths를 동기화합니다.
- 추적 TTF(`tests/fixtures/fonts/RHWPExactKerningSmoke.ttf`)는 기존대로 rust-test-input으로 Rust·Render Diff·Native Skia를 모두 실행합니다.

## 관련 이슈

closes #6215

## 테스트

- [x] **`cargo fmt --all -- --check`** — 워크트리에 `tests/generated`가 없어 전체 게이트는 generated 파일 부재로 종료했습니다. 이 PR은 `.rs`를 건드리지 않았고, 변경 파일은 모두 Unix LF입니다 (`crlf=0`).
- [x] 새 integration test는 `tests/cases/*.rs`에 추가하지 않았고 `tests/generated/`를 커밋하지 않음
- [x] `src/**`의 `#[cfg(test)]`를 변경하지 않음
- [x] classifier/policy Node 계약: `node --test scripts/tests/ci-impact-classifier.test.cjs` (41 pass), `node --test scripts/tests/ci-impact-policy.test.cjs` (35 pass)
- [x] CI·Render Diff·review-only Python 계약: `python -m unittest scripts/tests/test_ci_impact_workflow.py scripts/tests/test_render_diff_workflow.py scripts/tests/test_review_only_fast_pass_workflows.py` (63 pass)
- [ ] `cargo clippy -- -D warnings` — 해당 없음 (Rust 제품 코드 변경 없음)
- [ ] 관련 샘플 SVG — 해당 없음 (kerning 제품/fixture bytes 비범위)

## Full CI와 후속 review 기록 정책

이 PR은 `.github/workflows/render-diff.yml`과 `scripts/ci-impact-classifier.cjs`·`scripts/ci-impact-policy.cjs`를 바꾸므로 classifier/workflow 계약 변경입니다. preflight는 `fail-closed:classifier-contract` / `fail-closed:workflow-contract`로 **Full CI**를 선택합니다. 이번 enforcement 등록 PR 자체는 선택 분류가 아니라 전체 검증이 맞습니다.

후속 review 기록(`mydocs/**`)은 Render Diff trigger에서 계속 제외됩니다(#3559). generator 자체는 `isCiExecutionPath`가 아니므로, 이 등록이 병합된 뒤 generator-only PR의 trailing review-only commit이 current-head Full CI를 강제하지 않습니다.

## 검증 명령

```
node --test scripts/tests/ci-impact-classifier.test.cjs
# 41 pass, exit 0

node --test scripts/tests/ci-impact-policy.test.cjs
# 35 pass, exit 0

python -m unittest scripts/tests/test_ci_impact_workflow.py scripts/tests/test_render_diff_workflow.py scripts/tests/test_review_only_fast_pass_workflows.py
# 63 pass, exit 0
```
