### PR TITLE
test: 표 행 컷 0.1px 관용이 0.07px 코드줄 이월을 흡수함을 핀한다 (#6368)

### DIFF
--- a/tests/cases/issue_6368_row_cut_fp_epsilon.rs
+++ b/tests/cases/issue_6368_row_cut_fp_epsilon.rs
@@ -1,0 +1,72 @@
+//! [Issue #6368] 표 행 컷 기본 용량 비교의 부동소수 끝자리 관용.
+//!
+//! `samples/hwpctl_API_v2.4.hwp` Example 코드 상자(1×1 RowBreak 표)의 마지막
+//! 코드 줄은 유닛 합 vs 예산이 **0.07px대** 초과다(이슈 서술 0.07px, RHWP_DIAG_6368
+//! 실측 0.0267px). 관용이 0이면 그 줄만 13쪽 머리의 고아로 이월된다
+//! (p12→13 table_fragment 24자). 현재 devel 의
+//! `ROW_CUT_CAPACITY_FP_EPSILON_PX = 0.1` 은 그 끝자리만 흡수해 한글처럼 12쪽에
+//! 남긴다. 0.5px 로 올리면 실제 경계 초과(giant_cell 0.1867px · issue2439 0.4px)
+//! 까지 삼키므로 이 핀은 관용 폭을 키우지 않는다.
+//!
+//! 한글 정답지 총쪽수 105는 유지해야 한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+
+const SAMPLE: &str = "samples/hwpctl_API_v2.4.hwp";
+/// 한컴 정답지 12쪽에 남는 Example 코드 상자 마지막 줄.
+const LAST_CODE_LINE: &str = r#"tbset.SetItem("Cols", 5);"#;
+const HANGUL_PAGE_COUNT: u32 = 105;
+
+fn load_doc() -> DocumentCore {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    DocumentCore::from_bytes(&fs::read(&path).expect("read sample")).expect("open")
+}
+
+fn page_text(doc: &DocumentCore, page: u32) -> String {
+    doc.extract_page_text_native(page)
+        .unwrap_or_else(|e| panic!("{}쪽 텍스트 추출: {e}", page + 1))
+}
+
+fn first_nonempty_line(text: &str) -> &str {
+    text.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("")
+}
+
+#[test]
+fn issue_6368_hwpctl_api_example_last_line_stays_on_page_12() {
+    let doc = load_doc();
+    assert_eq!(
+        doc.page_count(),
+        HANGUL_PAGE_COUNT,
+        "#6368: 행 컷 0.1px 관용은 한글 총쪽수 105를 건드리면 안 된다"
+    );
+
+    let page12 = page_text(&doc, 11);
+    let page13 = page_text(&doc, 12);
+
+    assert!(
+        page12.contains(LAST_CODE_LINE),
+        "#6368: 0.07px 초과 코드줄이 12쪽에 남아야 한다 \
+         (관용 0이면 13쪽으로 이월)\n--- 12쪽 ---\n{page12}"
+    );
+    // 같은 문서 13쪽 Remarks 예제에도 `SetItem("Cols", 5)` 가 다시 나온다.
+    // 결함은 "12쪽 마지막 줄이 13쪽 **머리**의 고아로 이월" 이므로 첫 줄만 본다.
+    assert_ne!(
+        first_nonempty_line(&page13),
+        LAST_CODE_LINE,
+        "#6368: 12쪽 마지막 코드줄이 13쪽 머리의 고아로 이월되면 안 된다\n\
+         --- 13쪽 ---\n{page13}"
+    );
+    assert_eq!(
+        first_nonempty_line(&page13),
+        r#"var table = HwpCtrl.InsertCtrl("tbl", tbset);"#,
+        "#6368: 한글 정답지처럼 13쪽은 Example 다음 줄로 시작해야 한다\n\
+         --- 13쪽 ---\n{page13}"
+    );
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

`ROW_CUT_CAPACITY_FP_EPSILON_PX = 0.1` 은 이미 devel 에 있습니다 (#6369 → 통합 #6397). 이 PR은 레이아웃을 바꾸지 않고, 그 0.1px 관용이 **0.07px대 초과 코드줄을 12쪽에 남기는** 계약을 회귀 테스트로 고정합니다.

- 표본: `samples/hwpctl_API_v2.4.hwp`
- 12쪽에 `tbset.SetItem("Cols", 5);` 가 남아야 한다 (관용 0이면 13쪽 머리로 이월)
- 13쪽 첫 줄은 Example 다음 줄 `var table = HwpCtrl.InsertCtrl("tbl", tbset);`
- 한글 총쪽수 105 유지
- 관용을 0.5px 로 **올리지 않음** (giant_cell 0.1867px · issue2439 0.4px 실초과를 삼키기 때문)

잔여 8개 쪽 경계 표류는 이 컷 경로를 지나지 않는 별개 근인이라 범위 밖입니다.

## 관련 이슈

closes #6368

(이미 병합된 0.1px 관용이 이슈의 0.07px 구멍을 닫았고, 이 PR이 그 경계를 핀합니다.)

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (이 워크트리는 `tests/generated` 가 없어 `--all` 이 해당 경로에서 실패한다. 신규 파일만 `rustfmt --edition 2021 --config newline_style=Unix --check` 로 확인, Unix LF)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음 (`--sync-cargo-targets` 메인터너 registry PR은 marker 블록만 예외)
- [ ] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요) — src 미변경
- [x] `cargo test` 통과 — `cargo test --test issue_6368_row_cut_fp_epsilon` **1 passed / 1.99s** (로컬 임시 `[[test]]` 로 실행 후 Cargo.toml 원복, 커밋에 없음)
- [ ] `cargo clippy -- -D warnings` 통과 — src 미변경, 전체 clippy 미실행
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 레이아웃 변경 없음, 텍스트 소유만 핀
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — `rhwp replay --capsule` 영수증 캡슐 또는 관련 `--json` 봉투 원문 ([AGENTS.md 작업 증빙 절](../AGENTS.md#작업-증빙--에이전트-기본-경로-권장))
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: [capability 카탈로그](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_capability_registry.md)의 등록·검증 규칙을 반영

> `node scripts/rust-test-suite-manifest.mjs --prepare`와 이어지는 `--check`는 파생 suite를
> 준비한 PR review worktree와 CI의 절차입니다. 일반 기여자의 source PR checkout에서는
> 실행하거나 결과를 커밋하지 마세요. 새 `tests/cases/*.rs` 원본은 검토·CI에서 weight 기준으로
> 자동 배정됩니다. 상세 절차는 [CONTRIBUTING.md](../CONTRIBUTING.md)를 따릅니다.

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (테스트만 추가, 조판 경로 불변)
- 재현·측정: `samples/hwpctl_API_v2.4.hwp` 페이지 추출 1.99s. 관용 상수는 0.1 유지.

## 스크린샷

레이아웃 변경 없음. 시각 증적은 통합 검토 #6397 / [PR #6369 review](https://github.com/edwardkim/rhwp/blob/devel/mydocs/pr/archives/pr_6369_review.md) 에 이미 있습니다.
