### PR TITLE
[5991] 암호 문서 다른 이름으로 저장이 보호 의도를 기본 계승한다

### DIFF
--- a/rhwp-studio/src/command/commands/file.ts
+++ b/rhwp-studio/src/command/commands/file.ts
@@ -7,6 +7,7 @@ import {
 import { PageSetupDialog } from '@/ui/page-setup-dialog';
 import { AboutDialog } from '@/ui/about-dialog';
 import { showSaveAs } from '@/ui/save-as-dialog';
+import { showConfirm } from '@/ui/confirm-dialog';
 import { showHwpSavePasswordDialog } from '@/ui/hwp-password-dialog';
 import { showUnsavedChangesDialog } from '@/ui/unsaved-changes-dialog';
 import { showHmlSaveFormatDialog } from '@/ui/hml-save-format-dialog';
@@ -273,12 +274,27 @@ async function promptSaveAsOptions(
   services: CommandServices,
   format: SaveFormat,
 ): Promise<SaveAsOptions | null> {
+  const protectedDoc = services.wasm.requiresPasswordForSave;
+  const passwordFormat = format !== 'hml';
   const selection = await showSaveAs(
     saveBaseNameFor(services.wasm.fileName, format),
     format,
-    { allowPassword: format !== 'hml' },
+    {
+      allowPassword: passwordFormat,
+      inheritPassword: protectedDoc && passwordFormat,
+    },
   );
   if (selection === null) return null;
+
+  if (protectedDoc && format === 'hml') {
+    const confirmed = await showConfirm(
+      '보호 해제',
+      'HML 형식은 문서 암호를 지원하지 않습니다. 암호 없이 저장하면 보호가 해제됩니다. 계속할까요?',
+    );
+    if (!confirmed) return null;
+    return { fileName: selection.fileName, password: null };
+  }
+
   if (!selection.configurePassword) {
     return { fileName: selection.fileName, password: null };
   }

--- a/rhwp-studio/src/ui/save-as-dialog.ts
+++ b/rhwp-studio/src/ui/save-as-dialog.ts
@@ -2,6 +2,7 @@
  * 다른 이름으로 저장 대화상자
  *
  * 새 문서 저장 시 파일 이름과 선택 암호 설정 요청을 받는다.
+ * 이미 보호된 문서는 기본 확인이 암호를 계승하고, 평문은 명시적 선택만 허용한다 (#5991).
  * showSaveAs() 헬퍼로 간단히 사용 가능.
  */
 import { ModalDialog } from './dialog';
@@ -10,6 +11,11 @@ import { fileNameForFormat, type SaveFormat } from '@/command/save-target';
 export interface SaveAsDialogResult {
   fileName: string;
   configurePassword: boolean;
+}
+
+export interface SaveAsDialogOptions {
+  allowPassword?: boolean;
+  inheritPassword?: boolean;
 }
 
 class SaveAsDialog extends ModalDialog {
@@ -21,6 +27,7 @@ class SaveAsDialog extends ModalDialog {
     defaultName: string,
     private readonly format: SaveFormat,
     private readonly allowPassword: boolean,
+    private readonly inheritPassword: boolean,
   ) {
     super('다른 이름으로 저장', 380);
     this.defaultName = defaultName;
@@ -54,6 +61,16 @@ class SaveAsDialog extends ModalDialog {
     });
     body.appendChild(this.input);
 
+    if (this.inheritPassword) {
+      const note = document.createElement('p');
+      note.style.margin = '12px 0 0';
+      note.style.fontSize = '12px';
+      note.style.lineHeight = '1.5';
+      note.textContent =
+        '이 문서는 암호로 보호되어 있습니다. 확인하면 암호를 다시 입력합니다. 평문 사본은 암호 없이 저장을 선택하세요.';
+      body.appendChild(note);
+    }
+
     if (this.allowPassword) {
       const passwordButton = document.createElement('button');
       passwordButton.type = 'button';
@@ -67,6 +84,21 @@ class SaveAsDialog extends ModalDialog {
         this.hide();
       });
       body.appendChild(passwordButton);
+
+      if (this.inheritPassword) {
+        const plaintextButton = document.createElement('button');
+        plaintextButton.type = 'button';
+        plaintextButton.className = 'dialog-btn';
+        plaintextButton.textContent = '암호 없이 저장';
+        plaintextButton.style.marginTop = '8px';
+        plaintextButton.addEventListener('click', () => {
+          const value = this.confirmValue();
+          if (value === null) return;
+          this.resolve({ fileName: value, configurePassword: false });
+          this.hide();
+        });
+        body.appendChild(plaintextButton);
+      }
     }
 
     return body;
@@ -84,7 +116,8 @@ class SaveAsDialog extends ModalDialog {
   protected onConfirm(): boolean {
     const fileName = this.confirmValue();
     if (fileName === null) return false;
-    this.resolve({ fileName, configurePassword: false });
+    // 보호된 문서의 기본 확인은 암호를 계승한다. 평문은 `암호 없이 저장`만.
+    this.resolve({ fileName, configurePassword: this.inheritPassword });
     return true;
   }
 
@@ -114,11 +147,18 @@ class SaveAsDialog extends ModalDialog {
 /**
  * 파일 이름 입력 대화상자를 표시한다. HWP/HWPX에서 `allowPassword`를 켜면 사용자가
  * `암호 설정...`을 선택해 다음 암호 입력 대화상자로 진행할 수 있다.
+ * `inheritPassword`가 켜지면 기본 확인이 암호 입력으로 이어지고, 평문은
+ * `암호 없이 저장`을 눌러야 한다 (#5991).
  */
 export function showSaveAs(
   defaultName: string,
   format: SaveFormat = 'hwp',
-  options: { allowPassword?: boolean } = {},
+  options: SaveAsDialogOptions = {},
 ): Promise<SaveAsDialogResult | null> {
-  return new SaveAsDialog(defaultName, format, options.allowPassword === true).showAsync();
+  return new SaveAsDialog(
+    defaultName,
+    format,
+    options.allowPassword === true,
+    options.inheritPassword === true,
+  ).showAsync();
 }

--- a/rhwp-studio/tests/hwp-password-save.test.ts
+++ b/rhwp-studio/tests/hwp-password-save.test.ts
@@ -35,7 +35,8 @@ test('암호 저장 dialog는 확인 입력, 최소 길이, 닫기 시 DOM 초�
 test('다른 이름·HWP·HWPX 저장은 공통 대화상자에서 암호 설정을 선택한다', () => {
   assert.match(commandSource, /async function promptSaveAsOptions/, '공통 저장 옵션 대화상자 경로가 있어야 합니다');
   assert.match(commandSource, /showSaveAs\(/, '파일명을 먼저 받는 대화상자를 열어야 합니다');
-  assert.match(codeOnly(commandSource), /allowPassword: format !== 'hml'/, 'HWP/HWPX에만 암호 설정을 노출해야 합니다');
+  assert.match(codeOnly(commandSource), /const passwordFormat = format !== 'hml'/, 'HWP/HWPX에만 암호 설정을 노출해야 합니다');
+  assert.match(codeOnly(commandSource), /allowPassword: passwordFormat/, '암호 지원 형식에서만 암호 설정을 노출해야 합니다');
   assert.match(commandSource, /showHwpSavePasswordDialog\(selection\.fileName\)/, '암호 설정을 누르면 암호/확인 대화상자를 열어야 합니다');
   assert.match(commandSource, /exportPasswordProtectedDocumentWithReportForFormat/, '내용 손실 보고를 포함한 전용 암호 serializer를 선택해야 합니다');
   assert.match(commandSource, /암호 설정 저장은 HWP 또는 HWPX 형식에서만 지원합니다/, 'HML 암호 저장을 거부해야 합니다');
@@ -87,6 +88,70 @@ test('다른 이름 저장은 새 문서명 상태와 최근 문서를 함께 �
   assert.match(mainSource, /refreshDocumentStatus: \(\) => \{[\s\S]*?wasm\.fileName/, '상태바 갱신은 현재 문서명을 사용해야 합니다');
   assert.match(codeOnly(mainSource), /RECENT_SUBMENU_COLLAPSED_LIMIT = 8/, '최근 문서는 기본 8개만 보여야 합니다');
   assert.match(mainSource, /최근 문서 더보기/, '9개 이상이면 더보기 항목을 제공해야 합니다');
+});
+
+test('보호된 문서의 Save As 기본 확인은 평문 exporter를 고르지 않는다', () => {
+  const prompt = between(commandSource, 'async function promptSaveAsOptions', 'async function saveAsFormat');
+  const onConfirm = between(saveAsDialogSource, 'protected onConfirm()', 'override hide()');
+  assert.match(
+    codeOnly(prompt),
+    /inheritPassword: protectedDoc && passwordFormat/,
+    '암호 지원 형식 Save As는 보호 의도를 기본 계승해야 합니다',
+  );
+  assert.match(
+    codeOnly(onConfirm),
+    /configurePassword: this.inheritPassword/,
+    '보호된 문서의 확인 단추는 암호 설정 흐름으로 이어져야 합니다',
+  );
+  assert.match(
+    prompt,
+    /showHwpSavePasswordDialog\(selection\.fileName\)/,
+    '기본 확인 뒤 암호를 다시 입력받아야 합니다',
+  );
+  assert.doesNotMatch(
+    codeOnly(onConfirm),
+    /configurePassword: false/,
+    '기본 확인이 평문을 암묵 선택하면 안 됩니다',
+  );
+});
+
+test('평문 사본은 명시적 보호 해제 동작에서만 만든다', () => {
+  assert.match(
+    codeOnly(saveAsDialogSource),
+    /plaintextButton\.textContent = '암호 없이 저장'/,
+    '보호된 문서에 암호 없이 저장 선택이 있어야 합니다',
+  );
+  assert.match(
+    saveAsDialogSource,
+    /configurePassword: false/,
+    '암호 없이 저장만 평문 결과를 내야 합니다',
+  );
+  const prompt = between(commandSource, 'async function promptSaveAsOptions', 'async function saveAsFormat');
+  assert.match(
+    prompt,
+    /HML 형식은 문서 암호를 지원하지 않습니다/,
+    '암호 미지원 형식은 보호 해제 경고를 거쳐야 합니다',
+  );
+  assert.match(prompt, /showConfirm\(/, '보호 해제 경고는 확인 대화상자여야 합니다');
+  assert.match(
+    prompt,
+    /if \(!confirmed\) return null/,
+    '경고를 취소하면 기존 보호 의도를 유지해야 합니다',
+  );
+});
+
+test('Save As 암호 입력 취소는 persist 전에 보호 상태를 바꾸지 않는다', () => {
+  const prompt = between(commandSource, 'async function promptSaveAsOptions', 'async function saveAsFormat');
+  const saveAs = between(commandSource, 'async function saveAsFormat', 'function reportSaveError');
+  const passwordCancel = prompt.indexOf('if (password === null) return null;');
+  const createPayload = saveAs.indexOf('createSavePayload(');
+  const protectionCommit = saveAs.indexOf('services.wasm.requiresPasswordForSave = password !== null;');
+  assert.ok(passwordCancel >= 0, '암호 입력 취소 경로가 있어야 합니다');
+  assert.ok(createPayload >= 0, 'export는 옵션이 확정된 뒤에만 호출해야 합니다');
+  assert.ok(
+    protectionCommit > createPayload,
+    '보호 상태 변경은 persist 성공 콜백에서만 이루어져야 합니다',
+  );
 });
 
 test('Studio public WASM 배포물도 암호 저장 binding을 제공한다', () => {


### PR DESCRIPTION
## 요약

암호로 연 문서를 `다른 이름으로 저장`할 때, 기본 확인이 보호 의도를 경고 없이 끄던 경로를 막습니다. HWP/HWPX는 암호를 다시 입력받아 보호를 계승하고, 평문 사본은 명시적 선택에서만 만듭니다.

Closes #5991

## 문제

일반 저장(#5986 / #5990)은 보호 의도를 유지하지만, Save As 대화상자의 기본 확인은 `configurePassword: false`였습니다. 사용자가 `암호 설정...`을 누르지 않으면 평문 exporter가 선택되고, 성공한 persist 뒤에 `requiresPasswordForSave`도 꺼졌습니다.

## 수정

- 보호된 문서의 HWP/HWPX Save As 기본 확인은 암호 입력 대화상자로 이어집니다. rhwp는 원래 암호 문자열을 보관하지 않으므로 저장 전에 다시 받습니다.
- 평문 사본은 `암호 없이 저장`을 누른 경우에만 만듭니다.
- HML처럼 암호를 지원하지 않는 형식은 보호 해제 경고를 확인받은 뒤에만 저장합니다.
- 대화상자 취소, 암호 입력 취소, export/쓰기 실패는 기존처럼 persist 성공 콜백 전에 보호 의도와 dirty를 바꾸지 않습니다.
- 암호 문자열은 장기 상태·로그·DOM 저장소에 넣지 않습니다. 시도가 끝나면 지역 참조만 비웁니다.

## 검증

```
node --test tests/hwp-password-save.test.ts tests/hwp-password-open.test.ts
```

15 pass. 새 가드는 기본 확인이 평문 exporter를 고르지 않는지, 평문은 명시적 해제에서만 생기는지, 암호 입력 취소가 persist 전 상태를 건드리지 않는지를 고정합니다.
