### PR TITLE
fix(capabilities): run 실패 봉투 예외를 jsonContract.failure 에 적는다 (#3884 G3)

### DIFF
--- a/mydocs/tech/agent_architecture/invariants.md
+++ b/mydocs/tech/agent_architecture/invariants.md
@@ -182,10 +182,9 @@ $ rhwp run <비 JSON 파일> --json      → exit=2  stdout=0B    ← 규약 준
 **`prevalidation_failure_is_exit_2_with_no_output`** 이다. 이름의 "no output"은 **출력 파일 부재**이고, stdout 은
 오히려 **파싱해서 `invalid[]` 를 단언한다**(`:127`).
 
-> **미해결**: `capabilities.jsonContract.failure` 는 여전히 예외를 적지 않는다
-> ("단건 명령 실패 시 stdout 0바이트; batch 는 error 레코드 + 최종 exit 1") —
-> [`open_gaps.md` G-02](open_gaps.md#g-02--run-의-실패-경로-예외를-자기서술이-적지-않는다) ·
-> [#3880](https://github.com/edwardkim/rhwp/issues/3880) T4.
+> `capabilities.jsonContract.failure` 가 이 예외를 적는다
+> ("예외: run — 실패도 봉투를 stdout 으로 낸다(계획 안 문서 부재 등 입력 오류 exit 1 + error, …)") —
+> [#3884](https://github.com/edwardkim/rhwp/issues/3884) G3.
 
 ---
 

--- a/mydocs/tech/agent_architecture/layer_model.md
+++ b/mydocs/tech/agent_architecture/layer_model.md
@@ -472,7 +472,7 @@ M20 이 시작된 뒤에 고치면 언어 수만큼의 예외가 이미 심어�
 
 ```
 $ rhwp capabilities | jq -r '.jsonContract.failure'
-단건 명령 실패 시 stdout 0바이트; batch 는 error 레코드 + 최종 exit 1
+단건 명령 실패 시 stdout 0바이트; batch 는 error 레코드 + 최종 exit 1. 예외: run — 실패도 봉투를 stdout 으로 낸다(계획 안 문서 부재 등 입력 오류 exit 1 + error, 계획 무효 exit 2 + invalid[], 단언 실패 exit 3 + verify 저널)
 ```
 
 실물은 다르다.

--- a/mydocs/tech/agent_architecture/open_gaps.md
+++ b/mydocs/tech/agent_architecture/open_gaps.md
@@ -107,8 +107,9 @@ $ rhwp capabilities | jq '.commands[] | select(.name=="dump")'
 
 *층* L1 — *이슈* [#3880](https://github.com/edwardkim/rhwp/issues/3880) T4
 
-**증상.** `capabilities.jsonContract.failure` 는 "단건 명령 실패 시 stdout 0바이트"라고 말하는데 `run` 은 예외다. 자기서술만
-읽는 소비자가 깨진다.
+**증상.** `run` 은 실패에도 봉투를 stdout 으로 낸다. 자기서술이 이 예외를 빼면
+"실패 = stdout 0바이트"를 믿는 소비자가 깨진다. 선언은 `jsonContract.failure` 에
+계획 안 문서 부재(exit 1 + error)를 포함해 적는다.
 
 **재현 — 예외의 경계까지 확정했다.**
 
@@ -119,7 +120,7 @@ $ rhwp run                                 → exit=2  stdout=0B    ← 규약 �
 $ rhwp run <비 JSON 파일> --json             → exit=2  stdout=0B    ← 규약 준수
 
 $ rhwp capabilities | jq -r '.jsonContract.failure'
-단건 명령 실패 시 stdout 0바이트; batch 는 error 레코드 + 최종 exit 1
+단건 명령 실패 시 stdout 0바이트; batch 는 error 레코드 + 최종 exit 1. 예외: run — 실패도 봉투를 stdout 으로 낸다(계획 안 문서 부재 등 입력 오류 exit 1 + error, 계획 무효 exit 2 + invalid[], 단언 실패 exit 3 + verify 저널)
 ```
 
 > [#3876](https://github.com/edwardkim/rhwp/pull/3876) 은 "exit 1 + 200 B",

--- a/mydocs/tech/agent_runtime/envelope_parity.md
+++ b/mydocs/tech/agent_runtime/envelope_parity.md
@@ -238,8 +238,8 @@ fn classify_hwp_error(msg: &str) -> LoadError {
 않고 사실만 적는다. 패리티 규칙은 이 현실을 덮어야 한다.
 
 **① `run --json` 은 실패에도 봉투를 낸다.** `capabilities.jsonContract.failure` 는
-"단건 명령 실패 시 stdout 0바이트; batch 는 error 레코드 + 최종 exit 1"이라고
-선언하는데, `run` 은 셋째 경우다:
+이 예외를 적는다 — "예외: run — 실패도 봉투를 stdout 으로 낸다(계획 안 문서 부재 등
+입력 오류 exit 1 + error, …)". `run` 은 셋째 경우다:
 
 ```console
 $ rhwp run --plan-json '{"planVersion":"1.0"}' --json

--- a/mydocs/tech/agent_runtime/failure_dictionary.md
+++ b/mydocs/tech/agent_runtime/failure_dictionary.md
@@ -64,7 +64,7 @@ last_verified: 2026-08-03
 
 선언(`capabilities.jsonContract.failure`)은 이렇다:
 
-> 단건 명령 실패 시 stdout 0바이트; batch 는 error 레코드 + 최종 exit 1
+> 단건 명령 실패 시 stdout 0바이트; batch 는 error 레코드 + 최종 exit 1. 예외: run — 실패도 봉투를 stdout 으로 낸다(계획 안 문서 부재 등 입력 오류 exit 1 + error, 계획 무효 exit 2 + invalid[], 단언 실패 exit 3 + verify 저널)
 
 실측으로 확인한 값:
 

--- a/src/cli/metadata/capabilities/mod.rs
+++ b/src/cli/metadata/capabilities/mod.rs
@@ -668,7 +668,7 @@ pub(crate) fn capabilities_value() -> serde_json::Value {
             "schemaPolicy": "필드 추가 허용, 변경·삭제는 schemaVersion 범프",
             // [#3884 G3] run 의 예외는 설계다(판정을 데이터로 보고) — 적지 않으면
             // "실패 = stdout 0바이트"를 믿는 소비자가 run 에서 깨진다.
-            "failure": "단건 명령 실패 시 stdout 0바이트; batch 는 error 레코드 + 최종 exit 1. 예외: run — 실패도 봉투를 stdout 으로 낸다(입력 오류 exit 1 + error, 계획 무효 exit 2 + invalid[], 단언 실패 exit 3 + verify 저널)",
+            "failure": "단건 명령 실패 시 stdout 0바이트; batch 는 error 레코드 + 최종 exit 1. 예외: run — 실패도 봉투를 stdout 으로 낸다(계획 안 문서 부재 등 입력 오류 exit 1 + error, 계획 무효 exit 2 + invalid[], 단언 실패 exit 3 + verify 저널)",
             // [#3707] 봉투에 담기는 문서 유래 문자열의 유니코드 기만 판정. 이 키가
             // 있으면 바이너리가 검사한다는 뜻이다 — 키가 없으면 '깨끗함'이 아니라
             // '검사하지 않음'으로 읽어야 한다.

--- a/tests/cases/issue_3884_g3_run_json_exception.rs
+++ b/tests/cases/issue_3884_g3_run_json_exception.rs
@@ -1,0 +1,119 @@
+//! [#3884 G3] `run` 실패 봉투 예외가 capabilities 에 자기서술되고, 계획 안 문서
+//! 부재 실측과 맞는다.
+//!
+//! `run_plan_engine` 은 MCP `hwp_run_plan` 과 저널을 공유하므로 실패를 stdout
+//! 0바이트로 바꾸지 않는다. 소비자는 `jsonContract.failure` 의 예외를 읽고
+//! 봉투를 파싱한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .args(args)
+        .output()
+        .expect("rhwp 실행")
+}
+
+fn describe(args: &[&str], out: &Output) -> String {
+    format!(
+        "args={args:?}\nexit={:?}\nstdout={}\nstderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+fn write_plan(tag: &str, plan: &serde_json::Value) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "rhwp-3884-g3-{tag}-{}-{}.json",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::write(&path, serde_json::to_vec_pretty(plan).expect("plan json")).expect("plan write");
+    path
+}
+
+fn capabilities_failure() -> String {
+    let args = ["capabilities"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("capabilities JSON");
+    v["jsonContract"]["failure"]
+        .as_str()
+        .expect("jsonContract.failure")
+        .to_string()
+}
+
+#[test]
+fn capabilities_failure_declares_run_missing_document_exception() {
+    let failure = capabilities_failure();
+    assert!(
+        failure.contains("run"),
+        "run 의 stdout 예외가 자기서술에 없다: {failure}"
+    );
+    assert!(
+        failure.contains("계획 안 문서 부재"),
+        "계획 안 문서 부재가 jsonContract.failure 에 없다: {failure}"
+    );
+    assert!(
+        failure.contains("error"),
+        "입력 오류 봉투 키 error 가 자기서술에 없다: {failure}"
+    );
+    assert!(
+        failure.contains("invalid"),
+        "계획 무효 invalid[] 예외가 자기서술에 없다: {failure}"
+    );
+}
+
+#[test]
+fn run_json_missing_document_emits_error_envelope() {
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": "no-such-file-3884-g3.hwp",
+        "output": "out-3884-g3.hwp",
+        "steps": [{ "action": "replace_text", "find": "a", "replace": "b" }],
+    });
+    let plan_path = write_plan("missing-doc", &plan);
+    let args = ["run", plan_path.to_str().expect("utf-8"), "--json"];
+    let out = run(&args);
+    let _ = std::fs::remove_file(&plan_path);
+
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "계획 안 문서 부재는 입력 오류(exit 1)다: {}",
+        describe(&args, &out)
+    );
+    assert!(
+        !out.stdout.is_empty(),
+        "run 실패도 봉투를 stdout 으로 낸다: {}",
+        describe(&args, &out)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!("stdout JSON 아님 ({e}): {}", describe(&args, &out)));
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("입력을 읽을 수 없습니다"),
+        "문서 부재 사유가 error 에 없다: {v}"
+    );
+    assert!(
+        err.contains("no-such-file-3884-g3.hwp"),
+        "없는 경로가 error 에 없다: {v}"
+    );
+
+    let failure = capabilities_failure();
+    assert!(
+        failure.contains("exit 1") && failure.contains("error"),
+        "자기서술(입력 오류 exit 1 + error)이 실측과 어긋난다: {failure}"
+    );
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

`run` 의 실패 경로 stdout 예외를 `capabilities.jsonContract.failure` 에 **계획 안 문서 부재**까지 명시한다. `run` 구현은 바꾸지 않는다.

`run_plan_engine` 은 MCP `hwp_run_plan` 과 저널을 공유하므로, 계획 파싱에 들어간 뒤의 실패는 stdout 0바이트가 아니라 봉투다. 이슈 #3884 의 구판 실측(exit 2 · 137 B)은 `input` 필드 누락(사용법) 경로에 가깝고, **현재 devel** 에서 계획 안 문서가 없으면 **exit 1 + `error` 봉투(200 B)** 이다. 자기서술이 이 예외를 빼면 "실패 = stdout 0바이트"를 믿는 소비자가 깨진다.

이 PR 은 **G3 만**. G1은 #6404, G2는 #6411. G4(inspect·edit 하위 명령 자기서술)는 남긴다. `#3884` 를 닫지 않는다.

## 관련 이슈

#3884

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음 (`--sync-cargo-targets` 메인터너 registry PR은 marker 블록만 예외)
- [ ] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
- [x] `cargo test --test issue_3884_g3_run_json_exception --bin rhwp` 통과 (2/2)
- [ ] `cargo clippy -- -D warnings` 통과 (문구·시험만)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — `rhwp replay --capsule` 영수증 캡슐 또는 관련 `--json` 봉투 원문 ([AGENTS.md 작업 증빙 절](../AGENTS.md#작업-증빙--에이전트-기본-경로-권장))
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: [capability 카탈로그](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_capability_registry.md)의 등록·검증 규칙을 반영

## 실측

계획 `input` 이 없는 파일을 가리킬 때 (`run <plan.json> --json`):

| 항목 | 값 |
|---|---|
| exit | **1** |
| stdout | **200 B** JSON `{"error":"입력을 읽을 수 없습니다 - …","schemaVersion":"1.0",…}` |
| stderr | 0 B |

`jsonContract.failure` 는 `계획 안 문서 부재 등 입력 오류 exit 1 + error` 를 포함한다.

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 — 자기서술 문구와 계약 시험만
- 재현·측정: 위 실측 표. `run` 엔진 변경 없음

## 스크린샷

해당 없음 (capabilities 문구·CLI 봉투 계약).
