### PR TITLE
fix(ir-diff): 쪽수가 다르면 identical:true를 내지 않는다 (#4658)

### DIFF
--- a/mydocs/manual/agent_knowledge_map.md
+++ b/mydocs/manual/agent_knowledge_map.md
@@ -148,7 +148,7 @@ IR·provenance·plan 네 축을 한 번에 조립하고, 빠진 축은 `missingA
 
 | 하려는 일 | 명령 (MCP 도구) | 판정 필드 | 권위 |
 |---|---|---|---|
-| 두 문서 IR 차이 | `ir-diff --json` (`hwp_ir_diff`) | `identical`·`diffCount`·`categories` | [ir-diff 매뉴얼](ir_diff_command.md) |
+| 두 문서 IR 차이 | `ir-diff --json` (`hwp_ir_diff`) | `identical`·`diffCount`·`categories`·`pageCountA`·`pageCountB` | [ir-diff 매뉴얼](ir_diff_command.md) |
 | 라운드트립 시각 회귀 | `render-diff --json` (`hwp_render_diff`) | `status`·`maxDisp`·`regression` | [CLI 매뉴얼](cli_commands.md) §render-diff |
 | 조판 결과 덤프 | `dump-pages --json` | `pages[].columns[].items[]` | [dump 매뉴얼](dump_command.md) |
 | IR 모양 코드 생성 | `export-ir-schema --json` | `schema`·`definitionCount` | [CLI 매뉴얼](cli_commands.md) |
@@ -686,7 +686,7 @@ IR·provenance·plan 네 축을 한 번에 조립하고, 빠진 축은 `missingA
 
 | 필드 | 타입 | 의미 · `null` 의 뜻 | 등장 명령 |
 |---|---|---|---|
-| `identical` | bool | IR 이 같은가. **차이는 오류가 아니라 데이터(exit 3)** | `ir-diff`·`verify` 안 |
+| `identical` | bool | IR 필드와 `pageCount` 가 같은가. 쪽수가 달라도 false. **차이는 오류가 아니라 데이터(exit 3)** | `ir-diff`·`verify` 안 |
 | `diffCount` | number | 차이 개수 | `ir-diff`·`verify` 안 |
 | `categories` | object | 차이의 분류별 개수 — 키 이름 자체가 문서 파생일 수 있다 | `ir-diff` |
 | `status` | string | `render-diff` 판정(`OK`·`OVER` 등) | `render-diff` |
@@ -701,7 +701,7 @@ IR·provenance·plan 네 축을 한 번에 조립하고, 빠진 축은 `missingA
 | `worstPage` | number | 최대 변위가 난 쪽 | `render-diff` |
 | `overPages` | number | 임계를 넘은 쪽 수 | `render-diff` |
 | `structPages` / `hardStructPages` | number | 구조 불일치 쪽 수 / 그중 완화 규칙으로도 못 넘긴 쪽 수 | `render-diff` |
-| `pageCountA` / `pageCountB` | number | 양쪽 쪽 수 | `render-diff` |
+| `pageCountA` / `pageCountB` | number | 양쪽 쪽 수. `ir-diff` 는 `info --json` 과 같은 조판 쪽수 | `render-diff`·`ir-diff` |
 | `pageCountMismatch` | bool | 쪽 수가 다른가 | `render-diff` |
 | `pageFilter` | number\|null | `-p` 로 좁혔나. `null` = 전 쪽 | `render-diff`·`dump-pages`·`layout-anomaly` |
 | `strict` | bool | 확정 이상 신호를 종료 코드 3으로 취급할지. 빈 쪽 신호는 `true`여도 실패시키지 않는다 | `layout-anomaly` |

--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -1561,8 +1561,10 @@ HML 원본 문서를 의미 보존 HWPML 2.91 XML로 저장한다.
 두 파일의 IR 비교(HWPX↔HWP 불일치 검출). 상세: [ir_diff_command.md](ir_diff_command.md)
 - 비교: text, char_count/offsets/shapes, line_segs, controls, tab_extended, ParaShape, TabDef,
   표(page_break/outer_margin/treat_as_char/wrap/size/offset), 그림·도형(rel_to 등)
-- `--json` (#3274): 판정 봉투 **한 줄** JSON 을 stdout 으로 —
-  `{"schemaVersion":"1.0","a","b","identical","diffCount","categories":{카테고리:건수}}`.
+- `--json` (#3274, #4658): 판정 봉투 **한 줄** JSON 을 stdout 으로 —
+  `{"schemaVersion":"1.0","a","b","identical","diffCount","categories":{카테고리:건수},"pageCountA","pageCountB"}`.
+  `pageCountA`/`pageCountB` 는 `info --json` 과 같은 조판 쪽수다. IR 필드가 같아도
+  쪽수가 다르면 `identical:false` 이고 `categories.pageCount` 가 1 이다 (IR 동일 ≠ 조판 동일).
   종료 코드 0=동일 / **3=차이 발견**(위 "종료 코드 (#2707)" 표의 "IR 차이 검출" 코드와 동일 의미) /
   1=읽기·파싱 실패(stdout 0바이트) / 2=사용법 오류 → 변환 파이프라인 게이트:
   `rhwp ir-diff 원본.hwp 변환본.hwpx --json || 격리처리`

--- a/mydocs/manual/ir_diff_command.md
+++ b/mydocs/manual/ir_diff_command.md
@@ -37,7 +37,7 @@ rhwp ir-diff <파일A> <파일B> [-s <구역>] [-p <문단>] [--summary] [--max-
 | `--para <번호>` | `-p` | 특정 문단만 비교 (0부터 시작) |
 | `--summary` |  | 카테고리별 차이 카운트만 출력 (paragraph 헤더 + 개별 차이 라인 생략). **`--json` 병용 시 JSON 이 이겨** 카운트 텍스트는 출력하지 않음 |
 | `--max-lines <N>` |  | 출력 라인 수를 N 으로 제한, 초과 시 truncation 마커 표시 (`=== 비교 완료` 라인은 항상 출력). **단 `--json` 병용 시에는 봉투 한 줄만 나가고 이 텍스트 출력은 전부 생략** |
-| `--json` (#3274) |  | 판정 봉투 JSON 한 줄만 stdout 출력 (`schemaVersion`·`a`·`b`·`identical`·`diffCount`·`categories`). 종료 코드: 차이 발견 3, 읽기·파싱 실패 1(stdout 0바이트), 인자 부족 2 |
+| `--json` (#3274, #4658) |  | 판정 봉투 JSON 한 줄만 stdout 출력 (`schemaVersion`·`a`·`b`·`identical`·`diffCount`·`categories`·`pageCountA`·`pageCountB`). `pageCount*` 는 `info --json` 과 같은 조판 쪽수. 쪽수가 다르면 `identical:false` 이고 `categories.pageCount` 가 집계된다. 종료 코드: 차이 발견 3, 읽기·파싱 실패 1(stdout 0바이트), 인자 부족 2 |
 
 > **병용·인자 규칙(#3274)**: `--summary`/`--max-lines` 와 `--json` 을 함께 주면 **stdout 순수성을 위해 JSON 이 이긴다**(텍스트 출력 전부 생략). 값을 받는 `-s`/`-p`/`--max-lines` 는 다음 토큰이 플래그면 값으로 삼키지 않는다. **알 수 없는 옵션(오타 포함)은 현재 조용히 무시**되어 exit 2 가 아니므로(전역 계약 §종료 코드의 예외, #3178 정렬은 별도 이슈), 게이트 스크립트는 플래그 철자를 정확히 쓸 것.
 
@@ -56,7 +56,7 @@ rhwp ir-diff samples/hwpx/aift.hwpx samples/aift.hwp --max-lines 50
 ```bash
 # 대량 변환 후 내용 보존 검증 — 차이가 있으면 exit 3 으로 즉시 신호
 rhwp ir-diff 원본.hwp 변환본.hwpx --json || echo "격리 대상"
-# {"a":"원본.hwp","b":"변환본.hwpx","categories":{...},"diffCount":N,"identical":false,"schemaVersion":"1.0"}
+# {"a":"원본.hwp","b":"변환본.hwpx","categories":{...},"diffCount":N,"identical":false,"pageCountA":N,"pageCountB":M,"schemaVersion":"1.0"}
 ```
 
 
@@ -134,6 +134,14 @@ rhwp ir-diff samples/tac-img-02.hwpx samples/tac-img-02.hwp 2>&1 | tail -1
 - `B` = 두 번째 파일 (보통 HWP)
 - `[PS N]` = ParaShape 인덱스 N번의 차이
 - `[TD N]` = TabDef 인덱스 N번의 차이
+
+## IR 동일 ≠ 조판 동일 (#4658)
+
+`identical:true` 는 **비교하는 IR 필드**가 같고 `pageCountA == pageCountB` 일 때만이다.
+조판은 IR + 출처 프로파일(HWP5-origin 마커 등, IR 밖 zip/CFB)의 함수라, IR 필드가
+같아도 `info.pageCount` 가 갈릴 수 있다 (`samples/2026_oss_rst.hwp` 6쪽 vs
+`samples/hwpx/2026_oss_rst.hwpx` 7쪽). 그 경우 JSON 은 양쪽 `pageCount*` 를 신고
+`identical:false`·`categories.pageCount` 로 게이트한다. 두 번째 IR 을 만들지 않는다.
 
 ## 정상적인 차이 (무시 가능)
 

--- a/mydocs/working/issue_4658_ir_diff_pagecount.md
+++ b/mydocs/working/issue_4658_ir_diff_pagecount.md
@@ -1,0 +1,59 @@
+---
+kind: working
+status: active
+issue: 4658
+---
+
+# ir-diff 쪽수 계약 (#4658)
+
+작업 브랜치: `fix/4658-ir-diff-pagecount`
+대상: `rhwp ir-diff --json`
+
+한 줄 요약: IR 필드가 같아도 `info.pageCount` 가 다르면 `identical:true` 를 내지 않는다.
+
+## 이슈가 요구한 것
+
+`samples/2026_oss_rst.hwp`(6쪽) 와 `samples/hwpx/2026_oss_rst.hwpx`(7쪽) 를
+`ir-diff --json` 하면 종전엔 `identical:true`·`diffCount:0` 이었다. 조판이
+다른데 IR 동등으로 읽히면 변환 게이트가 거짓 통과한다.
+
+하지 말 것: 두 파일의 쪽수를 같게 맞추기, 두 번째 IR 발명.
+
+## 원인 (읽기 B)
+
+IR 비교는 이미 `line_segs`·표 `page_break`·셀 재귀를 본다. 6↔7 은 빠진 IR
+필드가 아니라 **출처 프로파일**이다. 커밋된 hwpx 에는 `META-INF/rhwp-hwp5-origin`
+이 없고 native HWPX 조판(분할 tolerance 등)을 타고, hwp 는 HWP5 시멘틱을 탄다.
+이슈 댓글(planet6897)과 같다. `identical` 은 조판 동등을 함의하지 않는다.
+
+## 계약
+
+- `--json` 봉투는 항상 `pageCountA`·`pageCountB` 를 싣는다. 값은 `info --json` 과
+  같은 조판 쪽수다.
+- 쪽수가 다르면 `identical:false`, `diffCount>=1`, `categories.pageCount` 가 1,
+  종료 코드 3.
+- IR 비교 목록을 넓히지 않는다. 출처 마커를 IR 필드로 승격하지 않는다.
+
+## 만진 경로
+
+- `src/cli/queries/ir_comparison.rs` — `info` 와 같은 `load_document` 로 쪽수를 읽어 비교
+- `src/cli/metadata/capabilities/extended.rs` — `recordFields` 에 `pageCountA`/`pageCountB`
+- `tests/cases/issue_4658_ir_diff_pagecount.rs`
+- `mydocs/manual/ir_diff_command.md` · `cli_commands.md` · `agent_knowledge_map.md`
+
+만지지 않은 경로: 페이지네이션 엔진, HWPX 직렬화, 스킬 본문, `tests/generated`.
+
+## 시험
+
+```
+cargo fmt --all -- --check
+cargo test --test issue_4658_ir_diff_pagecount -- --nocapture
+rhwp info samples/2026_oss_rst.hwp --json
+rhwp info samples/hwpx/2026_oss_rst.hwpx --json
+rhwp ir-diff samples/2026_oss_rst.hwp samples/hwpx/2026_oss_rst.hwpx --json
+```
+
+## PR 메모
+
+`closes #4658`. `gh pr create --repo edwardkim/rhwp --base devel --body-file`.
+첫 체크박스 = `cargo fmt --all -- --check`.

--- a/src/cli/metadata/capabilities/extended.rs
+++ b/src/cli/metadata/capabilities/extended.rs
@@ -682,6 +682,8 @@ pub(super) fn extend(commands: &mut Vec<serde_json::Value>) {
                 "identical",
                 "diffCount",
                 "categories",
+                "pageCountA",
+                "pageCountB",
             ],
         ),
         // [#4113 / #3918 승격 2호] 독립 사후검증 게이트 — 기대 조건 집합 대조.

--- a/src/cli/queries/ir_comparison.rs
+++ b/src/cli/queries/ir_comparison.rs
@@ -6,8 +6,9 @@ use std::path::Path;
 use rhwp::model::document::Document;
 use rhwp::provenance;
 use rhwp::schema_registry::ENVELOPE_SCHEMA_VERSION;
+use rhwp::wasm_api::HwpDocument;
 
-use crate::{classify_hwp_error, cli_password, EXIT_OK, EXIT_RUNTIME, EXIT_USAGE};
+use crate::{load_document, EXIT_OK, EXIT_RUNTIME, EXIT_USAGE};
 
 fn control_tag(c: &rhwp::model::control::Control) -> &'static str {
     use rhwp::model::control::Control;
@@ -807,7 +808,7 @@ impl IrDiffArgs {
     }
 }
 
-fn load_ir_diff_document(path: &str, password: Option<&str>) -> Result<Document, i32> {
+fn load_ir_diff_document(path: &str) -> Result<HwpDocument, i32> {
     let data = match fs::read(path) {
         Ok(data) => data,
         Err(e) => {
@@ -815,13 +816,9 @@ fn load_ir_diff_document(path: &str, password: Option<&str>) -> Result<Document,
             return Err(EXIT_RUNTIME);
         }
     };
-    let parsed = match password {
-        Some(password) => rhwp::parser::parse_document_with_password(&data, password.as_bytes()),
-        None => rhwp::parser::parse_document(&data),
-    };
-    parsed.map_err(|e| {
+    load_document(&data).map_err(|e| {
         eprintln!("오류: {} 파싱 실패", path);
-        classify_hwp_error(&e.to_string()).report()
+        e.report()
     })
 }
 
@@ -969,7 +966,13 @@ fn compare_ir_tab_defs(doc_a: &Document, doc_b: &Document, em: &mut IrDiffEmitte
     total_diffs
 }
 
-fn finish_ir_diff(args: &IrDiffArgs, em: IrDiffEmitter, total_diffs: u32) -> i32 {
+fn finish_ir_diff(
+    args: &IrDiffArgs,
+    em: IrDiffEmitter,
+    total_diffs: u32,
+    page_count_a: u32,
+    page_count_b: u32,
+) -> i32 {
     if args.summary_mode && !args.json_mode {
         println!("=== 카테고리별 차이 요약 ===");
         let mut entries: Vec<(String, u32)> = em.summary_buckets.clone().into_iter().collect();
@@ -986,6 +989,8 @@ fn finish_ir_diff(args: &IrDiffArgs, em: IrDiffEmitter, total_diffs: u32) -> i32
             "identical": total_diffs == 0,
             "diffCount": total_diffs,
             "categories": em.summary_buckets,
+            "pageCountA": page_count_a,
+            "pageCountB": page_count_b,
         });
         println!("{}", provenance::marked(envelope, "ir-diff"));
         return if total_diffs == 0 { EXIT_OK } else { 3 };
@@ -999,15 +1004,18 @@ pub(crate) fn ir_diff(args: &[String]) -> i32 {
         Ok(args) => args,
         Err(exit) => return exit,
     };
-    let password = cli_password();
-    let doc_a = match load_ir_diff_document(&args.file_a, password.as_deref()) {
+    let doc_a = match load_ir_diff_document(&args.file_a) {
         Ok(doc) => doc,
         Err(exit) => return exit,
     };
-    let doc_b = match load_ir_diff_document(&args.file_b, password.as_deref()) {
+    let doc_b = match load_ir_diff_document(&args.file_b) {
         Ok(doc) => doc,
         Err(exit) => return exit,
     };
+    let page_count_a = doc_a.page_count();
+    let page_count_b = doc_b.page_count();
+    let ir_a = doc_a.document();
+    let ir_b = doc_b.document();
 
     let name_a = Path::new(&args.file_a)
         .file_name()
@@ -1027,16 +1035,20 @@ pub(crate) fn ir_diff(args: &[String]) -> i32 {
         truncated: false,
         summary_buckets: std::collections::BTreeMap::new(),
     };
-    let mut total_diffs = compare_ir_sections(
-        &doc_a,
-        &doc_b,
-        args.section_filter,
-        args.para_filter,
-        &mut em,
-    );
-    total_diffs += compare_ir_para_shapes(&doc_a, &doc_b, &mut em);
-    total_diffs += compare_ir_tab_defs(&doc_a, &doc_b, &mut em);
-    finish_ir_diff(&args, em, total_diffs)
+    let mut total_diffs =
+        compare_ir_sections(ir_a, ir_b, args.section_filter, args.para_filter, &mut em);
+    total_diffs += compare_ir_para_shapes(ir_a, ir_b, &mut em);
+    total_diffs += compare_ir_tab_defs(ir_a, ir_b, &mut em);
+    // [#4658] IR 비교는 출처 프로파일(HWP5-origin 마커 등)을 보지 않는다.
+    // info.pageCount 가 갈리면 identical:true 는 조판 동등이라는 거짓 신호다.
+    if page_count_a != page_count_b {
+        em.diff(format!(
+            "pageCount: A={} vs B={}",
+            page_count_a, page_count_b
+        ));
+        total_diffs += 1;
+    }
+    finish_ir_diff(&args, em, total_diffs, page_count_a, page_count_b)
 }
 
 #[cfg(test)]

--- a/tests/cases/issue_4658_ir_diff_pagecount.rs
+++ b/tests/cases/issue_4658_ir_diff_pagecount.rs
@@ -1,0 +1,126 @@
+//! [#4658] ir-diff --json 은 IR 필드가 같아도 pageCount 가 다르면 identical:true 를 내지 않는다.
+//!
+//! `samples/2026_oss_rst.hwp` 와 `samples/hwpx/2026_oss_rst.hwpx` 는 IR 비교 필드가
+//! 같고 쪽수만 갈린다(출처 프로파일 — HWP5-origin 마커). ir-diff 는 조판 전용
+//! 데이터를 두 번째 IR 로 올리지 않지만, JSON 봉투는 `info --json` 과 같은
+//! pageCount 를 양쪽 싣고 쪽수가 다르면 identical:false + categories.pageCount 로
+//! 게이트한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const HWP: &str = "samples/2026_oss_rst.hwp";
+const HWPX: &str = "samples/hwpx/2026_oss_rst.hwpx";
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn parse_json(args: &[&str], output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(args, output)
+        )
+    })
+}
+
+fn info_page_count(path: &Path) -> u64 {
+    let p = path.to_str().expect("utf-8 path");
+    let args = ["info", p, "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    parse_json(&args, &output)["pageCount"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("info.pageCount 필요: {}", describe(&args, &output)))
+}
+
+#[test]
+fn ir_diff_json_always_reports_page_counts() {
+    let a = sample(HWP);
+    if !a.exists() {
+        eprintln!("샘플 없음 — 건너뜀: {HWP}");
+        return;
+    }
+    let a_str = a.to_str().unwrap();
+    let args = ["ir-diff", a_str, a_str, "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_json(&args, &output);
+    let pages = info_page_count(&a);
+    assert_eq!(v["identical"], true, "{v}");
+    assert_eq!(v["diffCount"], 0, "{v}");
+    assert_eq!(v["pageCountA"], pages, "{v}");
+    assert_eq!(v["pageCountB"], pages, "{v}");
+    assert_eq!(v["pageCountA"], v["pageCountB"], "{v}");
+}
+
+#[test]
+fn oss_rst_ir_diff_is_not_identical_when_page_counts_differ() {
+    let hwp = sample(HWP);
+    let hwpx = sample(HWPX);
+    if !hwp.exists() || !hwpx.exists() {
+        eprintln!("샘플 없음 — 건너뜀: {HWP} / {HWPX}");
+        return;
+    }
+    let a = hwp.to_str().unwrap();
+    let b = hwpx.to_str().unwrap();
+    let args = ["ir-diff", a, b, "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_json(&args, &output);
+    let pages_a = info_page_count(&hwp);
+    let pages_b = info_page_count(&hwpx);
+    assert_ne!(
+        pages_a, pages_b,
+        "전제: {HWP} 와 {HWPX} 의 info.pageCount 가 달라야 한다 ({pages_a} vs {pages_b})"
+    );
+    assert_eq!(v["pageCountA"], pages_a, "{v}");
+    assert_eq!(v["pageCountB"], pages_b, "{v}");
+    assert_eq!(v["identical"], false, "{v}");
+    assert!(
+        v["diffCount"].as_u64().unwrap() >= 1,
+        "pageCount 차이가 diffCount 에 잡혀야 한다: {v}"
+    );
+    let cats = v["categories"].as_object().expect("categories 객체");
+    assert!(
+        cats.keys().any(|k| k == "pageCount"),
+        "named diff pageCount 가 categories 에 있어야 한다: {v}"
+    );
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

`ir-diff --json` 이 IR 필드만 같아도 `identical:true` 를 내던 구멍을 닫습니다.
조판 쪽수(`info.pageCount`)가 다르면 `identical:false` 이고, 봉투에 양쪽 `pageCountA`/`pageCountB` 를 싣습니다.

`samples/2026_oss_rst.hwp`(6쪽) 와 `samples/hwpx/2026_oss_rst.hwpx`(7쪽) 는 IR 비교 필드가 같고 쪽수만 갈립니다. 원인은 빠진 IR 필드가 아니라 출처 프로파일(HWP5-origin 마커)입니다. 이 PR 은 두 파일의 쪽수를 맞추거나 두 번째 IR 을 만들지 않습니다.

## 관련 이슈

closes #4658

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음
- [ ] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (해당 없음)
- [x] 관련 `cargo test` 통과 (`regression_suite_010` 의 `issue_4658_ir_diff_pagecount`)
- [x] `cargo clippy --locked -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 (해당 없음 — 렌더 변경 없음)
- [ ] 웹(WASM) 렌더링 확인 (해당 없음)
- [ ] rhwp-studio 편집·UI 변경 시: 해당 없음
- [x] 작업 증빙: `rhwp ir-diff samples/2026_oss_rst.hwp samples/hwpx/2026_oss_rst.hwpx --json` → `identical:false`, `pageCountA:6`, `pageCountB:7`, `categories.pageCount:1`, exit 3. `info --json` 쪽수와 일치.
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 없음

## 재현

```
rhwp info samples/2026_oss_rst.hwp --json          # pageCount 6
rhwp info samples/hwpx/2026_oss_rst.hwpx --json    # pageCount 7
rhwp ir-diff samples/2026_oss_rst.hwp samples/hwpx/2026_oss_rst.hwpx --json
# identical:false, pageCountA:6, pageCountB:7, categories.pageCount:1, exit 3
```

## 성능 영향 및 측정 결과

- 예상 영향: `ir-diff` 가 `info` 와 같은 경로로 조판해 쪽수를 읽으므로 대문서에서 비교가 무거워질 수 있음
- 재현·측정: 공개 샘플 `2026_oss_rst` 쌍은 1초 안쪽
