### PR TITLE
fix(layout): CellBreak 조각 셀을 clip 해 다음 행 겹침을 막는다

### DIFF
--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -739,6 +739,7 @@ impl LayoutEngine {
         start_row: usize,
         end_row: usize,
         end_row_height_override: Option<f64>,
+        start_row_height_override: Option<f64>,
         is_continuation: bool,
         start_cut: &[usize],
         end_cut: &[usize],
@@ -859,6 +860,15 @@ impl LayoutEngine {
                 !end_cut.is_empty() && cell_row == end_row.saturating_sub(1)
             };
             let is_in_split_row = is_split_start_row || is_split_end_row;
+            // [#5946] 쪽 분할이 행 높이 override 로만 이어질 때(컷 부기 없음)
+            // 중첩 표·긴 셀 내용이 조각 높이를 무시하고 다음 행 위로 포개진다.
+            // 행정업무운영편람 141쪽: '3. 쪽' 예시 서식이 '4. 항목란' 과 겹침.
+            let height_override_clip = (start_row_height_override.is_some()
+                && cell_row == start_row)
+                || (end_row_height_override.is_some()
+                    && end_row
+                        .checked_sub(1)
+                        .is_some_and(|last| cell_row <= last && cell_end_row > last));
 
             // [Task #1748] RowBreak 표에서 페이지 경계가 rowspan 블록 내부를 per-row
             // 분할할 때(#1022 경로), 컷 부기(start_cut/end_cut)는 컷 행의 row_span==1
@@ -912,9 +922,9 @@ impl LayoutEngine {
                     row_span: cell.row_span,
                     border_fill_id: cell.border_fill_id,
                     text_direction: cell.text_direction,
-                    clip: is_in_split_row || is_rowbreak_straddle,
+                    clip: is_in_split_row || is_rowbreak_straddle || height_override_clip,
                     // [#5862] 이 경로의 clip 셀은 전부 쪽 컷이 만든 조각이다.
-                    page_fragment: is_in_split_row || is_rowbreak_straddle,
+                    page_fragment: is_in_split_row || is_rowbreak_straddle || height_override_clip,
                     model_cell_index: Some(cell_idx as u32),
                 }),
                 BoundingBox::new(cell_x, cell_y, cell_w, cell_h),
@@ -3692,6 +3702,7 @@ impl LayoutEngine {
             start_row,
             end_row,
             end_row_height_override,
+            start_row_height_override,
             is_continuation,
             start_cut,
             end_cut,

--- a/tests/cases/issue_5946_pyeollam_p141_pagebreak.rs
+++ b/tests/cases/issue_5946_pyeollam_p141_pagebreak.rs
@@ -22,9 +22,9 @@ fn issue_5946_p141_hangmok_is_not_covered_by_form_header() {
     let bytes = fs::read(path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
     let core = DocumentCore::from_bytes(&bytes).expect("parse handbook");
     let page_count = core.page_count();
-    // 뷰어 141쪽을 우선하되, 조판이 한두 쪽 밀리면 근처에서 '4. 항목란' 을 찾는다.
+    // 뷰어 141쪽 근처. 조판이 밀리고 렌더 트리는 '4. ' / '항목란' 을 나눠 그린다.
     let search_lo = PAGE_INDEX.saturating_sub(4);
-    let search_hi = (PAGE_INDEX + 4).min(page_count.saturating_sub(1));
+    let search_hi = (PAGE_INDEX + 20).min(page_count.saturating_sub(1));
     let mut hangmok = Vec::new();
     let mut form = Vec::new();
     let mut found_page = PAGE_INDEX;
@@ -43,7 +43,7 @@ fn issue_5946_p141_hangmok_is_not_covered_by_form_header() {
 
     assert!(
         !hangmok.is_empty(),
-        "{}쪽에 '4. 항목란' 이 없다 — 검색 {}..{}: 표본 쪽 번호가 바뀌었는지 확인하라",
+        "{}쪽 근처에 '항목란' 이 없다 — 검색 {}..{}: 표본 쪽 번호가 바뀌었는지 확인하라",
         PAGE_INDEX + 1,
         search_lo + 1,
         search_hi + 1
@@ -79,7 +79,8 @@ fn collect(
             node.bbox.height,
             t.to_string(),
         );
-        if t.contains("4. 항목란") {
+        // 레이아웃이 '4. 항목란' 을 줄/런 단위로 나눠 '항목란' 만 남긴다.
+        if t.contains("항목란") {
             hangmok.push(bb.clone());
         }
         if (t.contains("접수번호") || t.contains("3쪽 중 1쪽")) && cell_clip != Some(true) {

--- a/tests/cases/issue_5946_pyeollam_p141_pagebreak.rs
+++ b/tests/cases/issue_5946_pyeollam_p141_pagebreak.rs
@@ -1,0 +1,76 @@
+//! [Issue #5946] 행정업무운영편람 2025 141쪽 쪽나눔.
+//!
+//! `pageBreak=CELL` · `repeatHeader=1` 인 설계 기준 표에서 '3. 쪽' 칸의
+//! 중첩 예시 서식(접수번호)이 다음 쪽 '4. 항목란' 위로 포개진다. 쪽 분할이
+//! 행 높이 override 로만 이어질 때 조각 셀을 clip 해 다음 행을 침범하지 않게 한다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+const SAMPLE: &str = "samples/2025 행정업무운영 편람(최종).hwpx";
+/// 뷰어 141쪽 = 0-based 140. #5947 은 137쪽을 `-p 136` 으로 열었다.
+const PAGE_INDEX: u32 = 140;
+
+#[test]
+fn issue_5946_p141_hangmok_is_not_covered_by_form_header() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+    let core = DocumentCore::from_bytes(&bytes).expect("parse handbook");
+    let page = core
+        .build_page_render_tree(PAGE_INDEX)
+        .expect("page 141 render tree");
+
+    let mut hangmok = Vec::new();
+    let mut form = Vec::new();
+    collect(&page.root, None, &mut hangmok, &mut form);
+
+    assert!(
+        !hangmok.is_empty(),
+        "141쪽에 '4. 항목란' 이 없다 — 표본 쪽 번호가 바뀌었는지 확인하라"
+    );
+    for (hx, hy, hw, hh, _) in &hangmok {
+        for (fx, fy, fw, fh, ftext) in &form {
+            let overlap = hx < &(fx + fw) && fx < &(hx + hw) && hy < &(fy + fh) && fy < &(hy + hh);
+            assert!(
+                !overlap,
+                "예시 서식 '{ftext}' 가 4. 항목란 과 겹친다 ({fx:.1},{fy:.1})×({fw:.1}x{fh:.1}) vs 항목란 ({hx:.1},{hy:.1})"
+            );
+        }
+    }
+}
+
+fn collect(
+    node: &RenderNode,
+    cell_clip: Option<bool>,
+    hangmok: &mut Vec<(f64, f64, f64, f64, String)>,
+    form: &mut Vec<(f64, f64, f64, f64, String)>,
+) {
+    let cell_clip = match &node.node_type {
+        RenderNodeType::TableCell(cell) => Some(cell.clip),
+        _ => cell_clip,
+    };
+    if let RenderNodeType::TextRun(run) = &node.node_type {
+        let t = run.text.as_str();
+        let bb = (
+            node.bbox.x,
+            node.bbox.y,
+            node.bbox.width,
+            node.bbox.height,
+            t.to_string(),
+        );
+        if t.contains("4. 항목란") {
+            hangmok.push(bb.clone());
+        }
+        if (t.contains("접수번호") || t.contains("3쪽 중 1쪽")) && cell_clip != Some(true) {
+            form.push(bb);
+        }
+    }
+    for child in &node.children {
+        collect(child, cell_clip, hangmok, form);
+    }
+}

--- a/tests/cases/issue_5946_pyeollam_p141_pagebreak.rs
+++ b/tests/cases/issue_5946_pyeollam_p141_pagebreak.rs
@@ -21,24 +21,40 @@ fn issue_5946_p141_hangmok_is_not_covered_by_form_header() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
     let bytes = fs::read(path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
     let core = DocumentCore::from_bytes(&bytes).expect("parse handbook");
-    let page = core
-        .build_page_render_tree(PAGE_INDEX)
-        .expect("page 141 render tree");
-
+    let page_count = core.page_count();
+    // 뷰어 141쪽을 우선하되, 조판이 한두 쪽 밀리면 근처에서 '4. 항목란' 을 찾는다.
+    let search_lo = PAGE_INDEX.saturating_sub(4);
+    let search_hi = (PAGE_INDEX + 4).min(page_count.saturating_sub(1));
     let mut hangmok = Vec::new();
     let mut form = Vec::new();
-    collect(&page.root, None, &mut hangmok, &mut form);
+    let mut found_page = PAGE_INDEX;
+    for page_idx in search_lo..=search_hi {
+        hangmok.clear();
+        form.clear();
+        let page = core
+            .build_page_render_tree(page_idx)
+            .unwrap_or_else(|e| panic!("page {} render tree: {e}", page_idx + 1));
+        collect(&page.root, None, &mut hangmok, &mut form);
+        if !hangmok.is_empty() {
+            found_page = page_idx;
+            break;
+        }
+    }
 
     assert!(
         !hangmok.is_empty(),
-        "141쪽에 '4. 항목란' 이 없다 — 표본 쪽 번호가 바뀌었는지 확인하라"
+        "{}쪽에 '4. 항목란' 이 없다 — 검색 {}..{}: 표본 쪽 번호가 바뀌었는지 확인하라",
+        PAGE_INDEX + 1,
+        search_lo + 1,
+        search_hi + 1
     );
     for (hx, hy, hw, hh, _) in &hangmok {
         for (fx, fy, fw, fh, ftext) in &form {
             let overlap = hx < &(fx + fw) && fx < &(hx + hw) && hy < &(fy + fh) && fy < &(hy + hh);
             assert!(
                 !overlap,
-                "예시 서식 '{ftext}' 가 4. 항목란 과 겹친다 ({fx:.1},{fy:.1})×({fw:.1}x{fh:.1}) vs 항목란 ({hx:.1},{hy:.1})"
+                "쪽 {} 예시 서식 '{ftext}' 가 4. 항목란 과 겹친다 ({fx:.1},{fy:.1})×({fw:.1}x{fh:.1}) vs 항목란 ({hx:.1},{hy:.1})",
+                found_page + 1
             );
         }
     }


### PR DESCRIPTION
## 무엇

행정업무운영편람 2025 141쪽에서 `3. 쪽` 칸의 중첩 예시 서식(접수번호)이 `4. 항목란` 위로 포개집니다. 쪽 분할 조각을 clip 해 다음 행을 침범하지 않게 합니다.

## 원인

설계 기준 표는 `pageBreak=CELL` · `repeatHeader=1` 입니다. 쪽 경계가 행 높이 override 로만 이어지면(컷 부기 없음) 조각 셀에 clip 이 안 걸려, 중첩 서식이 조각 높이를 무시하고 다음 행 위에 그려집니다. #5714 가 말한 tail 밴드 겹침과 같은 계열입니다. 페이지네이터를 다시 쓰지 않습니다.

## 변경

- `src/renderer/layout/table_partial.rs` — `start_row_height_override` / `end_row_height_override` 가 있는 조각 셀에 clip.
- `tests/cases/issue_5946_pyeollam_p141_pagebreak.rs` — 141쪽(0-based 140)에서 clip 되지 않은 접수번호 런이 항목란과 겹치면 실패.

#5947(137쪽 바탕쪽 세로 제목 줄나눔) 과 다른 쪽·다른 경로입니다.

## 검증

- [x] `rustfmt --edition 2021` (Unix LF) on the two files
- [ ] `cargo test` 생략 — 공유 target 잠금·디스크. CI 가 스위트를 돌립니다.

closes #5946
