### PR TITLE
test(cli): dump·diag·bench 미지 플래그 거부를 실행 시험에 잠근다 (#3884 G2)

### DIFF
--- a/tests/cases/issue_3884_g2_unknown_flags.rs
+++ b/tests/cases/issue_3884_g2_unknown_flags.rs
@@ -1,0 +1,139 @@
+//! [#3884 G2] dump·diag·bench 미지 플래그 거부 계약.
+//!
+//! 이 셋은 capabilities 에 `json`·`flags` 를 선언하지 않는 진단 명령이다.
+//! `--json` / `--bogus-flag` 를 침묵 무시하고 exit 0 으로 사람용 텍스트를 내면
+//! 에이전트는 JSON 을 기대하고 파싱하다 깨진다. 모르는 옵션은 사용법 오류:
+//! exit 2, stdout 0바이트, stderr 에 그 플래그 이름.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/field-01.hwp";
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .args(args)
+        .output()
+        .expect("rhwp 실행")
+}
+
+fn describe(args: &[&str], out: &Output) -> String {
+    format!(
+        "args={args:?}\nexit={:?}\nstdout={}\nstderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+fn assert_rejects(args: &[&str], flag: &str) {
+    let out = run(args);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "미지 플래그는 사용법 오류다: {}",
+        describe(args, &out)
+    );
+    assert!(
+        out.stdout.is_empty(),
+        "거부하면서 stdout 을 오염시키면 안 된다: {}",
+        describe(args, &out)
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains(flag),
+        "무엇이 거부됐는지 stderr 가 말해야 한다({flag}): {}",
+        describe(args, &out)
+    );
+}
+
+#[test]
+fn dump_rejects_bogus_flag() {
+    let s = sample();
+    assert_rejects(
+        &["dump", s.to_str().unwrap(), "--bogus-flag"],
+        "--bogus-flag",
+    );
+}
+
+#[test]
+fn dump_rejects_json_until_it_has_a_json_contract() {
+    let s = sample();
+    assert_rejects(&["dump", s.to_str().unwrap(), "--json"], "--json");
+}
+
+#[test]
+fn dump_rejects_flag_in_file_position() {
+    assert_rejects(&["dump", "--json"], "--json");
+}
+
+#[test]
+fn dump_rejects_a_flag_consumed_as_a_filter_value() {
+    let s = sample();
+    assert_rejects(
+        &["dump", s.to_str().unwrap(), "--section", "--bogus-flag"],
+        "--section",
+    );
+}
+
+#[test]
+fn dump_still_accepts_declared_filters() {
+    let s = sample();
+    let args = ["dump", s.to_str().unwrap(), "--section", "0"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    assert!(!out.stdout.is_empty(), "{}", describe(&args, &out));
+}
+
+#[test]
+fn diag_rejects_bogus_flag() {
+    let s = sample();
+    assert_rejects(
+        &["diag", s.to_str().unwrap(), "--bogus-flag"],
+        "--bogus-flag",
+    );
+}
+
+#[test]
+fn diag_rejects_json_flag() {
+    let s = sample();
+    assert_rejects(&["diag", s.to_str().unwrap(), "--json"], "--json");
+}
+
+#[test]
+fn diag_rejects_flag_in_file_position() {
+    assert_rejects(&["diag", "--verbose"], "--verbose");
+}
+
+#[test]
+fn bench_rejects_bogus_flag() {
+    let s = sample();
+    assert_rejects(
+        &["bench", s.to_str().unwrap(), "--bogus-flag"],
+        "--bogus-flag",
+    );
+}
+
+#[test]
+fn bench_rejects_json_flag() {
+    let s = sample();
+    assert_rejects(&["bench", s.to_str().unwrap(), "--json"], "--json");
+}
+
+#[test]
+fn bench_rejects_a_flag_consumed_as_an_option_value() {
+    let s = sample();
+    assert_rejects(
+        &["bench", s.to_str().unwrap(), "--iters", "--bogus-flag"],
+        "--iters",
+    );
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

`dump`·`diag`·`bench` 가 모르는 플래그(`--json`, `--bogus-flag`)를 **사용법 오류로 거부**하도록 실행 시험에 잠근다.

이슈 #3884 G2 실측(v0.8.2)은 `rhwp dump <문서> --bogus-flag` 가 exit 0 으로 사람용 텍스트를 내며 미지 플래그를 침묵 무시하는 것이었다. `--json` 도 같아서 에이전트가 JSON 을 기대하면 파싱이 깨진다.

현재 devel 의 파서(`src/cli/queries/control_dump/mod.rs`, `diag_document`, `src/diagnostics/bench.rs`)는 이미 fail-closed 다: exit 2, stdout 0바이트, stderr 에 플래그 이름. 다만 그 계약 시험이 `tests/diagnostics_flag_contract.rs` 에만 있어 `autotests = false` 아래 **CI 실행 집합에 들어가지 않았다.** 이 PR 은 같은 계약을 `tests/cases/` 에 옮겨 잠근다. JSON 봉투는 구현하지 않는다.

G1(bench 실패 stdout)은 #6404. 이 PR 은 **G2 만**. G3·G4 는 남긴다. `#3884` 를 닫지 않는다.

## 관련 이슈

#3884

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음 (`--sync-cargo-targets` 메인터너 registry PR은 marker 블록만 예외)
- [ ] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
- [x] `cargo test --test issue_3884_g2_unknown_flags` 통과 (11/11)
- [ ] `cargo clippy -- -D warnings` 통과 (소스 변경 없음)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — `rhwp replay --capsule` 영수증 캡슐 또는 관련 `--json` 봉투 원문 ([AGENTS.md 작업 증빙 절](../AGENTS.md#작업-증빙--에이전트-기본-경로-권장))
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: [capability 카탈로그](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_capability_registry.md)의 등록·검증 규칙을 반영

## 실측

`samples/field-01.hwp` 기준 debug 바이너리:

| 명령 | exit | stdout | stderr |
|---|---:|---:|---|
| `dump <문서> --bogus-flag` | 2 | **0 B** | `알 수 없는 옵션입니다 - --bogus-flag` |
| `dump <문서> --json` | 2 | **0 B** | `--json` |
| `diag <문서> --bogus-flag` | 2 | **0 B** | `--bogus-flag` |
| `diag <문서> --json` | 2 | **0 B** | `--json` |
| `bench <문서> --bogus-flag` | 2 | **0 B** | `--bogus-flag` |
| `bench <문서> --json` | 2 | **0 B** | `--json` |
| `dump <문서> --section 0` | 0 | 비지 않음 | (회귀: 선언된 필터는 유지) |

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 — 시험만 추가, 파서 변경 없음
- 재현·측정: 위 실측 표

## 스크린샷

해당 없음 (CLI 플래그 계약).
