### PR TITLE
[renderer] 쪽 분할 셀 TAC 그림이 페인트 높이만큼 흐름을 전진시켜 아래 표·본문 겹침을 없앤다

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -4377,18 +4377,8 @@ impl LayoutEngine {
                 .as_ref()
                 .map(|flow| flow.extra_rows)
                 .unwrap_or(0);
-            let cell_tac_flow_h = if cell_ctx.is_some() {
-                para.and_then(|p| {
-                    crate::renderer::composed_line_tac_object_height_px(
-                        p, composed, line_idx, self.dpi,
-                    )
-                })
-                .unwrap_or(0.0)
-            } else {
-                0.0
-            };
-            let line_flow_height = line_height.max(cell_tac_flow_h)
-                + equation_tac_extra_rows as f64 * (line_height + line_spacing_px);
+            let line_flow_height =
+                line_height + equation_tac_extra_rows as f64 * (line_height + line_spacing_px);
             let render_line_flow_height =
                 if cell_ctx.is_none() && para_index >= self.endnote_para_base.get() {
                     // 미주 lineSeg의 행 진행값이 실제 TextLine bbox보다 작으면 단일 줄 미주가

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -4377,8 +4377,18 @@ impl LayoutEngine {
                 .as_ref()
                 .map(|flow| flow.extra_rows)
                 .unwrap_or(0);
-            let line_flow_height =
-                line_height + equation_tac_extra_rows as f64 * (line_height + line_spacing_px);
+            let cell_tac_flow_h = if cell_ctx.is_some() {
+                para.and_then(|p| {
+                    crate::renderer::composed_line_tac_object_height_px(
+                        p, composed, line_idx, self.dpi,
+                    )
+                })
+                .unwrap_or(0.0)
+            } else {
+                0.0
+            };
+            let line_flow_height = line_height.max(cell_tac_flow_h)
+                + equation_tac_extra_rows as f64 * (line_height + line_spacing_px);
             let render_line_flow_height =
                 if cell_ctx.is_none() && para_index >= self.endnote_para_base.get() {
                     // 미주 lineSeg의 행 진행값이 실제 TextLine bbox보다 작으면 단일 줄 미주가

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -29,6 +29,9 @@ const ROWBREAK_STALE_PAGE_SCALE_PICTURE_OFFSET_MIN_HU: i32 = -40_000;
 /// remarks 셋째 줄 소유 회귀로 실증됐다. 그래서 잡음대(≤0.03px)와 실초과(≥0.19px)
 /// 사이의 0.1px 로 고정한다.
 const ROW_CUT_CAPACITY_FP_EPSILON_PX: f64 = 0.1;
+/// 쪽 스케일 칸 바닥값 — `cell_units` 쪽 프레임 판정과 같다. 이보다 작은 칸은
+/// 한 쪽에 들어가므로 [#6114] TAC 그림 높이 회계를 적용하지 않는다.
+const PAGE_SCALE_CELL_HEIGHT_PX: f64 = 800.0;
 
 /// [#2424 프로파일] 분할 표 컷 프리미티브 실측 카운터 — `RHWP_2424_PROFILE` 전용, 동작 불변.
 /// 프로세스 누적이며 `RHWP_2424_STEP_PROFILE` 출력(typeset.rs)이 스냅샷을 읽는다.
@@ -101,6 +104,17 @@ fn cell_para_line_anchor_y(
     } else {
         base_y + hwpunit_to_px(vertical_pos_hu, dpi)
     }
+}
+
+/// [#6114] 쪽 나눔이 허용되고 선언 높이가 쪽 규모인 칸.
+/// 이 칸의 그림-only TAC 줄만 페인트 높이로 조각 회계·흐름을 민다.
+fn cell_is_page_split_candidate(
+    cell: &crate::model::table::Cell,
+    table: &crate::model::table::Table,
+    dpi: f64,
+) -> bool {
+    !matches!(table.page_break, TablePageBreak::None)
+        && hwpunit_to_px(cell.height.min(i32::MAX as u32) as i32, dpi) >= PAGE_SCALE_CELL_HEIGHT_PX
 }
 
 fn has_initial_tac_shape_host(paragraphs: &[Paragraph]) -> bool {
@@ -5097,8 +5111,9 @@ impl LayoutEngine {
                 }
             };
             let mut tac_img_y = para_y_before_compose;
-            // [#6114] 폴백으로 그린 TAC 그림의 페인트 하단. composed 줄 높이가
-            // 글줄(26px)이면 흐름이 그림(312px)을 못 따라가 아래 표가 겹친다.
+            // [#6114] 쪽 분할 칸에서만 폴백 TAC 그림 페인트 하단으로 흐름을 민다.
+            // 일반 칸까지 밀면 칸 상자 밖 글이 아래 본문과 겹친다.
+            let split_cell_tac_flow = fragment_cut_units.is_some();
             let mut tac_flow_bottom: Option<f64> = None;
             // [#5712] 같은 문단에서 앞서 배치된 비-TAC TopAndBottom 중첩 표가
             // para_y 를 전진시켰는지 — co-anchored TAC 표의 적층 판별에 쓴다.
@@ -5278,11 +5293,13 @@ impl LayoutEngine {
                                     cell_context.as_ref(),
                                     styles,
                                 );
-                                tac_flow_bottom = Some(
-                                    tac_flow_bottom
-                                        .unwrap_or(f64::MIN)
-                                        .max(tac_img_y + clamped_h),
-                                );
+                                if split_cell_tac_flow {
+                                    tac_flow_bottom = Some(
+                                        tac_flow_bottom
+                                            .unwrap_or(f64::MIN)
+                                            .max(tac_img_y + clamped_h),
+                                    );
+                                }
                                 inline_x += clamped_w;
                                 continue;
                             }
@@ -9398,13 +9415,17 @@ impl LayoutEngine {
             } else {
                 None
             };
+            // [#6114] 쪽 분할 칸의 그림-only TAC 줄만 페인트 높이를 조각 회계에
+            // 넣는다. 일반 칸·본문 섞인 줄까지 max 하면 컷이 빨라져 글이 겹친다.
+            let apply_split_cell_tac = cell_is_page_split_candidate(cell, table, self.dpi);
             let corrected_h = |line: &ComposedLine, li: usize| -> f64 {
                 let raw_lh = hwpunit_to_px(line.line_height, self.dpi);
-                // [#6114] 저장 줄이 글줄 높이만 담아도 그 줄 TAC 그림은 자기 높이만큼
-                // 칸 조각 회계에 들어가야 한다. max 라 이미 그림 높이인 LINE_SEG 는 불변.
-                let tac_h =
+                let tac_h = if apply_split_cell_tac {
                     crate::renderer::composed_line_tac_object_height_px(p, &comp, li, self.dpi)
-                        .unwrap_or(0.0);
+                        .unwrap_or(0.0)
+                } else {
+                    0.0
+                };
                 let with_tac = |h: f64| h.max(tac_h);
                 // [Task #1811] HWPX RowBreak 셀의 synthetic lineSeg 는 저장 근거가 아니라
                 // reflow 산물이다. row cut 측정에서 다시 corrected_line_height 를 적용하면

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -5097,6 +5097,9 @@ impl LayoutEngine {
                 }
             };
             let mut tac_img_y = para_y_before_compose;
+            // [#6114] 폴백으로 그린 TAC 그림의 페인트 하단. composed 줄 높이가
+            // 글줄(26px)이면 흐름이 그림(312px)을 못 따라가 아래 표가 겹친다.
+            let mut tac_flow_bottom: Option<f64> = None;
             // [#5712] 같은 문단에서 앞서 배치된 비-TAC TopAndBottom 중첩 표가
             // para_y 를 전진시켰는지 — co-anchored TAC 표의 적층 판별에 쓴다.
             let mut prior_float_table_stacked = false;
@@ -5274,6 +5277,11 @@ impl LayoutEngine {
                                     Some(ctrl_idx),
                                     cell_context.as_ref(),
                                     styles,
+                                );
+                                tac_flow_bottom = Some(
+                                    tac_flow_bottom
+                                        .unwrap_or(f64::MIN)
+                                        .max(tac_img_y + clamped_h),
                                 );
                                 inline_x += clamped_w;
                                 continue;
@@ -6475,6 +6483,9 @@ impl LayoutEngine {
             }
             if rendered_top_and_bottom_non_inline {
                 para_y += self.paragraph_top_and_bottom_non_inline_flow_height(&para.controls);
+            }
+            if let Some(bottom) = tac_flow_bottom {
+                para_y = para_y.max(bottom);
             }
 
             // 마지막 인라인 Shape 이후의 남은 텍스트 렌더링 (예: "일")
@@ -9389,6 +9400,12 @@ impl LayoutEngine {
             };
             let corrected_h = |line: &ComposedLine, li: usize| -> f64 {
                 let raw_lh = hwpunit_to_px(line.line_height, self.dpi);
+                // [#6114] 저장 줄이 글줄 높이만 담아도 그 줄 TAC 그림은 자기 높이만큼
+                // 칸 조각 회계에 들어가야 한다. max 라 이미 그림 높이인 LINE_SEG 는 불변.
+                let tac_h =
+                    crate::renderer::composed_line_tac_object_height_px(p, &comp, li, self.dpi)
+                        .unwrap_or(0.0);
+                let with_tac = |h: f64| h.max(tac_h);
                 // [Task #1811] HWPX RowBreak 셀의 synthetic lineSeg 는 저장 근거가 아니라
                 // reflow 산물이다. row cut 측정에서 다시 corrected_line_height 를 적용하면
                 // HWP 기준보다 줄 유닛이 커져 p4→p5 split 이 한 유닛 빨라진다.
@@ -9396,7 +9413,7 @@ impl LayoutEngine {
                     && is_block_rowbreak
                     && para_uses_synthetic_line_segs
                 {
-                    return raw_lh;
+                    return with_tac(raw_lh);
                 }
                 // [#2112] 실제 저장 LINE_SEG 를 보유한 셀 문단은 저장 줄높이를 신뢰한다.
                 // 한글은 압축 줄높이(lh < 글자크기)를 저장값대로 렌더하는데 corrected
@@ -9404,7 +9421,7 @@ impl LayoutEngine {
                 // +76.8px, 표 합계 +335px → 다쪽 표 쪽수 밀림). 보정은 lineseg 부재
                 // 폴백(#674/#993 원 목적)에만 유지.
                 if p.line_segs.iter().any(|ls| !line_seg_is_synthetic(ls)) {
-                    return raw_lh;
+                    return with_tac(raw_lh);
                 }
                 match para_style {
                     Some(ps) => {
@@ -9443,19 +9460,21 @@ impl LayoutEngine {
                         // max_fs*ls% 팽창을 em 으로 교정 — CellBreak 표.
                         // [#2150/#2169] 일반화: 한글 NO_LS fresh 공식 — 비마지막 줄
                         // fs×ls% 동치 + 셀 마지막 줄만 em (ls 사다리 + 80168 per-row 확정).
-                        crate::renderer::corrected_line_height_for_variant_synthetic(
-                            raw_lh,
-                            max_fs,
-                            ps.line_spacing_type,
-                            ps.line_spacing,
-                            crate::renderer::para_has_no_stored_line_segs(p)
-                                && (!p.text.is_empty() || p.controls.is_empty())
-                                && (matches!(table.page_break, TablePageBreak::CellBreak)
+                        with_tac(
+                            crate::renderer::corrected_line_height_for_variant_synthetic(
+                                raw_lh,
+                                max_fs,
+                                ps.line_spacing_type,
+                                ps.line_spacing,
+                                crate::renderer::para_has_no_stored_line_segs(p)
+                                    && (!p.text.is_empty() || p.controls.is_empty())
+                                    && (matches!(table.page_break, TablePageBreak::CellBreak)
                                     // [#2070 실험] 셀 마지막 줄 = em (5축 전면).
                                     || cell_last_line_idx == Some(li)),
+                            ),
                         )
                     }
-                    None => raw_lh,
+                    None => with_tac(raw_lh),
                 }
             };
             let has_table_in_para = p.controls.iter().any(|c| matches!(c, Control::Table(_)));

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -1894,9 +1894,10 @@ impl LayoutEngine {
                     // 흐름 y 를 함께 들고 간다.
                     let mut inline_tac_line = 0usize;
                     let mut inline_tac_y = para_y_before_compose;
-                    // TAC 폴백 개체의 페인트 하단. composed 줄 높이가 글줄만 담으면
-                    // (#6114 312px 차트 → 26px 전진) 아래 표가 그림 위에 겹친다.
-                    // 폭 초과 개행(#6122)과 단독 그림 모두 이 값으로 흐름을 민다.
+                    // 폭 초과로 줄을 내린 개체의 하단(#6122). 쪽 분할 칸의 단독 TAC
+                    // 그림(#6114)도 같은 값으로 흐름을 민다 — 일반 칸까지 밀면
+                    // 칸 상자 밖 글이 아래 본문과 겹친다.
+                    let split_cell_tac_flow = cut_units.is_some();
                     let mut wrapped_tac_flow_bottom: Option<f64> = None;
                     let mut rendered_top_and_bottom_non_inline = false;
 
@@ -2013,11 +2014,13 @@ impl LayoutEngine {
                                                 Some(&cell_context),
                                                 styles,
                                             );
-                                            wrapped_tac_flow_bottom = Some(
-                                                wrapped_tac_flow_bottom
-                                                    .unwrap_or(f64::MIN)
-                                                    .max(empty_tac_y + clamped_h),
-                                            );
+                                            if split_cell_tac_flow {
+                                                wrapped_tac_flow_bottom = Some(
+                                                    wrapped_tac_flow_bottom
+                                                        .unwrap_or(f64::MIN)
+                                                        .max(empty_tac_y + clamped_h),
+                                                );
+                                            }
                                             empty_tac_x += clamped_w;
                                             continue;
                                         }
@@ -2103,11 +2106,13 @@ impl LayoutEngine {
                                             Some(&cell_context),
                                             styles,
                                         );
-                                        wrapped_tac_flow_bottom = Some(
-                                            wrapped_tac_flow_bottom
-                                                .unwrap_or(f64::MIN)
-                                                .max(inline_tac_y + clamped_h),
-                                        );
+                                        if split_cell_tac_flow {
+                                            wrapped_tac_flow_bottom = Some(
+                                                wrapped_tac_flow_bottom
+                                                    .unwrap_or(f64::MIN)
+                                                    .max(inline_tac_y + clamped_h),
+                                            );
+                                        }
                                         inline_x += clamped_w;
                                         continue;
                                     }

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -1894,8 +1894,9 @@ impl LayoutEngine {
                     // 흐름 y 를 함께 들고 간다.
                     let mut inline_tac_line = 0usize;
                     let mut inline_tac_y = para_y_before_compose;
-                    // 폭 초과로 줄을 내린 개체의 하단 — composed 는 그 개체를 줄 높이에
-                    // 계상하지 않아(첫 줄이 글꼴 줄높이 그대로다) 흐름이 모자란다.
+                    // TAC 폴백 개체의 페인트 하단. composed 줄 높이가 글줄만 담으면
+                    // (#6114 312px 차트 → 26px 전진) 아래 표가 그림 위에 겹친다.
+                    // 폭 초과 개행(#6122)과 단독 그림 모두 이 값으로 흐름을 민다.
                     let mut wrapped_tac_flow_bottom: Option<f64> = None;
                     let mut rendered_top_and_bottom_non_inline = false;
 
@@ -2012,6 +2013,11 @@ impl LayoutEngine {
                                                 Some(&cell_context),
                                                 styles,
                                             );
+                                            wrapped_tac_flow_bottom = Some(
+                                                wrapped_tac_flow_bottom
+                                                    .unwrap_or(f64::MIN)
+                                                    .max(empty_tac_y + clamped_h),
+                                            );
                                             empty_tac_x += clamped_w;
                                             continue;
                                         }
@@ -2096,6 +2102,11 @@ impl LayoutEngine {
                                             Some(ctrl_idx),
                                             Some(&cell_context),
                                             styles,
+                                        );
+                                        wrapped_tac_flow_bottom = Some(
+                                            wrapped_tac_flow_bottom
+                                                .unwrap_or(f64::MIN)
+                                                .max(inline_tac_y + clamped_h),
                                         );
                                         inline_x += clamped_w;
                                         continue;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1200,16 +1200,21 @@ fn para_text_is_picture_only_host(para: &crate::model::paragraph::Paragraph) -> 
     })
 }
 
-/// 합성 줄이 담은 글자처럼(TAC) 그림/도형의 최대 흐름 높이.
+/// 쪽 분할 칸의 그림-only 문단에서, 합성 줄이 담은 TAC 그림의 흐름 높이.
 ///
-/// 저장 LINE_SEG 가 글줄 높이만 담고 있어도 그 줄의 TAC 개체는 자기 높이만큼
-/// 칸 흐름을 밀어야 한다 (#6114: 312px 차트가 26px 만 전진해 아래 표가 겹침).
+/// 저장 LINE_SEG 가 글줄만 담아도 그 줄의 TAC 그림은 자기 높이만큼 칸 조각
+/// 회계에 들어가야 한다 (#6114: 312px 차트가 26px 만 전진해 아래 표가 겹침).
+/// 본문과 섞인 줄에는 쓰지 않는다 — 일반 칸 글줄까지 그림 높이로 키우면
+/// 칸 상자 밖으로 글이 밀려 text-overlap 이 는다.
 pub(crate) fn composed_line_tac_object_height_px(
     para: &crate::model::paragraph::Paragraph,
     composed: &composer::ComposedParagraph,
     line_idx: usize,
     dpi: f64,
 ) -> Option<f64> {
+    if !para_text_is_picture_only_host(para) {
+        return None;
+    }
     let line = composed.lines.get(line_idx)?;
     let start = line.char_start;
     let end = composed

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1191,6 +1191,70 @@ pub(crate) fn line_owning_tac_object_height_px(
         })
 }
 
+fn para_text_is_picture_only_host(para: &crate::model::paragraph::Paragraph) -> bool {
+    para.text.chars().all(|ch| {
+        ch.is_whitespace()
+            || ch == '\u{FFFC}'
+            || ch <= '\u{001F}'
+            || ('\u{E000}'..='\u{F8FF}').contains(&ch)
+    })
+}
+
+/// 합성 줄이 담은 글자처럼(TAC) 그림/도형의 최대 흐름 높이.
+///
+/// 저장 LINE_SEG 가 글줄 높이만 담고 있어도 그 줄의 TAC 개체는 자기 높이만큼
+/// 칸 흐름을 밀어야 한다 (#6114: 312px 차트가 26px 만 전진해 아래 표가 겹침).
+pub(crate) fn composed_line_tac_object_height_px(
+    para: &crate::model::paragraph::Paragraph,
+    composed: &composer::ComposedParagraph,
+    line_idx: usize,
+    dpi: f64,
+) -> Option<f64> {
+    let line = composed.lines.get(line_idx)?;
+    let start = line.char_start;
+    let end = composed
+        .lines
+        .get(line_idx + 1)
+        .map(|next| next.char_start)
+        .unwrap_or_else(|| para.text.chars().count().saturating_add(1))
+        .max(start.saturating_add(1));
+
+    let mut max_h = 0.0f64;
+    for &(pos, _, ci) in &composed.tac_controls {
+        if pos < start || pos >= end {
+            continue;
+        }
+        if let Some(height) = para
+            .controls
+            .get(ci)
+            .and_then(|ctrl| tac_object_flow_height_px(ctrl, dpi))
+        {
+            max_h = max_h.max(height);
+        }
+    }
+
+    if max_h <= 0.5 && para_text_is_picture_only_host(para) {
+        let heights: Vec<f64> = para
+            .controls
+            .iter()
+            .filter_map(|ctrl| tac_object_flow_height_px(ctrl, dpi))
+            .filter(|height| *height > 0.5)
+            .collect();
+        if heights.len() == 1 && line_idx == 0 {
+            max_h = heights[0];
+        } else if heights.len() > 1
+            && line_idx < heights.len()
+            && composed.lines.len() == heights.len()
+        {
+            max_h = heights[line_idx];
+        } else if line_idx == 0 && composed.lines.len() <= 1 {
+            max_h = heights.into_iter().fold(0.0, f64::max);
+        }
+    }
+
+    (max_h > 0.5).then_some(max_h)
+}
+
 /// 셀의 저장 vpos 흐름이 문단 위치를 구분해 담고 있는지 ("사다리" 온전성).
 ///
 /// 셀 안 문단이 전부 `vpos == 0` 으로 저장된 문서(중첩 표 안쪽 셀에서 흔하다)에서는

--- a/tests/cases/issue_6114_split_cell_tac_image_flow.rs
+++ b/tests/cases/issue_6114_split_cell_tac_image_flow.rs
@@ -1,0 +1,236 @@
+//! [Issue #6114] 쪽 분할 셀 안 글자처럼 취급(TAC) 그림이 페인트 높이(312px)가
+//! 아니라 글줄 1줄(26px)만 흐름을 전진시켜 아래 표·본문이 그림 위에 겹친다.
+//!
+//! 저장 LINE_SEG 가 글줄 높이(1950HU≈26px)만 담고, 그림 본체는 23430HU≈312px
+//! 인 칸 — 한글은 그림 높이만큼 칸을 밀고, 칸이 제자리에서 쪽을 나눈다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::bin_data::BinDataContent;
+use rhwp::model::control::Control;
+use rhwp::model::image::Picture;
+use rhwp::model::paragraph::{CharShapeRef, LineSeg, Paragraph};
+use rhwp::model::shape::{CommonObjAttr, TextWrap, VertRelTo};
+use rhwp::model::table::{Cell, Table, TablePageBreak};
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+/// 96dpi 에서 26px 글줄. 7200 HU/inch → px = HU / 75.
+const TEXT_LINE_HU: i32 = 1950;
+/// 이슈 원본 ARMA 차트 129.0×82.7mm.
+const CHART_W_HU: u32 = 36_572;
+const CHART_H_HU: u32 = 23_430;
+const CHART_H_PX: f64 = 312.4;
+/// 이슈 원본 별지 신고서 129.0×191.9mm.
+const FORM_H_HU: u32 = 54_402;
+const FORM_H_PX: f64 = 725.36;
+
+const PNG_1X1: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+    0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54, 0x08, 0xD7, 0x63, 0xF8, 0xFF, 0xFF, 0x3F,
+    0x00, 0x05, 0xFE, 0x02, 0xFE, 0xDC, 0xCC, 0x59, 0xE7, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
+    0x44, 0xAE, 0x42, 0x60, 0x82,
+];
+
+fn line_seg() -> LineSeg {
+    LineSeg {
+        line_height: TEXT_LINE_HU,
+        baseline_distance: 1_658,
+        text_height: TEXT_LINE_HU,
+        ..Default::default()
+    }
+}
+
+fn tac_picture(bin_id: u16, width: u32, height: u32) -> Picture {
+    let mut pic = Picture::default();
+    pic.common = CommonObjAttr {
+        treat_as_char: true,
+        text_wrap: TextWrap::TopAndBottom,
+        vert_rel_to: VertRelTo::Para,
+        width,
+        height,
+        ..Default::default()
+    };
+    pic.image_attr.bin_data_id = bin_id;
+    pic
+}
+
+fn picture_para(pic: Picture) -> Paragraph {
+    Paragraph {
+        char_count: 1,
+        char_shapes: vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }],
+        line_segs: vec![line_seg()],
+        controls: vec![Control::Picture(Box::new(pic))],
+        ..Default::default()
+    }
+}
+
+fn text_para(text: &str) -> Paragraph {
+    let n = text.chars().count() as u32;
+    Paragraph {
+        text: text.to_string(),
+        char_count: n + 1,
+        char_offsets: (0..n).collect(),
+        char_shapes: vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }],
+        line_segs: vec![line_seg()],
+        ..Default::default()
+    }
+}
+
+fn build_core() -> DocumentCore {
+    let mut core = DocumentCore::new_empty();
+    core.create_blank_document_native().expect("blank document");
+
+    let mut table = Table {
+        row_count: 1,
+        col_count: 1,
+        row_sizes: vec![1],
+        page_break: TablePageBreak::RowBreak,
+        cells: vec![Cell {
+            col: 0,
+            row: 0,
+            col_span: 1,
+            row_span: 1,
+            width: 40_000,
+            height: 90_000,
+            paragraphs: vec![
+                picture_para(tac_picture(1, CHART_W_HU, CHART_H_HU)),
+                text_para("전망치표"),
+                picture_para(tac_picture(2, CHART_W_HU, FORM_H_HU)),
+            ],
+            ..Default::default()
+        }],
+        common: CommonObjAttr {
+            treat_as_char: false,
+            text_wrap: TextWrap::TopAndBottom,
+            vert_rel_to: VertRelTo::Para,
+            width: 40_000,
+            height: 90_000,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    table.rebuild_grid();
+
+    let mut doc = core.document().clone();
+    let para_shape_id = doc.sections[0].paragraphs[0].para_shape_id;
+    doc.sections[0].paragraphs = vec![Paragraph {
+        para_shape_id,
+        char_count: 1,
+        char_shapes: vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }],
+        line_segs: vec![LineSeg {
+            line_height: 400,
+            baseline_distance: 320,
+            ..Default::default()
+        }],
+        controls: vec![Control::Table(Box::new(table))],
+        ..Default::default()
+    }];
+    doc.bin_data_content = vec![
+        BinDataContent {
+            id: 1,
+            data: PNG_1X1.to_vec().into(),
+            extension: "png".to_string(),
+        },
+        BinDataContent {
+            id: 2,
+            data: PNG_1X1.to_vec().into(),
+            extension: "png".to_string(),
+        },
+    ];
+    core.set_document(doc);
+    core
+}
+
+fn walk<'a>(node: &'a RenderNode, out: &mut Vec<&'a RenderNode>) {
+    out.push(node);
+    for child in &node.children {
+        walk(child, out);
+    }
+}
+
+#[test]
+fn issue_6114_tac_image_in_split_cell_advances_painted_height() {
+    let core = build_core();
+    let page0 = core.build_page_render_tree(0).expect("page 1");
+    let mut nodes = Vec::new();
+    walk(&page0.root, &mut nodes);
+
+    let mut images: Vec<(f64, f64, f64)> = nodes
+        .iter()
+        .filter_map(|n| match n.node_type {
+            RenderNodeType::Image(_) => Some((n.bbox.y, n.bbox.height, n.bbox.y + n.bbox.height)),
+            _ => None,
+        })
+        .collect();
+    images.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+    assert!(
+        !images.is_empty(),
+        "차트 TAC 그림이 1쪽에 그려져야 한다: {images:?}"
+    );
+
+    let (chart_y, chart_h, chart_bottom) = images
+        .iter()
+        .copied()
+        .find(|(_, h, _)| (*h - CHART_H_PX).abs() < 2.0)
+        .expect("312px 차트 그림");
+    assert!(
+        (chart_h - CHART_H_PX).abs() < 2.0,
+        "차트 높이 {chart_h:.1} (기대 {CHART_H_PX:.1})"
+    );
+
+    let text_y = nodes
+        .iter()
+        .find_map(|n| match &n.node_type {
+            RenderNodeType::TextRun(run) if run.text.contains("전망") => Some(n.bbox.y),
+            _ => None,
+        })
+        .expect("'전망치표' 본문");
+
+    assert!(
+        text_y >= chart_bottom - 1.0,
+        "본문이 차트 아래로 흘러야 한다 (결함 시 차트 상단에서 26px): \
+         차트 y={chart_y:.1} h={chart_h:.1} bottom={chart_bottom:.1}, 본문 y={text_y:.1}"
+    );
+    assert!(
+        text_y - chart_y > 200.0,
+        "흐름이 글줄(26px)이 아니라 그림 높이만큼 전진해야 한다: Δ={:.1}",
+        text_y - chart_y
+    );
+
+    let mut form = None;
+    for page in 0..core.page_count() {
+        let tree = core
+            .build_page_render_tree(page)
+            .unwrap_or_else(|e| panic!("page {} tree: {e}", page + 1));
+        let mut page_nodes = Vec::new();
+        walk(&tree.root, &mut page_nodes);
+        for n in page_nodes {
+            if matches!(n.node_type, RenderNodeType::Image(_))
+                && (n.bbox.height - FORM_H_PX).abs() < 2.0
+            {
+                form = Some((page, n.bbox.y, n.bbox.height));
+            }
+        }
+    }
+    let (form_page, form_y, form_h) = form.expect("725px 별지 그림");
+    assert!(
+        (form_h - FORM_H_PX).abs() < 2.0,
+        "별지 그림 높이 {form_h:.1}"
+    );
+    if form_page == 0 {
+        assert!(
+            form_y >= chart_bottom - 1.0,
+            "별지 그림이 차트와 겹치면 안 된다: form y={form_y:.1} chart bottom={chart_bottom:.1}"
+        );
+    }
+}


### PR DESCRIPTION
## 변경 요약

쪽 분할 칸 안 글자처럼 취급(TAC) 그림이 페인트 높이(312px·725px)가 아니라 글줄 1줄(26px)만 흐름을 전진시켜, 아래 표·본문이 그림 위에 겹치고 칸이 제자리에서 나뉘지 않던 #6114 를 고칩니다.

저장 LINE_SEG 가 글줄 높이만 담아도 그 줄의 TAC 그림은 자기 높이만큼 칸 조각 회계와 페인트 흐름에 들어갑니다. 이미 그림 높이인 LINE_SEG 는 `max` 이라 변하지 않습니다.

- `composed_line_tac_object_height_px`: 합성 줄이 담은 TAC 그림/도형 높이
- `cell_units` 줄 높이: 그 값으로 조각 컷 회계
- 셀 안 `layout_composed_paragraph` 전진과 TAC 폴백 페인트 하단으로 `para_y` 를 밀어 아래 내용이 그림 위에 겹치지 않게 함

## 관련 이슈

Closes #6114

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음
- [x] `src/**`의 `#[cfg(test)]` 변경 없음 (소스 유닛 테스트 수 동결)
- [x] focused: `issue_6114_tac_image_in_split_cell_advances_painted_height` 통과
- [ ] `cargo clippy -- -D warnings` — 공유 타깃 디스크 포화로 이번 제출에서 생략, CI Lint에 위임
- [x] 합성 픽스처(차트 23430HU + 본문 + 별지 54402HU, LINE_SEG=1950HU)로 본문이 차트 아래(Δ>200px)에 놓임을 확인

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (쪽 분할 칸 TAC 그림 줄만 높이 max)
- 재현·측정: 합성 픽스처 focused 테스트