### PR TITLE
test(ci): issue_2007 저장 프레임 경계 테스트를 병렬에서 격리한다

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,6 +7,12 @@ nextest-version = { required = "0.9.91", recommended = "0.9.140" }
 filter = "test(/(^|::)overflow_cell_baseline::/)"
 priority = 100
 
+# [#4207] 저장 프레임 경계 테스트는 같은 조판 바이너리의 이웃과 병렬이면
+# 간헐 red 가 난다. 전 스레드를 점유해 단독 실행한다. 단언은 매 CI 그대로 돈다.
+[[profile.default.overrides]]
+filter = "test(issue_2007_intra_paragraph_saved_frame_break_is_preserved)"
+threads-required = "num-test-threads"
+
 # B/C/D archive workers use this profile only to emit a compact JUnit report.
 # Successful devel runs retain it for the baseline; same-repository PRs retain a
 # short-lived candidate that a later trusted post-merge verifier may consume.
@@ -16,3 +22,7 @@ report-name = "rhwp-nextest-duration-observation"
 store-success-output = false
 store-failure-output = true
 report-skipped = "none"
+
+[[profile.ci-duration-observation.overrides]]
+filter = "test(issue_2007_intra_paragraph_saved_frame_break_is_preserved)"
+threads-required = "num-test-threads"

--- a/tests/issue_2007_nested_cell_pagination.rs
+++ b/tests/issue_2007_nested_cell_pagination.rs
@@ -17,9 +17,23 @@
 
 use std::fs;
 use std::path::Path;
+use std::sync::{Mutex, MutexGuard};
 
 use rhwp::document_core::DocumentCore;
 use rhwp::renderer::render_tree::{BoundingBox, RenderNode, RenderNodeType};
+
+/// [#4207] 이 파일의 테스트는 같은 픽스처를 조판한다. 생성 suite 한 프로세스에서
+/// 병렬이면 LayoutEngine 의 cell-units 포인터 캐시가 allocator 재사용으로
+/// 저장 프레임 경계를 흔든다(shard 간헐 red, 무관 PR 오염).
+/// 단언은 그대로 두고 조판만 직렬화한다. CI nextest 는 별도 프로세스가 기본이라
+/// `.config/nextest.toml` 에서 해당 테스트를 exclusive 로 돌린다.
+static ISSUE_2007_LAYOUT_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock_issue_2007_layout() -> MutexGuard<'static, ()> {
+    ISSUE_2007_LAYOUT_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
 
 fn page_text(node: &RenderNode, out: &mut String) {
     if let RenderNodeType::TextRun(run) = &node.node_type {
@@ -501,6 +515,7 @@ fn has_nested_cell_text_overlap(node: &RenderNode) -> bool {
 
 #[test]
 fn issue_2007_nested_cell_content_paginates() {
+    let _issue_2007_layout = lock_issue_2007_layout();
     let repo_root = env!("CARGO_MANIFEST_DIR");
     let hwp_path =
         Path::new(repo_root).join("samples/basic/issue2007_nested_cell_pagination_42065.hwp");
@@ -580,6 +595,7 @@ fn issue_2007_nested_cell_content_paginates() {
 
 #[test]
 fn issue_2007_nested_cell_cursor_has_no_boundary_duplication() {
+    let _issue_2007_layout = lock_issue_2007_layout();
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("samples/basic/issue2007_nested_cell_pagination_42065.hwp");
     let bytes = fs::read(&path).expect("fixture read");
@@ -613,6 +629,7 @@ fn issue_2007_nested_cell_cursor_has_no_boundary_duplication() {
 
 #[test]
 fn issue_2007_recursive_partial_render_is_page_order_independent() {
+    let _issue_2007_layout = lock_issue_2007_layout();
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("samples/basic/issue2007_nested_cell_pagination_42065.hwp");
     let bytes = fs::read(&path).expect("fixture read");
@@ -638,6 +655,7 @@ fn issue_2007_recursive_partial_render_is_page_order_independent() {
 
 #[test]
 fn issue_2007_intra_paragraph_saved_frame_break_is_preserved() {
+    let _issue_2007_layout = lock_issue_2007_layout();
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("samples/basic/issue2007_nested_cell_pagination_42065.hwp");
     let bytes = fs::read(&path).expect("fixture read");
@@ -669,6 +687,7 @@ fn issue_2007_intra_paragraph_saved_frame_break_is_preserved() {
 
 #[test]
 fn issue_2007_saved_frame_tail_nested_table_starts_before_next_frame() {
+    let _issue_2007_layout = lock_issue_2007_layout();
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("samples/basic/issue2007_nested_cell_pagination_42065.hwp");
     let bytes = fs::read(&path).expect("fixture read");
@@ -700,6 +719,7 @@ fn issue_2007_saved_frame_tail_nested_table_starts_before_next_frame() {
 
 #[test]
 fn issue_2007_nested_table_right_outer_border_is_not_clipped() {
+    let _issue_2007_layout = lock_issue_2007_layout();
     let repo_root = env!("CARGO_MANIFEST_DIR");
     let hwp_path =
         Path::new(repo_root).join("samples/basic/issue2007_nested_cell_pagination_42065.hwp");
@@ -738,6 +758,7 @@ fn issue_2007_nested_table_right_outer_border_is_not_clipped() {
 
 #[test]
 fn issue_2007_wrapper_clip_keeps_completed_nested_table_right_borders() {
+    let _issue_2007_layout = lock_issue_2007_layout();
     let repo_root = env!("CARGO_MANIFEST_DIR");
     let hwp_path =
         Path::new(repo_root).join("samples/basic/issue2007_nested_cell_pagination_42065.hwp");
@@ -791,6 +812,7 @@ fn issue_2007_wrapper_clip_keeps_completed_nested_table_right_borders() {
 
 #[test]
 fn issue_2007_continuation_ancestor_clip_keeps_deep_right_border() {
+    let _issue_2007_layout = lock_issue_2007_layout();
     let repo_root = env!("CARGO_MANIFEST_DIR");
     let hwp_path =
         Path::new(repo_root).join("samples/basic/issue2007_nested_cell_pagination_42065.hwp");
@@ -822,6 +844,7 @@ fn issue_2007_continuation_ancestor_clip_keeps_deep_right_border() {
 
 #[test]
 fn issue_2007_single_cell_continuation_does_not_repaint_boundary_fragments() {
+    let _issue_2007_layout = lock_issue_2007_layout();
     let repo_root = env!("CARGO_MANIFEST_DIR");
     let hwp_path =
         Path::new(repo_root).join("samples/basic/issue2007_nested_cell_pagination_42065.hwp");
@@ -910,6 +933,7 @@ fn issue_2007_single_cell_continuation_does_not_repaint_boundary_fragments() {
 
 #[test]
 fn issue_2007_completed_multiline_table_keeps_following_heading_in_next_viewport() {
+    let _issue_2007_layout = lock_issue_2007_layout();
     let repo_root = env!("CARGO_MANIFEST_DIR");
     let hwp_path =
         Path::new(repo_root).join("samples/basic/issue2007_nested_cell_pagination_42065.hwp");
@@ -947,6 +971,7 @@ fn issue_2007_completed_multiline_table_keeps_following_heading_in_next_viewport
 
 #[test]
 fn issue_2007_continuation_frame_restarts_and_drops_previous_page_residual() {
+    let _issue_2007_layout = lock_issue_2007_layout();
     let repo_root = env!("CARGO_MANIFEST_DIR");
     let hwp_path =
         Path::new(repo_root).join("samples/basic/issue2007_nested_cell_pagination_42065.hwp");
@@ -1206,6 +1231,7 @@ fn issue_2007_continuation_frame_restarts_and_drops_previous_page_residual() {
 
 #[test]
 fn issue_2007_cell_vpos_reset_does_not_overlap_following_paragraphs() {
+    let _issue_2007_layout = lock_issue_2007_layout();
     let repo_root = env!("CARGO_MANIFEST_DIR");
     let hwp_path =
         Path::new(repo_root).join("samples/basic/issue2007_nested_cell_pagination_42065.hwp");
@@ -1253,6 +1279,7 @@ fn issue_2007_cell_vpos_reset_does_not_overlap_following_paragraphs() {
 
 #[test]
 fn issue_4159_terminal_nested_bottom_border_is_inside_all_cell_clips() {
+    let _issue_2007_layout = lock_issue_2007_layout();
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("samples/basic/issue2007_nested_cell_pagination_42065.hwp");
     let bytes = fs::read(&path).expect("fixture read");
@@ -1296,6 +1323,7 @@ fn issue_4159_terminal_nested_bottom_border_is_inside_all_cell_clips() {
 
 #[test]
 fn issue_4159_svg_terminal_bottom_border_is_visible_inside_outer_cell_clip() {
+    let _issue_2007_layout = lock_issue_2007_layout();
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("samples/basic/issue2007_nested_cell_pagination_42065.hwp");
     let bytes = fs::read(&path).expect("fixture read");
@@ -1339,6 +1367,7 @@ fn issue_4159_svg_terminal_bottom_border_is_visible_inside_outer_cell_clip() {
 
 #[test]
 fn issue_2007_continuation_viewport_does_not_center_nested_cell_content() {
+    let _issue_2007_layout = lock_issue_2007_layout();
     let repo_root = env!("CARGO_MANIFEST_DIR");
     let hwp_path =
         Path::new(repo_root).join("samples/basic/issue2007_nested_cell_pagination_42065.hwp");


### PR DESCRIPTION
## 무엇

`issue_2007_intra_paragraph_saved_frame_break_is_preserved` 가 CI shard 에서 간헐 red 가 나 무관한 PR 의 Build & Test 를 오염시킵니다. 단언은 그대로 두고, 같은 픽스처를 조판하는 테스트만 직렬화합니다.

## 원인

이 테스트는 `regression_suite_023` 에 묶여 같은 바이너리의 이웃과 병렬로 조판됩니다. `LayoutEngine` 의 cell-units 캐시는 셀 포인터를 키로 쓰므로, 임시 표 clone 주소가 allocator 재사용되면 저장 프레임 쪽 경계가 흔들립니다. #4194 처럼 문서·신규 테스트만 바꾼 브랜치에서도 shard-3 이 같은 테스트로 red 였습니다.

## 변경

- `tests/issue_2007_nested_cell_pagination.rs` — 파일 단위 mutex 로 조판 직렬화. 단언·픽스처·페이지 기대값은 불변.
- `.config/nextest.toml` — 해당 테스트가 전 스레드를 점유해 단독 실행(`threads-required = num-test-threads`). default 와 `ci-duration-observation` 둘 다.

`#[ignore]` 하지 않습니다. 매 CI 에서 같은 계약을 돌립니다.

## 검증

- [x] `cargo fmt --all -- --check` (rustfmt `newline_style=Unix`)
- [ ] `cargo test` `issue_2007_intra_paragraph_saved_frame_break_is_preserved` (로컬 디스크 한도로 이 워크트리에서 전체 링크는 생략. 단언 본문 불변.)

closes #4207
