### PR TITLE
fix(layout): 저장 사다리를 따른 셀 문단의 과폭 줄을 압축해 칸 안에 맞춘다 (#6389)

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -4508,9 +4508,28 @@ impl LayoutEngine {
                             .abs()
                             <= 2.0
                 });
+            // [#6389] 저장 사다리 증언의 다줄 일반화. 조합이 저장 줄 수를 그대로
+            // 따랐고 모든 저장 줄폭이 셀 열폭 이내면, 한글이 이 내용을 이 폭에
+            // 담았다는 증언이다 — 편람 p68 셀은 kopub/no-ttf 오라클 PDF 모두
+            // 저장 줄과 문자 단위로 일치하는데, 내장 메트릭 진행폭이 실측(0.83em)
+            // 보다 넓어(1.0em) 압축을 억제하면 `○` 문단 줄들이 셀 우측 테두리를
+            // +72~85px 넘는다. 열폭보다 넓게 기록된 사다리(병합·재저장 안 된 낡은
+            // 캐시)는 증언이 성립하지 않으므로 종전대로 억제(클리핑)한다.
+            let stored_ladder_fits_frame = cell_ctx.is_some()
+                && para.is_some_and(|p| {
+                    !p.line_segs.is_empty()
+                        && composed.lines.len() == p.line_segs.len()
+                        && p.line_segs.iter().all(|seg| {
+                            seg.tag & crate::model::paragraph::LineSeg::TAG_IMPLEMENTATION_PROPERTY
+                                == 0
+                                && hwpunit_to_px(seg.segment_width, self.dpi)
+                                    <= effective_col_w + 2.0
+                        })
+                });
             let suppress_cell_overflow_spacing = cell_ctx.is_some()
                 && total_text_width > available_width * 1.15
-                && !stored_single_line_fits_cell;
+                && !stored_single_line_fits_cell
+                && !stored_ladder_fits_frame;
             let is_hancom_company_pua_logo_line =
                 is_hancom_company_pua_logo_line(comp_line, alignment);
 

--- a/tests/cases/issue_6389_cell_stored_ladder_compresses_to_fit.rs
+++ b/tests/cases/issue_6389_cell_stored_ladder_compresses_to_fit.rs
@@ -1,0 +1,89 @@
+//! [Issue #6389] 편람 p68 본문 표 셀의 `○` 문단 줄들이 셀 우측 테두리를 +72~85px 넘는다.
+//!
+//! 이 셀 문단들의 저장 사다리(2~4줄, 각 `segment_width=37560HU`=셀 안쪽 폭)는
+//! kopub/no-ttf 오라클 PDF 와 문자 단위로 일치한다 — 한글이 이 내용을 이 폭에
+//! 담았다는 증언이다. 그런데 내장 KoPub돋움체 한글 진행폭(1.0em)이 오라클
+//! 실측(≈0.83em)보다 넓어 자연 폭이 줄 상자의 1.12~1.17배가 되고, 억제 임계
+//! (1.15)를 넘은 줄은 압축이 꺼져 자연 폭 그대로 칸 밖에 그려졌다.
+//!
+//! #6196 이 한 줄 사다리에 연 증언 예외를 다줄 사다리로 일반화한다: 조합이
+//! 저장 줄 수를 그대로 따랐고 모든 저장 줄폭이 셀 열폭 이내면 억제하지 않고
+//! 압축해 칸 안에 맞춘다. 열폭보다 넓게 기록된 사다리([sw>w] 낡은 캐시)는
+//! 증언이 성립하지 않아 종전대로 클리핑된다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+const SAMPLE: &str = "samples/2025 행정업무운영 편람(최종).hwp";
+/// 대상 셀의 식별 텍스트 — p68(0기준 67) 본문 표 r1c1 첫 문단.
+const CELL_MARKER: &str = "모든 기록물";
+/// 줄 끝 공백 한 칸은 한글도 칸 밖으로 걸치므로 허용한다(반각 ≈ 6.7px + 여유).
+const TRAILING_SPACE_ALLOWANCE_PX: f64 = 8.0;
+
+#[test]
+fn issue_6389_manual_p68_stored_ladder_cell_stays_inside_cell() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let core = DocumentCore::from_bytes(&std::fs::read(path).expect("read sample")).expect("open");
+    let page = core.build_page_render_tree(67).expect("p68 render tree");
+
+    let mut overflow = Vec::new();
+    let mut checked = 0usize;
+    walk(&page.root, None, false, &mut checked, &mut overflow);
+
+    assert!(
+        checked > 0,
+        "대상 셀({CELL_MARKER})의 텍스트를 찾지 못했다 — 쪽 배분이 바뀌었는지 확인하라"
+    );
+    assert!(
+        overflow.is_empty(),
+        "저장 사다리 셀의 줄이 칸 밖으로 나간다 — {}건 (칸 우변 초과 px, 텍스트): {:?}",
+        overflow.len(),
+        overflow
+    );
+}
+
+/// 대상 셀(marker 텍스트를 담은 셀) 안 TextRun 중 칸 우변을 넘는 것을 모은다.
+fn walk(
+    node: &RenderNode,
+    cell_right: Option<f64>,
+    in_target_cell: bool,
+    checked: &mut usize,
+    out: &mut Vec<(String, String)>,
+) {
+    let (cell_right, in_target_cell) = match &node.node_type {
+        RenderNodeType::TableCell(_) => {
+            let holds_marker = subtree_contains(node, CELL_MARKER);
+            (
+                holds_marker.then_some(node.bbox.x + node.bbox.width),
+                holds_marker,
+            )
+        }
+        _ => (cell_right, in_target_cell),
+    };
+    if let (Some(right), true, RenderNodeType::TextRun(run)) =
+        (cell_right, in_target_cell, &node.node_type)
+    {
+        if !run.text.trim().is_empty() {
+            *checked += 1;
+            let run_right = node.bbox.x + node.bbox.width;
+            if run_right > right + TRAILING_SPACE_ALLOWANCE_PX {
+                out.push((format!("+{:.1}", run_right - right), run.text.clone()));
+            }
+        }
+    }
+    for child in &node.children {
+        walk(child, cell_right, in_target_cell, checked, out);
+    }
+}
+
+fn subtree_contains(node: &RenderNode, needle: &str) -> bool {
+    if let RenderNodeType::TextRun(run) = &node.node_type {
+        if run.text.contains(needle) {
+            return true;
+        }
+    }
+    node.children.iter().any(|c| subtree_contains(c, needle))
+}

--- a/tests/fixtures/text_overlap_baseline.tsv
+++ b/tests/fixtures/text_overlap_baseline.tsv
@@ -1,44 +1,22 @@
-2025 행정업무운영 편람(최종).hwp	49
-2025 행정업무운영 편람(최종).hwpx	50
-21_언어_기출_편집가능본.hwp	1
-3-09월_교육_통합_2023.hwp	14
-3-09월_교육_통합_2023.hwpx	14
-3-10월_교육_통합_2022.hwp	1
-3-10월_교육_통합_2022.hwpx	1
-3-11월_실전_통합_2022.hwp	11
-3-11월_실전_통합_2022.hwpx	11
-3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20.hwp	11
-3-11월_실전_통합_2024-구분선없음구분선위20미주사이20구분선아래20.hwpx	11
-3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0.hwp	14
-3-11월_실전_통합_2024-구분선위0미주사이0구분선아래0.hwpx	14
-3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2.hwp	11
-3-11월_실전_통합_2024-구분선위0미주사이20구분선아래2.hwpx	11
-3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2.hwp	11
-3-11월_실전_통합_2024-구분선위0미주사이7구분선아래2.hwpx	11
-3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20.hwp	11
-3-11월_실전_통합_2024-구분선위0미주사이7구분선아래20.hwpx	10
-3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.hwp	11
-3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.hwpx	13
-3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2.hwp	11
-3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2.hwpx	10
-3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.hwp	10
-3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.hwpx	10
+정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp	58
+정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwpx	244
+2025 행정업무운영 편람(최종).hwp	21
+2025 행정업무운영 편람(최종).hwpx	22
+3-09월_교육_통합_2023.hwp	7
+3-09월_교육_통합_2023.hwpx	7
+3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.hwpx	1
 76076_regulatory_analysis.hwp	6
 80168_regulatory_analysis.hwp	9
 86712_regulatory_analysis.hwp	4
-HWP5-nopassword-123456.hwpx	6
-SO-SUEOP.hwp	34
-SO-SUEOP.hwpx	34
 basic/issue1994_behindtext_table_20200830.hwp	5
 basic/sungeo.hwp	23
-exam-kor-2p.hwp	1
-exam-kor-3p.hwp	25
-exam-kor-4p.hwp	14
-exam_kor.hwp	4
-exam_science.hwp	4
+exam_science.hwp	2
 exam_social.hwp	4
+exam-kor-2p.hwp	1
+exam-kor-3p.hwp	23
+exam-kor-4p.hwp	14
 group-drawing-02.hwp	5
-hwp-multi-001.hwp	202
+hwp-multi-001.hwp	97
 hwp3-sample-hwp5.hwp	3
 hwp3-sample-hwpx.hwpx	3
 hwp3-sample10-hwp5.hwp	147
@@ -57,61 +35,58 @@ hwp3-sample16.hwp	22
 hwp3-sample5-hwp5-v2018.hwp	12
 hwp3-sample5-hwp5-v2024.hwp	12
 hwp3-sample5-hwp5.hwp	12
+HWP5-nopassword-123456.hwpx	6
 hwp5-tbl-attr-1916.hwp	5
 hwpctl_API_v2.4.hwp	5
-hwpx/2024년 1분기 해외직접투자 보도자료 ff.hwp	78
-hwpx/2024년 1분기 해외직접투자 보도자료 ff.hwpx	78
-hwpx/2024년 2분기 해외직접투자 보도자료ff.hwpx	102
-hwpx/2024년 연간 해외직접투자 보도자료 _ ff.hwpx	256
-hwpx/2025년 1분기 해외직접투자 보도자료f.hwpx	76
-hwpx/2025년 2분기 해외직접투자 (최종).hwpx	109
+hwpx_sample2.hwp	35
+hwpx_sample2.hwpx	37
+hwpx/2024년 연간 해외직접투자 보도자료 _ ff.hwpx	77
+hwpx/2024년 1분기 해외직접투자 보도자료 ff.hwp	76
+hwpx/2024년 1분기 해외직접투자 보도자료 ff.hwpx	76
+hwpx/2024년 2분기 해외직접투자 보도자료ff.hwpx	86
+hwpx/2025년 1분기 해외직접투자 보도자료f.hwpx	75
+hwpx/2025년 2분기 해외직접투자 (최종).hwpx	100
+hwpx/exam_social.hwpx	4
 hwpx/exam-kor-2p.hwpx	1
 hwpx/exam-kor-3p.hwpx	23
 hwpx/exam-kor-4p.hwpx	14
-hwpx/exam_kor.hwpx	3
-hwpx/exam_social.hwpx	4
-hwpx/hancom-hwp/2024년 1분기 해외직접투자 보도자료 ff.hwp	78
-hwpx/hancom-hwp/2024년 2분기 해외직접투자 보도자료ff.hwp	102
-hwpx/hancom-hwp/2024년 연간 해외직접투자 보도자료 _ ff.hwp	256
-hwpx/hancom-hwp/2025년 1분기 해외직접투자 보도자료f.hwp	76
-hwpx/hancom-hwp/2025년 2분기 해외직접투자 (최종).hwp	109
+hwpx/hancom-hwp/2024년 연간 해외직접투자 보도자료 _ ff.hwp	77
+hwpx/hancom-hwp/2024년 1분기 해외직접투자 보도자료 ff.hwp	76
+hwpx/hancom-hwp/2024년 2분기 해외직접투자 보도자료ff.hwp	86
+hwpx/hancom-hwp/2025년 1분기 해외직접투자 보도자료f.hwp	75
+hwpx/hancom-hwp/2025년 2분기 해외직접투자 (최종).hwp	100
 hwpx/hancom-hwp/hang_job_01.hwp	1
-hwpx/hancom-hwp/hwpx-01.hwp	78
-hwpx/hancom-hwp/hwpx-02.hwp	256
-hwpx/hancom-hwp/hwpx-h-01.hwp	78
-hwpx/hancom-hwp/hwpx-h-02.hwp	109
-hwpx/hancom-hwp/hwpx-h-03.hwp	76
-hwpx/hancom-hwp/mel-001.hwp	21
-hwpx/hwpx-01.hwpx	78
-hwpx/hwpx-h-01.hwpx	78
-hwpx/hwpx-h-02.hwpx	109
-hwpx/hwpx-h-03.hwpx	76
+hwpx/hancom-hwp/hwpx-01.hwp	76
+hwpx/hancom-hwp/hwpx-02.hwp	77
+hwpx/hancom-hwp/hwpx-h-01.hwp	76
+hwpx/hancom-hwp/hwpx-h-02.hwp	100
+hwpx/hancom-hwp/hwpx-h-03.hwp	75
+hwpx/hancom-hwp/mel-001.hwp	1
+hwpx/hwpx-01.hwpx	76
+hwpx/hwpx-h-01.hwpx	76
+hwpx/hwpx-h-02.hwpx	100
+hwpx/hwpx-h-03.hwpx	75
 hwpx/k-water-rfp.hwpx	1
-hwpx/mel-001.hwpx	7
+hwpx/mel-001.hwpx	1
 hwpx/opengov/36382669_결재문서본문_’26년 제3차 강사선정 심의회 운영결과.hwpx	1
 hwpx/opengov/36384689_결재문서본문_화재발생종합보고서(제2026-298호).hwpx	3
 hwpx/opengov/36385226_결재문서본문_제2처리장 슬러지인발용 에어리프트 브로워 2호기 소모품 교체 보고.hwpx	4
 hwpx/opengov/36387103_결재문서본문_수질검사 신청 민원 처리 결과 안내.hwpx	4
-hwpx_sample2.hwp	37
-hwpx_sample2.hwpx	37
 issue-986-receipt.hwp	5
-issue1549_empty_host_float_clamp.hwpx	1
 issue1549_multipositive_float_tables.hwpx	6
 issue1853_caption_precedes_body_split.hwpx	11
 issue1858_paper_anchor_float_stack.hwpx	6
 issue1880_takeplace_host_before.hwpx	1
+issue1891_external_bindata_link.hwpx	3
 issue1891/76076_regulatory_analysis.hwpx	7
 issue1891/80168_regulatory_analysis.hwpx	9
 issue1891/80250_regulatory_analysis.hwpx	2
 issue1891/86712_regulatory_analysis.hwpx	4
-issue1891_external_bindata_link.hwpx	3
 issue1921/59043_regulatory_analysis.hwp	4
-issue1937_rowbreak_footnote_overpagination.hwp	136
+issue1937_rowbreak_footnote_overpagination.hwp	135
 issue1949_giant_cell_nested_tables_perf.hwp	8
 issue1949_giant_cell_nested_tables_perf.hwpx	8
-issue2004_cell_image_stack.hwp	1
-issue2004_cell_image_stack.hwpx	1
-issue2006/1790387_prep_final_report.hwpx	124
+issue2006/1790387_prep_final_report.hwpx	100
 issue2217/20200830.hwp	5
 issue2470/36341511_masked.hwpx	9
 issue2559/1341000_research_report_footnotes.hwp	27
@@ -121,7 +96,7 @@ issue4090/156492236_규제샌드박스_min.hwpx	4
 issue4491/30213_1.혼합단지등 제도개선 방안.hwp	3
 issue4514/sample1-repro.hwp	1
 issue4690/30098_indent_over_stored_cs.hwp	2
-issue5169_viewtext_changetracking.hwp	28
+issue5169_viewtext_changetracking.hwp	17
 issue5679/10857_delegation_rules.hwp	6
 issue5699/37787_regulatory_impact.hwp	4
 issue5714/1490000-200800034_vietnam_labor_report.hwp	4
@@ -146,10 +121,12 @@ issue6284/child_policy_top_caption_charts.hwpx	56
 k-water-rfp-2024.hwp	1
 k-water-rfp.hwp	1
 kps-ai.hwp	2
-mel-001.hwp	21
+mel-001.hwp	1
 multi-table-001.hwp	1
 multi-table-002.hwp	1
 rowbreak-problem-pages.hwpx	1
+SO-SUEOP.hwp	34
+SO-SUEOP.hwpx	34
 synam-001.hwp	15
 table_giant_cell_overfill.hwpx	18
 table_scattered_header_rowbreak.hwp	1
@@ -159,16 +136,14 @@ task1716/table_scattered_header_rowbreak.hwpx	1
 task1718/table_giant_cell_overfill.hwp	1
 task1725/text_footnote_tail_overpagination.hwp	40
 task1725/text_footnote_tail_overpagination.hwpx	34
-task1753/deferred_takeplace_fill_ahead.hwp	4
-task1753/deferred_takeplace_fill_ahead.hwpx	3
+task1753/deferred_takeplace_fill_ahead.hwp	1
+task1753/deferred_takeplace_fill_ahead.hwpx	1
 task1768/distribution_doc.hwpx	1
 task2070/1130000-201900011_D0150004-1-002_2017년기준 시장구조조사.hwp	96
 task2093/1192000_hydrogen_policy_research.hwp	1
 task2097/21217935_simsa_jipyo.hwp	75
 task2097/75544_pii_bunseok.hwpx	8
 task2279/36404953_gyeoljae.hwpx	1
-task2287/1342000_edu_curriculum_map.hwp	105
-task2430/1382000_domestic_violence_survey.hwp	20
+task2287/1342000_edu_curriculum_map.hwp	95
+task2430/1382000_domestic_violence_survey.hwp	18
 task3307/issue3307_outline_number.hwpx	3
-정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp	58
-정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwpx	245


### PR DESCRIPTION
## 무엇을 고치나

표 셀이 한글의 저장 줄 나눔(LINE_SEG)을 그대로 따라 그릴 때, 내장 글꼴 폭이 한글 실측보다 넓으면 줄이 셀 오른쪽 테두리를 뚫고 나가거나(편람 68쪽 +72~85px) 좁은 통계 칸에서 수치가 경계에 잘려 나갑니다("(△51.1)"→"(△51."). 근본 분석은 #6389 에 있습니다.

셀 과폭 자간 압축의 억제 조건(자연 폭 > 가용 폭 ×1.15)에 #6196 이 한 줄 사다리에 열어 둔 증언 예외를 다줄 사다리로 일반화합니다: **조합이 저장 줄 수를 그대로 따랐고 모든 저장 줄폭이 셀 열폭 이내면**, 한글이 이 내용을 이 폭에 담았다는 증언으로 보고 기존 압축 경로(공백 −50% → 잔여 자간 흡수)로 칸 안에 맞춥니다. 한글 자신도 대체 글꼴로 그릴 때 같은 방식으로 눌러 맞추는 것을 오라클 PDF 2종(kopub/no-ttf, 저장 줄과 각각 15/15·16/16 문자 일치)으로 확인했습니다. 열폭보다 넓게 기록된 낡은 사다리([sw>w])는 증언이 성립하지 않아 종전대로 클리핑됩니다.

## 전/후

| 편람 68쪽 — 수정 전 (테두리 밖) | 수정 후 (칸 안) |
|---|---|
| ![before](https://raw.githubusercontent.com/jeong-sik/rhwp/assets/cell-width-verdicts/p68_before_crop.png) | ![after](https://raw.githubusercontent.com/jeong-sik/rhwp/assets/cell-width-verdicts/p68_after_crop.png) |

| 보도자료 통계표 — 수정 전 (수치 절단) | 수정 후 (복원) |
|---|---|
| ![bodo before](https://raw.githubusercontent.com/jeong-sik/rhwp/assets/cell-width-verdicts/bodo_before_crop.png) | ![bodo after](https://raw.githubusercontent.com/jeong-sik/rhwp/assets/cell-width-verdicts/bodo_after_crop.png) |

## 검증

- 글자 겹침 스윕 946건: 증가 0, 총량 대폭 감소(해외직접투자 보도자료 계열 256→77, hwp-multi-001 202→97, 편람 등). baseline 을 이 브랜치 실측(149문서/4,198건)으로 조였습니다 — 종전 baseline(5,316건)은 실측 대비 천장이 느슨한 상태였습니다.
- 셀 줄수 일치 계측(#6363 계측기): 줄바꿈 이동 0 — 이 수정은 그리기만 바꿉니다.
- 전체 nextest 통과, 표적 스위트(#5952 4/4 · #6175 · #6196 · #1285) 통과, fmt 클린.
- 신규 회귀 테스트: 편람 68쪽 실물 고정, 수정을 끄면 빨강이 되는 것까지 확인했습니다.

## 남은 것

글꼴 폭 자체(KoPub돋움체 내장 1.0em vs 실측 0.872em)는 이 PR 범위 밖입니다 — 두 오라클 코호트(설치/치환) 경계 설계가 필요해 #6389 에 실측과 실험 브랜치(exp/kopub-dotum-872)로 정리해 뒀습니다.
