### PR TITLE
test: 셀 줄나눔 계측기 v3 — 기록 없음·쪽 나눔 조각 분류 왜곡을 고친다 (#6363)

### DIFF
--- a/scripts/cell-lineseg-agreement-baseline.json
+++ b/scripts/cell-lineseg-agreement-baseline.json
@@ -1,16 +1,18 @@
 {
   "_comment": [
-    "셀 안 문단의 줄 나눔이 한/글 저장 기록과 일치하는 비율 (내용 키 짝짓기).",
+    "셀 안 문단의 줄 나눔이 한/글 저장 기록과 일치하는 비율 (내용 키 짝짓기, v3).",
+    "비교 모수는 저장 줄수가 있는 셀만. 기록 없음(noStoredRecord)은 불일치가 아니다.",
     "갱신: node scripts/cell-lineseg-agreement.mjs --update",
     "이 비율은 내려갈 수 없다. 올리는 것이 목표다."
   ],
   "documents": 369,
   "unpairedStored": 886,
   "unpairedRendered": 11701,
-  "cells": 169444,
+  "noStoredRecord": 44723,
+  "cells": 124721,
   "agree": 124053,
-  "disagree": 45391,
-  "renderedMore": 44845,
+  "disagree": 668,
+  "renderedMore": 122,
   "renderedFewer": 546,
-  "agreementPercent": 73.21
+  "agreementPercent": 99.46
 }

--- a/scripts/cell-lineseg-agreement.mjs
+++ b/scripts/cell-lineseg-agreement.mjs
@@ -12,9 +12,11 @@
 // 다르면 문서를 통째로 건너뛰었다(600 문서 중 231 건너뜀 — 셀 구조가 복잡한, 즉 개선과
 // 회귀가 실제로 일어나는 문서가 사각에 몰렸다). 지금은 셀을 (행, 열, 텍스트 접두사)
 // 내용 키로 짝짓는다. 못 짝지은 셀만 `unpaired*` 로 세고 문서는 버리지 않는다.
-// 같은 키가 여럿이면(빈 셀 격자 등) 순서대로 맞춘다. 머리말/꼬리말 표 셀은 쪽마다
-// 렌더가 복제되므로 `unpairedRendered` 가 저장 쪽보다 큰 것이 정상이다 — 첫 복제가
-// 저장 기록과 짝지어지고 나머지는 판정 없이 남는다.
+// 같은 키가 여럿이면(빈 셀 격자 등) 순서대로 맞춘다.
+//
+// **v3 분류 (#6363)** — 기록 없는 문단(저장 줄수 0)은 불일치가 아니라 `noStoredRecord` 다.
+// 쪽 나눔 조각은 통짜 저장 셀과 첫 조각만 비교하지 않는다: `hdr=true`(제목 행 반복)는
+// 각 조각을 같은 저장 값과 개별 비교하고, `hdr=false` 는 같은 (행,열) 조각을 합산한다.
 //
 // 사용:
 //   node scripts/cell-lineseg-agreement.mjs            기준선과 비교, 회귀면 exit 1
@@ -30,7 +32,7 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
 export const BASELINE_PATH = path.join(SCRIPT_DIR, 'cell-lineseg-agreement-baseline.json');
 
-const CELL_LINE = /셀\[\d+\] r=(\d+),c=(\d+) .*?text="([^"]*)"/;
+const CELL_LINE = /셀\[\d+\] r=(\d+),c=(\d+) .*?hdr=(true|false) .*?text="([^"]*)"/;
 const TABLE_LINE = /(?:내부표|표): /;
 const PARA_LINE = /p\[\d+\]/;
 const LINE_SEG = /ls\[\d+\] ts=/g;
@@ -57,7 +59,13 @@ export function storedCells(dumpText) {
     const cellMatch = CELL_LINE.exec(line);
     if (cellMatch) {
       while (stack.length > 0 && stack[stack.length - 1].indent >= indent) stack.pop();
-      const cell = { row: Number(cellMatch[1]), col: Number(cellMatch[2]), text: cellMatch[3], lines: 0 };
+      const cell = {
+        row: Number(cellMatch[1]),
+        col: Number(cellMatch[2]),
+        header: cellMatch[3] === 'true',
+        text: cellMatch[4],
+        lines: 0,
+      };
       cells.push(cell);
       stack.push({ indent, cell });
       continue;
@@ -97,36 +105,113 @@ export function renderedCells(tree) {
   return cells;
 }
 
+function cellKey(cell) {
+  return `${cell.row}:${cell.col}:${textKey(cell.text)}`;
+}
+
+function posKey(cell) {
+  return `${cell.row}:${cell.col}`;
+}
+
+function judgePair(storedLines, renderedLines, totals) {
+  if (renderedLines === 0) return;
+  if (storedLines === 0) {
+    totals.noStoredRecord += 1;
+    return;
+  }
+  totals.cells += 1;
+  const delta = renderedLines - storedLines;
+  if (delta === 0) totals.agree += 1;
+  else {
+    totals.disagree += 1;
+    if (delta > 0) totals.renderedMore += 1;
+    else totals.renderedFewer += 1;
+  }
+}
+
+/**
+ * 문서에 (행,열)이 유일한 `hdr=false` 저장 셀이면, 쪽 나눔으로 쪼개진 렌더
+ * 조각을 합산한다. 첫 조각의 텍스트를 남겨 저장 접두사와 내용 키가 맞는다.
+ * (행,열)이 여러 표에 반복되면 합치지 않는다 — #6354 사각을 되돌리지 않기 위함.
+ */
+export function mergePageSplitFragments(stored, rendered) {
+  const storedAtPos = new Map();
+  for (const cell of stored) {
+    const pos = posKey(cell);
+    if (!storedAtPos.has(pos)) storedAtPos.set(pos, []);
+    storedAtPos.get(pos).push(cell);
+  }
+  const mergeable = new Set();
+  for (const [pos, list] of storedAtPos) {
+    if (list.length === 1 && !list[0].header) mergeable.add(pos);
+  }
+  const mergedAtPos = new Map();
+  const out = [];
+  for (const cell of rendered) {
+    const pos = posKey(cell);
+    if (!mergeable.has(pos)) {
+      out.push(cell);
+      continue;
+    }
+    const existing = mergedAtPos.get(pos);
+    if (!existing) {
+      const merged = { row: cell.row, col: cell.col, text: cell.text, lines: cell.lines };
+      mergedAtPos.set(pos, merged);
+      out.push(merged);
+    } else {
+      existing.lines += cell.lines;
+    }
+  }
+  return out;
+}
+
 /**
  * 내용 키로 셀을 짝지어 집계한다.
  *
  * 렌더 0줄 셀은 판정하지 않는다(줄 나눔이 없는 자리) — 짝짓기에는 참여시켜
  * 다른 셀의 상대를 빼앗지 않게 한다. 못 짝지은 셀은 양쪽 각각 센다.
+ *
+ * 저장 줄수 0 은 비교 모수에서 빼고 `noStoredRecord` 로 센다. 같은 키에 저장 1개·
+ * 렌더 여러 개이면 `hdr=true` 는 조각마다 비교하고 `hdr=false` 는 줄 수를 합산한다.
  */
 export function tallyDocument(stored, rendered, totals) {
+  const renderedForPairing = mergePageSplitFragments(stored, rendered);
   const buckets = new Map();
-  for (const c of stored) {
-    const key = `${c.row}:${c.col}:${textKey(c.text)}`;
+  for (const cell of stored) {
+    const key = cellKey(cell);
     if (!buckets.has(key)) buckets.set(key, []);
-    buckets.get(key).push(c);
+    buckets.get(key).push(cell);
   }
-  for (const r of rendered) {
-    const key = `${r.row}:${r.col}:${textKey(r.text)}`;
-    const queue = buckets.get(key);
-    if (!queue || queue.length === 0) {
-      totals.unpairedRendered += 1;
+  const renderedBuckets = new Map();
+  for (const cell of renderedForPairing) {
+    const key = cellKey(cell);
+    if (!renderedBuckets.has(key)) renderedBuckets.set(key, []);
+    renderedBuckets.get(key).push(cell);
+  }
+
+  const keys = new Set([...buckets.keys(), ...renderedBuckets.keys()]);
+  for (const key of keys) {
+    const storedQueue = buckets.get(key) ?? [];
+    const renderedQueue = renderedBuckets.get(key) ?? [];
+    if (storedQueue.length === 1 && renderedQueue.length > 1) {
+      const storedCell = storedQueue[0];
+      if (storedCell.header) {
+        for (const renderedCell of renderedQueue) {
+          judgePair(storedCell.lines, renderedCell.lines, totals);
+        }
+      } else if (renderedQueue.some((cell) => cell.lines > 0)) {
+        const summed = renderedQueue.reduce((n, cell) => n + cell.lines, 0);
+        judgePair(storedCell.lines, summed, totals);
+      }
+      storedQueue.length = 0;
       continue;
     }
-    const s = queue.shift();
-    if (r.lines === 0) continue;
-    totals.cells += 1;
-    const delta = r.lines - s.lines;
-    if (delta === 0) totals.agree += 1;
-    else {
-      totals.disagree += 1;
-      if (delta > 0) totals.renderedMore += 1;
-      else totals.renderedFewer += 1;
+    while (storedQueue.length > 0 && renderedQueue.length > 0) {
+      const storedCell = storedQueue.shift();
+      const renderedCell = renderedQueue.shift();
+      judgePair(storedCell.lines, renderedCell.lines, totals);
     }
+    totals.unpairedRendered += renderedQueue.length;
   }
   for (const queue of buckets.values()) totals.unpairedStored += queue.length;
 }
@@ -135,7 +220,7 @@ export function agreementPercent(totals) {
   return totals.cells === 0 ? 0 : (totals.agree / totals.cells) * 100;
 }
 
-/** 일치가 줄거나, 못 짝지은 셀이 늘거나, 측정 모수가 줄면 회귀다. */
+/** 일치가 줄거나, 못 짝지은 셀이 늘거나, 측정 모수가 줄거나, 기록 없음이 늘면 회귀다. */
 export function compareAgreement(actual, baseline) {
   const regressions = [];
   const improvements = [];
@@ -153,6 +238,11 @@ export function compareAgreement(actual, baseline) {
   if (actual.cells < baseline.cells) {
     regressions.push({ what: '측정 셀', now: actual.cells, was: baseline.cells });
   }
+  const noStoredNow = actual.noStoredRecord ?? 0;
+  const noStoredWas = baseline.noStoredRecord ?? 0;
+  if (noStoredNow > noStoredWas) {
+    regressions.push({ what: '기록 없는 셀', now: noStoredNow, was: noStoredWas });
+  }
   return { regressions, improvements };
 }
 
@@ -161,6 +251,7 @@ function emptyTotals() {
     documents: 0,
     unpairedStored: 0,
     unpairedRendered: 0,
+    noStoredRecord: 0,
     cells: 0,
     agree: 0,
     disagree: 0,
@@ -203,6 +294,7 @@ function sweep() {
 
 function report(t) {
   console.log(`  문서 ${t.documents}개 (못 짝지은 셀: 저장 ${t.unpairedStored} / 렌더 ${t.unpairedRendered})`);
+  console.log(`  기록 없음 ${t.noStoredRecord}개 (비교 모수에서 제외)`);
   console.log(`  측정 셀 ${t.cells}개   일치 ${t.agree} = ${agreementPercent(t).toFixed(2)}%`);
   console.log(`  불일치 ${t.disagree}  (rhwp 가 더 많이 ${t.renderedMore} / 더 적게 ${t.renderedFewer})`);
 }
@@ -213,7 +305,8 @@ function main() {
   if (args.includes('--update')) {
     const doc = {
       _comment: [
-        '셀 안 문단의 줄 나눔이 한/글 저장 기록과 일치하는 비율 (내용 키 짝짓기).',
+        '셀 안 문단의 줄 나눔이 한/글 저장 기록과 일치하는 비율 (내용 키 짝짓기, v3).',
+        '비교 모수는 저장 줄수가 있는 셀만. 기록 없음은 noStoredRecord.',
         '갱신: node scripts/cell-lineseg-agreement.mjs --update',
         '이 비율은 내려갈 수 없다. 올리는 것이 목표다.',
       ],

--- a/scripts/tests/cell-lineseg-agreement.test.mjs
+++ b/scripts/tests/cell-lineseg-agreement.test.mjs
@@ -4,6 +4,8 @@
 // (1) 중첩 표의 ls 줄이 바깥 셀로 새면 저장 줄 수가 부풀고,
 // (2) 못 짝지은 셀을 조용히 버리면 "안 재서 통과"가 생기고,
 // (3) 렌더 0줄 셀을 판정하면 빈 셀이 불일치로 잡힌다.
+// (4) 저장 줄수 0 을 불일치로 세면 일치율이 73%로 깎이고 (#6363),
+// (5) 쪽 나눔 조각을 통짜 저장 셀과 비교하면 "더 적게"가 부풀고.
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
@@ -21,6 +23,7 @@ function totals() {
     documents: 0,
     unpairedStored: 0,
     unpairedRendered: 0,
+    noStoredRecord: 0,
     cells: 0,
     agree: 0,
     disagree: 0,
@@ -29,7 +32,11 @@ function totals() {
   };
 }
 
-const cell = (row, col, text, lines) => ({ row, col, text, lines });
+const cell = (row, col, text, lines, header) => {
+  const out = { row, col, text, lines };
+  if (header !== undefined) out.header = header;
+  return out;
+};
 
 test('텍스트 키는 공백과 줄 구분 기호를 걷고 앞 12자만 쓴다', () => {
   assert.equal(textKey('성 명|  '), '성명');
@@ -42,7 +49,7 @@ test('dump 에서 셀·행·열·텍스트·저장 줄 수를 뽑는다', () => 
     '  [0]   셀[0] r=0,c=0 rs=1,cs=1 h=100 w=200 pad=(0,0,0,0) valign=Top aim=false hdr=false bf=1 paras=1 text="가나"',
     '  [0]     p[0] ps_id=1 ctrls=0 text_len=2 ls[0] ts=0 vpos=0 lh=100 ls=0 cs=0 sw=200',
   ].join('\n');
-  assert.deepEqual(storedCells(dump), [cell(0, 0, '가나', 1)]);
+  assert.deepEqual(storedCells(dump), [cell(0, 0, '가나', 1, false)]);
 });
 
 test('중첩 표의 ls 는 안쪽 셀에 붙고 바깥 셀로 새지 않는다', () => {
@@ -56,7 +63,7 @@ test('중첩 표의 ls 는 안쪽 셀에 붙고 바깥 셀로 새지 않는다',
     '  [0]     p[2] ps_id=1 ctrls=0 text_len=1 ls[0] ts=0 vpos=9 lh=1 ls=0 cs=0 sw=1',
   ].join('\n');
   const cells = storedCells(dump);
-  assert.deepEqual(cells, [cell(0, 0, '밖', 2), cell(0, 0, '안', 1)]);
+  assert.deepEqual(cells, [cell(0, 0, '밖', 2, false), cell(0, 0, '안', 1, false)]);
 });
 
 test('render tree 에서 Cell 별 TextLine 수와 텍스트를 뽑는다', () => {
@@ -158,4 +165,71 @@ test('일치율이 오르면 개선으로 보고한다', () => {
 
 test('빈 집계의 일치율은 0 이다', () => {
   assert.equal(agreementPercent(totals()), 0);
+});
+
+test('dump 가 hdr=true 를 저장 셀에 붙인다', () => {
+  const dump = [
+    '  [0] 표: 1행×1열, 셀=1, padding=(0,0,0,0), cs=0',
+    '  [0]   셀[0] r=0,c=0 rs=1,cs=1 h=100 w=200 pad=(0,0,0,0) valign=Top aim=false hdr=true bf=1 paras=1 text="제목"',
+    '  [0]     p[0] ps_id=1 ctrls=0 text_len=2 ls[0] ts=0 vpos=0 lh=100 ls=0 cs=0 sw=200',
+  ].join('\n');
+  assert.deepEqual(storedCells(dump), [cell(0, 0, '제목', 1, true)]);
+});
+
+test('저장 줄수 0 은 불일치가 아니라 기록 없음이다', () => {
+  const t = totals();
+  tallyDocument([cell(0, 0, '가', 0)], [cell(0, 0, '가', 2)], t);
+  assert.equal(t.noStoredRecord, 1);
+  assert.equal(t.cells, 0);
+  assert.equal(t.disagree, 0);
+  assert.equal(t.renderedMore, 0);
+  assert.equal(agreementPercent(t), 0);
+});
+
+test('제목 행 반복은 각 조각을 같은 저장 값과 개별 비교한다', () => {
+  const t = totals();
+  tallyDocument(
+    [cell(0, 0, '제목', 2, true)],
+    [cell(0, 0, '제목', 2), cell(0, 0, '제목', 2), cell(0, 0, '제목', 2)],
+    t,
+  );
+  assert.equal(t.cells, 3);
+  assert.equal(t.agree, 3);
+  assert.equal(t.unpairedRendered, 0);
+});
+
+test('쪽 나눔 조각은 합산해 통짜 저장 셀과 비교한다', () => {
+  const t = totals();
+  tallyDocument(
+    [cell(0, 0, '긴본문시작부분', 52, false)],
+    [
+      cell(0, 0, '긴본문시작부분', 15),
+      cell(0, 0, '이어지는조각텍스트', 20),
+      cell(0, 0, '마지막조각텍스트', 17),
+    ],
+    t,
+  );
+  assert.equal(t.cells, 1);
+  assert.equal(t.agree, 1);
+  assert.equal(t.renderedFewer, 0);
+  assert.equal(t.unpairedRendered, 0);
+});
+
+test('같은 좌표의 저장 셀이 둘이면 쪽 나눔 합산을 하지 않는다', () => {
+  const t = totals();
+  tallyDocument(
+    [cell(0, 0, '갑', 2, false), cell(0, 0, '을', 3, false)],
+    [cell(0, 0, '갑', 2), cell(0, 0, '을', 3)],
+    t,
+  );
+  assert.equal(t.agree, 2);
+  assert.equal(t.unpairedRendered, 0);
+});
+
+test('기록 없는 셀이 늘면 회귀다', () => {
+  const now = { ...totals(), cells: 100, agree: 100, noStoredRecord: 5 };
+  const was = { ...totals(), cells: 100, agree: 100, noStoredRecord: 1 };
+  const { regressions } = compareAgreement(now, was);
+  assert.equal(regressions.length, 1);
+  assert.equal(regressions[0].what, '기록 없는 셀');
 });


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

셀 줄나눔 계측기(`scripts/cell-lineseg-agreement.mjs`) v3 분류 왜곡을 고칩니다. **렌더러는 건드리지 않습니다.**

1. 저장 줄수 0 → `noStoredRecord` 로 분리. 비교 모수에서 제외. (이슈의 44,723건 "rhwp가 더 많이")
2. 같은 키에 저장 1개·렌더 여러 개:
   - `hdr=true` (제목 행 반복) → 각 조각을 같은 저장 값과 개별 비교
   - `hdr=false` (쪽 나눔) → (행,열이 문서에서 유일하면) 조각 줄 수를 합산해 통짜 저장 셀과 비교
3. 기준선 스키마 갱신: 비교 가능한 셀 일치율 **99.46%** (124,053/124,721). 기록 없음 증가는 파서 회귀.

## 관련 이슈

closes #6363

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** — JS 계측기만 변경. 신규/수정 파일 Unix LF
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음 — 기존 하네스 `scripts/tests/cell-lineseg-agreement.test.mjs` 확장
- [ ] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 — src 미변경
- [x] `node --test scripts/tests/cell-lineseg-agreement.test.mjs` **19 passed** (기존 13 + v3 6)
- [ ] `cargo clippy -- -D warnings` 통과 — Rust 미변경
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 조판 변경 없음
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: capability 카탈로그 규칙 반영

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (계측기 분류만)
- 재현·측정: 단위 테스트로 s=0 불일치 제거·52줄 통짜 vs 15+20+17 합산을 고정. 전수 스윕은 릴리스 바이너리 필요, 기준선 숫자는 이슈 실측(비교 가능 셀 99.46%)을 반영.

## 스크린샷

해당 없음 (조판 불변, 계측기 분류).
