### PR TITLE
fix(layout): 깨진 음수 셀 pad 를 표 기본 0 으로 폴백한다

### DIFF
--- a/src/model/table.rs
+++ b/src/model/table.rs
@@ -297,7 +297,11 @@ impl Cell {
         let pick = |c: i16, t: i16, unspec_axis: bool| -> i16 {
             // [#1785 위생 한도 유지] 10mm급(>=2500HU) 보존 pad 는 한컴이 렌더에
             // 쓰지 않는다(36381023 render-diff) — 전축0 미지정 규칙에서도 제외.
-            if (unspec_axis && c < 2500) || self.use_cell_padding_axis(c, t, false) {
+            // [#6358] 음수는 깨진 저장값(37787 셀 pad=-19215). `c < 2500` 만 보면
+            // 통과해 안쪽 높이가 부풀어 Center 정렬이 셀 밖 +130px 로 나간다.
+            // aim=true 경로(`use_cell_padding_axis`: `cell_padding >= 0`)와 같이
+            // 결측 센티널로 보고 표 기본으로 폴백한다.
+            if (unspec_axis && c >= 0 && c < 2500) || self.use_cell_padding_axis(c, t, false) {
                 c
             } else {
                 t

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -4146,20 +4146,22 @@ impl LayoutEngine {
             table.padding.right,
             allow_saved_small_cell_margin,
         );
-        let use_cell_top = (table_pad_unspec && cell.padding.top < 2500)
+        // [#6358] 음수 pad 는 `c < 2500` 위생 한도를 통과하므로 0 하한을 같이 둔다.
+        let use_cell_top = (table_pad_unspec && cell.padding.top >= 0 && cell.padding.top < 2500)
             || Self::should_use_cell_padding_axis_for_context(
                 cell,
                 cell.padding.top,
                 table.padding.top,
                 allow_saved_small_cell_margin,
             );
-        let use_cell_bottom = (table_pad_unspec && cell.padding.bottom < 2500)
-            || Self::should_use_cell_padding_axis_for_context(
-                cell,
-                cell.padding.bottom,
-                table.padding.bottom,
-                allow_saved_small_cell_margin,
-            );
+        let use_cell_bottom =
+            (table_pad_unspec && cell.padding.bottom >= 0 && cell.padding.bottom < 2500)
+                || Self::should_use_cell_padding_axis_for_context(
+                    cell,
+                    cell.padding.bottom,
+                    table.padding.bottom,
+                    allow_saved_small_cell_margin,
+                );
 
         let pad_left = if use_cell_left {
             hwpunit_to_px(cell.padding.left as i32, self.dpi)

--- a/tests/cases/issue_6358_negative_cell_pad_clamp.rs
+++ b/tests/cases/issue_6358_negative_cell_pad_clamp.rs
@@ -1,0 +1,51 @@
+//! [Issue #6358] 깨진 음수 셀 pad 가 Center 정렬 텍스트를 셀 밖 +130px 로 보낸다.
+//!
+//! 전축0 표의 수직 미지정 폴백은 `cell.pad < 2500` 이면 셀 저장값을 쓴다.
+//! 음수(-19215 HU)도 그 한도를 통과해 `inner_height` 가 부풀고, valign=Center
+//! 가 `" □ 비용 : "` 런을 자기 셀(y≈236) 밖 y≈366 에 놓는다.
+//! 음수는 결측 센티널로 보고 표 기본(0)으로 폴백한다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::model::table::Cell;
+use rhwp::model::Padding;
+
+#[test]
+fn issue_6358_negative_vertical_pad_falls_back_to_table_zero() {
+    let cell = Cell {
+        padding: Padding {
+            left: -13888,
+            right: -14867,
+            top: 32,
+            bottom: -19215,
+        },
+        apply_inner_margin: false,
+        ..Default::default()
+    };
+    let paint = cell.effective_padding(&Padding::default());
+    assert_eq!(
+        (paint.left, paint.right, paint.top, paint.bottom),
+        (0, 0, 32, 0),
+        "음수 수직 pad 는 전축0 폴백에서 표 기본 0 이어야 한다"
+    );
+}
+
+#[test]
+fn issue_6358_small_positive_vertical_pad_is_kept() {
+    let cell = Cell {
+        padding: Padding {
+            left: 0,
+            right: 0,
+            top: 141,
+            bottom: 141,
+        },
+        apply_inner_margin: false,
+        ..Default::default()
+    };
+    let paint = cell.effective_padding(&Padding::default());
+    assert_eq!(
+        (paint.left, paint.right, paint.top, paint.bottom),
+        (0, 0, 141, 141),
+        "정상 수직 pad 141 은 #2195 전축0 폴백을 유지해야 한다"
+    );
+}


### PR DESCRIPTION
## 무엇

깨진 음수 셀 pad 문서에서 `" □ 비용 : "` TextRun 이 자기 셀 밖 y+130px 에 그려집니다. 음수 pad 를 결측으로 보고 표 기본 0 으로 폴백합니다.

## 원인

전축0 표의 수직 미지정 폴백은 `cell.pad < 2500` 이면 셀 저장값을 씁니다. `samples/issue5699/37787_regulatory_impact.hwp` 11쪽 셀은 `pad=(-13888,-14867,32,-19215)` 입니다. 가로는 #6357 이 표 기본 0 을 쓰게 고쳤고, 세로는 `bottom=-19215` 가 한도를 통과합니다. `inner_height` 가 부풀어 valign=Center 가 런을 y=236 셀에서 y=366 으로 내립니다.

aim=true 경로(`use_cell_padding_axis`)는 이미 `cell_padding >= 0` 입니다. 전축0 폴백만 빠져 있었습니다.

## 변경

- `Cell::effective_padding` — 수직 폴백에 `c >= 0 && c < 2500`.
- `resolve_cell_padding_for_context` — 같은 하한. 표 레이아웃을 다시 쓰지 않습니다.
- `tests/cases/issue_6358_negative_cell_pad_clamp.rs` — 37787 쓰레기 pad 와 정상 141HU 수직 폴백.

## 검증

- [x] `rustfmt --edition 2021` (Unix LF) on the three files
- [ ] `cargo test` 생략 — 워크트리 생성 후 디스크 0.83GB (<2GB). rustc 를 돌리지 않습니다.

closes #6358
