### PR TITLE
fix(renderer): 같은 vertpos 조각을 한 줄로 세어 표 칸 높이 이중 계상을 막는다

### DIFF
--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -14,8 +14,15 @@ use crate::model::table::{Table, TablePageBreak};
 
 /// [#6299] 같은 `vertical_pos` 를 공유하는 LINE_SEG 는 한 줄의 가로 조각
 /// (어울림 개체 좌·우). 높이 회계에서는 이어지는 두 번째 이후 조각을 건너뛴다.
+///
+/// `vertical_pos` 만 같으면 건너뛰지 않는다. HWP3 와 페이지 분할 픽스처는
+/// 모든 줄의 `vertical_pos` 가 0 이고, 그 경우 줄마다 높이를 더해야 한다.
+/// 가로 조각은 `column_start` 가 갈라진다.
 fn is_same_vertpos_wrap_fragment(segs: &[LineSeg], idx: usize) -> bool {
-    idx > 0 && idx < segs.len() && segs[idx].vertical_pos == segs[idx - 1].vertical_pos
+    idx > 0
+        && idx < segs.len()
+        && segs[idx].vertical_pos == segs[idx - 1].vertical_pos
+        && segs[idx].column_start != segs[idx - 1].column_start
 }
 
 /// 합성 줄이 저장 LINE_SEG 와 1:1 일 때만 조각 건너뛰기를 적용한다.
@@ -40,8 +47,10 @@ fn is_last_visual_line_for_cell_height(
     }
     segs.get(line_idx + 1..)
         .map(|rest| {
-            rest.iter()
-                .all(|s| s.vertical_pos == segs[line_idx].vertical_pos)
+            rest.iter().all(|s| {
+                s.vertical_pos == segs[line_idx].vertical_pos
+                    && s.column_start != segs[line_idx].column_start
+            })
         })
         .unwrap_or(true)
 }

--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -8,9 +8,43 @@ use super::style_resolver::ResolvedStyleSet;
 use super::{hwpunit_to_px, DEFAULT_DPI};
 use crate::model::control::Control;
 use crate::model::footnote::{Footnote, FootnoteShape};
-use crate::model::paragraph::Paragraph;
+use crate::model::paragraph::{LineSeg, Paragraph};
 use crate::model::shape::{Caption, CommonObjAttr, TextWrap, VertRelTo};
 use crate::model::table::{Table, TablePageBreak};
+
+/// [#6299] 같은 `vertical_pos` 를 공유하는 LINE_SEG 는 한 줄의 가로 조각
+/// (어울림 개체 좌·우). 높이 회계에서는 이어지는 두 번째 이후 조각을 건너뛴다.
+fn is_same_vertpos_wrap_fragment(segs: &[LineSeg], idx: usize) -> bool {
+    idx > 0 && idx < segs.len() && segs[idx].vertical_pos == segs[idx - 1].vertical_pos
+}
+
+/// 합성 줄이 저장 LINE_SEG 와 1:1 일 때만 조각 건너뛰기를 적용한다.
+/// 재래핑으로 줄 수가 달라지면 합성 줄이 이미 시각 줄이다.
+fn skip_same_vertpos_composed_fragment(
+    segs: &[LineSeg],
+    composed_line_count: usize,
+    line_idx: usize,
+) -> bool {
+    composed_line_count == segs.len() && is_same_vertpos_wrap_fragment(segs, line_idx)
+}
+
+/// 셀 마지막 줄 trailing 판정 — 같은 vertpos 조각은 한 줄이므로, 뒤에 남은
+/// seg 가 전부 이 줄의 가로 조각이면 마지막 시각 줄이다.
+fn is_last_visual_line_for_cell_height(
+    segs: &[LineSeg],
+    composed_line_count: usize,
+    line_idx: usize,
+) -> bool {
+    if composed_line_count != segs.len() || segs.is_empty() {
+        return line_idx + 1 == composed_line_count;
+    }
+    segs.get(line_idx + 1..)
+        .map(|rest| {
+            rest.iter()
+                .all(|s| s.vertical_pos == segs[line_idx].vertical_pos)
+        })
+        .unwrap_or(true)
+}
 
 /// treat_as_char 표가 인라인(텍스트와 나란히)인지 판별
 ///
@@ -1016,8 +1050,10 @@ impl HeightMeasurer {
                     .unwrap_or(0);
                 para.line_segs
                     .iter()
+                    .enumerate()
                     .skip(skip)
-                    .map(|seg| {
+                    .filter(|(i, _)| !is_same_vertpos_wrap_fragment(&para.line_segs, *i))
+                    .map(|(_, seg)| {
                         (
                             hwpunit_to_px(seg.line_height, self.dpi),
                             hwpunit_to_px(seg.line_spacing, self.dpi),
@@ -1027,7 +1063,9 @@ impl HeightMeasurer {
             } else {
                 para.line_segs
                     .iter()
-                    .map(|seg| {
+                    .enumerate()
+                    .filter(|(i, _)| !is_same_vertpos_wrap_fragment(&para.line_segs, *i))
+                    .map(|(_, seg)| {
                         (
                             hwpunit_to_px(seg.line_height, self.dpi),
                             hwpunit_to_px(seg.line_spacing, self.dpi),
@@ -1706,6 +1744,13 @@ impl HeightMeasurer {
                                     .iter()
                                     .enumerate()
                                     .map(|(i, line)| {
+                                        if skip_same_vertpos_composed_fragment(
+                                            &p.line_segs,
+                                            line_count,
+                                            i,
+                                        ) {
+                                            return 0.0;
+                                        }
                                         let raw_lh = hwpunit_to_px(line.line_height, self.dpi);
                                         let max_fs = line
                                             .runs
@@ -1718,8 +1763,12 @@ impl HeightMeasurer {
                                                     .unwrap_or(0.0)
                                             })
                                             .fold(0.0f64, f64::max);
-                                        let is_cell_last_line =
-                                            is_last_para && i + 1 == line_count;
+                                        let is_cell_last_line = is_last_para
+                                            && is_last_visual_line_for_cell_height(
+                                                &p.line_segs,
+                                                line_count,
+                                                i,
+                                            );
                                         // [#2169] NO_LS 순수 빈 문단 — 문단 char shape fs
                                         // 폴백 (한글은 완전한 em 줄박스로 취급).
                                         let max_fs = if max_fs <= 0.0
@@ -2557,6 +2606,13 @@ impl HeightMeasurer {
                                     .iter()
                                     .enumerate()
                                     .map(|(i, line)| {
+                                        if skip_same_vertpos_composed_fragment(
+                                            &p.line_segs,
+                                            line_count,
+                                            i,
+                                        ) {
+                                            return 0.0;
+                                        }
                                         let raw_lh = hwpunit_to_px(line.line_height, self.dpi);
                                         let max_fs = line
                                             .runs
@@ -2569,8 +2625,12 @@ impl HeightMeasurer {
                                                     .unwrap_or(0.0)
                                             })
                                             .fold(0.0f64, f64::max);
-                                        let is_cell_last_line =
-                                            is_last_para && i + 1 == line_count;
+                                        let is_cell_last_line = is_last_para
+                                            && is_last_visual_line_for_cell_height(
+                                                &p.line_segs,
+                                                line_count,
+                                                i,
+                                            );
                                         // [#2169] NO_LS 순수 빈 문단 — 문단 char shape fs
                                         // 폴백 (한글은 완전한 em 줄박스로 취급).
                                         let max_fs = if max_fs <= 0.0
@@ -2993,6 +3053,11 @@ impl HeightMeasurer {
                                 && matches!(table.page_break, TablePageBreak::CellBreak);
                             let line_count = comp.lines.len();
                             for (li, line) in comp.lines.iter().enumerate() {
+                                if skip_same_vertpos_composed_fragment(&p.line_segs, line_count, li)
+                                {
+                                    line_heights.push(0.0);
+                                    continue;
+                                }
                                 let raw_lh = hwpunit_to_px(line.line_height, self.dpi);
                                 let max_fs = line
                                     .runs
@@ -3006,7 +3071,12 @@ impl HeightMeasurer {
                                     })
                                     .fold(0.0f64, f64::max);
                                 // 셀의 마지막 줄(마지막 문단의 마지막 줄)은 ls 제외
-                                let is_cell_last_line = is_last_para && li + 1 == line_count;
+                                let is_cell_last_line = is_last_para
+                                    && is_last_visual_line_for_cell_height(
+                                        &p.line_segs,
+                                        line_count,
+                                        li,
+                                    );
                                 // [#2169] NO_LS 순수 빈 문단 — char shape fs 폴백.
                                 let max_fs = if max_fs <= 0.0
                                     && crate::renderer::para_has_no_stored_line_segs(p)

--- a/tests/cases/issue_6299_same_vertpos_one_line.rs
+++ b/tests/cases/issue_6299_same_vertpos_one_line.rs
@@ -1,0 +1,161 @@
+//! [#6299] 같은 `vertpos` 의 LINE_SEG 조각(어울림 개체 좌·우)을 각각 별개 줄로
+//! 세면 표 칸 높이가 2배가 되고, `vertAlign=CENTER` 칸 내용이 내려와 겹친다.
+//!
+//! 저장 사다리는 한 글줄을 그림 좌·우로 쪼개도 **같은 vertpos** 를 적는다.
+//! 높이 회계는 그 짝을 한 줄로 센다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::model::document::{Document, Section};
+use rhwp::model::page::PageDef;
+use rhwp::model::paragraph::{LineSeg, Paragraph};
+use rhwp::model::style::ParaShape;
+use rhwp::model::table::{Cell, Table, VerticalAlign};
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+/// 시각 줄 높이(HWPUNIT) — 96dpi 에서 16.0px.
+const LINE_H: i32 = 1200;
+/// 선언 칸 높이 — 내용보다 작게 두어 측정이 행을 키우게 한다.
+const DECLARED_H: u32 = 800;
+const CELL_W: u32 = 20000;
+
+fn wrap_frag(text_start: u32, vertical_pos: i32, left: bool) -> LineSeg {
+    LineSeg {
+        text_start,
+        vertical_pos,
+        line_height: LINE_H,
+        text_height: LINE_H,
+        baseline_distance: LINE_H * 85 / 100,
+        line_spacing: 0,
+        column_start: if left { 0 } else { 9000 },
+        segment_width: 8000,
+        tag: if left {
+            LineSeg::TAG_FIRST_SEGMENT
+        } else {
+            LineSeg::TAG_LAST_SEGMENT
+        },
+        ..Default::default()
+    }
+}
+
+fn paragraph_with_segs(text: &str, segs: Vec<LineSeg>) -> Paragraph {
+    let n = text.chars().count() as u32;
+    Paragraph {
+        text: text.to_string(),
+        char_count: n,
+        char_offsets: (0..=n).collect(),
+        line_segs: segs,
+        ..Default::default()
+    }
+}
+
+fn table_with_cell_para(para: Paragraph) -> Table {
+    let mut cell = Cell {
+        col: 0,
+        row: 0,
+        col_span: 1,
+        row_span: 1,
+        width: CELL_W,
+        height: DECLARED_H,
+        paragraphs: vec![para],
+        apply_inner_margin: true,
+        vertical_align: VerticalAlign::Center,
+        ..Default::default()
+    };
+    cell.padding = Default::default();
+
+    let mut table = Table {
+        row_count: 1,
+        col_count: 1,
+        cells: vec![cell],
+        dirty: true,
+        ..Default::default()
+    };
+    table.common.width = CELL_W;
+    table.common.height = DECLARED_H;
+    table.padding = Default::default();
+    table.rebuild_grid();
+    table
+}
+
+fn document_with_table(table: Table) -> Document {
+    let mut doc = Document::default();
+    doc.doc_info.para_shapes = vec![ParaShape::default()];
+
+    let mut anchor = Paragraph::default();
+    anchor.controls.push(Control::Table(Box::new(table)));
+
+    let mut section = Section::default();
+    section.section_def.page_def = PageDef {
+        width: 59529,
+        height: 84189,
+        margin_left: 8504,
+        margin_right: 8504,
+        margin_top: 5668,
+        margin_bottom: 4252,
+        margin_header: 4252,
+        margin_footer: 4252,
+        ..Default::default()
+    };
+    section.paragraphs.push(anchor);
+    doc.sections.push(section);
+    doc
+}
+
+fn cell_height(doc: Document) -> f64 {
+    let mut core = DocumentCore::new_empty();
+    core.set_document(doc);
+    let tree = core
+        .build_page_render_tree(0)
+        .expect("render tree 생성 실패");
+    let mut heights = Vec::new();
+    collect_table_heights(&tree.root, &mut heights);
+    *heights.first().expect("표가 있어야 한다")
+}
+
+fn collect_table_heights(node: &RenderNode, out: &mut Vec<f64>) {
+    if matches!(node.node_type, RenderNodeType::Table(_)) {
+        out.push(node.bbox.height);
+        return;
+    }
+    for child in &node.children {
+        collect_table_heights(child, out);
+    }
+}
+
+/// 두 시각 줄이 좌·우 조각 4개로 쪼개져도 칸 높이는 두 줄분이다.
+#[test]
+fn issue_6299_same_vertpos_fragments_count_as_one_line() {
+    let para = paragraph_with_segs(
+        "가나다라",
+        vec![
+            wrap_frag(0, 0, true),
+            wrap_frag(1, 0, false),
+            wrap_frag(2, LINE_H, true),
+            wrap_frag(3, LINE_H, false),
+        ],
+    );
+    let h = cell_height(document_with_table(table_with_cell_para(para)));
+
+    // 2줄 × 16px = 32px. 수정 전엔 4조각을 합산해 ~64px.
+    assert!(
+        h < 48.0,
+        "같은 vertpos 조각을 별개 줄로 세면 칸이 2배가 된다: {h:.1}px"
+    );
+    assert!(h > 20.0, "시각 두 줄 높이는 유지돼야 한다: {h:.1}px");
+}
+
+/// 서로 다른 vertpos 의 두 줄은 종전대로 둘 다 센다.
+#[test]
+fn issue_6299_distinct_vertpos_lines_still_sum() {
+    let para = paragraph_with_segs(
+        "가나",
+        vec![wrap_frag(0, 0, true), wrap_frag(1, LINE_H, true)],
+    );
+    let h = cell_height(document_with_table(table_with_cell_para(para)));
+    assert!(
+        h > 20.0,
+        "서로 다른 vertpos 두 줄은 합산돼야 한다: {h:.1}px"
+    );
+}

--- a/tests/cases/issue_6299_same_vertpos_one_line.rs
+++ b/tests/cases/issue_6299_same_vertpos_one_line.rs
@@ -35,7 +35,6 @@ fn wrap_frag(text_start: u32, vertical_pos: i32, left: bool) -> LineSeg {
         } else {
             LineSeg::TAG_LAST_SEGMENT
         },
-        ..Default::default()
     }
 }
 


### PR DESCRIPTION
Closes #6299

## 문제
어울림(Square) 개체를 끼고 있는 칸에서 한 글줄이 그림 좌·우 LINE_SEG 조각으로 쪼개진다. 저장 사다리는 그 짝을 **같은 `vertpos`** 로 적는데, 높이 합산이 조각을 각각 별개 줄로 세어 칸 content 가 2배가 됐다.

`valign=CENTER` 칸에서는 과대한 높이의 한가운데에 내용이 놓여 27.9pt 아래로 내려가고, 다음 행과 겹친다(156518878 1쪽).

## 원인
`height_measurer.rs` 의 저장 사다리 갈래가 `line_segs` / `compose_paragraph` 줄을 **개수대로** 합산한다. 같은 파일의 TAC 표 갈래에는 vpos 기반 보정이 있지만, 일반 칸 경로에는 없었다.

## 변경
- `skip_same_vertpos_composed_fragment` — 합성 줄이 저장 LINE_SEG 와 1:1 일 때, 이어지는 같은 `vertical_pos` 조각은 높이 0 으로 건너뛴다.
- 재래핑으로 줄 수가 달라지면 합성 줄이 이미 시각 줄이므로 적용하지 않는다.
- 셀 마지막 줄 trailing 판정도 시각 줄 기준으로 맞춘다.
- 문단 `line_segs` 합산 경로도 같은 규칙을 쓴다.

줄 분할 엔진은 건드리지 않는다.

## 검증
`tests/cases/issue_6299_same_vertpos_one_line.rs`

- 좌·우 조각 4개(시각 2줄)여도 표 높이가 두 줄분이다 (수정 전엔 4줄분).
- 서로 다른 vertpos 두 줄은 종전대로 합산된다.

`cargo test --test regression_suite_021 issue_6299` — 2 passed.
src `#[cfg(test)]` 무변경.