### PR TITLE
perf(studio): 다중 쪽·개요 보기의 적응형 render scale과 총 Canvas 픽셀 예산

### DIFF
--- a/rhwp-studio/src/view/adaptive-render-scale.ts
+++ b/rhwp-studio/src/view/adaptive-render-scale.ts
@@ -1,0 +1,278 @@
+import type { LayerRenderProfile } from '@/core/types';
+
+export const RENDER_DPR_BUCKETS = [1, 1.5, 2] as const;
+export type RenderDprBucket = (typeof RENDER_DPR_BUCKETS)[number];
+export type AdaptiveRenderTier = 'overview' | 'preview' | 'screen' | 'export';
+export type AdaptiveRenderInteraction = 'idle' | 'pinch' | 'fast-scroll';
+
+/** 한 행에 이 쪽 수 이상이면 overview tier. */
+export const OVERVIEW_PAGES_PER_ROW = 3;
+export const DEFAULT_PAGE_LAYER_COUNT = 4;
+/** 동시에 보이는 페이지 Canvas(레이어 포함) 물리 픽셀 상한. */
+export const MAX_VISIBLE_CANVAS_PIXELS = 32_000_000;
+/** 프리페치·보존 중인 페이지까지 포함한 물리 픽셀 상한. */
+export const MAX_RETAINED_CANVAS_PIXELS = 48_000_000;
+export const DPR_BUCKET_HYSTERESIS = 0.12;
+
+const MID_LOW = 1.25;
+const MID_HIGH = 1.75;
+
+export function isExportRenderProfile(profile: LayerRenderProfile | string): boolean {
+  return profile === 'print' || profile === 'highQuality';
+}
+
+export function isOverviewLayout(pagesPerRow: number): boolean {
+  return Number.isFinite(pagesPerRow) && pagesPerRow >= OVERVIEW_PAGES_PER_ROW;
+}
+
+export function pageCanvasPixels(
+  pageWidth: number,
+  pageHeight: number,
+  zoom: number,
+  dpr: number,
+): number {
+  const cssW = Math.max(0, pageWidth) * Math.max(0, zoom);
+  const cssH = Math.max(0, pageHeight) * Math.max(0, zoom);
+  const scale = Math.max(0, dpr);
+  return cssW * cssH * scale * scale;
+}
+
+export function estimateSurfacePixels(args: {
+  pageWidth: number;
+  pageHeight: number;
+  zoom: number;
+  dpr: number;
+  pageCount: number;
+  layerCount: number;
+}): number {
+  const pages = Math.max(0, args.pageCount);
+  const layers = Math.max(1, args.layerCount);
+  return pageCanvasPixels(args.pageWidth, args.pageHeight, args.zoom, args.dpr) * pages * layers;
+}
+
+export function quantizeDprBucket(
+  requestedDpr: number,
+  previous?: RenderDprBucket | null,
+): RenderDprBucket {
+  const requested = Number.isFinite(requestedDpr) && requestedDpr > 0 ? requestedDpr : 1;
+  if (previous === 1 && requested < MID_LOW + DPR_BUCKET_HYSTERESIS) return 1;
+  if (
+    previous === 1.5
+    && requested > MID_LOW - DPR_BUCKET_HYSTERESIS
+    && requested < MID_HIGH + DPR_BUCKET_HYSTERESIS
+  ) {
+    return 1.5;
+  }
+  if (previous === 2 && requested > MID_HIGH - DPR_BUCKET_HYSTERESIS) return 2;
+  if (requested < MID_LOW) return 1;
+  if (requested < MID_HIGH) return 1.5;
+  return 2;
+}
+
+/** overview는 raw DPR≥2에서 full-DPR 대비 Canvas 픽셀을 50% 이상 줄인다. */
+export function overviewDprBucket(_rawDpr: number): RenderDprBucket {
+  return 1;
+}
+
+export function screenEffectiveDpr(
+  rawDpr: number,
+  previous?: RenderDprBucket | null,
+): number {
+  const raw = Number.isFinite(rawDpr) && rawDpr > 0 ? rawDpr : 1;
+  if (raw > 2) return raw;
+  return quantizeDprBucket(raw, previous);
+}
+
+export interface AdaptiveRenderScaleInput {
+  pageWidth: number;
+  pageHeight: number;
+  zoom: number;
+  rawDpr: number;
+  pagesPerRow: number;
+  visiblePageCount: number;
+  retainedPageCount: number;
+  layerCount?: number;
+  isFocused?: boolean;
+  isEditing?: boolean;
+  interaction?: AdaptiveRenderInteraction;
+  renderProfile?: LayerRenderProfile | string;
+  previousBucket?: RenderDprBucket | null;
+}
+
+export interface AdaptiveRenderScaleResult {
+  displayZoom: number;
+  renderScale: number;
+  rawDpr: number;
+  effectiveDpr: number;
+  bucket: RenderDprBucket;
+  tier: AdaptiveRenderTier;
+  cssWidth: number;
+  cssHeight: number;
+  canvasWidth: number;
+  canvasHeight: number;
+  canvasPixels: number;
+  layerCount: number;
+  estimatedVisibleSurfacePixels: number;
+  estimatedRetainedSurfacePixels: number;
+}
+
+function safeZoom(zoom: number): number {
+  return Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
+}
+
+function safePositive(value: number, fallback: number): number {
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function asBucket(dpr: number): RenderDprBucket {
+  if (dpr >= 2) return 2;
+  if (dpr >= 1.5) return 1.5;
+  return 1;
+}
+
+function demoteBucket(bucket: RenderDprBucket): RenderDprBucket {
+  if (bucket === 2) return 1.5;
+  return 1;
+}
+
+function fitToPixelBudget(args: {
+  pageWidth: number;
+  pageHeight: number;
+  zoom: number;
+  dpr: number;
+  visiblePageCount: number;
+  retainedPageCount: number;
+  layerCount: number;
+}): number {
+  let dpr = args.dpr;
+  let bucket: RenderDprBucket = dpr > 2 ? 2 : asBucket(dpr);
+  for (let i = 0; i < 3; i++) {
+    const visible = estimateSurfacePixels({
+      ...args,
+      dpr: bucket,
+      pageCount: args.visiblePageCount,
+    });
+    const retained = estimateSurfacePixels({
+      ...args,
+      dpr: bucket,
+      pageCount: args.retainedPageCount,
+    });
+    if (visible <= MAX_VISIBLE_CANVAS_PIXELS && retained <= MAX_RETAINED_CANVAS_PIXELS) {
+      return dpr > 2 && bucket === 2 ? dpr : bucket;
+    }
+    const next = demoteBucket(bucket);
+    if (next === bucket) return bucket;
+    bucket = next;
+    dpr = next;
+  }
+  return bucket;
+}
+
+export function canvasCssSize(
+  pageWidth: number,
+  pageHeight: number,
+  zoom: number,
+  renderScale: number,
+): { width: number; height: number } {
+  const safe = safeZoom(zoom);
+  const dpr = renderScale / safe;
+  return {
+    width: Math.max(1, Math.ceil(pageWidth * renderScale)) / dpr,
+    height: Math.max(1, Math.ceil(pageHeight * renderScale)) / dpr,
+  };
+}
+
+export function resolveAdaptiveRenderScale(
+  input: AdaptiveRenderScaleInput,
+): AdaptiveRenderScaleResult {
+  const zoom = safeZoom(input.zoom);
+  const rawDpr = safePositive(input.rawDpr, 1);
+  const pageWidth = safePositive(input.pageWidth, 1);
+  const pageHeight = safePositive(input.pageHeight, 1);
+  const layerCount = Math.max(1, Math.round(input.layerCount ?? DEFAULT_PAGE_LAYER_COUNT));
+  const visiblePageCount = Math.max(1, Math.round(input.visiblePageCount || 1));
+  const retainedPageCount = Math.max(
+    visiblePageCount,
+    Math.round(input.retainedPageCount || visiblePageCount),
+  );
+  const profile = input.renderProfile ?? 'screen';
+  const promoted = input.isFocused === true || input.isEditing === true;
+  const overview = isOverviewLayout(input.pagesPerRow);
+  const interaction = input.interaction ?? 'idle';
+  const previous = input.previousBucket ?? null;
+
+  let tier: AdaptiveRenderTier;
+  let effectiveDpr: number;
+
+  if (isExportRenderProfile(profile)) {
+    tier = 'export';
+    effectiveDpr = rawDpr;
+  } else if (interaction !== 'idle') {
+    tier = 'preview';
+    if (previous) {
+      effectiveDpr = previous;
+    } else if (overview && !promoted) {
+      effectiveDpr = overviewDprBucket(rawDpr);
+    } else {
+      effectiveDpr = screenEffectiveDpr(rawDpr, previous);
+    }
+  } else if (overview && !promoted) {
+    tier = 'overview';
+    effectiveDpr = overviewDprBucket(rawDpr);
+  } else {
+    tier = 'screen';
+    effectiveDpr = screenEffectiveDpr(rawDpr, previous);
+  }
+
+  if (tier !== 'export' && overview && !promoted) {
+    effectiveDpr = fitToPixelBudget({
+      pageWidth,
+      pageHeight,
+      zoom,
+      dpr: effectiveDpr,
+      visiblePageCount,
+      retainedPageCount,
+      layerCount,
+    });
+  }
+
+  const bucket: RenderDprBucket = effectiveDpr > 2 ? 2 : asBucket(effectiveDpr);
+  const renderScale = zoom * effectiveDpr;
+  const cssWidth = pageWidth * zoom;
+  const cssHeight = pageHeight * zoom;
+  const canvasWidth = Math.max(1, Math.ceil(pageWidth * renderScale));
+  const canvasHeight = Math.max(1, Math.ceil(pageHeight * renderScale));
+  const estimatedVisibleSurfacePixels = estimateSurfacePixels({
+    pageWidth,
+    pageHeight,
+    zoom,
+    dpr: effectiveDpr,
+    pageCount: visiblePageCount,
+    layerCount,
+  });
+  const estimatedRetainedSurfacePixels = estimateSurfacePixels({
+    pageWidth,
+    pageHeight,
+    zoom,
+    dpr: effectiveDpr,
+    pageCount: retainedPageCount,
+    layerCount,
+  });
+
+  return {
+    displayZoom: zoom,
+    renderScale,
+    rawDpr,
+    effectiveDpr,
+    bucket,
+    tier,
+    cssWidth,
+    cssHeight,
+    canvasWidth,
+    canvasHeight,
+    canvasPixels: canvasWidth * canvasHeight,
+    layerCount,
+    estimatedVisibleSurfacePixels,
+    estimatedRetainedSurfacePixels,
+  };
+}

--- a/rhwp-studio/src/view/canvas-view.ts
+++ b/rhwp-studio/src/view/canvas-view.ts
@@ -11,6 +11,11 @@ import type { CanvasKitRenderDiagnostics } from './canvaskit-renderer';
 import type { FontDecisionTraceRecordV1 } from '@/core/font-decision-trace';
 import { clampRenderScale, type RenderBackend } from './render-backend';
 import {
+  DEFAULT_PAGE_LAYER_COUNT,
+  resolveAdaptiveRenderScale,
+  type RenderDprBucket,
+} from './adaptive-render-scale.ts';
+import {
   RendererSession,
   type RendererSessionDiagnostics,
   type RendererSessionSelection,
@@ -69,6 +74,7 @@ export class CanvasView {
   private currentVisiblePages: number[] = [];
   private editingPageIndex: number | null = null;
   private activePageSnapshot: ActivePageSnapshot | null = null;
+  private pageRenderBuckets = new Map<number, RenderDprBucket>();
   private unsubscribers: (() => void)[] = [];
   private pendingTextEditRefreshes = new Map<number, PageRenderContext>();
   private textEditRefreshRafId: number | null = null;
@@ -636,8 +642,32 @@ export class CanvasView {
       console.error(`[CanvasView] 페이지 ${pageIdx} 정보가 없습니다`);
       return false;
     }
-    // iOS/WebKit과 GPU surface가 감당하기 어려운 물리 픽셀 수를 중앙 정책으로 제한한다.
-    const renderScale = clampRenderScale(pageInfo, zoom * rawDpr);
+    const interaction = this.viewportManager.isZoomAnimating() ? 'pinch' : 'idle';
+    const layerCount = this.pageRenderer.getBackend() === 'canvaskit'
+      ? 1
+      : DEFAULT_PAGE_LAYER_COUNT;
+    const pagesPerRow = this.virtualScroll.isHorizontalMode()
+      ? Math.max(this.currentVisiblePages.length, 1)
+      : this.virtualScroll.pagesPerRow;
+    const decision = resolveAdaptiveRenderScale({
+      pageWidth: pageInfo.width,
+      pageHeight: pageInfo.height,
+      zoom,
+      rawDpr,
+      pagesPerRow,
+      visiblePageCount: this.currentVisiblePages.length,
+      retainedPageCount: this.canvasPool.activePages.length,
+      layerCount,
+      isFocused: this.activePageSnapshot?.pageIndex === pageIdx
+        && this.activePageSnapshot.source === 'editing',
+      isEditing: this.editingPageIndex === pageIdx,
+      interaction,
+      renderProfile: this.pageRenderer.getRenderProfile(),
+      previousBucket: this.pageRenderBuckets.get(pageIdx) ?? null,
+    });
+    this.pageRenderBuckets.set(pageIdx, decision.bucket);
+    // 표시 zoom과 내부 render scale을 분리하고, 페이지당 67M 상한은 기존 clamp를 유지한다.
+    const renderScale = clampRenderScale(pageInfo, decision.renderScale);
     const dpr = renderScale / (zoom > 0 ? zoom : 1);
 
     // Canvas를 DOM에 추가하고 위치를 설정한다
@@ -696,6 +726,9 @@ export class CanvasView {
     renderedCanvas.style.height = `${renderedCanvas.height / dpr}px`;
     renderedCanvas.style.transformOrigin = '';
     renderedCanvas.dataset.rhwpRenderedZoom = String(zoom);
+    renderedCanvas.dataset.rhwpRenderTier = decision.tier;
+    renderedCanvas.dataset.rhwpRenderBucket = String(decision.bucket);
+    renderedCanvas.dataset.rhwpEffectiveDpr = String(dpr);
     this.renderGridOverlay(pageIdx, renderedCanvas);
     if (renderResult.needsTextEditStaticLayerVerification) {
       this.scheduleTextEditStaticLayerVerification(pageIdx);
@@ -1087,6 +1120,7 @@ export class CanvasView {
     this.pageRenderer.removeAllPageLayers(this.scrollContent);
     this.removeAllGridOverlays();
     this.canvasPool.releaseAll();
+    this.pageRenderBuckets.clear();
   }
 
   private refreshGridOverlays(): void {

--- a/rhwp-studio/src/view/page-renderer.ts
+++ b/rhwp-studio/src/view/page-renderer.ts
@@ -280,6 +280,10 @@ export class PageRenderer {
     return this.backend;
   }
 
+  getRenderProfile(): LayerRenderProfile {
+    return this.renderProfile;
+  }
+
   getCanvasKitRenderDiagnostics(pageIdx: number): CanvasKitRenderDiagnostics | null {
     const diagnostics = this.canvaskitDiagnosticsByPage.get(pageIdx);
     if (!diagnostics) return null;

--- a/rhwp-studio/tests/adaptive-render-scale.test.ts
+++ b/rhwp-studio/tests/adaptive-render-scale.test.ts
@@ -1,0 +1,252 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import type { PageInfo } from '../src/core/types.ts';
+import { clampRenderScale } from '../src/view/render-backend.ts';
+import {
+  canvasCssSize,
+  DEFAULT_PAGE_LAYER_COUNT,
+  MAX_VISIBLE_CANVAS_PIXELS,
+  overviewDprBucket,
+  pageCanvasPixels,
+  quantizeDprBucket,
+  resolveAdaptiveRenderScale,
+  type AdaptiveRenderScaleInput,
+} from '../src/view/adaptive-render-scale.ts';
+
+const A4 = { width: 793.7, height: 1122.5 };
+const A4_LANDSCAPE = { width: 1122.5, height: 793.7 };
+
+function baseInput(
+  overrides: Partial<AdaptiveRenderScaleInput> = {},
+): AdaptiveRenderScaleInput {
+  return {
+    pageWidth: A4.width,
+    pageHeight: A4.height,
+    zoom: 1,
+    rawDpr: 2,
+    pagesPerRow: 1,
+    visiblePageCount: 1,
+    retainedPageCount: 1,
+    layerCount: DEFAULT_PAGE_LAYER_COUNT,
+    interaction: 'idle',
+    renderProfile: 'screen',
+    ...overrides,
+  };
+}
+
+test('overview 3쪽 이상은 raw DPR 2를 쓰지 않고 bucket 1을 쓴다', () => {
+  const overview = resolveAdaptiveRenderScale(baseInput({
+    pagesPerRow: 3,
+    visiblePageCount: 6,
+    retainedPageCount: 8,
+    zoom: 0.25,
+  }));
+  assert.equal(overview.tier, 'overview');
+  assert.equal(overview.bucket, 1);
+  assert.equal(overview.effectiveDpr, 1);
+  assert.equal(overviewDprBucket(2), 1);
+});
+
+test('DPR 2 overview는 동일 CSS 크기 full-DPR 대비 Canvas 픽셀을 50% 이상 줄인다', () => {
+  const zoom = 0.36;
+  const full = resolveAdaptiveRenderScale(baseInput({
+    zoom,
+    pagesPerRow: 1,
+    rawDpr: 2,
+  }));
+  const overview = resolveAdaptiveRenderScale(baseInput({
+    zoom,
+    pagesPerRow: 4,
+    visiblePageCount: 8,
+    retainedPageCount: 10,
+    rawDpr: 2,
+  }));
+  assert.equal(full.effectiveDpr, 2);
+  assert.equal(overview.effectiveDpr, 1);
+  assert.ok(
+    overview.canvasPixels <= full.canvasPixels * 0.5,
+    `overview ${overview.canvasPixels} vs full ${full.canvasPixels}`,
+  );
+  assert.equal(overview.cssWidth, full.cssWidth);
+  assert.equal(overview.cssHeight, full.cssHeight);
+});
+
+test('tier가 바뀌어도 CSS 페이지 크기는 1 CSS px 이내로 같다', () => {
+  const zoom = 0.5;
+  const screen = resolveAdaptiveRenderScale(baseInput({ zoom, pagesPerRow: 2, rawDpr: 2 }));
+  const overview = resolveAdaptiveRenderScale(baseInput({ zoom, pagesPerRow: 4, rawDpr: 2 }));
+  const screenCss = canvasCssSize(A4.width, A4.height, zoom, screen.renderScale);
+  const overviewCss = canvasCssSize(A4.width, A4.height, zoom, overview.renderScale);
+  assert.ok(Math.abs(screenCss.width - overviewCss.width) <= 1);
+  assert.ok(Math.abs(screenCss.height - overviewCss.height) <= 1);
+  assert.ok(Math.abs(screenCss.width - A4.width * zoom) <= 1);
+  assert.ok(Math.abs(overviewCss.height - A4.height * zoom) <= 1);
+});
+
+test('DPR bucket은 1/1.5/2이며 경계에서 히스테리시스를 둔다', () => {
+  assert.equal(quantizeDprBucket(1.0), 1);
+  assert.equal(quantizeDprBucket(1.2), 1);
+  assert.equal(quantizeDprBucket(1.5), 1.5);
+  assert.equal(quantizeDprBucket(2.0), 2);
+  assert.equal(quantizeDprBucket(1.3, 1), 1);
+  assert.equal(quantizeDprBucket(1.4, 1), 1.5);
+  assert.equal(quantizeDprBucket(1.8, 1.5), 1.5);
+  assert.equal(quantizeDprBucket(1.9, 1.5), 2);
+  assert.equal(quantizeDprBucket(1.7, 2), 2);
+  assert.equal(quantizeDprBucket(1.6, 2), 1.5);
+});
+
+test('편집·포커스 페이지는 overview에서도 screen tier로 승격된다', () => {
+  const neighbor = resolveAdaptiveRenderScale(baseInput({
+    pagesPerRow: 4,
+    zoom: 0.25,
+    rawDpr: 2,
+    visiblePageCount: 8,
+  }));
+  const focused = resolveAdaptiveRenderScale(baseInput({
+    pagesPerRow: 4,
+    zoom: 0.25,
+    rawDpr: 2,
+    visiblePageCount: 8,
+    isEditing: true,
+  }));
+  assert.equal(neighbor.tier, 'overview');
+  assert.equal(neighbor.effectiveDpr, 1);
+  assert.equal(focused.tier, 'screen');
+  assert.equal(focused.effectiveDpr, 2);
+});
+
+test('단일 쪽·두 쪽 일반 편집은 DPR 2를 유지한다', () => {
+  for (const pagesPerRow of [1, 2]) {
+    const result = resolveAdaptiveRenderScale(baseInput({
+      pagesPerRow,
+      zoom: 1,
+      rawDpr: 2,
+      isEditing: true,
+    }));
+    assert.equal(result.tier, 'screen');
+    assert.equal(result.effectiveDpr, 2);
+    assert.equal(result.bucket, 2);
+    assert.equal(result.renderScale, 2);
+  }
+});
+
+test('print·highQuality는 화면용 적응형 정책을 쓰지 않는다', () => {
+  for (const renderProfile of ['print', 'highQuality'] as const) {
+    const result = resolveAdaptiveRenderScale(baseInput({
+      pagesPerRow: 4,
+      zoom: 0.25,
+      rawDpr: 2,
+      renderProfile,
+      visiblePageCount: 12,
+    }));
+    assert.equal(result.tier, 'export');
+    assert.equal(result.effectiveDpr, 2);
+    assert.equal(result.renderScale, 0.5);
+  }
+});
+
+test('핀치 중에는 이전 bucket을 preview로 유지한다', () => {
+  const result = resolveAdaptiveRenderScale(baseInput({
+    pagesPerRow: 2,
+    rawDpr: 2,
+    zoom: 1,
+    interaction: 'pinch',
+    previousBucket: 1,
+  }));
+  assert.equal(result.tier, 'preview');
+  assert.equal(result.effectiveDpr, 1);
+  assert.equal(result.bucket, 1);
+});
+
+test('overview 총 surface는 보이는 페이지·레이어 수를 반영한다', () => {
+  const result = resolveAdaptiveRenderScale(baseInput({
+    pagesPerRow: 4,
+    zoom: 0.25,
+    rawDpr: 2,
+    visiblePageCount: 8,
+    retainedPageCount: 12,
+    layerCount: 4,
+  }));
+  const onePage = pageCanvasPixels(A4.width, A4.height, 0.25, 1);
+  assert.equal(result.estimatedVisibleSurfacePixels, onePage * 8 * 4);
+  assert.equal(result.estimatedRetainedSurfacePixels, onePage * 12 * 4);
+  assert.ok(result.estimatedVisibleSurfacePixels <= MAX_VISIBLE_CANVAS_PIXELS);
+});
+
+test('A4/가로, DPR 1/2/3, zoom 25/36/50/100%, 1/2/4쪽 매트릭스', () => {
+  const papers = [A4, A4_LANDSCAPE];
+  const dprs = [1, 2, 3];
+  const zooms = [0.25, 0.36, 0.5, 1];
+  const columns = [1, 2, 4];
+  for (const paper of papers) {
+    for (const rawDpr of dprs) {
+      for (const zoom of zooms) {
+        for (const pagesPerRow of columns) {
+          const result = resolveAdaptiveRenderScale(baseInput({
+            pageWidth: paper.width,
+            pageHeight: paper.height,
+            rawDpr,
+            zoom,
+            pagesPerRow,
+            visiblePageCount: Math.max(1, pagesPerRow * 2),
+            retainedPageCount: Math.max(2, pagesPerRow * 3),
+          }));
+          const css = canvasCssSize(
+            paper.width,
+            paper.height,
+            zoom,
+            result.renderScale,
+          );
+          assert.ok(Math.abs(css.width - paper.width * zoom) <= 1);
+          assert.ok(Math.abs(css.height - paper.height * zoom) <= 1);
+          if (pagesPerRow >= 3) {
+            assert.equal(result.tier, 'overview');
+            if (rawDpr >= 2) {
+              const fullPixels = pageCanvasPixels(paper.width, paper.height, zoom, rawDpr);
+              assert.ok(
+                result.canvasPixels <= fullPixels * 0.5 + paper.width + paper.height,
+                `pixels ${result.canvasPixels} full ${fullPixels} dpr=${rawDpr} zoom=${zoom}`,
+              );
+            }
+          } else {
+            assert.equal(result.tier, 'screen');
+            if (rawDpr === 2) assert.equal(result.effectiveDpr, 2);
+            if (rawDpr === 1) assert.equal(result.effectiveDpr, 1);
+            if (rawDpr === 3) assert.equal(result.effectiveDpr, 3);
+          }
+        }
+      }
+    }
+  }
+});
+
+test('clampRenderScale는 적응형 결과 위에 기존 67M 상한을 유지한다', () => {
+  const pageInfo = { width: A4.width, height: A4.height } as PageInfo;
+  const overview = resolveAdaptiveRenderScale(baseInput({
+    pagesPerRow: 4,
+    zoom: 0.25,
+    rawDpr: 2,
+  }));
+  assert.equal(clampRenderScale(pageInfo, overview.renderScale), overview.renderScale);
+  const screen = resolveAdaptiveRenderScale(baseInput({
+    pagesPerRow: 1,
+    zoom: 1,
+    rawDpr: 2,
+  }));
+  assert.equal(clampRenderScale(pageInfo, screen.renderScale), screen.renderScale);
+});
+
+test('CanvasView는 표시 zoom과 render scale을 분리하고 Canvas2D/CanvasKit가 같은 renderScale을 쓴다', () => {
+  const canvasView = readFileSync(new URL('../src/view/canvas-view.ts', import.meta.url), 'utf8');
+  const pageRenderer = readFileSync(new URL('../src/view/page-renderer.ts', import.meta.url), 'utf8');
+  assert.match(canvasView, /resolveAdaptiveRenderScale\(/);
+  assert.match(canvasView, /clampRenderScale\(pageInfo,\s*decision\.renderScale\)/);
+  assert.equal(canvasView.includes('clampRenderScale(pageInfo, zoom * rawDpr)'), false);
+  assert.match(canvasView, /renderPage\(pageIdx,\s*canvas,\s*renderScale,\s*zoom,\s*dpr,\s*renderContext\)/);
+  assert.match(pageRenderer, /canvas\.width\s*=\s*Math\.max\(1,\s*Math\.ceil\(pageInfo\.width \* renderScale\)\)/);
+  assert.match(pageRenderer, /this\.canvaskitRenderer\.renderPage\(tree,\s*canvas,\s*renderScale,\s*pageInfo\)/);
+  assert.match(pageRenderer, /getRenderProfile\(\): LayerRenderProfile/);
+});


### PR DESCRIPTION
## 변경 요약

rhwp-studio 화면 렌더는 지금까지 `renderScale = zoom * devicePixelRatio`만 썼고, `clampRenderScale()`은 Canvas 하나당 약 67M 픽셀 상한만 적용했습니다. 한 행에 여러 쪽이 보이는 overview에서도 Retina/4K의 전체 DPR을 써서 물리 픽셀·레이어 메모리가 누적됩니다.

이 PR은 **표시 zoom과 내부 render scale을 분리**하고, 기존 Canvas2D/CanvasKit 렌더러는 그대로 둡니다.

- 한 행 3쪽 이상(가로 이동에서 가시 쪽이 3쪽 이상인 경우 포함)은 overview tier, effective DPR bucket `1`
- DPR 2 overview는 동일 CSS 크기의 full-DPR 대비 페이지 Canvas 픽셀을 50% 이상 축소 (실제로는 약 75%)
- CSS 페이지 크기·클릭/캐럿 좌표는 `dpr = renderScale / zoom`을 유지해 ±1 CSS px 이내
- 품질 bucket은 `1 / 1.5 / 2`이며 경계에 히스테리시스
- 편집·포커스 페이지는 screen tier로 승격 (DPR 2 유지)
- 단일 쪽·두 쪽 일반 편집은 기존 DPR 2를 유지
- `print` / `highQuality`는 화면용 적응형 정책에서 제외
- 보이는 페이지·보존 페이지·레이어 수를 반영한 총 Canvas 픽셀 예산(32M / 48M)
- 핀치(줌 애니메이션) 중에는 이전 bucket을 preview로 유지

## 관련 이슈

Closes #6041

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** — Rust 파일 변경 없음. 스파스 워크트리에 `crates/` 없음. `git diff --check` 통과, 줄끝 LF
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음 (`--sync-cargo-targets` 메인터너 registry PR은 marker 블록만 예외)
- [x] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요) — 해당 없음
- [ ] `cargo test` — Rust 동작 변경 없음. 아래 studio 단위 테스트로 대체
- [ ] `cargo clippy -- -D warnings` — Rust 동작 변경 없음
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — print/PDF/SVG/highQuality 경로 미변경
- [x] 웹 렌더링 확인 (해당하는 경우) — Canvas2D/CanvasKit가 같은 `renderScale`을 받는 소스 가드 + 물리 픽셀/CSS 계약 단위 테스트
- [x] rhwp-studio 편집·UI 변경 시: `node --test tests/adaptive-render-scale.test.ts` — 12 pass, 0 fail
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — 문서 편집 없음
- [x] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: capability 카탈로그 규칙 반영 — 해당 없음

```text
cd rhwp-studio && node --test tests/adaptive-render-scale.test.ts
tests 12, pass 12, fail 0
git diff --check
exit 0
```

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: DPR 2 overview(3쪽/행 이상)에서 페이지 Canvas 물리 픽셀이 full-DPR 대비 50% 이상 감소. 단일·두 쪽 편집 선명도는 유지
- 재현·측정: A4/가로 × DPR 1/2/3 × zoom 25/36/50/100% × 1/2/4열 매트릭스를 단위 테스트로 기록. 브라우저 실측은 디스크 제약으로 미측정

## 스크린샷

화면 좌표·CSS 크기는 유지하고 내부 bitmap만 낮추는 변경이라 스크린샷 차이는 개요 보기에서 약간 부드러운 텍스트로 나타납니다. 픽셀 예산 계약은 단위 테스트로 고정했습니다.
