### PR TITLE
test(capabilities): inspect·edit 하위 명령을 자기서술에 잠근다 (#3884 G4)

### DIFF
--- a/mydocs/manual/agent_troubleshooting_guide.md
+++ b/mydocs/manual/agent_troubleshooting_guide.md
@@ -88,8 +88,9 @@ exit=2
 ```
 
 - **원인**: 명령 이름 오타이거나, 다른 버전에만 있는 명령이다.
-- **처방**: `rhwp capabilities` 의 `commands[].name` 목록에서 고른다. 버전은
-  `rhwp --version` (실측 출력 `rhwp v0.8.2`, exit 0).
+- **처방**: `rhwp capabilities` 의 `commands[].name` 목록에서 고른다. `inspect`·`edit`
+  는 하위를 `commands[].subcommands[].name` 으로 싣는다 (`inspect hidden-text` 등).
+  버전은 `rhwp --version` (실측 출력 `rhwp v0.8.2`, exit 0).
 
 ### 인자 없이 실행하면 exit 2 (헬스체크 함정)
 

--- a/tests/cases/issue_3884_g4_inspect_edit_subcommands.rs
+++ b/tests/cases/issue_3884_g4_inspect_edit_subcommands.rs
@@ -1,0 +1,135 @@
+//! [#3884 G4] inspect·edit 하위 명령이 capabilities 에 자기서술된다.
+//!
+//! `.commands[].name` 만 읽으면 `inspect`/`edit` 두 이름만 보인다. 실제 호출은
+//! `rhwp inspect <hidden-text|injection|unicode>` 와
+//! `rhwp edit <fill-fields|replace-text|set-cell|insert-image|redact|sanitize>`
+//! 이다. 하위를 `subcommands[]` 로 실어 `--search` 가 부모를 찾게 한다.
+//! 새 CLI 동사는 만들지 않는다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::process::{Command, Output};
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .args(args)
+        .output()
+        .expect("rhwp 실행")
+}
+
+fn capabilities() -> serde_json::Value {
+    let out = run(&["capabilities"]);
+    assert_eq!(out.status.code(), Some(0), "capabilities 실행 실패");
+    serde_json::from_slice(&out.stdout).expect("capabilities stdout 이 순수 JSON 이 아니다")
+}
+
+fn command_entry<'a>(caps: &'a serde_json::Value, name: &str) -> &'a serde_json::Value {
+    caps["commands"]
+        .as_array()
+        .expect("commands 배열 없음")
+        .iter()
+        .find(|c| c["name"].as_str() == Some(name))
+        .unwrap_or_else(|| panic!("commands 에 {name} 항목이 없다"))
+}
+
+fn declared_names(parent: &str) -> Vec<String> {
+    let caps = capabilities();
+    let entry = command_entry(&caps, parent);
+    let subs = entry["subcommands"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{parent} 항목에 subcommands 선언이 없다 (#3884 G4)"));
+    subs.iter()
+        .map(|s| {
+            let name = s["name"]
+                .as_str()
+                .expect("subcommands[].name 누락")
+                .to_string();
+            let summary = s["summary"].as_str().expect("subcommands[].summary 누락");
+            assert!(
+                !summary.trim().is_empty(),
+                "{parent} {name} 의 summary 가 비었다"
+            );
+            name
+        })
+        .collect()
+}
+
+fn usage_listed(parent: &str) -> Vec<String> {
+    let out = run(&[parent]);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "{parent} 무인자는 usage 오류(exit 2)여야 한다"
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    let anchor = format!("rhwp {parent} <");
+    let start = err
+        .find(&anchor)
+        .unwrap_or_else(|| panic!("{parent} USAGE 에서 '{anchor}' 를 못 찾았다:\n{err}"))
+        + anchor.len();
+    let rest = &err[start..];
+    let end = rest.find('>').expect("USAGE 하위 목록의 '>' 누락");
+    rest[..end]
+        .split('|')
+        .map(|s| s.trim().to_string())
+        .collect()
+}
+
+#[test]
+fn capabilities_lists_g4_inspect_edit_subcommands() {
+    let inspect = declared_names("inspect");
+    for name in ["hidden-text", "injection", "unicode"] {
+        assert!(
+            inspect.iter().any(|n| n == name),
+            "inspect.subcommands 에 {name} 이 없다: {inspect:?}"
+        );
+    }
+    let edit = declared_names("edit");
+    for name in [
+        "fill-fields",
+        "replace-text",
+        "set-cell",
+        "insert-image",
+        "redact",
+        "sanitize",
+    ] {
+        assert!(
+            edit.iter().any(|n| n == name),
+            "edit.subcommands 에 {name} 이 없다: {edit:?}"
+        );
+    }
+}
+
+#[test]
+fn declared_subcommands_match_dispatch_usage() {
+    for parent in ["inspect", "edit"] {
+        assert_eq!(
+            declared_names(parent),
+            usage_listed(parent),
+            "{parent}: capabilities.subcommands 선언과 USAGE 실물이 다르다"
+        );
+    }
+}
+
+#[test]
+fn search_finds_parent_by_subcommand_keyword() {
+    for (keyword, parent) in [("redact", "edit"), ("hidden-text", "inspect")] {
+        let out = run(&["capabilities", "--search", keyword, "--json"]);
+        assert_eq!(out.status.code(), Some(0));
+        let v: serde_json::Value = serde_json::from_slice(&out.stdout)
+            .expect("--search --json stdout 이 순수 JSON 이 아니다");
+        let names: Vec<&str> = v["commands"]
+            .as_array()
+            .expect("commands 배열 없음")
+            .iter()
+            .filter_map(|c| c["name"].as_str())
+            .collect();
+        assert!(
+            names.contains(&parent),
+            "--search {keyword} 가 {parent} 를 못 찾았다 (결과: {names:?})"
+        );
+    }
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

`inspect`·`edit` 의 하위 명령이 `capabilities.commands[].subcommands` 에 자기서술되는 계약을 `tests/cases` 에 잠근다. 새 CLI 동사는 만들지 않고 inspect/edit 동작도 바꾸지 않는다.

이슈 #3884 G4 의 구판 실측은 `.commands[].name` 이 `["inspect","edit"]` 만 보여, 매니페스트만 읽는 에이전트가 `inspect hidden-text` / `edit redact` 를 모른다는 것이었다. 현재 devel 은 이미 부모 항목에 `subcommands[]`(이름+요약)를 달고 `--search` 가 하위 이름·요약을 본다. 다만 그 계약 시험이 `tests/capabilities_subcommands_contract.rs` 에만 있어 `autotests = false` 아래 CI 실행 집합에 들어가지 않았다.

이 PR 은 G4 의 이슈 본문 9종을 명시 단언한다.

- inspect: `hidden-text`, `injection`, `unicode`
- edit: `fill-fields`, `replace-text`, `set-cell`, `insert-image`, `redact`, `sanitize`

그리고 선언이 USAGE 실물과 같고, `--search redact` / `--search hidden-text` 가 부모를 찾는다.

G1 #6404 · G2 #6411 · G3 #6419 는 아직 열린 PR 이라 **`closes #3884` 하지 않는다.** G4 만.

## 관련 이슈

#3884

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음 (`--sync-cargo-targets` 메인터너 registry PR은 marker 블록만 예외)
- [ ] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
- [ ] `cargo test` 통과 (디스크 절약으로 로컬 재컴파일 생략. 선언은 기존 debug 바이너리로 실측)
- [ ] `cargo clippy -- -D warnings` 통과 (소스 변경 없음)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — `rhwp replay --capsule` 영수증 캡슐 또는 관련 `--json` 봉투 원문 ([AGENTS.md 작업 증빙 절](../AGENTS.md#작업-증빙--에이전트-기본-경로-권장))
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: [capability 카탈로그](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_capability_registry.md)의 등록·검증 규칙을 반영

## 실측

기존 debug 바이너리 `rhwp capabilities`:

| 항목 | 값 |
|---|---|
| `.commands[].name` 중 inspect/edit | `["inspect","edit"]` (이슈 jq 와 동일) |
| `inspect.subcommands` | 4 (`hidden-text`, `injection`, `unicode`, `watermark`) |
| `edit.subcommands` | 88, 이슈 6종 포함 (`fill-fields` … `sanitize`) |

USAGE 실물도 같은 하위 목록을 싣는다.

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 — 시험·안내 문구만
- 재현·측정: 위 실측. 새 명령 없음

## 스크린샷

해당 없음 (capabilities 자기서술).
