### PR TITLE
fix(layout): 셀 자동 축소 자간을 안쪽 폭에 수렴시킨다

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -1314,6 +1314,38 @@ fn right_tab_block_width_with_tac(
     Some(estimate_text_width(&tail, &ts) + tac_w)
 }
 
+/// [#6303] 셀 오버플로우 자간을 안쪽 폭에 수렴시킨다.
+///
+/// 선형 1회 `slack/N` 은 말미 글자·narrow glyph 클램프 때문에 목표보다 1~2% 헐겁다.
+/// underflow 경로와 같이 실측 폭으로 맞춘다. 줄바꿈(pageCount)에는 관여하지 않는다.
+fn converge_cell_overflow_char_spacing(
+    comp_line: &ComposedLine,
+    styles: &ResolvedStyleSet,
+    tab_width: f64,
+    total_char_count: usize,
+    total_text_width: f64,
+    available_width: f64,
+) -> f64 {
+    let avg_char_w = total_text_width / total_char_count as f64;
+    let min_sp = -avg_char_w * 0.5;
+    let mut extra = ((available_width - total_text_width) / total_char_count as f64).max(min_sp);
+    for _ in 0..4 {
+        let mut measured = 0.0f64;
+        for run in &comp_line.runs {
+            let mut ts = resolved_to_text_style(styles, run.char_style_id, run.lang_index);
+            ts.default_tab_width = tab_width;
+            ts.extra_char_spacing = extra;
+            measured += estimate_text_width(&run.text, &ts);
+        }
+        let delta = available_width - measured;
+        if delta >= -0.05 && delta.abs() < 0.25 {
+            break;
+        }
+        extra = (extra + delta / total_char_count as f64).max(min_sp);
+    }
+    extra.min(0.0)
+}
+
 /// [Task #2067] 정렬(양쪽/배분/나눔)·오버플로우·셀 underflow 에 따른 여분 간격 계산.
 /// 반환 = (extra_word_sp, extra_char_sp, extra_dash_sp). Task #352 dash leader 분배 포함.
 #[allow(clippy::too_many_arguments)]
@@ -1593,6 +1625,19 @@ fn compute_line_extra_spacing(
             } else if suppress_cell_overflow_spacing && slack < 0.0 {
                 // 셀의 좁은 내부 폭은 줄바꿈 기준일 뿐, 숫자/문자를 수평 압축하지 않는다.
                 (0.0, 0.0, 0.0)
+            } else if in_cell && slack < 0.0 {
+                (
+                    0.0,
+                    converge_cell_overflow_char_spacing(
+                        comp_line,
+                        styles,
+                        tab_width,
+                        total_char_count,
+                        total_text_width,
+                        available_width,
+                    ),
+                    0.0,
+                )
             } else {
                 let raw = slack / total_char_count as f64;
                 let avg_char_w = total_text_width / total_char_count as f64;
@@ -1649,6 +1694,22 @@ fn compute_line_extra_spacing(
         // 비정렬(왼쪽/오른쪽/가운데) 텍스트가 오버플로우할 때 글자 간격 압축
         if suppress_cell_overflow_spacing {
             (0.0, 0.0, 0.0)
+        } else if in_cell {
+            // [#6303] 칸 폭 자동 축소(#6196) 가 선형 slack/N 한 번이면 목표가
+            // 1~2% 헐거워 긴 행 꼬리가 괘선 밖으로 나간다. 줄바꿈은 그대로 두고
+            // 실측 폭만 안쪽 폭에 수렴시킨다.
+            (
+                0.0,
+                converge_cell_overflow_char_spacing(
+                    comp_line,
+                    styles,
+                    tab_width,
+                    total_char_count,
+                    total_text_width,
+                    available_width,
+                ),
+                0.0,
+            )
         } else {
             let raw = (available_width - total_text_width) / total_char_count as f64;
             let avg_char_w = total_text_width / total_char_count as f64;

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -1700,6 +1700,7 @@ fn compute_line_extra_spacing(
             // [#6303] 칸 폭 자동 축소(#6196) 가 선형 slack/N 한 번이면 목표가
             // 1~2% 헐거워 긴 행 꼬리가 괘선 밖으로 나간다. 저장 한 줄이 안쪽 폭을
             // 15% 넘게 넘는 칸에서만 줄바꿈은 그대로 두고 실측 폭을 수렴시킨다.
+            // 일반 in_cell 줄까지 수렴하면 page-local hash·text-overlap 이 흔들린다.
             (
                 0.0,
                 converge_cell_overflow_char_spacing(

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -1314,10 +1314,11 @@ fn right_tab_block_width_with_tac(
     Some(estimate_text_width(&tail, &ts) + tac_w)
 }
 
-/// [#6303] 셀 오버플로우 자간을 안쪽 폭에 수렴시킨다.
+/// [#6303] 칸 폭 자동 축소(#6196) 셀의 오버플로우 자간을 안쪽 폭에 수렴시킨다.
 ///
-/// 선형 1회 `slack/N` 은 말미 글자·narrow glyph 클램프 때문에 목표보다 1~2% 헐겁다.
-/// underflow 경로와 같이 실측 폭으로 맞춘다. 줄바꿈(pageCount)에는 관여하지 않는다.
+/// 저장 사다리가 한 줄·안쪽 폭으로 적어 둔 칸이 자연 폭에서 안쪽 폭을 15% 넘게
+/// 놓친 경우에만 쓴다. 선형 1회 `slack/N` 은 말미 글자·narrow glyph 클램프 때문에
+/// 목표보다 1~2% 헐겁다. 일반 문단·일반 셀의 자간은 그대로 둔다.
 fn converge_cell_overflow_char_spacing(
     comp_line: &ComposedLine,
     styles: &ResolvedStyleSet,
@@ -1360,6 +1361,7 @@ fn compute_line_extra_spacing(
     has_tabs: bool,
     renders_synthetic_wrap_trailing_space: bool,
     suppress_cell_overflow_spacing: bool,
+    converge_auto_shrink_cell: bool,
     total_char_count: usize,
     total_text_width: f64,
     available_width: f64,
@@ -1625,7 +1627,7 @@ fn compute_line_extra_spacing(
             } else if suppress_cell_overflow_spacing && slack < 0.0 {
                 // 셀의 좁은 내부 폭은 줄바꿈 기준일 뿐, 숫자/문자를 수평 압축하지 않는다.
                 (0.0, 0.0, 0.0)
-            } else if in_cell && slack < 0.0 {
+            } else if converge_auto_shrink_cell && slack < 0.0 {
                 (
                     0.0,
                     converge_cell_overflow_char_spacing(
@@ -1694,10 +1696,10 @@ fn compute_line_extra_spacing(
         // 비정렬(왼쪽/오른쪽/가운데) 텍스트가 오버플로우할 때 글자 간격 압축
         if suppress_cell_overflow_spacing {
             (0.0, 0.0, 0.0)
-        } else if in_cell {
+        } else if converge_auto_shrink_cell {
             // [#6303] 칸 폭 자동 축소(#6196) 가 선형 slack/N 한 번이면 목표가
-            // 1~2% 헐거워 긴 행 꼬리가 괘선 밖으로 나간다. 줄바꿈은 그대로 두고
-            // 실측 폭만 안쪽 폭에 수렴시킨다.
+            // 1~2% 헐거워 긴 행 꼬리가 괘선 밖으로 나간다. 저장 한 줄이 안쪽 폭을
+            // 15% 넘게 넘는 칸에서만 줄바꿈은 그대로 두고 실측 폭을 수렴시킨다.
             (
                 0.0,
                 converge_cell_overflow_char_spacing(
@@ -4572,6 +4574,11 @@ impl LayoutEngine {
             let suppress_cell_overflow_spacing = cell_ctx.is_some()
                 && total_text_width > available_width * 1.15
                 && !stored_single_line_fits_cell;
+            // [#6303] 자동 축소는 저장 한 줄이 **안쪽 폭을 놓친** 칸에만 수렴한다.
+            // 일반 셀·문단의 선형 slack/N 을 바꾸면 page-local hash 와 text-overlap 이
+            // 흔들린다. 1.15 는 #6196 억제 임계와 같다.
+            let converge_auto_shrink_cell =
+                stored_single_line_fits_cell && total_text_width > available_width * 1.15;
             let is_hancom_company_pua_logo_line =
                 is_hancom_company_pua_logo_line(comp_line, alignment);
 
@@ -4592,6 +4599,7 @@ impl LayoutEngine {
                     has_tabs,
                     renders_synthetic_wrap_trailing_space,
                     suppress_cell_overflow_spacing,
+                    converge_auto_shrink_cell,
                     total_char_count,
                     total_text_width,
                     available_width,
@@ -8225,6 +8233,7 @@ mod issue_2809_split_alignment_tests {
             false,
             false,
             false,
+            false,
             5,
             30.0,
             90.0,
@@ -8260,6 +8269,7 @@ mod issue_2809_split_alignment_tests {
             false,
             true,
             false,
+            false,
             6,
             natural_width,
             available_width,
@@ -8293,6 +8303,7 @@ mod issue_2809_split_alignment_tests {
             Alignment::Split,
             true,
             true,
+            false,
             false,
             false,
             false,
@@ -8346,6 +8357,7 @@ mod issue_2809_split_alignment_tests {
             false,
             false,
             false,
+            false,
             12,
             62.5,
             481.8,
@@ -8362,6 +8374,7 @@ mod issue_2809_split_alignment_tests {
             Alignment::Justify,
             false,
             true,
+            false,
             false,
             false,
             false,
@@ -8409,6 +8422,7 @@ mod issue_4657_distribute_alignment_tests {
             false,
             false,
             true,
+            false,
             false,
             false,
             false,

--- a/tests/cases/issue_6303_cell_shrink_target_slack.rs
+++ b/tests/cases/issue_6303_cell_shrink_target_slack.rs
@@ -1,0 +1,77 @@
+//! [Issue #6303] 칸 폭 자동 축소(#6196) 의 목표 폭이 1~2% 헐거우면
+//! 긴 행 꼬리가 괘선 밖으로 나가 잘린다.
+//!
+//! #6196 은 저장 사다리 한 줄 칸에서 자간 압축을 다시 켰다. 압축 자체는
+//! 동작하지만 선형 `slack/N` 한 번이면 실측 폭이 안쪽 폭에 못 미친다.
+//! 짧은 행(축소 불필요)은 그대로 두고, 긴 행만 괘선 안에 들어가게 한다.
+//!
+//! 표본은 #6196 과 같다 — 그 문서 4쪽 마지막 열에도 잔여 +0.68pt 가 남는다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+const SAMPLE: &str = "samples/issue6196/cell_char_spacing_fit.hwp";
+/// 마지막 열 칸의 좌변 — 이 x 이상에서 시작하는 칸만 본다.
+const LAST_COL_MIN_X: f64 = 470.0;
+/// 한글은 긴 행을 괘선에 맞춘다. 0.5px 는 #6196 잠금보다 타이트하고,
+/// 잔여 +0.68pt(~0.9px) 를 놓치지 않는다.
+const BORDER_SLACK_PX: f64 = 0.25;
+
+#[test]
+fn issue_6303_long_cell_row_tail_stays_inside_border() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let core = DocumentCore::from_bytes(&std::fs::read(path).expect("read sample")).expect("open");
+    let page = core.build_page_render_tree(0).expect("page 1 render tree");
+
+    let mut overflow = Vec::new();
+    let mut checked = 0usize;
+    let mut max_over = 0.0f64;
+    walk(&page.root, None, &mut checked, &mut overflow, &mut max_over);
+
+    assert!(
+        checked > 0,
+        "마지막 열 칸의 텍스트를 찾지 못했다 — 표본이 바뀌었는지 확인하라"
+    );
+    assert!(
+        overflow.is_empty(),
+        "긴 행 꼬리가 괘선을 넘는다 — {}건 max {:+.2}px: {:?}",
+        overflow.len(),
+        max_over,
+        overflow
+    );
+}
+
+fn walk(
+    node: &RenderNode,
+    cell: Option<f64>,
+    checked: &mut usize,
+    out: &mut Vec<(String, String)>,
+    max_over: &mut f64,
+) {
+    let cell = match &node.node_type {
+        RenderNodeType::TableCell(_) if node.bbox.x >= LAST_COL_MIN_X => {
+            Some(node.bbox.x + node.bbox.width)
+        }
+        RenderNodeType::TableCell(_) => None,
+        _ => cell,
+    };
+    if let (Some(right), RenderNodeType::TextRun(run)) = (cell, &node.node_type) {
+        if !run.text.trim().is_empty() {
+            *checked += 1;
+            let over = node.bbox.x + node.bbox.width - right;
+            if over > *max_over {
+                *max_over = over;
+            }
+            if over > BORDER_SLACK_PX {
+                out.push((format!("{:+.2}", over), run.text.clone()));
+            }
+        }
+    }
+    for child in &node.children {
+        walk(child, cell, checked, out, max_over);
+    }
+}


### PR DESCRIPTION
## 무엇

칸 폭 자동 축소(#6196) 가 켜진 뒤에도 긴 행 꼬리가 괘선 밖으로 1~2% 나가 잘립니다. 축소 게이트는 그대로 두고, 셀 오버플로우 자간의 목표만 안쪽 폭에 수렴시킵니다.

## 원인

#6196 은 저장 사다리 한 줄 칸에서 자간 압축 억제를 해제했습니다. 압축량은 선형 `slack/N` 한 번이라, narrow glyph 클램프·말미 글자 때문에 실측 폭이 목표보다 헐겁습니다. 짧은 행은 축소가 필요 없고, 긴 행만 글자 수에 비례해 괘선을 넘습니다(33쪽 9행 최대 +3.9pt).

## 변경

- `src/renderer/layout/paragraph_layout.rs` — 셀 안에서만 underflow 와 같은 실측 수렴. 본문 오버플로우 경로·`1.15` 억제 임계·#6196 게이트는 불변. 줄바꿈(pageCount)에 관여하지 않습니다.
- `tests/cases/issue_6303_cell_shrink_target_slack.rs` — #6196 표본 마지막 열을 괘선 여유 0.25px 로 잠급니다.

`#[ignore]` 하지 않습니다.

## 검증

- [x] `cargo fmt --all -- --check` (rustfmt `newline_style=Unix`)
- [ ] `cargo test` `issue_6303_long_cell_row_tail_stays_inside_border` / `issue_6196_stored_single_line_cell_compresses_to_fit` (고유 target dir 에서 링크 진행)

closes #6303
