### PR TITLE
fix(clipboard): 교차 문서 HTML 붙여넣기에서 셀존 배경과 문단 정렬을 보존한다

### DIFF
--- a/src/document_core/commands/clipboard.rs
+++ b/src/document_core/commands/clipboard.rs
@@ -20,6 +20,27 @@ const PASTE_CASCADE_STEP_HU: u32 = 567;
 /// 같은 값·형태 — 병적으로 깊은 중첩 문서에서 export 재귀가 스택을 태우지 않게 막는다.
 const MAX_NEST_DEPTH: usize = 8;
 
+/// [#4275] HTML 내보내기에 쓸 셀 BorderFill — `table.zones` 가 덮어쓴 유효 값.
+/// 셀 고유 `border_fill_id` 만 보면 cellzone 회색 헤더 등이 빠진다.
+fn html_cell_border_fill_id(
+    table: &crate::model::table::Table,
+    cell: &crate::model::table::Cell,
+) -> u16 {
+    table
+        .zones
+        .iter()
+        .rev()
+        .find(|zone| {
+            zone.border_fill_id > 0
+                && zone.start_row <= cell.row
+                && cell.row <= zone.end_row
+                && zone.start_col <= cell.col
+                && cell.col <= zone.end_col
+        })
+        .map(|zone| zone.border_fill_id)
+        .unwrap_or(cell.border_fill_id)
+}
+
 /// 셀 HTML 내보내기에서 지원하지 않는 컨트롤을 경고 주석에 남기기 위한 표시 이름.
 /// `Control::Table`/`Control::Picture`는 `control_to_html`이 직접 처리하므로 이 경로를
 /// 타지 않지만, 매치 순서가 바뀌어도 무해한 이름을 반환하도록 모든 변형을 다룬다.
@@ -1733,8 +1754,10 @@ impl DocumentCore {
                 // (styles.border_styles는 0-based). 다른 소비처(예:
                 // renderer/layout/table_layout.rs, document_core/queries/hidden_text.rs)와
                 // 동일하게 -1 보정한다. [#4412]
-                if cell.border_fill_id > 0 {
-                    let idx = (cell.border_fill_id as usize).saturating_sub(1);
+                // [#4275] cellzone overlay 가 있으면 그 유효 id 를 쓴다.
+                let fill_id = html_cell_border_fill_id(table, cell);
+                if fill_id > 0 {
+                    let idx = (fill_id as usize).saturating_sub(1);
                     if let Some(bs) = self.styles.border_styles.get(idx) {
                         self.apply_border_fill_css(&mut td_style, bs);
                     }

--- a/src/document_core/html_table_import.rs
+++ b/src/document_core/html_table_import.rs
@@ -355,11 +355,7 @@ impl DocumentCore {
                 }
             };
 
-            // 셀 문단의 para_shape_id (DIFF-3 수정)
-            // 기본 "본문" ParaShape (id=0) 사용 — 유효한 참조를 보장
-            let cell_para_shape_id: u16 = 0;
-
-            // 셀 문단 보정: char_count_msb, char_count, para_shape_id, raw_header_extra, line_segs
+            // 셀 문단 보정: char_count_msb, char_count, raw_header_extra, line_segs
             let mut cell_paragraphs = cell_paragraphs;
             for cp_para in &mut cell_paragraphs {
                 cp_para.char_count_msb = true; // 셀 문단은 항상 MSB 설정
@@ -367,8 +363,8 @@ impl DocumentCore {
                 let text_chars = cp_para.text.chars().count() as u32;
                 cp_para.char_count = text_chars + 1;
 
-                // para_shape_id: 기본 "본문" ParaShape 사용 (DIFF-3)
-                cp_para.para_shape_id = cell_para_shape_id;
+                // [#4275] CSS 에서 만든 para_shape_id 를 보존한다. 종전에는 무조건 0 으로
+                // 덮어 정렬·줄간격이 교차 문서 HTML 붙여넣기에서 사라졌다.
 
                 // DIFF-2: char_shapes가 비어있으면 기본 CharShapeRef 추가
                 // 모든 셀 문단은 최소 1개의 명시적 CharShapeRef를 가져야 함

--- a/tests/cases/issue_4275_nested_table_paste_style.rs
+++ b/tests/cases/issue_4275_nested_table_paste_style.rs
@@ -1,0 +1,174 @@
+//! [#4275] 다른 문서로 중첩 표를 HTML 붙여넣으면 셀존 배경·문단 정렬이 유지된다.
+//!
+//! 같은 문서 native 클립보드는 스타일을 보존하지만, 새 문서는 HTML 경로로 넘어가
+//! `table.zones` 유효 BorderFill 과 CSS 로 만든 `para_shape_id` 가 빠졌다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::model::document::{Document, Section};
+use rhwp::model::paragraph::Paragraph;
+use rhwp::model::style::{
+    Alignment, BorderFill, BorderLine, BorderLineType, Fill, FillType, ParaShape, SolidFill,
+};
+use rhwp::model::table::{Cell, Table, TableZone};
+
+const GREY: u32 = 0x00C0C0C0;
+
+fn grey_fill() -> BorderFill {
+    let line = BorderLine {
+        line_type: BorderLineType::Solid,
+        width: 2,
+        color: 0,
+    };
+    BorderFill {
+        borders: [line, line, line, line],
+        fill: Fill {
+            fill_type: FillType::Solid,
+            solid: Some(SolidFill {
+                background_color: GREY,
+                pattern_color: 0,
+                pattern_type: 0,
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn cell(text: &str, para_shape_id: u16) -> Cell {
+    let n = text.chars().count() as u32;
+    Cell {
+        col: 0,
+        row: 0,
+        col_span: 1,
+        row_span: 1,
+        width: 4000,
+        height: 1000,
+        border_fill_id: 1,
+        paragraphs: vec![Paragraph {
+            text: text.to_string(),
+            char_count: n,
+            char_offsets: (0..=n).collect(),
+            para_shape_id,
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+fn inner_table() -> Table {
+    let mut table = Table {
+        row_count: 1,
+        col_count: 1,
+        cells: vec![cell("유형", 1)],
+        zones: vec![TableZone {
+            start_col: 0,
+            start_row: 0,
+            end_col: 0,
+            end_row: 0,
+            border_fill_id: 3,
+        }],
+        dirty: true,
+        ..Default::default()
+    };
+    table.common.width = 4000;
+    table.common.height = 1000;
+    table.rebuild_grid();
+    table
+}
+
+fn source_document() -> Document {
+    let mut center = ParaShape::default();
+    center.alignment = Alignment::Center;
+    center.line_spacing = 160;
+    let mut doc = Document::default();
+    doc.doc_info.para_shapes = vec![ParaShape::default(), center];
+    doc.doc_info.border_fills = vec![BorderFill::default(), BorderFill::default(), grey_fill()];
+
+    let mut host = Paragraph::default();
+    host.controls.push(Control::Table(Box::new(inner_table())));
+
+    let mut section = Section::default();
+    section.paragraphs.push(host);
+    doc.sections.push(section);
+    doc
+}
+
+fn pasted_table(core: &DocumentCore) -> &Table {
+    for para in &core.document().sections[0].paragraphs {
+        for ctrl in &para.controls {
+            if let Control::Table(t) = ctrl {
+                return t;
+            }
+        }
+    }
+    panic!("붙여넣은 표가 없다");
+}
+
+fn cell_fill_color(core: &DocumentCore, table: &Table) -> Option<u32> {
+    let cell = &table.cells[0];
+    let id = if cell.border_fill_id > 0 {
+        cell.border_fill_id
+    } else {
+        return None;
+    };
+    let bf = core
+        .document()
+        .doc_info
+        .border_fills
+        .get((id as usize).saturating_sub(1))?;
+    bf.fill.solid.as_ref().map(|s| s.background_color)
+}
+
+#[test]
+fn issue_4275_cellzone_fill_exported_in_html() {
+    let mut src = DocumentCore::new_empty();
+    src.set_document(source_document());
+    let html = src
+        .export_control_html_native(0, 0, &[], 0)
+        .expect("HTML 내보내기");
+    assert!(
+        html.to_lowercase().contains("background-color:#c0c0c0"),
+        "cellzone 회색 배경이 HTML 에 있어야 한다:\n{html}"
+    );
+    assert!(
+        html.contains("text-align:center"),
+        "셀 문단 가운데 정렬이 HTML 에 있어야 한다:\n{html}"
+    );
+}
+
+#[test]
+fn issue_4275_cross_document_html_paste_keeps_cell_style() {
+    let mut src = DocumentCore::new_empty();
+    src.set_document(source_document());
+    let html = src
+        .export_control_html_native(0, 0, &[], 0)
+        .expect("HTML 내보내기");
+
+    let mut dst = DocumentCore::new_empty();
+    dst.create_blank_document_native().expect("빈 문서");
+    dst.paste_html_native(0, 0, 0, &html)
+        .expect("교차 문서 HTML 붙여넣기");
+
+    let table = pasted_table(&dst);
+    let fill = cell_fill_color(&dst, table);
+    assert_eq!(
+        fill,
+        Some(GREY),
+        "붙여넣은 헤더 셀 배경이 회색이어야 한다: {fill:?}"
+    );
+
+    let ps_id = table.cells[0].paragraphs[0].para_shape_id;
+    let align = dst
+        .document()
+        .doc_info
+        .para_shapes
+        .get(ps_id as usize)
+        .map(|ps| ps.alignment);
+    assert_eq!(
+        align,
+        Some(Alignment::Center),
+        "붙여넣은 셀 문단 정렬이 가운데여야 한다 (para_shape_id={ps_id})"
+    );
+}


### PR DESCRIPTION
Closes #4275

## 문제
중첩 표를 복사해 **다른 문서**에 붙여넣으면 회색 헤더 배경·테두리와 셀 문단 정렬·줄간격이 빠진다. 같은 문서 native 클립보드는 정상이다. 새 문서는 시스템 HTML 경로로 넘어간다.

## 원인
1. `table_to_html` 이 셀 고유 `border_fill_id` 만 내보낸다. `table.zones` 가 덮어쓴 유효 BorderFill(cellzone 회색 헤더)이 HTML 에 없다.
2. HTML 표 import 가 CSS 로 만든 `para_shape_id` 를 무조건 0 으로 덮어 정렬·줄간격을 잃는다.

## 변경
- HTML 내보내기에 cellzone 유효 BorderFill 을 실는다. 클립보드 형식은 그대로다.
- import 후 셀 문단 `para_shape_id` 를 덮지 않는다.

같은 문서 native 붙여넣기·일반 HTML 표 붙여넣기는 그대로다.

## 검증
`tests/cases/issue_4275_nested_table_paste_style.rs`

- cellzone 회색이 HTML `background-color:#c0c0c0` 으로 나간다.
- 빈 문서에 `paste_html_native` 하면 배경색과 `text-align:center` 가 남는다.

`cargo test --test regression_suite_003 issue_4275` — 2 passed.
src `#[cfg(test)]` 무변경.