### PR TITLE
fix(studio): 자동 쪽 배치 핀치 줌에서 열 토폴로지와 Canvas를 안정화한다

### DIFF
--- a/rhwp-studio/src/view/canvas-view.ts
+++ b/rhwp-studio/src/view/canvas-view.ts
@@ -83,6 +83,8 @@ export class CanvasView {
   private layoutViewportSize = { width: 0, height: 0 };
   private blankPagePlaceholder: HTMLElement | null = null;
   private lastPageSize: { width: number; height: number } | null = null;
+  /** [#6040] 핀치 중 토폴로지 commit 보류. 정착 시 한 번만 반영한다. */
+  private pinchHoldColumns: number | null = null;
   private disposed = false;
 
   constructor(
@@ -419,6 +421,7 @@ export class CanvasView {
       this.pageArrangement,
       this.pageMovement.direction,
       viewport.height,
+      this.pinchHoldColumns,
     );
     this.scrollContent.style.height = `${this.virtualScroll.getTotalHeight()}px`;
     this.scrollContent.style.width = `${this.virtualScroll.getTotalWidth()}px`;
@@ -816,6 +819,15 @@ export class CanvasView {
   private onZoomChanged(zoom: number, anchor: ZoomAnchor): void {
     if (this.pages.length === 0) return;
 
+    const animating = this.viewportManager.isZoomAnimating();
+    if (animating) {
+      if (this.pinchHoldColumns === null) {
+        this.pinchHoldColumns = this.virtualScroll.getColumns();
+      }
+    } else {
+      this.pinchHoldColumns = null;
+    }
+
     const scrollTop = this.viewportManager.getScrollY();
     const scrollLeft = this.viewportManager.getScrollX();
     const { width: vpWidth, height: vpHeight } = this.viewportManager.getViewportSize();
@@ -843,7 +855,7 @@ export class CanvasView {
 
     this.eventBus.emit('zoom-level-display', zoom);
 
-    if (this.viewportManager.isZoomAnimating()) {
+    if (animating) {
       this.cancelPendingTextEditRefresh();
       this.cancelTextEditStaticLayerVerification();
       this.cancelPendingPrefetch();
@@ -851,11 +863,29 @@ export class CanvasView {
       return;
     }
 
-    // 모든 Canvas 재렌더링
+    // [#6040] 정착만을 이유로 활성 Canvas를 전량 제거하지 않는다.
+    // 페이지 슬롯 토폴로지가 바뀌어도 Canvas는 pageIdx 소유라 좌표만 옮기고,
+    // 새 배율 래스터는 보이는 쪽부터 점진 교체한다.
     this.cancelPendingTextEditRefresh();
     this.cancelTextEditStaticLayerVerification();
-    this.releaseAllRenderedPages();
-    this.pageRenderer.cancelAll();
+    this.rerenderVisiblePagesAtCurrentZoom();
+  }
+
+  /** 줌 정착 후 기존 Canvas 좌표를 맞추고, 배율이 바뀐 보이는 쪽만 다시 그린다. */
+  private rerenderVisiblePagesAtCurrentZoom(): void {
+    const zoom = this.viewportManager.getZoom();
+    for (const pageIdx of [...this.canvasPool.activePages]) {
+      const canvas = this.canvasPool.getCanvas(pageIdx);
+      if (!canvas) continue;
+      this.positionPageElement(canvas, pageIdx);
+      this.scrollContent.querySelectorAll<HTMLElement>(
+        `[data-rhwp-overlay-page="${pageIdx}"], [data-rhwp-grid-page="${pageIdx}"]`,
+      ).forEach((element) => this.positionPageElement(element, pageIdx));
+      const renderedZoom = Number(canvas.dataset.rhwpRenderedZoom);
+      if (!Number.isFinite(renderedZoom) || Math.abs(renderedZoom - zoom) > 1e-4) {
+        this.renderPage(pageIdx);
+      }
+    }
     this.updateVisiblePages();
   }
 

--- a/rhwp-studio/src/view/virtual-scroll.ts
+++ b/rhwp-studio/src/view/virtual-scroll.ts
@@ -7,8 +7,47 @@ import {
 import type { PageMovementDirection } from './page-movement.ts';
 import { resolvePageGap } from './page-gap.ts';
 
-/** 그리드 모드 전환 줌 임계값 */
-const GRID_ZOOM_THRESHOLD = 0.5;
+/** [#6040] 열 수 왕복을 막기 위한 폭 여유. 한 임계값 통과당 commit 한 번. */
+export const AUTO_GRID_COLUMN_HYSTERESIS_PX = 12;
+
+/**
+ * [#6040] 자동 열 후보. 50% 전역 gate 없이 표시 페이지 폭·간격·편집 영역 폭으로
+ * 계산하고 실제 페이지 수를 넘지 않는다.
+ */
+export function autoGridColumnCandidate(
+  viewportWidth: number,
+  scaledPageWidth: number,
+  pageGap: number,
+  pageCount: number,
+): number {
+  if (!(viewportWidth > 0) || !(scaledPageWidth > 0) || pageCount <= 1) return 1;
+  const fitted = Math.floor((viewportWidth + pageGap) / (scaledPageWidth + pageGap));
+  return Math.max(1, Math.min(pageCount, fitted));
+}
+
+/**
+ * [#6040] 후보를 히스테리시스와 함께 commit 한다.
+ * 늘릴 때는 후보 폭 + 여유, 줄일 때는 현재 열이 더 이상 들어가지 않을 때만.
+ */
+export function commitAutoGridColumns(
+  candidate: number,
+  committed: number,
+  viewportWidth: number,
+  scaledPageWidth: number,
+  pageGap: number,
+  pageCount: number,
+): number {
+  const maxCols = Math.max(1, pageCount);
+  const next = Math.max(1, Math.min(maxCols, Math.floor(candidate)));
+  const prev = Math.max(1, Math.min(maxCols, Math.floor(committed || 1)));
+  if (next === prev) return prev;
+  if (next > prev) {
+    const needed = next * scaledPageWidth + (next - 1) * pageGap + AUTO_GRID_COLUMN_HYSTERESIS_PX;
+    return viewportWidth >= needed ? next : prev;
+  }
+  const keepWidth = prev * scaledPageWidth + (prev - 1) * pageGap - AUTO_GRID_COLUMN_HYSTERESIS_PX;
+  return viewportWidth < keepWidth ? next : prev;
+}
 
 /** [#3591] 가로 팬 여백 = clamp(창 폭 × 비율, 하한, 상한). 상한이 큰 화면에서의 증가를 끊는다. */
 const PAN_SPACE_RATIO = 0.25;
@@ -45,6 +84,7 @@ export class VirtualScroll {
     arrangement: PageArrangement = DEFAULT_PAGE_ARRANGEMENT,
     movement: PageMovementDirection = 'vertical',
     viewportHeight = 0,
+    holdColumns: number | null = null,
   ): void {
     this.pageGap = resolvePageGap(zoom, this.pageGapAt100Percent);
     this.pageHeights = pages.map((p) => p.height * zoom);
@@ -77,19 +117,32 @@ export class VirtualScroll {
         this.layoutUniformGrid(viewportWidth, normalized.columns);
         break;
       case 'auto':
-      default:
-        // 기존 자동 동작: 50% 이하에서만 뷰포트에 들어가는 최대 열 수를 쓴다.
-        this.gridMode = zoom <= GRID_ZOOM_THRESHOLD && viewportWidth > 0 && pages.length > 1;
+      default: {
+        const candidate = autoGridColumnCandidate(
+          viewportWidth,
+          this.maxPageWidth,
+          this.pageGap,
+          pages.length,
+        );
+        const held = typeof holdColumns === 'number' && holdColumns >= 1
+          ? Math.max(1, Math.min(pages.length, Math.floor(holdColumns)))
+          : null;
+        const columns = held ?? commitAutoGridColumns(
+          candidate,
+          this.columns,
+          viewportWidth,
+          this.maxPageWidth,
+          this.pageGap,
+          pages.length,
+        );
+        this.gridMode = columns > 1;
         if (this.gridMode) {
-          const columns = Math.max(
-            1,
-            Math.floor((viewportWidth + this.pageGap) / (this.maxPageWidth + this.pageGap)),
-          );
           this.layoutUniformGrid(viewportWidth, columns);
         } else {
           this.layoutSingleColumn();
         }
         break;
+      }
     }
     this.applyHorizontalPanSpace(viewportWidth);
   }

--- a/rhwp-studio/tests/canvas-view-page-arrangement.test.ts
+++ b/rhwp-studio/tests/canvas-view-page-arrangement.test.ts
@@ -52,7 +52,7 @@ test('CanvasView는 저장된 쪽 배치를 레이아웃 계산에 전달한다'
   );
   assert.match(
     canvasViewSource,
-    /setPageDimensions\([\s\S]*?this\.pageArrangement,[\s\S]*?this\.pageMovement\.direction,[\s\S]*?viewport\.height/,
+    /setPageDimensions\([\s\S]*?this\.pageArrangement,[\s\S]*?this\.pageMovement\.direction,[\s\S]*?viewport\.height,[\s\S]*?this\.pinchHoldColumns/,
   );
 });
 

--- a/rhwp-studio/tests/issue-6040-auto-grid-columns.test.ts
+++ b/rhwp-studio/tests/issue-6040-auto-grid-columns.test.ts
@@ -1,0 +1,106 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { resolvePageGap } from '../src/view/page-gap.ts';
+import {
+  autoGridColumnCandidate,
+  commitAutoGridColumns,
+  VirtualScroll,
+} from '../src/view/virtual-scroll.ts';
+
+function pages(n: number, width = 800, height = 1000) {
+  return Array.from({ length: n }, () => ({ width, height })) as never;
+}
+
+function occupiedCenter(scroll: VirtualScroll, pageCount: number): number {
+  const first = scroll.getPageLeft(0);
+  const last = scroll.getPageLeft(pageCount - 1) + scroll.getPageWidth(pageCount - 1);
+  return (first + last) / 2;
+}
+
+test('자동 열 후보는 50% gate 없이 폭으로 계산하고 페이지 수를 넘지 않는다', () => {
+  const gap = resolvePageGap(0.27, 10);
+  const pw = 800 * 0.27;
+  // 넓은 뷰포트: 폭만 보면 8열 이상이지만 3쪽 문서는 3열.
+  const candidate = autoGridColumnCandidate(2000, pw, gap, 3);
+  assert.equal(candidate, 3);
+
+  const twoFit = autoGridColumnCandidate(1000, 800 * 0.51, resolvePageGap(0.51, 10), 6);
+  assert.equal(twoFit, 2, '두 쪽만 들어가는 폭에서는 2열 (51%여도 1열이 아님)');
+});
+
+test('줌과 리사이즈가 같은 입력에서 같은 자동 열 후보를 낸다', () => {
+  const zoom = 0.4;
+  const viewport = 1600;
+  const pageWidth = 800;
+  const gap = resolvePageGap(zoom, 10);
+  const fromZoom = autoGridColumnCandidate(viewport, pageWidth * zoom, gap, 9);
+  const fromResize = autoGridColumnCandidate(viewport, pageWidth * zoom, gap, 9);
+  assert.equal(fromZoom, fromResize);
+  assert.ok(fromZoom >= 2);
+});
+
+test('3쪽 문서는 27%·17%에서 빈 열 없이 편집 영역 가운데에 온다', () => {
+  const scroll = new VirtualScroll(10);
+  for (const zoom of [0.27, 0.17]) {
+    scroll.setPageDimensions(pages(3), zoom, 2000, { kind: 'auto' });
+    assert.equal(scroll.getColumns(), 3, `${zoom} 열 수는 페이지 수`);
+    assert.equal(scroll.getPageOffset(0), scroll.getPageOffset(2));
+    const center = occupiedCenter(scroll, 3);
+    assert.ok(
+      Math.abs(center - 1000) <= 1,
+      `${zoom} 점유 묶음 중심 ${center} 이 뷰포트 중심 1000 에서 1px 이내`,
+    );
+  }
+});
+
+test('두 쪽만 들어가는 폭에서는 50%를 넘어도 2열이다', () => {
+  const scroll = new VirtualScroll(10);
+  const viewport = 1000;
+  scroll.setPageDimensions(pages(6), 0.51, viewport, { kind: 'auto' });
+  assert.equal(scroll.getColumns(), 2);
+  assert.equal(scroll.getPageOffset(0), scroll.getPageOffset(1));
+  assert.notEqual(scroll.getPageOffset(0), scroll.getPageOffset(2));
+});
+
+test('핀치 hold 열 수는 후보가 바뀌어도 토폴로지를 유지한다', () => {
+  const scroll = new VirtualScroll(10);
+  scroll.setPageDimensions(pages(6), 1, 900, { kind: 'auto' });
+  assert.equal(scroll.getColumns(), 1);
+  const held = scroll.getLayoutTopologyKey();
+  scroll.setPageDimensions(pages(6), 0.27, 2000, { kind: 'auto' }, 'vertical', 0, 1);
+  assert.equal(scroll.getColumns(), 1, '핀치 중에는 1열 snapshot 유지');
+  assert.equal(scroll.getLayoutTopologyKey(), held);
+  scroll.setPageDimensions(pages(6), 0.27, 2000, { kind: 'auto' });
+  assert.ok(scroll.getColumns() > 1, '정착 후 후보를 commit');
+});
+
+test('히스테리시스는 같은 임계값 주변에서 열 수를 왕복하지 않는다', () => {
+  const pw = 400;
+  const gap = 6;
+  const pageCount = 6;
+  const threeWidth = 3 * pw + 2 * gap;
+  const committed = commitAutoGridColumns(3, 2, threeWidth + 20, pw, gap, pageCount);
+  assert.equal(committed, 3);
+  const stillThree = commitAutoGridColumns(2, 3, threeWidth - 4, pw, gap, pageCount);
+  assert.equal(stillThree, 3, '4px 부족은 아직 3열 유지');
+  const drop = commitAutoGridColumns(2, 3, threeWidth - 20, pw, gap, pageCount);
+  assert.equal(drop, 2);
+});
+
+test('CanvasView 줌 정착은 전량 Canvas 해제를 하지 않고 핀치 열을 고정한다', () => {
+  const source = readFileSync(
+    fileURLToPath(new URL('../src/view/canvas-view.ts', import.meta.url)),
+    'utf8',
+  );
+  const start = source.search(/\n  (?:private )?onZoomChanged\(/);
+  const rest = source.slice(start + 1);
+  const relEnd = rest.search(/\n  (?:private )?updateRenderedPageZoomPreview\(/);
+  const method = source.slice(start, start + 1 + relEnd);
+  assert.match(method, /pinchHoldColumns/);
+  assert.match(method, /rerenderVisiblePagesAtCurrentZoom/);
+  assert.doesNotMatch(method, /releaseAllRenderedPages\(\)/);
+  assert.match(source, /this\.pinchHoldColumns,/);
+});

--- a/rhwp-studio/tests/virtual-scroll-page-arrangement.test.ts
+++ b/rhwp-studio/tests/virtual-scroll-page-arrangement.test.ts
@@ -7,15 +7,17 @@ function pages(n: number, width = 800, height = 1000) {
   return Array.from({ length: n }, () => ({ width, height })) as never;
 }
 
-test('자동은 기존 50% 임계값과 뷰포트 최대 열 계산을 보존한다', () => {
+test('자동은 50% gate 없이 뷰포트에 들어가는 열 수를 쓴다', () => {
   const scroll = new VirtualScroll(10);
   scroll.setPageDimensions(pages(6), 0.4, 2000, { kind: 'auto' });
   assert.equal(scroll.getColumns(), 6);
   assert.equal(scroll.getPageOffset(0), scroll.getPageOffset(5));
 
+  // 0.51 에서도 폭이 4열을 담으면 1열이 아니라 4열이다 (#6040).
   scroll.setPageDimensions(pages(6), 0.51, 2000, { kind: 'auto' });
-  assert.equal(scroll.getColumns(), 1);
-  assert.notEqual(scroll.getPageOffset(0), scroll.getPageOffset(1));
+  assert.equal(scroll.getColumns(), 4);
+  assert.equal(scroll.getPageOffset(0), scroll.getPageOffset(3));
+  assert.notEqual(scroll.getPageOffset(0), scroll.getPageOffset(4));
 });
 
 test('한 쪽은 낮은 배율에서도 한 행 한 쪽과 중앙 정렬을 유지한다', () => {


### PR DESCRIPTION
## 변경 요약

자동 쪽 배치의 열 수가 `zoom <= 0.5` 전역 gate 에 묶여 51%에서 1열, 50%에서 폭 계산이 켜지며 3열로 건너뛰었습니다. 3쪽 문서를 27%·17%로 줄이면 빈 열까지 포함한 그리드를 중앙 정렬해 실제 쪽 묶음이 왼쪽으로 치우쳤고, 줌 정착마다 활성 Canvas 를 전량 해제했습니다.

- 자동 열 후보는 표시 페이지 폭·간격·편집 영역 폭으로만 계산하고 `1..pageCount` 로 제한합니다. 50% gate 는 제거했습니다.
- 열 commit 에 12px 히스테리시스를 둡니다. 핀치 애니메이션 중에는 snapshot 열 수를 유지하고 정착 시 한 번만 commit 합니다.
- 줌 정착만을 이유로 `releaseAllRenderedPages` 하지 않고, 보이는 쪽부터 점진 재렌더합니다.
- 고정 쪽 모양(한 쪽/두 쪽/맞쪽/여러 쪽)은 기존처럼 줌이 행 토폴로지를 바꾸지 않습니다. 페이지네이션은 건드리지 않았습니다.

## 관련 이슈

Closes #6040

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (이 PR 은 TypeScript/studio 만. rustc 미실행, 디스크 제약)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음 (`--sync-cargo-targets` 메인터너 registry PR은 marker 블록만 예외)
- [ ] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
- [x] `cargo test` 통과 — 해당 없음. `node --test` 로 studio 단위 테스트 53건 통과 (`issue-6040-auto-grid-columns`, `virtual-scroll-page-arrangement`, `virtual-scroll-grid-page`, `canvas-view-page-arrangement`, `virtual-scroll-horizontal-pan`, `zoom-anchor`, `page-scroll-step`)
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — `rhwp replay --capsule` 영수증 캡슐 또는 관련 `--json` 봉투 원문 ([AGENTS.md 작업 증빙 절](../AGENTS.md#작업-증빙--에이전트-기본-경로-권장))
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: [capability 카탈로그](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_capability_registry.md)의 등록·검증 규칙을 반영

수용 기준 중 단위로 잠근 것: 50% gate 제거, 2열 선택, 3쪽 27%/17% 중심 오차 ≤1px, 줌=리사이즈 동일 후보, 히스테리시스, 핀치 hold, 정착 시 전량 Canvas 해제 없음. 프레임 long task 계측은 브라우저 e2e 가 필요합니다.

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 핀치 중 열 전환·Canvas 전량 해제 감소
- 재현·측정: 공개 studio 단위 테스트. rustc 미실행.