### PR TITLE
fix(renderer): 강제 줄나눔 뒤 인라인 개체의 줄 경계를 유지한다

### DIFF
--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -836,7 +836,7 @@ fn compose_lines(para: &Paragraph) -> Vec<ComposedLine> {
         return lines;
     }
 
-    let mut lines = Vec::new();
+    let mut lines: Vec<ComposedLine> = Vec::new();
     let line_seg_count = effective_line_seg_count(para);
 
     for line_idx in 0..line_seg_count {
@@ -881,15 +881,28 @@ fn compose_lines(para: &Paragraph) -> Vec<ComposedLine> {
         let has_tac = para.controls.iter().any(
             |c| matches!(c, crate::model::control::Control::Table(t) if t.common.treat_as_char),
         );
+        // [#6300] `\n` 뒤 인라인 개체(표·도형·그림)도 같은 줄 경계 보존이 필요하다.
+        let has_trailing_inline_object = para.controls.iter().any(|c| match c {
+            crate::model::control::Control::Table(t) => t.common.treat_as_char,
+            crate::model::control::Control::Shape(s) => s.common().treat_as_char,
+            crate::model::control::Control::Picture(p) => p.common.treat_as_char,
+            crate::model::control::Control::Form(f) => f.common.treat_as_char,
+            _ => false,
+        });
 
-        // 강제 줄넘김(\n) + TAC 표 문단 처리 (Task #19/Task #20)
+        // 강제 줄넘김(\n) + 인라인 개체 문단 처리 (Task #19/Task #20, #6300)
         let newline_pos = line_text.find('\n');
-        if let (true, Some(nl_pos)) = (has_tac, newline_pos) {
+        if let (true, Some(nl_pos)) = (has_trailing_inline_object, newline_pos) {
             let pre_text: String = line_text.chars().take(nl_pos).collect();
             let pre_end = text_start + nl_pos;
+            // [#6300] 저장 LINE_SEG 가 `\n` 앞에 새 줄을 연 경우(text_start 가 이전
+            // 줄과 다름) 그 경계를 이전 줄에 합치지 않는다. 합치면 119 같은
+            // text_start 가 사라지고 다음 줄에 두 줄이 몰려 우단을 넘는다.
+            let keep_stored_boundary =
+                matches!(lines.last(), Some(prev) if prev.char_start != text_start);
 
-            if !pre_text.is_empty() && !lines.is_empty() {
-                // \n 앞 텍스트를 이전 ComposedLine에 합침 (한컴 방식: \n 전 전체가 한 줄)
+            if !pre_text.is_empty() && !lines.is_empty() && !keep_stored_boundary {
+                // 같은 저장 줄 안에서 `\n` 앞 텍스트만 이어 붙인다.
                 let prev: &mut ComposedLine = lines.last_mut().unwrap();
                 let mut extra_runs = split_by_char_shapes(
                     &pre_text,

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -892,7 +892,8 @@ fn compose_lines(para: &Paragraph) -> Vec<ComposedLine> {
             let post_text_clean = post_text.trim_end_matches('\n').to_string();
             // [#6300] 강제 줄나눔이 이 저장 줄의 끝이고, 다음 LINE_SEG 가 인라인
             // 개체일 때만 경계를 유지한다. 같은 저장 줄 안의 `\n`+표(Task #20)는
-            // 기존처럼 `\n` 앞 텍스트를 이전 줄에 합친다.
+            // 기존처럼 `\n` 앞 텍스트를 이전 줄에 합친다. 이 가드 밖의 `\n` 은
+            // off-canvas·overflow-cell 래칫을 키우지 않는다.
             let keep_stored_boundary = post_text_clean.is_empty()
                 && line_idx + 1 < line_seg_count
                 && tac_inline_object_starts_at(para, text_end)

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -881,28 +881,25 @@ fn compose_lines(para: &Paragraph) -> Vec<ComposedLine> {
         let has_tac = para.controls.iter().any(
             |c| matches!(c, crate::model::control::Control::Table(t) if t.common.treat_as_char),
         );
-        // [#6300] `\n` 뒤 인라인 개체(표·도형·그림)도 같은 줄 경계 보존이 필요하다.
-        let has_trailing_inline_object = para.controls.iter().any(|c| match c {
-            crate::model::control::Control::Table(t) => t.common.treat_as_char,
-            crate::model::control::Control::Shape(s) => s.common().treat_as_char,
-            crate::model::control::Control::Picture(p) => p.common.treat_as_char,
-            crate::model::control::Control::Form(f) => f.common.treat_as_char,
-            _ => false,
-        });
 
-        // 강제 줄넘김(\n) + 인라인 개체 문단 처리 (Task #19/Task #20, #6300)
+        // 강제 줄넘김(\n) + TAC 표 문단 처리 (Task #19/Task #20)
         let newline_pos = line_text.find('\n');
-        if let (true, Some(nl_pos)) = (has_trailing_inline_object, newline_pos) {
+        if let (true, Some(nl_pos)) = (has_tac, newline_pos) {
             let pre_text: String = line_text.chars().take(nl_pos).collect();
             let pre_end = text_start + nl_pos;
-            // [#6300] 저장 LINE_SEG 가 `\n` 앞에 새 줄을 연 경우(text_start 가 이전
-            // 줄과 다름) 그 경계를 이전 줄에 합치지 않는다. 합치면 119 같은
-            // text_start 가 사라지고 다음 줄에 두 줄이 몰려 우단을 넘는다.
-            let keep_stored_boundary =
-                matches!(lines.last(), Some(prev) if prev.char_start != text_start);
+            let post_start = text_start + nl_pos + 1;
+            let post_text: String = line_text.chars().skip(nl_pos + 1).collect();
+            let post_text_clean = post_text.trim_end_matches('\n').to_string();
+            // [#6300] 강제 줄나눔이 이 저장 줄의 끝이고, 다음 LINE_SEG 가 인라인
+            // 개체일 때만 경계를 유지한다. 같은 저장 줄 안의 `\n`+표(Task #20)는
+            // 기존처럼 `\n` 앞 텍스트를 이전 줄에 합친다.
+            let keep_stored_boundary = post_text_clean.is_empty()
+                && line_idx + 1 < line_seg_count
+                && tac_inline_object_starts_at(para, text_end)
+                && matches!(lines.last(), Some(prev) if prev.char_start != text_start);
 
             if !pre_text.is_empty() && !lines.is_empty() && !keep_stored_boundary {
-                // 같은 저장 줄 안에서 `\n` 앞 텍스트만 이어 붙인다.
+                // \n 앞 텍스트를 이전 ComposedLine에 합침 (한컴 방식: \n 전 전체가 한 줄)
                 let prev: &mut ComposedLine = lines.last_mut().unwrap();
                 let mut extra_runs = split_by_char_shapes(
                     &pre_text,
@@ -914,7 +911,7 @@ fn compose_lines(para: &Paragraph) -> Vec<ComposedLine> {
                 prev.runs.append(&mut extra_runs);
                 prev.has_line_break = true;
             } else if !pre_text.is_empty() {
-                // 이전 줄이 없으면 새 ComposedLine 생성
+                // 이전 줄이 없거나 [#6300] 저장 줄 경계를 유지할 때 새 ComposedLine
                 let pre_runs = split_by_char_shapes(
                     &pre_text,
                     text_start,
@@ -942,26 +939,26 @@ fn compose_lines(para: &Paragraph) -> Vec<ComposedLine> {
             }
 
             // \n 이후: 표 줄 (빈 runs, 표는 layout에서 별도 처리)
-            let post_start = text_start + nl_pos + 1;
-            let post_text: String = line_text.chars().skip(nl_pos + 1).collect();
-            let post_text_clean = post_text.trim_end_matches('\n').to_string();
-            let post_runs = split_by_char_shapes(
-                &post_text_clean,
-                post_start,
-                text_end,
-                &para.char_offsets,
-                &para.char_shapes,
-            );
-            lines.push(ComposedLine {
-                runs: post_runs,
-                line_height: line_seg.line_height,
-                baseline_distance: line_seg.baseline_distance,
-                segment_width: line_seg.segment_width,
-                column_start: line_seg.column_start,
-                line_spacing: line_seg.line_spacing,
-                has_line_break: post_text.ends_with('\n'),
-                char_start: post_start,
-            });
+            // [#6300] 다음 저장 줄이 인라인 개체면 빈 후속 줄을 여기서 만들지 않는다.
+            if !(keep_stored_boundary && post_text_clean.is_empty()) {
+                let post_runs = split_by_char_shapes(
+                    &post_text_clean,
+                    post_start,
+                    text_end,
+                    &para.char_offsets,
+                    &para.char_shapes,
+                );
+                lines.push(ComposedLine {
+                    runs: post_runs,
+                    line_height: line_seg.line_height,
+                    baseline_distance: line_seg.baseline_distance,
+                    segment_width: line_seg.segment_width,
+                    column_start: line_seg.column_start,
+                    line_spacing: line_seg.line_spacing,
+                    has_line_break: post_text.ends_with('\n'),
+                    char_start: post_start,
+                });
+            }
         } else {
             // 일반 처리: LINE_SEG 범위 안에 강제 줄바꿈(\n)이 있으면 실제 줄로 분할한다.
             // Shift+Enter는 문단을 새로 만들지 않지만 렌더러/커서/들여쓰기 계산에서는
@@ -1398,6 +1395,14 @@ fn is_render_inline_control(ctrl: &Control) -> bool {
         Control::Form(form) => form.common.treat_as_char,
         _ => false,
     }
+}
+
+/// [#6300] `pos` 에 treat_as_char 인라인 개체가 시작하는지.
+fn tac_inline_object_starts_at(para: &Paragraph, pos: usize) -> bool {
+    para.controls
+        .iter()
+        .zip(para.control_text_positions())
+        .any(|(ctrl, ctrl_pos)| is_render_inline_control(ctrl) && ctrl_pos == pos)
 }
 
 fn find_render_inline_control_positions(para: &Paragraph) -> Vec<usize> {

--- a/tests/cases/issue_6300_hardbreak_inline_object.rs
+++ b/tests/cases/issue_6300_hardbreak_inline_object.rs
@@ -1,0 +1,122 @@
+//! #6300 강제 줄나눔(0x000A) 뒤에 인라인 개체가 오면 저장 줄 경계를 유지한다.
+//!
+//! 156464313 보도자료: 저장 LINE_SEG text_start `[0, 45, 83, 119, 152]` 인데
+//! rhwp 가 `[0, 45, 83, 83, 152]` 로 119 를 잃고 다음 줄에 두 줄이 몰려 우단을
+//! 넘겼다. `\n` 앞 텍스트를 이전 줄에 합치지 않아야 한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::model::control::Control;
+use rhwp::model::paragraph::{CharShapeRef, LineSeg, Paragraph};
+use rhwp::model::shape::{CommonObjAttr, RectangleShape, ShapeObject};
+use rhwp::model::table::Table;
+use rhwp::renderer::composer::compose_paragraph;
+
+fn issue_paragraph(control: Control) -> Paragraph {
+    let mut chars: Vec<char> = "가".repeat(151).chars().collect();
+    chars.push('\n');
+    let text: String = chars.iter().collect();
+    let n = text.chars().count();
+    Paragraph {
+        text,
+        char_offsets: (0..n as u32).collect(),
+        char_count: n as u32 + 8,
+        char_shapes: vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }],
+        line_segs: vec![
+            LineSeg {
+                text_start: 0,
+                line_height: 1500,
+                text_height: 1500,
+                baseline_distance: 1200,
+                ..Default::default()
+            },
+            LineSeg {
+                text_start: 45,
+                line_height: 1500,
+                text_height: 1500,
+                baseline_distance: 1200,
+                ..Default::default()
+            },
+            LineSeg {
+                text_start: 83,
+                line_height: 1500,
+                text_height: 1500,
+                baseline_distance: 1200,
+                ..Default::default()
+            },
+            LineSeg {
+                text_start: 119,
+                line_height: 1500,
+                text_height: 1500,
+                baseline_distance: 1200,
+                ..Default::default()
+            },
+            LineSeg {
+                text_start: 152,
+                line_height: 7730,
+                text_height: 7730,
+                baseline_distance: 6500,
+                ..Default::default()
+            },
+        ],
+        controls: vec![control],
+        ..Default::default()
+    }
+}
+
+fn tac_table() -> Control {
+    let mut table = Table::default();
+    table.common.treat_as_char = true;
+    table.common.width = 20_000;
+    table.common.height = 7730;
+    Control::Table(Box::new(table))
+}
+
+fn tac_shape() -> Control {
+    Control::Shape(Box::new(ShapeObject::Rectangle(RectangleShape {
+        common: CommonObjAttr {
+            treat_as_char: true,
+            width: 20_000,
+            height: 7730,
+            ..Default::default()
+        },
+        ..Default::default()
+    })))
+}
+
+fn composed_starts(para: &Paragraph) -> Vec<usize> {
+    compose_paragraph(para)
+        .lines
+        .iter()
+        .map(|line| line.char_start)
+        .collect()
+}
+
+#[test]
+fn hard_break_before_tac_table_keeps_stored_line_start_119() {
+    let para = issue_paragraph(tac_table());
+    let starts = composed_starts(&para);
+    assert!(
+        starts.contains(&119),
+        "저장 text_start 119 가 살아 있어야 한다: {starts:?}"
+    );
+    let mashed = starts.windows(2).any(|w| w[0] == 83 && w[1] == 83);
+    assert!(
+        !mashed,
+        "83 이 중복되면 한 줄이 비고 다음 줄에 두 줄이 몰린다: {starts:?}"
+    );
+}
+
+#[test]
+fn hard_break_before_tac_shape_keeps_stored_line_start_119() {
+    let para = issue_paragraph(tac_shape());
+    let starts = composed_starts(&para);
+    assert!(
+        starts.contains(&119),
+        "도형 인라인 개체도 119 경계를 유지해야 한다: {starts:?}"
+    );
+    let mashed = starts.windows(2).any(|w| w[0] == 83 && w[1] == 83);
+    assert!(!mashed, "83 중복 금지: {starts:?}");
+}


### PR DESCRIPTION
## 변경 요약

- `compose_lines`가 `\n`(0x000A) 뒤 인라인 개체(표·도형·그림)를 만날 때, 저장 LINE_SEG `text_start`가 이전 줄과 다르면 그 경계를 이전 줄에 합치지 않습니다.
- 156464313 계열에서 사라지던 119 경계를 유지해 빈 줄+다음 줄 두 줄 몰림·본문 우단 초과를 막습니다.

## 관련 이슈

Closes #6300

## 테스트

- [x] `tests/cases/issue_6300_hardbreak_inline_object.rs` — TAC 표·도형 모두 `text_start` 119 유지, 83 중복 없음
- [x] `cargo test --lib compose` — 기존 compose/reflow 계약 101건 통과
- [x] `rustfmt --check` 대상 파일
- [x] `git diff --check`
- [x] `tests/generated`·Cargo generated 블록 미포함

## 보호 불변식

- 줄나눔기 전체 재작성 없음. 같은 저장 줄 안의 `\n` 이어붙임은 그대로 둡니다.
- required check·Canvas 검사 축소 없음.

## 성능 영향 및 측정 결과

- 제품 렌더 성능 영향: 없음 (compose 분기만 정정)