### PR TITLE
fix(layout): 미주 다단 마지막 단 꼬리가 본문 하단을 14px 넘기지 않게 한다

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -1902,6 +1902,20 @@ fn square_wrap_table_line_anchor_y(
 }
 
 pub(crate) const ENDNOTE_COLUMN_BOTTOM_BLEED_TOLERANCE_PX: f64 = 24.0;
+/// [#4318] 마지막 단 split/tail 여유. 24px bleed 는 한 줄(≈12px)을 본문
+/// 프레임 아래(+14px)에 통째 남긴다. 저장 vpos 수 px 보정만 허용한다.
+pub(crate) const ENDNOTE_LAST_COLUMN_SPLIT_BLEED_PX: f64 = 4.0;
+
+/// [#4318] 마지막 단에서 `added_height` 를 붙이면 본문 하단을 넘기는지.
+pub(crate) fn endnote_last_column_tail_overflows_frame(
+    current_height: f64,
+    added_height: f64,
+    available: f64,
+) -> bool {
+    current_height > available * 0.90
+        && current_height + added_height > available + ENDNOTE_LAST_COLUMN_SPLIT_BLEED_PX
+}
+
 const ENDNOTE_COLUMN_BOTTOM_OVERFLOW_LOG_TOLERANCE_PX: f64 = 48.0;
 const ENDNOTE_EQUATION_TAIL_LINE_BOX_OVERFLOW_LOG_TOLERANCE_PX: f64 = 68.0;
 const ZERO_ENDNOTE_COLUMN_BOTTOM_OVERFLOW_LOG_TOLERANCE_PX: f64 = 33.0;

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -10555,6 +10555,11 @@ impl TypesetEngine {
             let zero_between_large_separator_margin = endnote_flow_profile
                 .map(EndnoteFlowProfile::visible_zero_between_large_separator_margin)
                 .unwrap_or(false);
+            // [#4318] 구분선 위/아래 20mm + 기본 미주 사이(7mm). 다른 미주
+            // 모양까지 4px bleed·꼬리 넘김을 쓰면 쪽수/off-canvas 가 흔들린다.
+            let both_large_separator_default_between = endnote_flow_profile
+                .map(EndnoteFlowProfile::visible_both_large_separator_default_between)
+                .unwrap_or(false);
             let endnote_has_text_or_equation = para_has_visible_text_or_equation(en_para);
             let endnote_has_visible_payload =
                 endnote_has_text_or_equation || para_has_non_tac_picture_or_shape(en_para);
@@ -11137,9 +11142,10 @@ impl TypesetEngine {
                     && (!default_between_notes_gap || zero_between_large_separator_margin)
                 {
                     // 보이는 구분선의 마지막 단에서는 renderer의 저장 vpos
-                    // 보정이 하단으로 수 px 내려갈 수 있다. 24px bleed 는
-                    // 한 줄(≈12px)을 본문 프레임 아래(+14px)에 남긴다(#4318).
-                    remaining_height + ENDNOTE_LAST_COLUMN_SPLIT_BLEED_PX
+                    // 보정이 하단으로 약간 내려갈 수 있다. 미주 사이가
+                    // 0이어도 구분선 위/아래가 큰 프로필은 같은 방식으로
+                    // 마지막 visible tail 한 줄을 현재 단에 남긴다.
+                    remaining_height + ENDNOTE_COLUMN_BOTTOM_BLEED_TOLERANCE_PX
                 } else {
                     remaining_height
                 };
@@ -11217,10 +11223,11 @@ impl TypesetEngine {
             } else {
                 split_endnote_to_fit
             };
-            // [#4318] 구분선 위/아래 20mm 마지막 단: 0/0/0 가드가 없어도
-            // 마지막 줄이 본문 하단을 넘기면 그 줄만 다음 쪽으로 넘긴다.
+            // [#4318] 구분선 위/아래 20mm + 기본 미주 사이 마지막 단: 0/0/0
+            // 가드가 없어도 마지막 줄이 본문 하단을 넘기면 그 줄만 넘긴다.
             let split_endnote_to_fit = if split_endnote_to_fit.is_none()
                 && compact_endnote_separator_profile
+                && both_large_separator_default_between
                 && has_visible_endnote_separator
                 && ep_idx > 0
                 && st.current_column + 1 >= st.col_count
@@ -12719,8 +12726,9 @@ impl TypesetEngine {
                                 .paragraphs
                                 .get(ep_idx + 1)
                                 .is_some_and(para_is_treat_as_char_picture_only)));
-            // [#4318] 0/0/0 가드가 아닌 구분선 20/20 마지막 단 한 줄 꼬리.
+            // [#4318] 구분선 위/아래 20mm + 기본 미주 사이 마지막 단 한 줄 꼬리.
             let last_column_visible_text_tail_starts_next_page = compact_endnote_separator_profile
+                && both_large_separator_default_between
                 && has_visible_endnote_separator
                 && ep_idx > 0
                 && st.current_column + 1 >= st.col_count
@@ -26174,6 +26182,15 @@ impl EndnoteFlowProfile {
 
     fn visible_zero_between_large_separator_margin(self) -> bool {
         self.visible_separator && self.between_notes_hu == 0 && self.large_separator_margin()
+    }
+
+    /// [#4318] 구분선 위/아래가 모두 7mm를 넘는 20mm급이고, 미주 사이는
+    /// 기본(0이 아닌 7mm 이하). 0/0/0·미주사이 0·미주사이 20은 제외한다.
+    fn visible_both_large_separator_default_between(self) -> bool {
+        self.visible_separator
+            && self.separator_above_hu > ENDNOTE_BETWEEN_NOTES_BASE_FLOW_HU
+            && self.separator_below_hu > ENDNOTE_BETWEEN_NOTES_BASE_FLOW_HU
+            && self.nonzero_default_between_notes()
     }
 
     fn visible_large_between_zero_above_compact_below(self) -> bool {

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -13600,6 +13600,22 @@ impl TypesetEngine {
                     .or(large_between_last_column_flow_tail_split)
                     .or(split_endnote_to_fit)
             };
+            // [#4318] 구분선 20/20+기본 미주사이 마지막 단: LINE_SEG 마지막
+            // 줄 vpos=0 reset 은 그 줄만 다음 쪽으로 보낸다. rhwp 는 reset
+            // 직전 줄을 본문 하단 아래로 그리므로 그 줄까지 함께 넘긴다.
+            let split_candidate = if both_large_separator_default_between
+                && compact_endnote_separator_profile
+                && has_visible_endnote_separator
+                && st.current_column + 1 >= st.col_count
+                && saved_page_reset_rewind
+            {
+                match split_candidate {
+                    Some(split) if split >= 2 => Some(split - 1),
+                    other => other,
+                }
+            } else {
+                split_candidate
+            };
             if self.emit_endnote_split(
                 st,
                 &fmt,

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -28,7 +28,10 @@ use crate::renderer::height_measurer::{
     MeasuredTable,
 };
 use crate::renderer::layout::table_layout::native_terminal_child_host_line_spacing;
-use crate::renderer::layout::{border_width_to_px, ENDNOTE_COLUMN_BOTTOM_BLEED_TOLERANCE_PX};
+use crate::renderer::layout::{
+    border_width_to_px, endnote_last_column_tail_overflows_frame,
+    ENDNOTE_COLUMN_BOTTOM_BLEED_TOLERANCE_PX, ENDNOTE_LAST_COLUMN_SPLIT_BLEED_PX,
+};
 use crate::renderer::page_layout::PageLayoutInfo;
 use crate::renderer::style_resolver::ResolvedStyleSet;
 use crate::renderer::{
@@ -11134,10 +11137,9 @@ impl TypesetEngine {
                     && (!default_between_notes_gap || zero_between_large_separator_margin)
                 {
                     // 보이는 구분선의 마지막 단에서는 renderer의 저장 vpos
-                    // 보정이 하단으로 약간 내려갈 수 있다. 미주 사이가
-                    // 0이어도 구분선 위/아래가 큰 프로필은 같은 방식으로
-                    // 마지막 visible tail 한 줄을 현재 단에 남긴다.
-                    remaining_height + ENDNOTE_COLUMN_BOTTOM_BLEED_TOLERANCE_PX
+                    // 보정이 하단으로 수 px 내려갈 수 있다. 24px bleed 는
+                    // 한 줄(≈12px)을 본문 프레임 아래(+14px)에 남긴다(#4318).
+                    remaining_height + ENDNOTE_LAST_COLUMN_SPLIT_BLEED_PX
                 } else {
                     remaining_height
                 };
@@ -11212,6 +11214,34 @@ impl TypesetEngine {
                 // 아래로 내려갈 수 있다. 한컴은 이 tail 한 줄을 다음 쪽
                 // 첫 줄로 넘기므로 마지막 줄 직전에 분할한다.
                 (head_fits && tail_overflows && last_line_visible).then_some(tail_split)
+            } else {
+                split_endnote_to_fit
+            };
+            // [#4318] 구분선 위/아래 20mm 마지막 단: 0/0/0 가드가 없어도
+            // 마지막 줄이 본문 하단을 넘기면 그 줄만 다음 쪽으로 넘긴다.
+            let split_endnote_to_fit = if split_endnote_to_fit.is_none()
+                && compact_endnote_separator_profile
+                && has_visible_endnote_separator
+                && ep_idx > 0
+                && st.current_column + 1 >= st.col_count
+                && fmt.line_heights.len() >= 2
+                && !local_vpos_rewind
+                && !internal_vpos_rewind
+                && endnote_has_visible_payload
+            {
+                let tail_split = fmt.line_heights.len() - 1;
+                let head_h = fmt.line_advances_sum(0..tail_split);
+                let tail_h = fmt.line_advance(tail_split);
+                let last_line_visible =
+                    line_has_visible_text_or_tac_equation(en_para, &composed, tail_split);
+                (st.current_height + head_h <= available + ENDNOTE_LAST_COLUMN_SPLIT_BLEED_PX
+                    && endnote_last_column_tail_overflows_frame(
+                        st.current_height + head_h,
+                        tail_h,
+                        available,
+                    )
+                    && last_line_visible)
+                    .then_some(tail_split)
             } else {
                 split_endnote_to_fit
             };
@@ -12689,6 +12719,21 @@ impl TypesetEngine {
                                 .paragraphs
                                 .get(ep_idx + 1)
                                 .is_some_and(para_is_treat_as_char_picture_only)));
+            // [#4318] 0/0/0 가드가 아닌 구분선 20/20 마지막 단 한 줄 꼬리.
+            let last_column_visible_text_tail_starts_next_page = compact_endnote_separator_profile
+                && has_visible_endnote_separator
+                && ep_idx > 0
+                && st.current_column + 1 >= st.col_count
+                && !local_vpos_rewind
+                && !internal_vpos_rewind
+                && !para_is_treat_as_char_picture_only(en_para)
+                && para_has_visible_text_or_equation(en_para)
+                && fmt.line_heights.len() == 1
+                && endnote_last_column_tail_overflows_frame(
+                    st.current_height,
+                    fmt.total_height,
+                    available,
+                );
             let large_between_zero_above_whole_note_small_bleed_fits =
                 compact_endnote_separator_profile
                     && visible_large_between_zero_above_compact_below
@@ -12715,6 +12760,7 @@ impl TypesetEngine {
                 || visible_separator_text_after_equation_tail_overflows_frame
                 || zero_visible_last_column_text_tail_starts_next_page
                 || zero_between_visible_last_column_text_tail_starts_next_page
+                || last_column_visible_text_tail_starts_next_page
                 || endnote_boundary_gap_tail_overflows_frame
                 || default_title_tail_body_advances_column
                 || large_between_title_tail_body_advances_page
@@ -12751,6 +12797,7 @@ impl TypesetEngine {
                     || visible_separator_text_after_equation_tail_overflows_frame
                     || zero_visible_last_column_text_tail_starts_next_page
                     || zero_between_visible_last_column_text_tail_starts_next_page
+                    || last_column_visible_text_tail_starts_next_page
                     || zero_between_large_separator_last_column_title_orphan
                     || large_between_last_column_final_lead_tac_tail_starts_next_page
                     || internal_reset_split_head_render_overflows

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -13601,17 +13601,32 @@ impl TypesetEngine {
                     .or(split_endnote_to_fit)
             };
             // [#4318] 구분선 20/20+기본 미주사이 마지막 단: LINE_SEG 마지막
-            // 줄 vpos=0 reset 은 그 줄만 다음 쪽으로 보낸다. rhwp 는 reset
-            // 직전 줄을 본문 하단 아래로 그리므로 그 줄까지 함께 넘긴다.
+            // 줄 vpos=0 reset 은 그 줄만 넘긴다. reset 앞 head 가 저장 vpos
+            // 기준으로 단 하단을 넘기면 들어가는 줄까지 줄여 넘긴다.
             let split_candidate = if both_large_separator_default_between
                 && compact_endnote_separator_profile
                 && has_visible_endnote_separator
                 && st.current_column + 1 >= st.col_count
                 && saved_page_reset_rewind
             {
-                match split_candidate {
-                    Some(split) if split >= 2 => Some(split - 1),
-                    other => other,
+                match (
+                    split_candidate,
+                    self.predict_current_column_para_y(
+                        &st,
+                        en_para_idx,
+                        paragraphs,
+                        &styles,
+                        measured_tables,
+                        Some(en_col_w),
+                    ),
+                ) {
+                    (Some(mut split), Some(render_y)) if split >= 2 => {
+                        while split >= 2 && render_y + fmt.line_advances_sum(0..split) > available {
+                            split -= 1;
+                        }
+                        Some(split)
+                    }
+                    (other, _) => other,
                 }
             } else {
                 split_candidate

--- a/tests/cases/issue_4318_endnote_last_column_frame.rs
+++ b/tests/cases/issue_4318_endnote_last_column_frame.rs
@@ -1,0 +1,75 @@
+//! [#4318] 미주 다단 17쪽 오른쪽 단 마지막 줄이 본문 프레임 안에 남는다.
+//!
+//! `samples/3-09월_교육_통합_2024-구분선아래20구분선위20.hwp` 17쪽. 한컴 PDF 는
+//! 프레임 밖 본문이 0px 인데, rhwp 는 오른쪽 단 마지막 줄
+//! (`의 가지 경우이므로 이 경우 구하는 확률은`) 이 본문 하단 1096.1px 을
+//! 약 14px 넘겼다. 24px bleed 로 한 줄(≈12px)을 마지막 단에 남긴 것이 원인.
+//!
+//! `ENDNOTE_PAGE_OFFCANVAS_GUARD_PX`(56) 는 건드리지 않는다 — 낮추면 한글
+//! 23쪽이 22쪽으로 줄어 #5886 이 열린다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+const SAMPLE: &str = "samples/3-09월_교육_통합_2024-구분선아래20구분선위20.hwp";
+const PAGE: u32 = 16;
+const HANGUL_PAGE_COUNT: u32 = 23;
+
+fn load() -> DocumentCore {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes =
+        std::fs::read(&path).unwrap_or_else(|e| panic!("{} 읽기 실패: {e}", path.display()));
+    DocumentCore::from_bytes(&bytes).unwrap_or_else(|e| panic!("{SAMPLE} 파싱 실패: {e}"))
+}
+
+fn body_bottom(node: &RenderNode) -> Option<f64> {
+    if matches!(node.node_type, RenderNodeType::Body { .. }) {
+        return Some(node.bbox.y + node.bbox.height);
+    }
+    node.children.iter().find_map(body_bottom)
+}
+
+fn collect_right_col_line_bottoms(node: &RenderNode, in_right: bool, out: &mut Vec<f64>) {
+    let in_right = in_right || matches!(node.node_type, RenderNodeType::Column(1));
+    let skip = matches!(
+        node.node_type,
+        RenderNodeType::Header | RenderNodeType::Footer
+    );
+    if skip {
+        return;
+    }
+    if in_right {
+        if let RenderNodeType::TextLine(_) = node.node_type {
+            out.push(node.bbox.y + node.bbox.height);
+        }
+    }
+    for child in &node.children {
+        collect_right_col_line_bottoms(child, in_right, out);
+    }
+}
+
+#[test]
+fn sep2020_page17_right_column_last_line_stays_inside_body() {
+    let core = load();
+    assert_eq!(
+        core.page_count(),
+        HANGUL_PAGE_COUNT,
+        "한글 23쪽을 유지해야 한다 (56px 용지밖 가드를 낮추면 22쪽으로 줄어 #5886)"
+    );
+    let tree = core
+        .build_page_render_tree(PAGE)
+        .expect("17쪽 렌더 트리");
+    let body_bottom = body_bottom(&tree.root).expect("Body");
+    let mut bottoms = Vec::new();
+    collect_right_col_line_bottoms(&tree.root, false, &mut bottoms);
+    assert!(
+        !bottoms.is_empty(),
+        "17쪽 오른쪽 단에 TextLine 이 없다 body_bottom={body_bottom:.1}"
+    );
+    let deepest = bottoms.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    assert!(
+        deepest <= body_bottom + 1.0,
+        "17쪽 오른쪽 단 마지막 줄 bottom={deepest:.1} 이 본문 하단 {body_bottom:.1} 을 넘는다"
+    );
+}

--- a/tests/cases/issue_4318_endnote_last_column_frame.rs
+++ b/tests/cases/issue_4318_endnote_last_column_frame.rs
@@ -57,9 +57,7 @@ fn sep2020_page17_right_column_last_line_stays_inside_body() {
         HANGUL_PAGE_COUNT,
         "한글 23쪽을 유지해야 한다 (56px 용지밖 가드를 낮추면 22쪽으로 줄어 #5886)"
     );
-    let tree = core
-        .build_page_render_tree(PAGE)
-        .expect("17쪽 렌더 트리");
+    let tree = core.build_page_render_tree(PAGE).expect("17쪽 렌더 트리");
     let body_bottom = body_bottom(&tree.root).expect("Body");
     let mut bottoms = Vec::new();
     collect_right_col_line_bottoms(&tree.root, false, &mut bottoms);

--- a/tests/issue_1355_endnote_title_gap_double.rs
+++ b/tests/issue_1355_endnote_title_gap_double.rs
@@ -12,6 +12,8 @@
 //!
 //! 가드: p18(0-idx 17) 좌측 컬럼 첫 미주 제목(문30)의 baseline y 가 이중계상 시의
 //! 위치(+약 26px)로 회귀하지 않는지 절대 bound 로 추적.
+//! #4318 이 17쪽 마지막 단 overflow 꼬리(pi=922 lines 2..5)를 18쪽 좌측
+//! 상단으로 넘기므로 문30 기준점은 ~336 이 아니라 ~375.
 
 use std::fs;
 use std::path::Path;
@@ -68,8 +70,8 @@ fn attr_f(tag: &str, key: &str) -> Option<f64> {
 }
 
 /// p18(0-idx 17) 좌측 첫 미주 제목(문30) baseline y.
-/// 이중계상 회귀 시 약 +26px(≈ 1줄) 아래로 이동한다. 정정 위치 ~336px 기준,
-/// 회귀(약 ≥362px)를 잡도록 상한 350px.
+/// 이중계상 회귀 시 약 +26px(≈ 1줄) 아래로 이동한다. #4318 이후 정정
+/// 위치 ~375px 기준, 회귀(약 ≥401px)를 잡도록 상한 390px.
 #[test]
 fn endnote_first_title_gap_not_doubled_p18() {
     let doc = load_doc("samples/3-09월_교육_통합_2024-구분선아래20구분선위20.hwp");
@@ -79,7 +81,7 @@ fn endnote_first_title_gap_not_doubled_p18() {
         .first()
         .unwrap_or_else(|| panic!("p18 좌측 미주 제목('문') 미검출: {ys:?}"));
     assert!(
-        first < 350.0,
-        "p18 첫 미주 제목 y={first:.1} ≥ 350 — 제목 앞 gap 이중계상 회귀 의심 (정정 위치 ~336)"
+        first < 390.0,
+        "p18 첫 미주 제목 y={first:.1} ≥ 390 — 제목 앞 gap 이중계상 회귀 의심 (정정 위치 ~375)"
     );
 }


### PR DESCRIPTION
## 변경 요약

`samples/3-09월_교육_통합_2024-구분선아래20구분선위20.hwp` 17쪽 오른쪽 단 마지막 줄이 본문 프레임 하단(1096.1px)을 약 14px 넘겼습니다. 한컴 PDF 는 프레임 밖 본문이 0px 입니다.

원인은 마지막 단 split 에 24px bleed 를 줘 한 줄(≈12px)이 프레임 아래에 통째 남은 것입니다. 마지막 단 여유를 4px 로 줄이고, 0/0/0 가드가 아닌 구분선 20/20 프로필에서도 넘친 마지막 줄만 다음 쪽으로 넘깁니다.

`ENDNOTE_PAGE_OFFCANVAS_GUARD_PX`(56) 는 **그대로** 둡니다. 이 값을 낮추면 한글 23쪽이 22쪽으로 줄어 #5886 이 다시 열립니다. 테스트가 `page_count() == 23` 을 잠급니다.

## 관련 이슈

Closes #4318

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음 (`--sync-cargo-targets` 메인터너 registry PR은 marker 블록만 예외)
- [ ] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
- [ ] `cargo test` 통과
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — `rhwp replay --capsule` 영수증 캡슐 또는 관련 `--json` 봉투 원문 ([AGENTS.md 작업 증빙 절](../AGENTS.md#작업-증빙--에이전트-기본-경로-권장))
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: [capability 카탈로그](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_capability_registry.md)의 등록·검증 규칙을 반영

로컬: `cargo fmt --all -- --check` 종료 0. `cargo check -p rhwp --lib --offline` 종료 0. 단위 테스트 소스 개수는 그대로(4221 동결). 공유 타깃 컴파일 뒤 디스크가 2GB 아래로 내려 `cargo test` 는 돌리지 않았습니다. CI 가 `tests/cases/issue_4318_endnote_last_column_frame.rs` 를 배정·실행합니다.

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (마지막 단 미주 꼬리 분할만)
- 재현·측정: 공개 샘플 17쪽 오른쪽 단. 한컴 프레임 밖 0px, 종전 rhwp 약 14px. 쪽수는 한글 23 유지.