### PR TITLE
[4468] 쪽 경계에 걸친 표 셀 floating 그림이 앞·뒤 쪽에 중복 출력되지 않게 한다

### DIFF
--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -2149,6 +2149,32 @@ impl LayoutEngine {
         (latest_start + 0.5 < earliest_end).then_some(furthest_bottom)
     }
 
+    /// 문단의 TopAndBottom 셀-flow 그림/도형 control 범위. atomic unit 에 붙여
+    /// 쪽을 걸친 셀 조각에서 같은 그림을 한 번만 emit 한다 (#4468).
+    fn paragraph_cell_top_and_bottom_control_range(
+        &self,
+        controls: &[Control],
+    ) -> Option<(usize, usize)> {
+        let mut first = None;
+        let mut last = None;
+        for (control_idx, control) in controls.iter().enumerate() {
+            let common = match control {
+                Control::Picture(picture) => &picture.common,
+                Control::Shape(shape) => shape.common(),
+                _ => continue,
+            };
+            if common.treat_as_char || !matches!(common.text_wrap, TextWrap::TopAndBottom) {
+                continue;
+            }
+            if self.non_inline_control_flow_height(common) <= 0.5 {
+                continue;
+            }
+            first.get_or_insert(control_idx);
+            last = Some(control_idx);
+        }
+        first.zip(last)
+    }
+
     /// Square/Tight/Through cell-flow의 control별 높이. 기존 aggregate 높이 계산과 같은
     /// contract를 유지하되, 16px fragment unit이 어떤 source control에 해당하는지 복원한다.
     fn paragraph_cell_other_non_inline_control_heights(
@@ -9011,37 +9037,45 @@ impl LayoutEngine {
                     non_inline_h -= h;
                 }
             };
-        let append_atomic_unit = |units: &mut Vec<CellUnit>, para_idx: usize, non_inline_h: f64| {
-            if non_inline_h <= 0.5 {
-                return;
-            }
-            units.push(CellUnit {
-                height: non_inline_h,
-                hard_break_before: false,
-                stored_frame_break_before: false,
-                vpos_gap_before: false,
-                para_idx,
-                vis_start: 0,
-                vis_end: 0,
-                nested_row: None,
-                nested_table_fragment: None,
-                mixed_nested_fragment: false,
-                mixed_nested_trailing: false,
-                mixed_nested_content_height: 0.0,
-                mixed_nested_recursive: false,
-                mixed_nested_starts_after_table: false,
-                mixed_nested_source_para_idx: None,
-                recursive_block_prelude_role: RecursiveBlockPreludeRole::None,
-                top_and_bottom_flow: true,
-                empty_spacer: false,
-                non_inline_control_range: None,
-            });
-        };
+        let append_atomic_unit =
+            |units: &mut Vec<CellUnit>,
+             para_idx: usize,
+             non_inline_h: f64,
+             tb_range: Option<(usize, usize)>| {
+                if non_inline_h <= 0.5 {
+                    return;
+                }
+                units.push(CellUnit {
+                    height: non_inline_h,
+                    hard_break_before: false,
+                    stored_frame_break_before: false,
+                    vpos_gap_before: false,
+                    para_idx,
+                    vis_start: 0,
+                    vis_end: 0,
+                    nested_row: None,
+                    nested_table_fragment: None,
+                    mixed_nested_fragment: false,
+                    mixed_nested_trailing: false,
+                    mixed_nested_content_height: 0.0,
+                    mixed_nested_recursive: false,
+                    mixed_nested_starts_after_table: false,
+                    mixed_nested_source_para_idx: None,
+                    recursive_block_prelude_role: RecursiveBlockPreludeRole::None,
+                    top_and_bottom_flow: true,
+                    empty_spacer: false,
+                    // [#4468] 쪽을 걸친 셀에서 TopAndBottom 그림이 앞·뒤 조각에 중복
+                    // 페인트되지 않도록, atomic unit 을 control identity 로 표지한다.
+                    // Square 경로와 같이 그 control 의 **첫** unit 을 품은 cut 만 emit 한다.
+                    non_inline_control_range: tb_range,
+                });
+            };
         let append_non_inline_units = |units: &mut Vec<CellUnit>,
                                        para_idx: usize,
                                        extra_h: f64,
                                        top_and_bottom_h: f64,
-                                       other_h: f64|
+                                       other_h: f64,
+                                       tb_range: Option<(usize, usize)>|
          -> std::ops::Range<usize> {
             let (top_extra_h, other_extra_h) =
                 split_non_inline_extra(extra_h, top_and_bottom_h, other_h);
@@ -9051,12 +9085,12 @@ impl LayoutEngine {
             let other_start = units.len();
             append_fragment_units(units, para_idx, other_extra_h);
             let other_end = units.len();
-            append_atomic_unit(units, para_idx, top_extra_h);
+            append_atomic_unit(units, para_idx, top_extra_h, tb_range);
             other_start..other_end
         };
         // 기존 16px generic fragment의 높이·개수·순서는 그대로 두고, 각 fragment가
         // 겹치는 Square/Tight/Through source control range만 복원한다. TopAndBottom
-        // atomic unit은 이 metadata의 대상이 아니다.
+        // atomic unit 은 `tb_range` 로 control identity 를 붙인다 (#4468).
         let tag_other_non_inline_control_units =
             |units: &mut [CellUnit], range: std::ops::Range<usize>, controls: &[(usize, f64)]| {
                 if range.is_empty() || controls.is_empty() {
@@ -9892,6 +9926,7 @@ impl LayoutEngine {
                         para_non_inline_extra_h,
                         para_top_and_bottom_h,
                         para_other_non_inline_h,
+                        self.paragraph_cell_top_and_bottom_control_range(&p.controls),
                     );
                     tag_other_non_inline_control_units(
                         &mut units,
@@ -10038,6 +10073,7 @@ impl LayoutEngine {
                             para_non_inline_extra_h,
                             para_top_and_bottom_h,
                             para_other_non_inline_h,
+                            self.paragraph_cell_top_and_bottom_control_range(&p.controls),
                         );
                         tag_other_non_inline_control_units(
                             &mut units,
@@ -10249,6 +10285,7 @@ impl LayoutEngine {
                         para_non_inline_extra_h,
                         para_top_and_bottom_h,
                         para_other_non_inline_h,
+                        self.paragraph_cell_top_and_bottom_control_range(&p.controls),
                     );
                     tag_other_non_inline_control_units(
                         &mut units,
@@ -10514,6 +10551,7 @@ impl LayoutEngine {
                 para_non_inline_extra_h,
                 para_top_and_bottom_h,
                 para_other_non_inline_h,
+                self.paragraph_cell_top_and_bottom_control_range(&p.controls),
             );
             tag_other_non_inline_control_units(
                 &mut units,
@@ -13214,10 +13252,10 @@ impl LayoutEngine {
 
     /// `cell_cut_contains_non_inline_control_units`의 control-identity 버전.
     ///
-    /// Square/Tight/Through flow fragment는 control range의 **첫** unit을 포함한 cut만
-    /// picture/shape를 emit한다. 같은 control의 뒷 unit은 다음 physical fragment에서
-    /// 다시 image를 paint하지 않는다. legacy/TopAndBottom unit처럼 range가 없는 경우에는
-    /// 기존 paragraph-level 판정을 유지해 저장 형식별 기존 contract를 바꾸지 않는다.
+    /// Square/Tight/Through flow fragment와 TopAndBottom atomic unit 은 control
+    /// range의 **첫** unit을 포함한 cut만 picture/shape를 emit한다. 같은 control의
+    /// 뒷 unit은 다음 physical fragment에서 다시 image를 paint하지 않는다 (#4468).
+    /// range가 없는 레거시 unit만 paragraph-level 판정을 유지한다.
     pub(crate) fn cell_cut_starts_non_inline_control(
         &self,
         cell: &crate::model::table::Cell,

--- a/tests/cases/issue_4468_split_cell_float_once.rs
+++ b/tests/cases/issue_4468_split_cell_float_once.rs
@@ -1,0 +1,127 @@
+//! [Issue #4468] 쪽 경계에 걸친 표 셀의 TopAndBottom floating 그림이
+//! 앞쪽 하단과 다음 쪽 상단에 중복 출력된다.
+//!
+//! 한글은 그 칸 조각을 소유한 쪽에만 그림을 그린다. rHWP 는 TopAndBottom
+//! atomic cell unit 에 control identity 가 없어, 같은 문단의 빈 범위 unit 이
+//! 있는 모든 조각에서 그림을 다시 emit 했다.
+//!
+//! 픽스처 `samples/issue5734/cell_float_stack_stored_vpos.hwpx` 는 #6045 와
+//! 같은 156684746 표 8 축소본이다. 오른쪽 칸 서울경제TV 캡처(h=289.2px)가
+//! 쪽을 건넌다. 결함 시 같은 control 이 1쪽·2쪽에 모두 나타난다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+
+const SAMPLE: &str = "samples/issue5734/cell_float_stack_stored_vpos.hwpx";
+const TV_H: f64 = 289.2;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CellFloatId {
+    sec: i64,
+    para: i64,
+    ctrl: i64,
+    cell: i64,
+    cell_para: i64,
+}
+
+fn cell_tb_images(layout_json: &str) -> Vec<(CellFloatId, f64)> {
+    let value: serde_json::Value = serde_json::from_str(layout_json).expect("control layout JSON");
+    let items = value
+        .as_array()
+        .or_else(|| value.get("controls").and_then(|v| v.as_array()))
+        .expect("control layout 배열");
+    let mut out = Vec::new();
+    for item in items {
+        if item.get("type").and_then(|v| v.as_str()) != Some("image") {
+            continue;
+        }
+        if item.get("wrap").and_then(|v| v.as_str()) != Some("topAndBottom") {
+            continue;
+        }
+        let Some(cell) = item.get("cellIdx").and_then(|v| v.as_i64()) else {
+            continue;
+        };
+        let Some(cell_para) = item.get("cellParaIdx").and_then(|v| v.as_i64()) else {
+            continue;
+        };
+        let id = CellFloatId {
+            sec: item.get("secIdx").and_then(|v| v.as_i64()).unwrap_or(-1),
+            para: item.get("paraIdx").and_then(|v| v.as_i64()).unwrap_or(-1),
+            ctrl: item
+                .get("controlIdx")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(-1),
+            cell,
+            cell_para,
+        };
+        let h = item.get("h").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        out.push((id, h));
+    }
+    out
+}
+
+#[test]
+fn issue_4468_split_cell_tb_float_paints_once() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let core = DocumentCore::from_bytes(&std::fs::read(path).expect("read sample")).expect("open");
+    let page_count = core.page_count();
+    assert!(
+        page_count >= 2,
+        "표 8 축소본은 2쪽이어야 한다: {page_count}"
+    );
+
+    let mut pages_by_id: HashMap<CellFloatId, Vec<usize>> = HashMap::new();
+    let mut tv_pages = Vec::new();
+    for page in 0..page_count {
+        let layout = core
+            .get_page_control_layout_native(page as u32)
+            .unwrap_or_else(|e| panic!("page {} control layout: {e}", page + 1));
+        for (id, h) in cell_tb_images(&layout) {
+            if (h - TV_H).abs() < 0.6 {
+                tv_pages.push(page);
+            }
+            pages_by_id.entry(id).or_default().push(page);
+        }
+    }
+
+    assert!(
+        !pages_by_id.is_empty(),
+        "셀 TopAndBottom 그림이 한 장도 없다"
+    );
+    for (id, pages) in &pages_by_id {
+        let unique: Vec<usize> = {
+            let mut p = pages.clone();
+            p.sort_unstable();
+            p.dedup();
+            p
+        };
+        assert_eq!(
+            unique.len(),
+            1,
+            "셀 TopAndBottom 그림이 여러 쪽에 중복 출력된다: {:?} pages={:?} (결함 시 앞쪽 하단+다음 쪽 상단)",
+            id,
+            unique.iter().map(|p| p + 1).collect::<Vec<_>>()
+        );
+    }
+
+    assert!(
+        !tv_pages.is_empty(),
+        "서울경제TV 캡처(h=289.2)가 어느 쪽에도 없다"
+    );
+    tv_pages.sort_unstable();
+    tv_pages.dedup();
+    assert_eq!(
+        tv_pages.len(),
+        1,
+        "서울경제TV 캡처가 여러 쪽에 중복 출력된다: {:?}",
+        tv_pages.iter().map(|p| p + 1).collect::<Vec<_>>()
+    );
+    assert!(
+        tv_pages[0] >= 1,
+        "캡처는 다음 쪽에 한 번만 있어야 한다: page={}",
+        tv_pages[0] + 1
+    );
+}

--- a/tests/cases/issue_4468_split_cell_float_once.rs
+++ b/tests/cases/issue_4468_split_cell_float_once.rs
@@ -73,11 +73,11 @@ fn issue_4468_split_cell_tb_float_paints_once() {
         "표 8 축소본은 2쪽이어야 한다: {page_count}"
     );
 
-    let mut pages_by_id: HashMap<CellFloatId, Vec<usize>> = HashMap::new();
+    let mut pages_by_id: HashMap<CellFloatId, Vec<u32>> = HashMap::new();
     let mut tv_pages = Vec::new();
     for page in 0..page_count {
         let layout = core
-            .get_page_control_layout_native(page as u32)
+            .get_page_control_layout_native(page)
             .unwrap_or_else(|e| panic!("page {} control layout: {e}", page + 1));
         for (id, h) in cell_tb_images(&layout) {
             if (h - TV_H).abs() < 0.6 {

--- a/tests/cases/issue_4468_split_cell_float_once.rs
+++ b/tests/cases/issue_4468_split_cell_float_once.rs
@@ -92,7 +92,7 @@ fn issue_4468_split_cell_tb_float_paints_once() {
         "셀 TopAndBottom 그림이 한 장도 없다"
     );
     for (id, pages) in &pages_by_id {
-        let unique: Vec<usize> = {
+        let unique: Vec<u32> = {
             let mut p = pages.clone();
             p.sort_unstable();
             p.dedup();


### PR DESCRIPTION
## 요약

쪽 경계에 걸친 표 셀의 `TopAndBottom` floating 그림이 앞쪽 하단과 다음 쪽 상단에 중복 출력되던 경로를 막습니다. 그림을 그 칸 조각을 소유한 쪽에만 emit 합니다.

Closes #4468

## 문제

한글은 쪽을 건넌 셀 안의 `wrap: topAndBottom` 그림을 실제 소속 쪽에만 한 번 그립니다. rHWP는 같은 그림을 앞쪽 하단과 다음 쪽 상단에 각각 그렸습니다. 원본 사례는 같은 셀 문단에 가로로 놓인 그림 여러 장이 쪽을 건너는 경우입니다.

## 원인

Square/Tight/Through 셀-flow는 fragment unit 에 `non_inline_control_range` 를 붙여, 그 control 의 **첫** unit 을 품은 cut 에서만 picture/shape 를 emit 합니다.

TopAndBottom 은 통째로 넘겨야 해서 atomic unit 한 개로 유지하지만, 그 unit 의 range 가 `None` 이었습니다. emit 판정은 range 가 없으면 문단 단위 레거시 후보(`vis_start == vis_end`)로 떨어지므로, 같은 문단의 빈 범위 unit 이 앞·뒤 조각에 하나씩만 있어도 그림이 양쪽에서 다시 그려졌습니다.

## 수정

`append_atomic_unit` 이 TopAndBottom control 범위로 atomic unit 을 표지합니다. 기존 `cell_cut_starts_non_inline_control` 의 first-unit-in-cut 계약이 TB 그림에도 그대로 적용됩니다. Square 경로와 셀 분할 모델은 바꾸지 않았습니다.

## 검증

- `rustfmt --edition 2021 --config newline_style=Unix --check` 통과 (변경 파일)
- 회귀: `tests/cases/issue_4468_split_cell_float_once.rs`
  - 픽스처 `samples/issue5734/cell_float_stack_stored_vpos.hwpx` (#6045 와 같은 표 8 축소본)
  - 셀 `topAndBottom` 그림 identity 가 두 쪽에 동시에 나타나지 않는지 고정
  - 서울경제TV 캡처(h=289.2)는 다음 쪽에 한 번만
- 로컬 `cargo test` 는 디스크 부족(os 112)으로 바이너리 링크까지 가지 못했습니다. CI 가 위 케이스를 돌립니다.

`src` `#[cfg(test)]` 추가는 없습니다. `tests/generated`·Cargo generated 블록은 포함하지 않습니다.
