### PR TITLE
perf(studio): 본문 국소 조판의 focusedPagePatch 를 렌더러에 넘긴다

### DIFF
--- a/rhwp-studio/src/core/local-text-replace-result.ts
+++ b/rhwp-studio/src/core/local-text-replace-result.ts
@@ -1,8 +1,40 @@
+export interface LocalBodyTextFocusedPagePatch {
+  pageIndex: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 export interface LocalBodyTextReplaceResult {
   ok: true;
   charOffset: number;
   documentPaginationPending: boolean;
   flowChanged: boolean;
+  /** 국소 조판이 쪽 트리 캐시를 고친 영역의 재페인트 사각형. */
+  focusedPagePatch?: LocalBodyTextFocusedPagePatch;
+}
+
+function parseFocusedPagePatch(value: unknown): LocalBodyTextFocusedPagePatch | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const candidate = value as Partial<LocalBodyTextFocusedPagePatch>;
+  const numbers = [candidate.x, candidate.y, candidate.width, candidate.height];
+  if (
+    !Number.isSafeInteger(candidate.pageIndex)
+    || (candidate.pageIndex as number) < 0
+    || !numbers.every((item) => typeof item === 'number' && Number.isFinite(item))
+    || (candidate.width as number) <= 0
+    || (candidate.height as number) <= 0
+  ) {
+    return undefined;
+  }
+  return {
+    pageIndex: candidate.pageIndex as number,
+    x: candidate.x as number,
+    y: candidate.y as number,
+    width: candidate.width as number,
+    height: candidate.height as number,
+  };
 }
 
 export function parseLocalBodyTextReplaceResult(
@@ -18,5 +50,14 @@ export function parseLocalBodyTextReplaceResult(
   ) {
     throw new Error('잘못된 local body text replace 결과');
   }
-  return parsed as LocalBodyTextReplaceResult;
+  const focusedPagePatch = parsed.flowChanged
+    ? undefined
+    : parseFocusedPagePatch(parsed.focusedPagePatch);
+  return {
+    ok: true,
+    charOffset: parsed.charOffset,
+    documentPaginationPending: parsed.documentPaginationPending,
+    flowChanged: parsed.flowChanged,
+    ...(focusedPagePatch ? { focusedPagePatch } : {}),
+  };
 }

--- a/rhwp-studio/src/core/local-text-replace-result.ts
+++ b/rhwp-studio/src/core/local-text-replace-result.ts
@@ -43,6 +43,7 @@ export function parseLocalBodyTextReplaceResult(
   const parsed = JSON.parse(raw) as Partial<LocalBodyTextReplaceResult>;
   if (
     parsed.ok !== true ||
+    typeof parsed.charOffset !== 'number' ||
     !Number.isInteger(parsed.charOffset) ||
     typeof parsed.documentPaginationPending !== 'boolean' ||
     typeof parsed.flowChanged !== 'boolean' ||

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -462,10 +462,12 @@ export function replaceBodyTextWithMutationEffects(
     deleteCount,
     text,
   );
+  const focusedPagePatch = !result.flowChanged ? result.focusedPagePatch : undefined;
   return {
     documentPaginationPending: result.documentPaginationPending,
     flowChanged: result.flowChanged,
     paginationCompleted: !result.documentPaginationPending,
+    ...(focusedPagePatch ? { focusedPagePatch } : {}),
   };
 }
 

--- a/rhwp-studio/tests/cell-flow-boundary.test.ts
+++ b/rhwp-studio/tests/cell-flow-boundary.test.ts
@@ -514,6 +514,28 @@ test('본문 insert와 delete command는 stable local replace effect를 반환�
   });
 });
 
+test('본문 local result의 focusedPagePatch 를 text-edit 렌더에 넘긴다', () => {
+  const wasm = new FakeWasm();
+  const position = { sectionIndex: 0, paragraphIndex: 2, charOffset: 3 };
+  wasm.queueBodyResult({
+    ok: true,
+    charOffset: 4,
+    documentPaginationPending: true,
+    flowChanged: false,
+    focusedPagePatch: { pageIndex: 0, x: 10, y: 20, width: 30, height: 12 },
+  });
+
+  assert.deepEqual(
+    replaceBodyTextWithMutationEffects(wasm, position, 0, '가'),
+    {
+      documentPaginationPending: true,
+      flowChanged: false,
+      paginationCompleted: false,
+      focusedPagePatch: { pageIndex: 0, x: 10, y: 20, width: 30, height: 12 },
+    },
+  );
+});
+
 test('본문 flow boundary local result는 pagination 완료 effect로 전달된다', () => {
   const wasm = new FakeWasm();
   const position = { sectionIndex: 0, paragraphIndex: 2, charOffset: 3 };

--- a/rhwp-studio/tests/local-text-replace-result.test.ts
+++ b/rhwp-studio/tests/local-text-replace-result.test.ts
@@ -33,3 +33,28 @@ test('모순되거나 불완전한 local result는 거부한다', () => {
   ));
   assert.throws(() => parseLocalBodyTextReplaceResult('{"ok":true}'));
 });
+
+test('stable local result의 focusedPagePatch 를 정규화한다', () => {
+  assert.deepEqual(parseLocalBodyTextReplaceResult(
+    '{"ok":true,"charOffset":4,"documentPaginationPending":true,"flowChanged":false,'
+    + '"focusedPagePatch":{"pageIndex":0,"x":10,"y":20,"width":30,"height":12}}',
+  ), {
+    ok: true,
+    charOffset: 4,
+    documentPaginationPending: true,
+    flowChanged: false,
+    focusedPagePatch: { pageIndex: 0, x: 10, y: 20, width: 30, height: 12 },
+  });
+});
+
+test('깨진 focusedPagePatch 는 무시하고 국소 조판 신호는 유지한다', () => {
+  assert.deepEqual(parseLocalBodyTextReplaceResult(
+    '{"ok":true,"charOffset":4,"documentPaginationPending":true,"flowChanged":false,'
+    + '"focusedPagePatch":{"pageIndex":0,"x":10,"y":20,"width":0,"height":12}}',
+  ), {
+    ok: true,
+    charOffset: 4,
+    documentPaginationPending: true,
+    flowChanged: false,
+  });
+});


### PR DESCRIPTION
## 무엇

본문에서 한 글자를 칠 때마다 보이는 쪽을 통째로 다시 그립니다. 표 셀 편집에 이미 있는 `focusedPagePatch` 부분 렌더를 본문 `replaceBodyTextLocal` 경로에도 연결합니다.

## 원인

Rust `replaceBodyTextLocal` 은 국소 조판 성공 시 `focusedPagePatch` dirty rect 를 JSON 에 넣습니다. studio 의 `parseLocalBodyTextReplaceResult` 와 `replaceBodyTextWithMutationEffects` 가 그 필드를 버리고, 렌더러는 patch 가 없으면 쪽 전체 `clearRect` 로 떨어집니다.

## 변경

- `local-text-replace-result.ts` — `focusedPagePatch` 정규화. flow 가 바뀌었거나 사각형이 깨지면 무시.
- `command.ts` — 셀 deferred 경로와 같이 text-edit effect 로 전달.
- 단위 테스트 2건.

이미지 많은 쪽에서 patch 를 포기하는 기존 `renderFocusedPagePatch` 가드는 그대로입니다 (#3315).

## 검증

- [x] `node --test tests/local-text-replace-result.test.ts` (5 pass)
- [ ] `tests/cell-flow-boundary.test.ts` 는 이 워크트리에 typescript 패키지가 없어 로컬 tsc 하네스만 실패. CI 가 돌립니다.

closes #5578
