### PR TITLE
fix(layout): 자리차지 표 밴드를 후속 TAC 제목 상자가 피하게 한다

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -9320,6 +9320,29 @@ impl LayoutEngine {
                 } else {
                     table_y_start
                 };
+                // [#6104] 자리차지(vert=Para) 표 밴드는 후속 TAC 제목 상자에도 적용돼야
+                // 한다. 문단 경로의 exclusion 소비는 FullParagraph 만 보고, TAC 표는
+                // PageItem::Table 로 따로 그려져 선행 표 데이터 행 위에 올라탔다
+                // (36483048 4쪽: 제목 상자 498.4..534.8 ↔ 표1 459.6..531.2). 이미
+                // 그린 선행 owner 밴드만 피하므로 앵커 예약 이중 계상(#4090)은 없다.
+                let table_y_start = if is_tac && !visible_float_exclusions.is_empty() {
+                    let tac_h = hwpunit_to_px(t.common.height as i32, self.dpi);
+                    let mut floor = table_y_start;
+                    for zone in visible_float_exclusions.iter() {
+                        if !zone.blocks_text || zone.owner_para >= para_index {
+                            continue;
+                        }
+                        let starts_in_zone = floor + 0.5 >= zone.top && floor < zone.bottom;
+                        let overlaps_zone =
+                            tac_h > 0.0 && floor < zone.top && floor + tac_h > zone.top + 0.5;
+                        if starts_in_zone || overlaps_zone {
+                            floor = floor.max(zone.bottom);
+                        }
+                    }
+                    floor
+                } else {
+                    table_y_start
+                };
                 // [Issue #1549] visible-host 의 양수 offset float 표는 host 텍스트(섹션 제목)가
                 // line 0 으로 그려지는 줄 *아래*에 와야 한다(한컴: 제목 위, 표 아래). 제목과 표는
                 // 같은 문단 앵커를 공유하고 선행 float exclusion 으로 함께 같은 y 까지 밀리므로,

--- a/tests/cases/issue_6104_tac_title_over_table.rs
+++ b/tests/cases/issue_6104_tac_title_over_table.rs
@@ -1,0 +1,145 @@
+//! [#6104] 문단 오프셋을 가진 자리차지 표 위로 뒤 문단의 TAC 제목 상자가 올라타지 않는다.
+//!
+//! 자리차지(TopAndBottom, vert=Para) 표는 앵커 y+offset 에 그려지고 exclusion 밴드를
+//! 남긴다. 뒤 문단의 글자처럼 취급(TAC) 표는 PageItem::Table 이라 문단 경로의
+//! 밴드 소비를 건너뛰어, 표 데이터 행을 덮었다(36483048 4쪽).
+//!
+//! 이미 그린 선행 밴드만 피하므로 앵커 예약 이중 계상(#4090)은 없다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::model::document::{Document, Section};
+use rhwp::model::page::PageDef;
+use rhwp::model::paragraph::{LineSeg, Paragraph};
+use rhwp::model::shape::{TextWrap, VertRelTo};
+use rhwp::model::style::ParaShape;
+use rhwp::model::table::{Cell, Table};
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+const LINE_H: i32 = 800;
+const OFFSET: u32 = 1500;
+const TB_H: u32 = 2000;
+const TAC_H: u32 = 1200;
+const CELL_W: u32 = 12000;
+
+fn cell(text: &str, height: u32) -> Cell {
+    let n = text.chars().count() as u32;
+    Cell {
+        col: 0,
+        row: 0,
+        col_span: 1,
+        row_span: 1,
+        width: CELL_W,
+        height,
+        paragraphs: vec![Paragraph {
+            text: text.to_string(),
+            char_count: n,
+            char_offsets: (0..=n).collect(),
+            ..Default::default()
+        }],
+        apply_inner_margin: true,
+        ..Default::default()
+    }
+}
+
+fn table_block(text: &str, height: u32, treat_as_char: bool, offset: u32) -> Table {
+    let mut table = Table {
+        row_count: 1,
+        col_count: 1,
+        cells: vec![cell(text, height)],
+        dirty: true,
+        ..Default::default()
+    };
+    table.common.width = CELL_W;
+    table.common.height = height;
+    table.common.treat_as_char = treat_as_char;
+    table.common.text_wrap = TextWrap::TopAndBottom;
+    table.common.vert_rel_to = VertRelTo::Para;
+    table.common.vertical_offset = offset;
+    table.rebuild_grid();
+    table
+}
+
+fn document() -> Document {
+    let mut doc = Document::default();
+    doc.doc_info.para_shapes = vec![ParaShape::default()];
+
+    let mut host = Paragraph {
+        text: "추진기간".to_string(),
+        char_count: 4,
+        char_offsets: (0..=4).collect(),
+        line_segs: vec![LineSeg {
+            text_start: 0,
+            vertical_pos: 0,
+            line_height: LINE_H,
+            text_height: LINE_H,
+            baseline_distance: LINE_H * 85 / 100,
+            segment_width: 40000,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    host.controls.push(Control::Table(Box::new(table_block(
+        "표1", TB_H, false, OFFSET,
+    ))));
+
+    let mut title = Paragraph::default();
+    title.controls.push(Control::Table(Box::new(table_block(
+        "제목", TAC_H, true, 0,
+    ))));
+
+    let mut section = Section::default();
+    section.section_def.page_def = PageDef {
+        width: 59529,
+        height: 84189,
+        margin_left: 8504,
+        margin_right: 8504,
+        margin_top: 5668,
+        margin_bottom: 4252,
+        margin_header: 4252,
+        margin_footer: 4252,
+        ..Default::default()
+    };
+    section.paragraphs.push(host);
+    section.paragraphs.push(title);
+    doc.sections.push(section);
+    doc
+}
+
+fn collect_tables(node: &RenderNode, out: &mut Vec<(usize, f64, f64)>) {
+    if let RenderNodeType::Table(tbl) = &node.node_type {
+        if let Some(pi) = tbl.para_index {
+            out.push((pi, node.bbox.y, node.bbox.height));
+        }
+    }
+    for child in &node.children {
+        collect_tables(child, out);
+    }
+}
+
+#[test]
+fn issue_6104_tac_title_clears_offset_topbottom_table() {
+    let mut core = DocumentCore::new_empty();
+    core.set_document(document());
+    let tree = core
+        .build_page_render_tree(0)
+        .expect("render tree 생성 실패");
+    let mut tables = Vec::new();
+    collect_tables(&tree.root, &mut tables);
+    let tb = tables
+        .iter()
+        .find(|(pi, _, _)| *pi == 0)
+        .expect("자리차지 표가 있어야 한다");
+    let tac = tables
+        .iter()
+        .find(|(pi, _, _)| *pi == 1)
+        .expect("TAC 제목 상자가 있어야 한다");
+    let tb_bottom = tb.1 + tb.2;
+    assert!(
+        tac.1 + 0.5 >= tb_bottom,
+        "TAC 제목 상자 상단({:.1})이 자리차지 표 하단({tb_bottom:.1}) 아래여야 한다 \
+         (결함 시 표 데이터 행을 덮음)",
+        tac.1
+    );
+}


### PR DESCRIPTION
Closes #6104

## 문제
문단 오프셋을 가진 자리차지(TopAndBottom, vert=Para) 표 위로 뒤 문단의 TAC 제목 상자(글자처럼 취급 표)가 올라가 데이터 행을 덮는다(36483048 4쪽).

문단 경로는 `visible_float_exclusions` 를 소비하지만, TAC 표는 `PageItem::Table` 이라 그 소비를 건너뛰었다.

## 변경
`layout_table_control_block` 에서 TAC 표가 선행 owner 의 이미 그린 자리차지 밴드와 겹치면 그 하단으로 내린다.

- 앵커에 높이를 다시 예약하지 않는다 — `y_offset` 이중 밀림·#4090 이중 계상 없음.
- 자리차지 표 자신의 배치·호스트 줄 계상은 그대로다(#6312 축과 분리).

## 검증
`tests/cases/issue_6104_tac_title_over_table.rs`

가시 텍스트 host + vert=Para 자리차지 표 뒤에 TAC 제목 상자를 두고, 제목 상자 상단이 자리차지 표 하단 아래인지 확인한다.

`cargo test --test regression_suite_022 issue_6104` — 1 passed.
src `#[cfg(test)]` 무변경.