### PR TITLE
fix(renderer): imgBrush ZOOM 을 칸 상자에 맞춰 종횡비 유지로 그린다 (#6310)

### DIFF
--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -784,6 +784,8 @@ pub enum ImageFillMode {
     TileVertLeft,
     TileVertRight,
     FitToSize,
+    /// HWPX `imgBrush mode="ZOOM"` — 영역에 맞춰 종횡비를 지키며 축소(#6310).
+    Zoom,
     Total,
     Center,
     CenterTop,

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -3041,6 +3041,7 @@ fn image_fill_mode_str(value: ImageFillMode) -> &'static str {
         ImageFillMode::TileVertLeft => "tileVertLeft",
         ImageFillMode::TileVertRight => "tileVertRight",
         ImageFillMode::FitToSize => "fitToSize",
+        ImageFillMode::Zoom => "zoom",
         ImageFillMode::Total => "total",
         ImageFillMode::Center => "center",
         ImageFillMode::CenterTop => "centerTop",

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1704,6 +1704,7 @@ fn parse_border_fill(
                                             "FIT" | "FIT_TO_SIZE" | "STRETCH" => {
                                                 ImageFillMode::FitToSize
                                             }
+                                            "ZOOM" => ImageFillMode::Zoom,
                                             "TOTAL" => ImageFillMode::Total,
                                             "TOP_LEFT_ALIGN" => ImageFillMode::LeftTop,
                                             _ => ImageFillMode::TileAll,

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4089,6 +4089,7 @@ fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError>
                                         "FIT" | "FIT_TO_SIZE" | "STRETCH" => {
                                             ImageFillMode::FitToSize
                                         }
+                                        "ZOOM" => ImageFillMode::Zoom,
                                         "TOTAL" => ImageFillMode::Total,
                                         "TOP_LEFT_ALIGN" => ImageFillMode::LeftTop,
                                         _ => ImageFillMode::TileAll,

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -2173,6 +2173,7 @@ fn image_fill_mode_detail(value: ImageFillMode) -> &'static str {
         ImageFillMode::TileVertLeft => "tileVertLeft",
         ImageFillMode::TileVertRight => "tileVertRight",
         ImageFillMode::FitToSize => "fitToSize",
+        ImageFillMode::Zoom => "zoom",
         ImageFillMode::Total => "total",
         ImageFillMode::Center => "center",
         ImageFillMode::CenterTop => "centerTop",

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -1570,6 +1570,14 @@ impl SvgRenderer {
                     bbox.x, bbox.y, bbox.width, bbox.height, data_uri,
                 ));
             }
+            ImageFillMode::Zoom => {
+                // [#6310] 칸/영역에 맞춰 종횡비를 지키며 축소(contain). TILE 원본 픽셀
+                // 배치가 아니다.
+                self.output.push_str(&format!(
+                    "<image x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" preserveAspectRatio=\"xMidYMid meet\" href=\"{}\"/>\n",
+                    bbox.x, bbox.y, bbox.width, bbox.height, data_uri,
+                ));
+            }
             ImageFillMode::TileAll => {
                 self.render_tiled_image(&render_bytes, &data_uri, bbox, true, true, None);
             }
@@ -1784,6 +1792,12 @@ impl SvgRenderer {
         let fill_mode = img.fill_mode.unwrap_or(ImageFillMode::FitToSize);
 
         match fill_mode {
+            ImageFillMode::Zoom => {
+                self.output.push_str(&format!(
+                    "<image x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" preserveAspectRatio=\"xMidYMid meet\" href=\"{}\"/>\n",
+                    bbox.x, bbox.y, bbox.width, bbox.height, data_uri,
+                ));
+            }
             ImageFillMode::FitToSize | ImageFillMode::Total => {
                 // 그림 자르기: crop이 있으면 원본 이미지의 일부만 표시
                 if let Some((cl, ct, cr, cb)) = img.crop {

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -3515,6 +3515,26 @@ impl WebCanvasRenderer {
     ) {
         let mode = fill_mode.unwrap_or(ImageFillMode::FitToSize);
         match mode {
+            ImageFillMode::Zoom => {
+                let (img_w, img_h) = match parse_image_dimensions_canvas(data) {
+                    Some((w, h)) if w > 0 && h > 0 => (w as f64, h as f64),
+                    _ => {
+                        self.draw_image(data, bbox.x, bbox.y, bbox.width, bbox.height);
+                        return;
+                    }
+                };
+                let scale = (bbox.width / img_w).min(bbox.height / img_h);
+                let w = img_w * scale;
+                let h = img_h * scale;
+                let x = bbox.x + (bbox.width - w) / 2.0;
+                let y = bbox.y + (bbox.height - h) / 2.0;
+                self.ctx.save();
+                self.ctx.begin_path();
+                self.ctx.rect(bbox.x, bbox.y, bbox.width, bbox.height);
+                self.ctx.clip();
+                self.draw_image(data, x, y, w, h);
+                self.ctx.restore();
+            }
             ImageFillMode::FitToSize | ImageFillMode::Total | ImageFillMode::None => {
                 // crop이 있으면 source rect 기반 drawImage 사용
                 if let Some(crop_rect) = crop {

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -2771,7 +2771,7 @@ fn serialize_shape_fill(w: &mut ByteWriter, fill: &Fill) {
                 ImageFillMode::TileVertLeft => 3,
                 ImageFillMode::TileVertRight => 4,
                 ImageFillMode::Total => 0,
-                ImageFillMode::FitToSize => 5,
+                ImageFillMode::FitToSize | ImageFillMode::Zoom => 5,
                 ImageFillMode::Center => 6,
                 ImageFillMode::CenterTop => 7,
                 ImageFillMode::CenterBottom => 8,

--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -530,7 +530,7 @@ fn image_fill_mode_to_u8(mode: ImageFillMode) -> u8 {
         ImageFillMode::TileVertLeft => 3,
         ImageFillMode::TileVertRight => 4,
         ImageFillMode::Total => 0,
-        ImageFillMode::FitToSize => 5,
+        ImageFillMode::FitToSize | ImageFillMode::Zoom => 5,
         ImageFillMode::Center => 6,
         ImageFillMode::CenterTop => 7,
         ImageFillMode::CenterBottom => 8,

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -995,6 +995,7 @@ pub(crate) fn write_fill_brush<W: Write>(
                 ImageFillMode::TileVertLeft => "TILE_VERT_LEFT",
                 ImageFillMode::TileVertRight => "TILE_VERT_RIGHT",
                 ImageFillMode::FitToSize => "FIT",
+                ImageFillMode::Zoom => "ZOOM",
                 ImageFillMode::Total => "TOTAL",
                 ImageFillMode::Center => "CENTER",
                 ImageFillMode::CenterTop => "CENTER_TOP",

--- a/tests/cases/issue_6310_imgbrush_zoom_cell.rs
+++ b/tests/cases/issue_6310_imgbrush_zoom_cell.rs
@@ -1,0 +1,136 @@
+//! [#6310] `hc:imgBrush mode="ZOOM"` 은 칸 상자에 맞춰 종횡비를 지키며 그린다.
+//!
+//! 종전엔 ZOOM 이 매핑되지 않아 TILE 로 붕괴했고, 원본 픽셀을 96dpi 로 환산한
+//! 크기로 그려 칸 clip 안에 흰 여백만 남았다 (156745900 로고 8.33배).
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{Cursor, Read, Write};
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::style::ImageFillMode;
+use rhwp::parser::hwpx::header::parse_hwpx_header;
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipArchive, ZipWriter};
+
+const SAMPLE: &str = "samples/tac-host-spacing.hwpx";
+
+/// 1×1 RGB PNG. 크기는 중요하지 않다 — ZOOM 은 칸 bbox 에 meet 로 얹는다.
+const PNG_1X1: &[u8] = &[
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+    0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
+    0x00, 0x00, 0x03, 0x00, 0x01, 0x00, 0x05, 0xfe, 0xd4, 0xef, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
+    0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+];
+
+fn zoom_header_xml() -> String {
+    r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head"
+         xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hh:refList>
+    <hh:borderFills itemCnt="1">
+      <hh:borderFill id="889">
+        <hh:fillBrush>
+          <hc:imgBrush mode="ZOOM">
+            <hc:img binaryItemIDRef="image1" bright="0" contrast="0" effect="REAL_PIC" alpha="0"/>
+          </hc:imgBrush>
+        </hh:fillBrush>
+      </hh:borderFill>
+    </hh:borderFills>
+  </hh:refList>
+</hh:head>"##
+        .to_string()
+}
+
+fn zoom_hwpx_bytes() -> Vec<u8> {
+    let src = std::fs::read(Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)).expect("sample");
+    let mut archive = ZipArchive::new(Cursor::new(&src)).expect("open zip");
+    let mut out = Cursor::new(Vec::new());
+    {
+        let mut writer = ZipWriter::new(&mut out);
+        let deflate = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+        let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+        for i in 0..archive.len() {
+            let mut entry = archive.by_index(i).expect("zip entry");
+            let name = entry.name().to_string();
+            let mut data = Vec::new();
+            entry.read_to_end(&mut data).expect("read zip entry");
+            if name == "Contents/header.xml" {
+                let xml = String::from_utf8(data).expect("header utf-8");
+                let xml = xml.replace(
+                    "</hh:borderFills>",
+                    r##"<hh:borderFill id="3" threeD="0" shadow="0" centerLine="NONE" breakCellSeparateLine="0"><hh:slash type="NONE" Crooked="0" isCounter="0"/><hh:backSlash type="NONE" Crooked="0" isCounter="0"/><hh:leftBorder type="NONE" width="0.1 mm" color="#000000"/><hh:rightBorder type="NONE" width="0.1 mm" color="#000000"/><hh:topBorder type="NONE" width="0.1 mm" color="#000000"/><hh:bottomBorder type="NONE" width="0.1 mm" color="#000000"/><hh:diagonal type="SOLID" width="0.1 mm" color="#000000"/><hh:fillBrush><hc:imgBrush mode="ZOOM"><hc:img binaryItemIDRef="image1" bright="0" contrast="0" effect="REAL_PIC" alpha="0"/></hc:imgBrush></hh:fillBrush></hh:borderFill></hh:borderFills>"##,
+                );
+                let xml = xml.replace("itemCnt=\"2\"", "itemCnt=\"3\"");
+                writer.start_file(name, deflate).expect("start");
+                writer.write_all(xml.as_bytes()).expect("write");
+            } else if name == "Contents/section0.xml" {
+                let xml = String::from_utf8(data).expect("section utf-8");
+                let xml = xml.replace("borderFillIDRef=\"2\"", "borderFillIDRef=\"3\"");
+                writer.start_file(name, deflate).expect("start");
+                writer.write_all(xml.as_bytes()).expect("write");
+            } else if name == "Contents/content.hpf" {
+                let xml = String::from_utf8(data).expect("hpf utf-8");
+                let xml = xml.replace(
+                    "</opf:manifest>",
+                    r#"<opf:item id="image1" href="BinData/image1.png" media-type="image/png"/></opf:manifest>"#,
+                );
+                writer.start_file(name, deflate).expect("start");
+                writer.write_all(xml.as_bytes()).expect("write");
+            } else if name == "mimetype" {
+                writer.start_file(name, stored).expect("start");
+                writer.write_all(&data).expect("write");
+            } else {
+                writer.start_file(name, deflate).expect("start");
+                writer.write_all(&data).expect("write");
+            }
+        }
+        writer
+            .start_file("BinData/image1.png", deflate)
+            .expect("png");
+        writer.write_all(PNG_1X1).expect("png bytes");
+        writer.finish().expect("finish zip");
+    }
+    out.into_inner()
+}
+
+#[test]
+fn header_imgbrush_zoom_is_not_collapsed_to_tile() {
+    let (doc_info, _) = parse_hwpx_header(&zoom_header_xml()).expect("header");
+    let img = doc_info
+        .border_fills
+        .first()
+        .and_then(|bf| bf.fill.image.as_ref())
+        .expect("imgBrush");
+    assert_eq!(
+        img.fill_mode,
+        ImageFillMode::Zoom,
+        "ZOOM 이 TILE 로 붕괴하면 원본 픽셀 크기로 그려진다"
+    );
+    assert_eq!(img.bin_data_id, 1);
+}
+
+#[test]
+fn zoom_cell_fill_svg_meets_the_cell_box() {
+    let bytes = zoom_hwpx_bytes();
+    let core = DocumentCore::from_bytes(&bytes).expect("open zoom hwpx");
+    let fills: Vec<_> = core
+        .document()
+        .doc_info
+        .border_fills
+        .iter()
+        .filter_map(|bf| bf.fill.image.as_ref())
+        .collect();
+    assert!(
+        fills.iter().any(|img| img.fill_mode == ImageFillMode::Zoom),
+        "문서의 imgBrush ZOOM 이 파싱되어야 한다: {:?}",
+        fills.iter().map(|i| i.fill_mode).collect::<Vec<_>>()
+    );
+
+    let svg = core.render_page_svg_native(0).expect("svg");
+    assert!(
+        svg.contains("preserveAspectRatio=\"xMidYMid meet\""),
+        "ZOOM 채우기는 칸 bbox 에 meet 로 얹혀야 한다. TILE 원본 픽셀 배치는 none+native size 다: {svg}"
+    );
+}


### PR DESCRIPTION
> **PR base 브랜치가 devel 인지 확인해주세요** (main 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 upstream/devel 에서 생성합니다.

## 변경 요약

표 칸 배경 `hc:imgBrush mode="ZOOM"` 이 매핑되지 않아 `TILE` 로 붕괴했다. 원본 픽셀을 96dpi 로 환산한 크기(1211px → 908.25pt, **8.33배**)로 그려 칸 clip 안에는 로고의 흰 여백만 남았다.

OWPML 은 ZOOM 을 TILE/TOTAL 과 다른 값으로 둔다. TOTAL 은 "크기에 맞추어"(늘림), ZOOM 은 **종횡비를 지키며 칸 상자에 맞추는 축소**다.

이 PR 은 그 한 모드만 고친다.

1. `ImageFillMode::Zoom` 추가, HWPX header/section 파서가 `"ZOOM"` 을 읽는다.
2. SVG·web canvas 는 칸 bbox 에 `xMidYMid meet`(contain) 로 그린다. FitToSize/TILE/CENTER 경로는 그대로다.
3. HWPX 직렬화는 `mode="ZOOM"` 을 보존한다. HWP5 이진에는 대응 값이 없어 FitToSize(5) 로 내린다.

## 관련 이슈

closes #6310

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. `cargo fmt --check` 만으로는 안 됨)
- [x] 새 테스트는 `tests/cases/issue_6310_imgbrush_zoom_cell.rs` 만. `tests/generated`·Cargo generated 미커밋
- [ ] `src/**` 새 `#[cfg(test)]` 없음
- [ ] `cargo test --test regression_suite_007 issue_6310` — 로컬은 공유 target 락으로 완주하지 못함. 파서 단언(`Zoom` ≠ `TileAll`)과 SVG `preserveAspectRatio="xMidYMid meet"` 을 고정
- [ ] clippy — 해당 범위만 변경, CI 판정
- [ ] 원본 `156745900` 은 저장소 밖 문서. 픽스처는 `samples/tac-host-spacing.hwpx` 에 ZOOM 칸 채우기를 주입

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 칸 배경 그림 1회 스케일. 레이아웃 좌표는 원래 칸 크기와 같았고 그리는 단계만 바뀐다.
- 재현·측정: 이슈 실측은 원본 픽셀×0.75pt. ZOOM 은 칸 bbox 안에 meet.

## 스크린샷

해당 없음 (원본 문서는 비공개 경로).

## 하지 않은 것

- TILE/CENTER/FIT/TOTAL 브러시 재작성 없음
- 상한·테스트 약화 없음
- 민감도 축·새 CLI 없음
