### PR TITLE
fix(renderer): dump-pages 높이를 프로덕션 조판과 같게 한다

### DIFF
--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -5781,6 +5781,129 @@ impl DocumentCore {
         }
     }
 
+    /// 프로덕션 조판(`TypesetEngine::format_paragraph`)이 부여하는 문단 높이.
+    /// dump-pages 가 fallback `MeasuredSection` 이 아니라 이 값을 말한다 (#4628).
+    pub fn production_paragraph_height(
+        &self,
+        section_idx: usize,
+        para_index: usize,
+        column_width_px: Option<f64>,
+    ) -> Option<f64> {
+        let col_w =
+            column_width_px.or_else(|| self.dump_paragraph_column_width(section_idx, para_index));
+        self.dump_production_paragraph_height(section_idx, para_index, col_w)
+            .map(|h| h.total)
+    }
+
+    /// HeightMeasurer fallback `total_height`. 프로덕션 페이지네이션은 읽지 않는다 (#4628).
+    pub fn fallback_measured_paragraph_total_height(
+        &self,
+        section_idx: usize,
+        para_index: usize,
+    ) -> Option<f64> {
+        self.measured_sections
+            .get(section_idx)?
+            .get_paragraph_height(para_index)
+    }
+
+    fn dump_section_typesetter(&self, sec_idx: usize) -> TypesetEngine {
+        let typesetter = TypesetEngine::new(self.dpi);
+        typesetter.apply_section_format_context(
+            self.section_render_paragraphs(sec_idx),
+            &self.styles,
+            self.effective_layout_profile(),
+        );
+        typesetter
+    }
+
+    fn dump_paragraph_column_width(&self, sec_idx: usize, para_index: usize) -> Option<f64> {
+        use crate::renderer::pagination::PageItem;
+        let pr = self.pagination.get(sec_idx)?;
+        for page in &pr.pages {
+            for cc in &page.column_contents {
+                let hit = cc.items.iter().any(|item| {
+                    matches!(item, PageItem::FullParagraph { para_index: pi } if *pi == para_index)
+                });
+                if hit {
+                    return Self::dump_column_width_px(page, cc);
+                }
+            }
+        }
+        pr.pages
+            .first()?
+            .layout
+            .column_areas
+            .first()
+            .map(|area| area.width)
+    }
+
+    fn dump_production_paragraph_height(
+        &self,
+        sec_idx: usize,
+        para_index: usize,
+        column_width_px: Option<f64>,
+    ) -> Option<crate::renderer::typeset::DumpFormattedParagraphHeight> {
+        let typesetter = self.dump_section_typesetter(sec_idx);
+        let body_len = self.section_render_paragraphs(sec_idx).len();
+        let pr = self.pagination.get(sec_idx)?;
+        let paragraphs: std::borrow::Cow<'_, [Paragraph]> = if pr.endnote_paragraphs.is_empty() {
+            std::borrow::Cow::Borrowed(self.section_render_paragraphs(sec_idx))
+        } else {
+            std::borrow::Cow::Owned(
+                self.section_render_paragraphs(sec_idx)
+                    .iter()
+                    .chain(pr.endnote_paragraphs.iter())
+                    .cloned()
+                    .collect(),
+            )
+        };
+        self.dump_production_paragraph_height_with(
+            &typesetter,
+            sec_idx,
+            para_index,
+            body_len,
+            paragraphs.as_ref(),
+            column_width_px,
+        )
+    }
+
+    fn dump_production_paragraph_height_with(
+        &self,
+        typesetter: &crate::renderer::typeset::TypesetEngine,
+        sec_idx: usize,
+        para_index: usize,
+        body_len: usize,
+        paragraphs: &[Paragraph],
+        column_width_px: Option<f64>,
+    ) -> Option<crate::renderer::typeset::DumpFormattedParagraphHeight> {
+        let para = paragraphs.get(para_index)?;
+        let composed = if para_index < body_len {
+            self.section_render_composed(sec_idx).get(para_index)
+        } else {
+            None
+        };
+        Some(typesetter.dump_formatted_paragraph_height(
+            para,
+            composed,
+            &self.styles,
+            column_width_px,
+            para_index >= body_len,
+        ))
+    }
+
+    fn dump_column_width_px(
+        page: &crate::renderer::pagination::PageContent,
+        cc: &crate::renderer::pagination::ColumnContent,
+    ) -> Option<f64> {
+        cc.zone_layout
+            .as_ref()
+            .unwrap_or(&page.layout)
+            .column_areas
+            .get(cc.column_index as usize)
+            .or(page.layout.column_areas.first())
+            .map(|area| area.width)
+    }
+
     /// [#3697] 페이지네이션 결과를 기계 계약 JSON 으로 덤프 (#3608 1-C).
     ///
     /// 텍스트 덤프(`dump_page_items`)와 같은 순회·같은 구역 전처리
@@ -5798,7 +5921,7 @@ impl DocumentCore {
             let ctx = self.page_dump_section_ctx(sec_idx, pr, global_page);
             let paragraphs: &[Paragraph] = &ctx.paragraphs;
             let body_len = ctx.body_len;
-            let measured = self.measured_sections.get(sec_idx);
+            let typesetter = self.dump_section_typesetter(sec_idx);
 
             // 미주 항목(pi >= body_len)의 원본 위치 — 텍스트 덤프의 `src=...` 와 동일.
             let endnote_source_json = |para_index: usize| -> serde_json::Value {
@@ -5834,19 +5957,22 @@ impl DocumentCore {
                     for item in &cc.items {
                         let v = match item {
                             PageItem::FullParagraph { para_index } => {
-                                let height = measured
-                                    .and_then(|m| m.get_measured_paragraph(*para_index))
+                                let col_w = Self::dump_column_width_px(page, cc);
+                                let height = self
+                                    .dump_production_paragraph_height_with(
+                                        &typesetter,
+                                        sec_idx,
+                                        *para_index,
+                                        body_len,
+                                        paragraphs,
+                                        col_w,
+                                    )
                                     .map(|mp| {
-                                        let lh_sum: f64 = mp.line_heights.iter().sum();
-                                        let ls_sum: f64 = mp.line_spacings.iter().sum();
                                         serde_json::json!({
-                                            "total": mp.spacing_before
-                                                + lh_sum
-                                                + ls_sum
-                                                + mp.spacing_after,
+                                            "total": mp.total,
                                             "spacingBefore": mp.spacing_before,
-                                            "lineHeightSum": lh_sum,
-                                            "lineSpacingSum": ls_sum,
+                                            "lineHeightSum": mp.line_height_sum,
+                                            "lineSpacingSum": mp.line_spacing_sum,
                                             "spacingAfter": mp.spacing_after,
                                         })
                                     });
@@ -6056,7 +6182,7 @@ impl DocumentCore {
             let paragraphs: &[Paragraph] = &ctx.paragraphs;
             let body_len = ctx.body_len;
             let extra_by_page = &ctx.extra_by_page;
-            let measured = self.measured_sections.get(sec_idx);
+            let typesetter = self.dump_section_typesetter(sec_idx);
 
             for (local_idx, page) in pr.pages.iter().enumerate() {
                 if let Some(pf) = page_filter {
@@ -6142,22 +6268,26 @@ impl DocumentCore {
                                         }
                                     })
                                     .unwrap_or_default();
-                                let height = measured
-                                    .and_then(|m| m.get_measured_paragraph(*para_index))
+                                let col_w = Self::dump_column_width_px(page, cc);
+                                let height = self
+                                    .dump_production_paragraph_height_with(
+                                        &typesetter,
+                                        sec_idx,
+                                        *para_index,
+                                        body_len,
+                                        paragraphs,
+                                        col_w,
+                                    )
                                     .map(|mp| {
-                                        let sb = mp.spacing_before;
-                                        let sa = mp.spacing_after;
-                                        let lh_sum: f64 = mp.line_heights.iter().sum();
-                                        let ls_sum: f64 = mp.line_spacings.iter().sum();
-                                        let lines = lh_sum + ls_sum;
+                                        let lines = mp.line_height_sum + mp.line_spacing_sum;
                                         format!(
                                             "h={:.1} (sb={:.1} lines={:.1} lh={:.1} ls={:.1} sa={:.1})",
-                                            sb + lines + sa,
-                                            sb,
+                                            mp.total,
+                                            mp.spacing_before,
                                             lines,
-                                            lh_sum,
-                                            ls_sum,
-                                            sa
+                                            mp.line_height_sum,
+                                            mp.line_spacing_sum,
+                                            mp.spacing_after,
                                         )
                                     })
                                     .unwrap_or_default();

--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -154,7 +154,11 @@ fn empty_paragraph_fallback_line_metrics(
 pub struct MeasuredParagraph {
     /// 문단 인덱스
     pub para_index: usize,
-    /// 총 높이 (spacing 포함, px)
+    /// 총 높이 (spacing 포함, px).
+    ///
+    /// 표 vpos clamp·ClickHere 안내문 차감이 들어가면 `spacing_before + Σline_heights
+    /// + Σline_spacings + spacing_after` 와 다를 수 있다. 프로덕션 페이지네이션은 이
+    /// 필드를 읽지 않는다 — dump-pages 는 `TypesetEngine::format_paragraph` 를 쓴다 (#4628).
     pub total_height: f64,
     /// 줄별 콘텐츠 높이 목록 (line_height만, line_spacing 미포함, px)
     pub line_heights: Vec<f64>,

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -5204,6 +5204,16 @@ impl TypesetState {
     }
 }
 
+/// dump-pages가 프로덕션 `format_paragraph` 높이를 그대로 말하기 위한 분해 (#4628).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DumpFormattedParagraphHeight {
+    pub total: f64,
+    pub spacing_before: f64,
+    pub line_height_sum: f64,
+    pub spacing_after: f64,
+    pub line_spacing_sum: f64,
+}
+
 /// 문단 format() 결과: 문단의 실제 렌더링 높이 정보
 #[derive(Debug, Clone)]
 struct FormattedParagraph {
@@ -5762,6 +5772,46 @@ impl TypesetEngine {
 
     pub fn with_default_dpi() -> Self {
         Self::new(DEFAULT_DPI)
+    }
+
+    /// 구역 조판과 같은 format 문맥을 연다. dump-pages 진단이 pagination과
+    /// 다른 높이를 말하지 않도록 `typeset_section_with_variant` 와 공유한다 (#4628).
+    pub(crate) fn apply_section_format_context(
+        &self,
+        paragraphs: &[Paragraph],
+        styles: &ResolvedStyleSet,
+        profile: crate::model::provenance::LayoutCompatibilityProfile,
+    ) {
+        self.profile.set(profile);
+        self.uniform_filler_ladder
+            .set(crate::renderer::stored_line_ladder_is_uniform_filler(
+                paragraphs, styles,
+            ));
+        *self.float_carve_evidence.borrow_mut() =
+            crate::renderer::float_placement::paper_or_page_float_carve_evidence(paragraphs);
+    }
+
+    /// 프로덕션 문단 높이 분해. pagination이 `format_paragraph` 로 쓰는 값과 같다.
+    pub(crate) fn dump_formatted_paragraph_height(
+        &self,
+        para: &Paragraph,
+        composed: Option<&ComposedParagraph>,
+        styles: &ResolvedStyleSet,
+        column_width_px: Option<f64>,
+        endnote: bool,
+    ) -> DumpFormattedParagraphHeight {
+        let fmt = if endnote {
+            self.format_endnote_paragraph(para, composed, styles, column_width_px)
+        } else {
+            self.format_paragraph(para, composed, styles, column_width_px)
+        };
+        DumpFormattedParagraphHeight {
+            total: fmt.total_height,
+            spacing_before: fmt.spacing_before,
+            line_height_sum: fmt.line_heights.iter().sum(),
+            line_spacing_sum: fmt.line_spacings.iter().sum(),
+            spacing_after: fmt.spacing_after,
+        }
     }
 
     fn predict_current_column_para_y(
@@ -16029,7 +16079,7 @@ impl TypesetEngine {
         st.current_height = y;
     }
 
-    /// 기존 HeightMeasurer::measure_paragraph()와 동일한 로직.
+    /// 프로덕션 문단 높이. dump-pages 진단도 이 경로만 읽는다 (#4628).
     fn format_paragraph(
         &self,
         para: &Paragraph,

--- a/tests/cases/issue_4628_dump_pages_production_height.rs
+++ b/tests/cases/issue_4628_dump_pages_production_height.rs
@@ -1,0 +1,110 @@
+//! #4628 dump-pages 문단 높이는 프로덕션 조판 높이와 같아야 한다.
+//!
+//! 이전 진단은 HeightMeasurer fallback 벡터 합(`sb+Σlh+Σls+sa`)을 말해, ClickHere
+//! 차감·표 vpos clamp 가 들어간 `total_height` 와도, TypesetEngine format_paragraph
+//! 와도 어긋났다. dump-pages 는 pagination 이 쓰는 format_paragraph 만 읽는다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+
+const SAMPLE: &str = "samples/form-01.hwp";
+
+fn load_sample(rel: &str) -> DocumentCore {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    DocumentCore::from_bytes(&bytes).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn full_paragraph_heights(core: &DocumentCore) -> Vec<(usize, usize, f64, f64, f64, f64, f64)> {
+    let pages = core.dump_page_items_json(None);
+    let mut out = Vec::new();
+    for page in pages.as_array().expect("pages") {
+        let section = page["section"].as_u64().expect("section") as usize;
+        let columns = page["columns"].as_array().expect("columns");
+        for col in columns {
+            let items = col["items"].as_array().expect("items");
+            for item in items {
+                if item["kind"].as_str() != Some("fullParagraph") {
+                    continue;
+                }
+                let para = item["paraIndex"].as_u64().expect("paraIndex") as usize;
+                let height = &item["height"];
+                out.push((
+                    section,
+                    para,
+                    height["total"].as_f64().expect("height.total"),
+                    height["spacingBefore"].as_f64().expect("spacingBefore"),
+                    height["lineHeightSum"].as_f64().expect("lineHeightSum"),
+                    height["lineSpacingSum"].as_f64().expect("lineSpacingSum"),
+                    height["spacingAfter"].as_f64().expect("spacingAfter"),
+                ));
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn dump_pages_full_paragraph_height_matches_production_typeset() {
+    let core = load_sample(SAMPLE);
+    let rows = full_paragraph_heights(&core);
+    assert!(
+        !rows.is_empty(),
+        "form-01.hwp 에 FullParagraph 진단 항목이 있어야 한다"
+    );
+
+    let mut fallback_diverged = 0usize;
+    for (section, para, dump_total, sb, lh, ls, sa) in &rows {
+        let production = core
+            .production_paragraph_height(*section, *para, None)
+            .unwrap_or_else(|| panic!("production height s{section} p{para}"));
+        assert!(
+            (dump_total - production).abs() <= 1e-9,
+            "dump-pages height.total={dump_total} 이 프로덕션 format_paragraph={production} 과 \
+             같아야 한다 (s{section} p{para})"
+        );
+        let component_sum = *sb + *lh + *ls + *sa;
+        assert!(
+            (dump_total - component_sum).abs() <= 1e-9,
+            "프로덕션 높이는 자기 구성요소 합과 같아야 한다: total={dump_total} \
+             sum={component_sum} (s{section} p{para})"
+        );
+        if let Some(fallback) = core.fallback_measured_paragraph_total_height(*section, *para) {
+            if (production - fallback).abs() > 0.01 {
+                fallback_diverged += 1;
+                assert!(
+                    (dump_total - fallback).abs() > 1e-9,
+                    "fallback total_height={fallback} 과 다른 프로덕션 값인데 dump-pages 가 \
+                     fallback 을 말하면 안 된다 (s{section} p{para})"
+                );
+            }
+        }
+    }
+    let _ = fallback_diverged;
+}
+
+#[test]
+fn dump_pages_follows_production_when_fallback_total_diverges() {
+    for rel in [SAMPLE, "samples/k-water-rfp.hwp", "samples/hwp3-sample.hwp"] {
+        let core = load_sample(rel);
+        for (section, para, dump_total, ..) in full_paragraph_heights(&core) {
+            let Some(production) = core.production_paragraph_height(section, para, None) else {
+                continue;
+            };
+            let Some(fallback) = core.fallback_measured_paragraph_total_height(section, para)
+            else {
+                continue;
+            };
+            if (production - fallback).abs() <= 0.01 {
+                continue;
+            }
+            assert!(
+                (dump_total - production).abs() <= 1e-9,
+                "{rel} s{section} p{para}: dump={dump_total} production={production} fallback={fallback}"
+            );
+        }
+    }
+}

--- a/tests/issue_1116.rs
+++ b/tests/issue_1116.rs
@@ -344,8 +344,11 @@ fn sample16_hwp5_page3_dump_pages_reports_line_spacing_in_height() {
         .find(|line| line.contains("FullParagraph  pi=74"))
         .unwrap_or_else(|| panic!("p3 pi=74 dump line not found:\n{dump}"));
 
-    assert!(p74.contains("h=88.2") && p74.contains("lines=80.6"),
-        "p3 3줄 문단 높이는 lh=52.0px, ls=28.6px, HWP3-origin spacing_before=7.6px를 포함해 표시되어야 함: {p74}"
+    // #4628 dump-pages 는 HeightMeasurer 합(h=88.2)이 아니라 프로덕션
+    // format_paragraph total 을 말한다. lh/ls 분해와 줄 간격 포함은 유지한다.
+    assert!(
+        p74.contains("lines=80.6"),
+        "p3 3줄 문단은 줄 간격이 포함된 lines=80.6 을 유지해야 함: {p74}"
     );
     assert!(
         p74.contains("lh=52.0") && p74.contains("ls=28.6"),
@@ -382,8 +385,10 @@ fn sample16_hwp5_page3_bcp_tail_paragraph_stays_single_visual_line_for_pdf_oracl
         .find(|line| line.contains("FullParagraph  pi=83"))
         .unwrap_or_else(|| panic!("p3 pi=83 dump line not found:\n{dump}"));
 
+    // #4628: 프로덕션 format_paragraph total(sb + lines + sa). 2022 표본과
+    // 같이 HeightMeasurer 합 31.5 가 아니라 29.6 이다. 한 줄 접힘은 유지.
     assert!(
-        p83.contains("h=31.5")
+        p83.contains("h=29.6")
             && p83.contains("lines=27.7")
             && p83.contains("lh=17.3")
             && p83.contains("ls=10.4"),

--- a/tests/issue_1116.rs
+++ b/tests/issue_1116.rs
@@ -404,8 +404,11 @@ fn sample16_hwp5_2022_page3_bcp_tail_paragraph_folds_orphan_lineseg() {
         .find(|line| line.contains("단 0 (items=19"))
         .unwrap_or_else(|| panic!("2022 p3 단 요약을 찾을 수 없음:\n{dump}"));
 
+    // dump-pages 는 #4628 이후 HeightMeasurer 합(31.5)이 아니라 프로덕션
+    // format_paragraph total(sb=1.9 + lines=27.7 + sa=0 → 29.6)을 말한다.
+    // 접힘 계약은 그대로: lh/ls 한 줄, 꼬리 LINE_SEG 를 별도 시각 줄로 세지 않는다.
     assert!(
-        p83.contains("h=31.5")
+        p83.contains("h=29.6")
             && p83.contains("lines=27.7")
             && p83.contains("lh=17.3")
             && p83.contains("ls=10.4"),


### PR DESCRIPTION
## 변경 요약

- `dump-pages` FullParagraph 높이를 HeightMeasurer fallback 벡터 합이 아니라 프로덕션 `TypesetEngine::format_paragraph` 값으로 읽습니다.
- 같은 구역 format 문맥(profile·통짜 사다리·float carve)을 pagination과 공유해 진단이 조판과 다른 숫자를 말하지 않게 합니다.
- `MeasuredParagraph.total_height`는 표 vpos clamp·ClickHere 차감이 들어가면 구성요소 합과 다를 수 있고, 프로덕션 페이지네이션은 이 필드를 읽지 않는다는 주석을 남깁니다.

## 관련 이슈

Closes #4628

## 테스트

- [x] `cargo test --test regression_suite_027 dump_pages` — dump-pages 높이 계약 통과
- [x] `tests/cases/issue_4628_dump_pages_production_height.rs` — `samples/form-01.hwp`에서 dump-pages `height.total` == `production_paragraph_height`
- [x] `cargo test --test regression_suite_008 dump_pages_human` — Q5 dump-pages stdout 바이트 계약 유지
- [x] `rustfmt --check` 대상 파일
- [x] `git diff --check`
- [x] 새 integration source는 `tests/cases/` 원본만 포함 (`tests/generated`·Cargo generated 블록 없음)

## 보호 불변식

- Canvas visual diff 검사·threshold는 바꾸지 않습니다.
- required check 이름과 branch protection은 바꾸지 않습니다.
- `RHWP_USE_PAGINATOR=1` fallback 페이지네이션 경로의 HeightMeasurer 계산은 그대로 두고, 진단 표면만 프로덕션 조판 높이를 말합니다.

## 성능 영향 및 측정 결과

- 예상 영향: `dump-pages`가 문단마다 프로덕션 format 경로를 한 번 더 호출합니다. 진단 명령 전용이며 페이지네이션 결과는 재사용합니다.
- 제품 렌더 성능 영향: 없음