### PR TITLE
perf(studio): 다중 페이지 스크롤에 행 가상화와 페이지 표면 LRU를 넣는다

### DIFF
--- a/rhwp-studio/src/view/canvas-view.ts
+++ b/rhwp-studio/src/view/canvas-view.ts
@@ -3,6 +3,15 @@ import { EventBus } from '@/core/event-bus';
 import type { PageInfo } from '@/core/types';
 import { VirtualScroll } from './virtual-scroll';
 import { CanvasPool } from './canvas-pool';
+import {
+  PageSurfaceLru,
+  pageSurfaceCacheKey,
+  quantizeRenderScaleTier,
+} from './page-surface-lru';
+import {
+  PageRenderScheduler,
+  syncVisibleRenderBudget,
+} from './page-render-scheduler';
 import { PageRenderer, type PageRenderContext, type PageRenderResult } from './page-renderer';
 import { ViewportManager } from './viewport-manager';
 import { CoordinateSystem } from './coordinate-system';
@@ -75,6 +84,11 @@ export class CanvasView {
   private textEditStaticLayerVerifyTimers = new Map<number, ReturnType<typeof setTimeout>>();
   private pendingPrefetchPages = new Set<number>();
   private deferredPrefetchTask: DeferredPrefetchTask | null = null;
+  private pageSurfaceLru = new PageSurfaceLru();
+  private pageRenderScheduler = new PageRenderScheduler();
+  private lastScrollY = 0;
+  private scrollDirection: 1 | -1 = 1;
+  private firstVisiblePaintDone = false;
   private rendererSelectionEpoch = 0;
   private rendererFallbackScheduled = false;
   private activeRendererDecisionKey: string | null = null;
@@ -199,6 +213,7 @@ export class CanvasView {
 
     this.container.scrollTop = 0;
     this.lastPageSize = { width: this.pages[0].width, height: this.pages[0].height };
+    this.firstVisiblePaintDone = false;
     this.updateVisiblePages();
     this.clearBlankPagePlaceholder();
     // 초기 replay가 예약한 document fallback을 load 완료 전에 확정한다.
@@ -306,12 +321,12 @@ export class CanvasView {
     const scrollY = this.viewportManager.getScrollY();
     const scrollX = this.viewportManager.getScrollX();
     const viewport = this.viewportManager.getViewportSize();
-    const visiblePages = this.virtualScroll.getVisiblePages(
+    const visiblePages = this.virtualScroll.getVisibilitySnapshot(
       scrollY,
       viewport.height,
       scrollX,
       viewport.width,
-    );
+    ).visiblePages;
     const failed = visiblePages.filter(pageIndex => !this.canvasPool.has(pageIndex));
     if (visiblePages.length === 0 || failed.length > 0) {
       throw new Error(`document-agent visible page render 실패: ${failed.join(',') || 'none'}`);
@@ -475,45 +490,119 @@ export class CanvasView {
     const scrollX = this.viewportManager.getScrollX();
     const { width: vpWidth, height: vpHeight } = this.viewportManager.getViewportSize();
 
-    const prefetchPages = this.virtualScroll.getPrefetchPages(
-      scrollY,
-      vpHeight,
-      scrollX,
-      vpWidth,
-    );
-    const visiblePages = this.virtualScroll.getVisiblePages(
-      scrollY,
-      vpHeight,
-      scrollX,
-      vpWidth,
-    );
-    const visibleSet = new Set(visiblePages);
-
-    // 벗어난 페이지 해제
-    const prefetchSet = new Set(prefetchPages);
-    for (const pageIdx of this.canvasPool.activePages) {
-      if (!prefetchSet.has(pageIdx)) {
-        this.cancelPendingTextEditRefresh(pageIdx);
-        this.cancelTextEditStaticLayerVerification(pageIdx);
-        this.pageRenderer.cancelReRender(pageIdx);
-        this.pageRenderer.removePageLayers(this.scrollContent, pageIdx);
-        this.pageRenderer.releasePageDiagnostics(pageIdx);
-        this.removeGridOverlay(pageIdx);
-        this.canvasPool.release(pageIdx);
-      }
+    if (scrollY !== this.lastScrollY) {
+      this.scrollDirection = scrollY > this.lastScrollY ? 1 : -1;
+      this.lastScrollY = scrollY;
     }
 
-    // 현재 보이는 페이지는 즉시 렌더한다. 인접 페이지는 스크롤 입력 뒤에 처리한다.
+    const snapshot = this.virtualScroll.getVisibilitySnapshot(
+      scrollY,
+      vpHeight,
+      scrollX,
+      vpWidth,
+    );
+    const work = this.virtualScroll.getWorkSet(snapshot, this.scrollDirection);
+    const visiblePages = snapshot.visiblePages;
+    const prefetchPages = work.prefetch;
+    const visibleSet = new Set(visiblePages);
+    this.currentVisiblePages = visiblePages;
+    const epoch = this.pageRenderScheduler.beginFrame();
+    this.cancelPendingPrefetch();
+
+    const protect = new Set(visiblePages);
+    this.pageSurfaceLru.evictToBudget(
+      (pageIdx) => this.releaseRenderedPage(pageIdx),
+      protect,
+    );
+
+    const missingVisible: number[] = [];
     for (const pageIdx of visiblePages) {
       this.pendingPrefetchPages.delete(pageIdx);
-      if (!this.canvasPool.has(pageIdx)) {
-        this.renderPage(pageIdx);
-      }
+      if (!this.isSurfaceCacheHit(pageIdx)) missingVisible.push(pageIdx);
     }
+
+    const budget = this.firstVisiblePaintDone
+      ? syncVisibleRenderBudget(this.virtualScroll.getColumns(), missingVisible.length)
+      : missingVisible.length <= 2
+        ? missingVisible.length
+        : syncVisibleRenderBudget(this.virtualScroll.getColumns(), missingVisible.length);
+    const syncPages = missingVisible.slice(0, budget);
+    const deferredVisible = missingVisible.slice(budget);
+    for (const pageIdx of syncPages) {
+      this.renderRetainedPage(pageIdx);
+    }
+    if (syncPages.length > 0 || missingVisible.length === 0) {
+      this.firstVisiblePaintDone = true;
+    }
+    if (deferredVisible.length > 0) {
+      this.pageRenderScheduler.scheduleVisible(deferredVisible, epoch, (pageIdx) => {
+        if (!this.isSurfaceCacheHit(pageIdx)) this.renderRetainedPage(pageIdx);
+      });
+    }
+
     this.schedulePrefetchPages(prefetchPages.filter((pageIdx) => !visibleSet.has(pageIdx)));
 
-    this.currentVisiblePages = visiblePages;
     this.updateActivePageSnapshot();
+  }
+
+  private surfaceCacheKeyFor(pageIdx: number): string {
+    const pageInfo = this.pages[pageIdx];
+    const zoom = this.viewportManager.getZoom();
+    const rawDpr = (typeof window !== 'undefined' && window.devicePixelRatio) || 1;
+    const scale = pageInfo ? clampRenderScale(pageInfo, zoom * rawDpr) : zoom;
+    const backend = this.pageRenderer.getBackend();
+    const revision = this.rendererSession.diagnostics()?.documentRevision ?? 0;
+    return pageSurfaceCacheKey({
+      pageIdx,
+      revision,
+      backend,
+      renderScaleTier: quantizeRenderScaleTier(scale),
+    });
+  }
+
+  private isSurfaceCacheHit(pageIdx: number): boolean {
+    if (!this.canvasPool.has(pageIdx)) return false;
+    return this.pageSurfaceLru.touch(pageIdx, this.surfaceCacheKeyFor(pageIdx));
+  }
+
+  private renderRetainedPage(pageIdx: number): void {
+    const key = this.surfaceCacheKeyFor(pageIdx);
+    const existing = this.canvasPool.getCanvas(pageIdx);
+    if (existing && this.pageSurfaceLru.has(pageIdx, key)) return;
+    if (existing) {
+      if (!this.renderCanvas(pageIdx, existing)) {
+        this.releaseRenderedPage(pageIdx);
+        return;
+      }
+    } else {
+      this.renderPage(pageIdx);
+    }
+    this.rememberSurface(pageIdx);
+  }
+
+  private rememberSurface(pageIdx: number): void {
+    const canvas = this.canvasPool.getCanvas(pageIdx);
+    if (!canvas) return;
+    this.pageSurfaceLru.put(
+      pageIdx,
+      this.surfaceCacheKeyFor(pageIdx),
+      Math.max(1, canvas.width) * Math.max(1, canvas.height),
+      (victim) => {
+        if (victim !== pageIdx) this.releaseRenderedPage(victim);
+      },
+      new Set(this.currentVisiblePages),
+    );
+  }
+
+  private releaseRenderedPage(pageIdx: number): void {
+    this.cancelPendingTextEditRefresh(pageIdx);
+    this.cancelTextEditStaticLayerVerification(pageIdx);
+    this.pageRenderer.cancelReRender(pageIdx);
+    this.pageRenderer.removePageLayers(this.scrollContent, pageIdx);
+    this.pageRenderer.releasePageDiagnostics(pageIdx);
+    this.removeGridOverlay(pageIdx);
+    this.canvasPool.release(pageIdx);
+    this.pageSurfaceLru.remove(pageIdx);
   }
 
   private pageIndexFromPayload(payload: unknown): number | null {
@@ -572,17 +661,21 @@ export class CanvasView {
       if (!candidateSet.has(pageIdx)) this.pendingPrefetchPages.delete(pageIdx);
     }
     for (const pageIdx of pageIndices) {
-      if (!this.canvasPool.has(pageIdx)) this.pendingPrefetchPages.add(pageIdx);
+      if (!this.isSurfaceCacheHit(pageIdx)) this.pendingPrefetchPages.add(pageIdx);
     }
     if (this.pendingPrefetchPages.size === 0 || this.deferredPrefetchTask !== null) return;
+    this.armPrefetchCallback();
+  }
 
+  private armPrefetchCallback(): void {
     const run = () => {
       this.deferredPrefetchTask = null;
-      const pages = Array.from(this.pendingPrefetchPages);
-      this.pendingPrefetchPages.clear();
-      for (const pageIdx of pages) {
-        if (!this.canvasPool.has(pageIdx)) this.renderPage(pageIdx);
-      }
+      const next = this.pendingPrefetchPages.values().next();
+      if (next.done) return;
+      const pageIdx = next.value;
+      this.pendingPrefetchPages.delete(pageIdx);
+      if (!this.isSurfaceCacheHit(pageIdx)) this.renderRetainedPage(pageIdx);
+      if (this.pendingPrefetchPages.size > 0) this.armPrefetchCallback();
     };
     const idleWindow = window as IdleCallbackWindow;
     if (typeof idleWindow.requestIdleCallback === 'function') {
@@ -599,6 +692,7 @@ export class CanvasView {
   }
 
   private cancelPendingPrefetch(): void {
+    this.pageRenderScheduler.cancelVisible();
     const task = this.deferredPrefetchTask;
     this.deferredPrefetchTask = null;
     this.pendingPrefetchPages.clear();
@@ -1078,6 +1172,7 @@ export class CanvasView {
     if (hadActivePage) this.eventBus.emit('active-page-changed', null);
     if (hadFocusedPage) this.eventBus.emit('focused-page-changed', null);
     this.pages = [];
+    this.firstVisiblePaintDone = false;
     this.scrollContent.replaceChildren();
     this.blankPagePlaceholder = null;
   }
@@ -1087,6 +1182,7 @@ export class CanvasView {
     this.pageRenderer.removeAllPageLayers(this.scrollContent);
     this.removeAllGridOverlays();
     this.canvasPool.releaseAll();
+    this.pageSurfaceLru.clear();
   }
 
   private refreshGridOverlays(): void {

--- a/rhwp-studio/src/view/page-render-scheduler.ts
+++ b/rhwp-studio/src/view/page-render-scheduler.ts
@@ -1,0 +1,90 @@
+export const MULTI_COLUMN_SYNC_RENDER_BUDGET = 1;
+
+export interface SchedulerHost {
+  requestAnimationFrame(callback: (time: number) => void): number;
+  cancelAnimationFrame(id: number): void;
+}
+
+function defaultHost(): SchedulerHost {
+  const raf = globalThis.requestAnimationFrame?.bind(globalThis);
+  const caf = globalThis.cancelAnimationFrame?.bind(globalThis);
+  if (raf && caf) {
+    return { requestAnimationFrame: raf, cancelAnimationFrame: caf };
+  }
+  return {
+    requestAnimationFrame: (callback) => globalThis.setTimeout(() => callback(0), 0) as unknown as number,
+    cancelAnimationFrame: (id) => globalThis.clearTimeout(id),
+  };
+}
+
+/**
+ * 단일/두 쪽은 보이는 쪽을 한 프레임에서 모두 그려 첫 페인트가 기준선보다
+ * 나빠지지 않게 한다. 한 행 여러 쪽(3열 이상)은 한 slice에 1페이지만 동기 렌더한다.
+ */
+export function syncVisibleRenderBudget(columns: number, missingVisibleCount: number): number {
+  if (missingVisibleCount <= 0) return 0;
+  if (columns <= 2) return missingVisibleCount;
+  return Math.min(MULTI_COLUMN_SYNC_RENDER_BUDGET, missingVisibleCount);
+}
+
+/**
+ * 가시 페이지 후속 작업을 rAF slice로 나눈다. 새 프레임(generation)이 오면
+ * 이전 slice는 버리고, 취소된 콜백은 render를 호출하지 않는다.
+ */
+export class PageRenderScheduler {
+  private generation = 0;
+  private visibleRaf: number | null = null;
+  private visibleQueue: number[] = [];
+  private readonly host: SchedulerHost;
+
+  constructor(host?: SchedulerHost) {
+    this.host = host ?? defaultHost();
+  }
+
+  beginFrame(): number {
+    this.generation += 1;
+    this.cancelVisible();
+    return this.generation;
+  }
+
+  currentGeneration(): number {
+    return this.generation;
+  }
+
+  cancelVisible(): void {
+    if (this.visibleRaf !== null) {
+      this.host.cancelAnimationFrame(this.visibleRaf);
+      this.visibleRaf = null;
+    }
+    this.visibleQueue = [];
+  }
+
+  pendingVisibleCount(): number {
+    return this.visibleQueue.length;
+  }
+
+  scheduleVisible(
+    pages: readonly number[],
+    generation: number,
+    render: (pageIdx: number) => void,
+  ): void {
+    this.visibleQueue = pages.slice();
+    const tick = (time: number) => {
+      void time;
+      this.visibleRaf = null;
+      if (generation !== this.generation) {
+        this.visibleQueue = [];
+        return;
+      }
+      const pageIdx = this.visibleQueue.shift();
+      if (pageIdx === undefined) return;
+      render(pageIdx);
+      if (this.visibleQueue.length > 0) {
+        this.visibleRaf = this.host.requestAnimationFrame(tick);
+      }
+    };
+    if (this.visibleQueue.length > 0) {
+      this.visibleRaf = this.host.requestAnimationFrame(tick);
+    }
+  }
+}

--- a/rhwp-studio/src/view/page-surface-lru.ts
+++ b/rhwp-studio/src/view/page-surface-lru.ts
@@ -1,0 +1,171 @@
+/** clampRenderScale 페이지 상한과 같은 픽셀 단위. 총 surface 예산의 studio 기본값. */
+export const PAGE_SURFACE_PIXEL_CAP = 67_108_864;
+
+/** 고정 행 수가 아니라 픽셀 예산으로 eviction한다. RGBA 바이트 = 픽셀 × 4. */
+export const TOTAL_SURFACE_PIXEL_BUDGET = PAGE_SURFACE_PIXEL_CAP;
+
+export interface PageSurfaceCacheKey {
+  pageIdx: number;
+  revision: number | string;
+  backend: string;
+  renderScaleTier: number;
+}
+
+export interface PageSurfaceLruStats {
+  hits: number;
+  misses: number;
+  evictions: number;
+  puts: number;
+  size: number;
+  pixels: number;
+  bytes: number;
+}
+
+export function quantizeRenderScaleTier(scale: number): number {
+  if (!Number.isFinite(scale) || scale <= 0) return 1;
+  return Math.round(scale * 1000) / 1000;
+}
+
+export function pageSurfaceCacheKey(parts: PageSurfaceCacheKey): string {
+  return `${parts.pageIdx}|${parts.revision}|${parts.backend}|${parts.renderScaleTier}`;
+}
+
+export function estimateSurfaceBytes(pixels: number): number {
+  return Math.max(0, pixels) * 4;
+}
+
+interface SurfaceEntry {
+  pageIdx: number;
+  key: string;
+  pixels: number;
+}
+
+/**
+ * 페이지·revision·backend·renderScale tier를 키로 하는 표면 LRU.
+ * Canvas 소유권은 CanvasPool에 두고, 여기선 키·예산·최근 사용만 추적한다.
+ */
+export class PageSurfaceLru {
+  private readonly budgetPixels: number;
+  private readonly order: string[] = [];
+  private readonly entries = new Map<string, SurfaceEntry>();
+  private readonly byPage = new Map<number, string>();
+  private hits = 0;
+  private misses = 0;
+  private evictions = 0;
+  private puts = 0;
+
+  constructor(budgetPixels = TOTAL_SURFACE_PIXEL_BUDGET) {
+    this.budgetPixels = Math.max(1, budgetPixels);
+  }
+
+  get budget(): number {
+    return this.budgetPixels;
+  }
+
+  has(pageIdx: number, key: string): boolean {
+    return this.byPage.get(pageIdx) === key;
+  }
+
+  touch(pageIdx: number, key: string): boolean {
+    if (!this.has(pageIdx, key)) {
+      this.misses += 1;
+      return false;
+    }
+    this.hits += 1;
+    this.moveToRecent(key);
+    return true;
+  }
+
+  put(
+    pageIdx: number,
+    key: string,
+    pixels: number,
+    onEvict: (pageIdx: number) => void,
+    protect: ReadonlySet<number> = new Set(),
+  ): void {
+    const safePixels = Math.max(1, pixels);
+    const previousKey = this.byPage.get(pageIdx);
+    if (previousKey && previousKey !== key) {
+      this.removeKey(previousKey);
+    }
+
+    const existing = this.entries.get(key);
+    if (existing) {
+      existing.pixels = safePixels;
+      this.moveToRecent(key);
+    } else {
+      this.entries.set(key, { pageIdx, key, pixels: safePixels });
+      this.byPage.set(pageIdx, key);
+      this.order.push(key);
+      this.puts += 1;
+    }
+
+    const keep = new Set(protect);
+    keep.add(pageIdx);
+    this.evictToBudget(onEvict, keep);
+  }
+
+  remove(pageIdx: number): void {
+    const key = this.byPage.get(pageIdx);
+    if (key) this.removeKey(key);
+  }
+
+  evictToBudget(onEvict: (pageIdx: number) => void, protect: ReadonlySet<number>): void {
+    let index = 0;
+    while (this.pixelCount() > this.budgetPixels && index < this.order.length) {
+      const key = this.order[index];
+      const entry = this.entries.get(key);
+      if (!entry || protect.has(entry.pageIdx)) {
+        index += 1;
+        continue;
+      }
+      this.removeKey(key);
+      this.evictions += 1;
+      onEvict(entry.pageIdx);
+    }
+  }
+
+  clear(): void {
+    this.order.length = 0;
+    this.entries.clear();
+    this.byPage.clear();
+  }
+
+  stats(): PageSurfaceLruStats {
+    const pixels = this.pixelCount();
+    return {
+      hits: this.hits,
+      misses: this.misses,
+      evictions: this.evictions,
+      puts: this.puts,
+      size: this.entries.size,
+      pixels,
+      bytes: estimateSurfaceBytes(pixels),
+    };
+  }
+
+  private pixelCount(): number {
+    let total = 0;
+    for (const entry of this.entries.values()) total += entry.pixels;
+    return total;
+  }
+
+  private moveToRecent(key: string): void {
+    const index = this.order.indexOf(key);
+    if (index < 0) {
+      this.order.push(key);
+      return;
+    }
+    this.order.splice(index, 1);
+    this.order.push(key);
+  }
+
+  private removeKey(key: string): void {
+    const entry = this.entries.get(key);
+    if (!entry) return;
+    this.entries.delete(key);
+    if (this.byPage.get(entry.pageIdx) === key) this.byPage.delete(entry.pageIdx);
+    const index = this.order.indexOf(key);
+    if (index >= 0) this.order.splice(index, 1);
+  }
+}

--- a/rhwp-studio/src/view/ruler.ts
+++ b/rhwp-studio/src/view/ruler.ts
@@ -1,7 +1,7 @@
 import { EventBus } from '@/core/event-bus';
 import { WasmBridge } from '@/core/wasm-bridge';
 import type { ParaProperties } from '@/core/types';
-import { VirtualScroll } from './virtual-scroll';
+import { uniqueRowIndices, VirtualScroll } from './virtual-scroll';
 import { ViewportManager } from './viewport-manager';
 import {
   horizontalPinCommit,
@@ -709,7 +709,21 @@ export class Ruler {
 
     // 가로 눈금자와 같은 마지막 편집 focus 쪽 한 장만 그린다. 저배율에서 보이는 모든
     // 페이지의 숫자를 반복하면 세로 눈금자가 다시 한 덩어리로 뭉치고 #6107 focus 계약도 깨진다.
-    const pageIdx = activePageIdx;
+    // 그리드의 같은 visible row는 열 수만큼 반복하지 않는다 (#6042).
+    const snapshot = this.virtualScroll.peekVisibilitySnapshot();
+    const candidatePages = snapshot && snapshot.visiblePages.length > 0
+      ? snapshot.visiblePages
+      : [activePageIdx];
+    const visibleRowsOnce = uniqueRowIndices(
+      candidatePages.map((page) => this.virtualScroll.getPageRow(page)),
+    );
+    const focusedRow = this.virtualScroll.getPageRow(activePageIdx);
+    let pageIdx = activePageIdx;
+    for (const row of visibleRowsOnce) {
+      if (row !== focusedRow) continue;
+      pageIdx = activePageIdx;
+      break;
+    }
     this.vPins = [];
     // 격자 보기: 같은 행의 쪽들이 같은 y를 공유해 핀이 겹친다 (가로 눈금자와 같은 이유).
     const gridMode = this.virtualScroll.isGridMode();

--- a/rhwp-studio/src/view/virtual-scroll.ts
+++ b/rhwp-studio/src/view/virtual-scroll.ts
@@ -15,6 +15,49 @@ const PAN_SPACE_RATIO = 0.25;
 const MIN_PAN_SPACE = 80;
 const MAX_PAN_SPACE = 240;
 
+export interface VisibilitySnapshot {
+  scrollY: number;
+  scrollX: number;
+  viewportHeight: number;
+  viewportWidth: number;
+  visiblePages: number[];
+  prefetchPages: number[];
+  visibleRows: number[];
+  firstVisibleRow: number;
+  lastVisibleRow: number;
+  probedRows: number;
+  probedPages: number;
+  computed: boolean;
+}
+
+export interface ViewportWorkSet {
+  visible: number[];
+  prefetch: number[];
+}
+
+/** 같은 행을 열 수만큼 반복하지 않는다. */
+export function uniqueRowIndices(rows: readonly number[]): number[] {
+  const seen = new Set<number>();
+  const out: number[] = [];
+  for (const row of rows) {
+    if (seen.has(row)) continue;
+    seen.add(row);
+    out.push(row);
+  }
+  return out;
+}
+
+function lowerBound(length: number, pred: (index: number) => boolean): number {
+  let lo = 0;
+  let hi = length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (pred(mid)) hi = mid;
+    else lo = mid + 1;
+  }
+  return lo;
+}
+
 export class VirtualScroll {
   private pageOffsets: number[] = [];
   private pageHeights: number[] = [];
@@ -23,12 +66,17 @@ export class VirtualScroll {
   private pageRows: number[] = [];
   private pageColumns: number[] = [];
   private rowPages: number[][] = [];
+  private rowTops: number[] = [];
+  private rowHeights: number[] = [];
   private maxPageWidth = 0;
   private totalHeight = 0;
   private totalWidth = 0;
   private columns = 1;
   private gridMode = false;
   private horizontalMode = false;
+  private layoutGeneration = 0;
+  private lastSnapshot: VisibilitySnapshot | null = null;
+  private lastSnapshotKey = '';
   private readonly pageGapAt100Percent: number;
   private pageGap: number;
 
@@ -47,6 +95,9 @@ export class VirtualScroll {
     viewportHeight = 0,
   ): void {
     this.pageGap = resolvePageGap(zoom, this.pageGapAt100Percent);
+    this.layoutGeneration += 1;
+    this.lastSnapshot = null;
+    this.lastSnapshotKey = '';
     this.pageHeights = pages.map((p) => p.height * zoom);
     this.pageWidths = pages.map((p) => p.width * zoom);
     this.maxPageWidth = Math.max(...this.pageWidths, 0);
@@ -121,6 +172,8 @@ export class VirtualScroll {
       left += this.pageWidths[pageIdx] + this.pageGap;
     }
     this.totalWidth = Math.max(viewportWidth, innerWidth + marginLeft * 2);
+    this.rowTops = this.pageOffsets.length > 0 ? [Math.min(...this.pageOffsets)] : [];
+    this.rowHeights = this.pageHeights.length > 0 ? [Math.max(...this.pageHeights)] : [];
   }
 
   /** 단일 열 배치 (기존 동작) */
@@ -131,6 +184,8 @@ export class VirtualScroll {
     this.pageRows = [];
     this.pageColumns = [];
     this.rowPages = [];
+    this.rowTops = [];
+    this.rowHeights = [];
     let offset = this.pageGap;
     for (let i = 0; i < this.pageHeights.length; i++) {
       this.pageOffsets.push(offset);
@@ -138,6 +193,8 @@ export class VirtualScroll {
       this.pageRows.push(i);
       this.pageColumns.push(0);
       this.rowPages.push([i]);
+      this.rowTops.push(offset);
+      this.rowHeights.push(this.pageHeights[i]);
       offset += this.pageHeights[i] + this.pageGap;
     }
     this.totalHeight = offset;
@@ -179,6 +236,8 @@ export class VirtualScroll {
     this.pageRows = new Array(this.pageHeights.length).fill(0);
     this.pageColumns = new Array(this.pageHeights.length).fill(0);
     this.rowPages = [];
+    this.rowTops = [];
+    this.rowHeights = [];
 
     if (slots.length === 0) {
       this.totalHeight = 0;
@@ -212,6 +271,8 @@ export class VirtualScroll {
     }
 
     const lastRow = rowCount - 1;
+    this.rowTops = rowTops;
+    this.rowHeights = rowHeights;
     this.totalHeight = rowTops[lastRow] + rowHeights[lastRow] + gap;
     this.totalWidth = Math.max(gridWidth + marginLeft * 2, viewportWidth);
   }
@@ -263,28 +324,7 @@ export class VirtualScroll {
     scrollX = 0,
     viewportWidth = 0,
   ): number[] {
-    const vpTop = scrollY;
-    const vpBottom = scrollY + viewportHeight;
-    const vpLeft = scrollX;
-    const vpRight = viewportWidth > 0 ? scrollX + viewportWidth : Infinity;
-    const visible: number[] = [];
-
-    for (let i = 0; i < this.pageOffsets.length; i++) {
-      const pageTop = this.pageOffsets[i];
-      const pageBottom = pageTop + this.pageHeights[i];
-      const pageLeft = this.getPageLeftResolved(i, this.totalWidth);
-      const pageRight = pageLeft + this.pageWidths[i];
-
-      if (
-        pageTop < vpBottom
-        && pageBottom > vpTop
-        && pageLeft < vpRight
-        && pageRight > vpLeft
-      ) {
-        visible.push(i);
-      }
-    }
-    return visible;
+    return this.getVisibilitySnapshot(scrollY, viewportHeight, scrollX, viewportWidth).visiblePages;
   }
 
   /** 프리페치 대상 페이지 (visible 범위 ± 1행) */
@@ -294,27 +334,182 @@ export class VirtualScroll {
     scrollX = 0,
     viewportWidth = 0,
   ): number[] {
-    const visible = this.getVisiblePages(scrollY, viewportHeight, scrollX, viewportWidth);
-    if (visible.length === 0) return [];
+    return this.getVisibilitySnapshot(scrollY, viewportHeight, scrollX, viewportWidth).prefetchPages;
+  }
 
-    const prefetch = new Set(visible);
+  peekVisibilitySnapshot(): VisibilitySnapshot | null {
+    return this.lastSnapshot;
+  }
+
+  /**
+   * 같은 프레임의 CanvasView·쪽 표시·ruler가 공유하는 가시성 스냅샷.
+   * 행 인덱스 이진 탐색으로 계산하고, 같은 뷰포트 키면 재사용한다.
+   */
+  getVisibilitySnapshot(
+    scrollY: number,
+    viewportHeight: number,
+    scrollX = 0,
+    viewportWidth = 0,
+  ): VisibilitySnapshot {
+    const key = `${this.layoutGeneration}|${scrollY}|${viewportHeight}|${scrollX}|${viewportWidth}`;
+    if (this.lastSnapshot && this.lastSnapshotKey === key) {
+      return this.lastSnapshot.computed
+        ? { ...this.lastSnapshot, computed: false }
+        : this.lastSnapshot;
+    }
+    const snapshot = this.computeVisibilitySnapshot(scrollY, viewportHeight, scrollX, viewportWidth);
+    this.lastSnapshot = snapshot;
+    this.lastSnapshotKey = key;
+    return snapshot;
+  }
+
+  /** visible / 진행 방향 prefetch. retention은 표면 LRU가 담당한다. */
+  getWorkSet(snapshot: VisibilitySnapshot, direction: 1 | -1): ViewportWorkSet {
+    const visible = snapshot.visiblePages.slice();
+    const visibleSet = new Set(visible);
+    const extras = snapshot.prefetchPages.filter((pageIdx) => !visibleSet.has(pageIdx));
+    if (extras.length === 0) return { visible, prefetch: extras };
+
+    const firstVisible = visible[0] ?? 0;
+    const lastVisible = visible[visible.length - 1] ?? 0;
+    const toward = extras.filter((pageIdx) => (
+      direction >= 0 ? pageIdx >= lastVisible : pageIdx <= firstVisible
+    ));
+    const away = extras.filter((pageIdx) => !toward.includes(pageIdx));
+    return { visible, prefetch: toward.concat(away) };
+  }
+
+  getPageRow(pageIdx: number): number {
+    return this.pageRows[pageIdx] ?? 0;
+  }
+
+  getRowPageList(row: number): readonly number[] {
+    return this.rowPages[row] ?? [];
+  }
+
+  getRowCount(): number {
+    return this.rowTops.length;
+  }
+
+  private computeVisibilitySnapshot(
+    scrollY: number,
+    viewportHeight: number,
+    scrollX: number,
+    viewportWidth: number,
+  ): VisibilitySnapshot {
+    const empty: VisibilitySnapshot = {
+      scrollY,
+      scrollX,
+      viewportHeight,
+      viewportWidth,
+      visiblePages: [],
+      prefetchPages: [],
+      visibleRows: [],
+      firstVisibleRow: -1,
+      lastVisibleRow: -1,
+      probedRows: 0,
+      probedPages: 0,
+      computed: true,
+    };
+    if (this.pageOffsets.length === 0) return empty;
+
+    const vpTop = scrollY;
+    const vpBottom = scrollY + viewportHeight;
+    const vpLeft = scrollX;
+    const vpRight = viewportWidth > 0 ? scrollX + viewportWidth : Infinity;
+    let probedRows = 0;
+    let probedPages = 0;
+
+    const pageIntersects = (pageIdx: number): boolean => {
+      probedPages += 1;
+      const pageTop = this.pageOffsets[pageIdx];
+      const pageBottom = pageTop + this.pageHeights[pageIdx];
+      const pageLeft = this.getPageLeftResolved(pageIdx, this.totalWidth);
+      const pageRight = pageLeft + this.pageWidths[pageIdx];
+      return pageTop < vpBottom
+        && pageBottom > vpTop
+        && pageLeft < vpRight
+        && pageRight > vpLeft;
+    };
+
+    const visible: number[] = [];
+    const visibleRows: number[] = [];
+    let firstVisibleRow = -1;
+    let lastVisibleRow = -1;
 
     if (this.horizontalMode) {
-      const first = visible[0];
-      const last = visible[visible.length - 1];
-      if (first > 0) prefetch.add(first - 1);
-      if (last + 1 < this.pageCount) prefetch.add(last + 1);
-      return Array.from(prefetch).sort((a, b) => a - b);
+      const n = this.pageOffsets.length;
+      const first = lowerBound(n, (index) => {
+        probedPages += 1;
+        return (this.pageLefts[index] ?? 0) + (this.pageWidths[index] ?? 0) > vpLeft;
+      });
+      const lastExcl = lowerBound(n, (index) => {
+        probedPages += 1;
+        return (this.pageLefts[index] ?? 0) >= vpRight;
+      });
+      for (let pageIdx = first; pageIdx < lastExcl; pageIdx++) {
+        if (pageIntersects(pageIdx)) visible.push(pageIdx);
+      }
+      if (visible.length > 0) {
+        firstVisibleRow = 0;
+        lastVisibleRow = 0;
+        visibleRows.push(0);
+      }
+      probedRows += 1;
+    } else {
+      const rowCount = this.rowTops.length;
+      const firstRow = lowerBound(rowCount, (row) => {
+        probedRows += 1;
+        return this.rowTops[row] + this.rowHeights[row] > vpTop;
+      });
+      const lastRowExcl = lowerBound(rowCount, (row) => {
+        probedRows += 1;
+        return this.rowTops[row] >= vpBottom;
+      });
+      for (let row = firstRow; row < lastRowExcl; row++) {
+        let rowHasVisible = false;
+        for (const pageIdx of this.rowPages[row] ?? []) {
+          if (pageIntersects(pageIdx)) {
+            visible.push(pageIdx);
+            rowHasVisible = true;
+          }
+        }
+        if (rowHasVisible) {
+          visibleRows.push(row);
+          if (firstVisibleRow < 0) firstVisibleRow = row;
+          lastVisibleRow = row;
+        }
+      }
     }
 
-    const visibleRows = visible.map((pageIdx) => this.pageRows[pageIdx] ?? 0);
-    const firstRow = Math.min(...visibleRows);
-    const lastRow = Math.max(...visibleRows);
-    for (const row of [firstRow - 1, lastRow + 1]) {
-      for (const pageIdx of this.rowPages[row] ?? []) prefetch.add(pageIdx);
+    const prefetch = new Set(visible);
+    if (visible.length > 0) {
+      if (this.horizontalMode) {
+        const first = visible[0];
+        const last = visible[visible.length - 1];
+        if (first > 0) prefetch.add(first - 1);
+        if (last + 1 < this.pageCount) prefetch.add(last + 1);
+      } else {
+        for (const row of [firstVisibleRow - 1, lastVisibleRow + 1]) {
+          for (const pageIdx of this.rowPages[row] ?? []) prefetch.add(pageIdx);
+        }
+      }
     }
 
-    return Array.from(prefetch).sort((a, b) => a - b);
+    return {
+      scrollY,
+      scrollX,
+      viewportHeight,
+      viewportWidth,
+      visiblePages: visible,
+      prefetchPages: Array.from(prefetch).sort((a, b) => a - b),
+      visibleRows,
+      firstVisibleRow,
+      lastVisibleRow,
+      probedRows,
+      probedPages,
+      computed: true,
+    };
   }
 
   /** 특정 문서 Y 좌표가 속하는 페이지 인덱스를 반환한다 */
@@ -329,12 +524,14 @@ export class VirtualScroll {
    */
   getPageAtY(docY: number): number {
     if (this.horizontalMode) return 0;
-    for (let i = this.pageOffsets.length - 1; i >= 0; i--) {
-      if (docY >= this.pageOffsets[i]) {
-        return i;
-      }
-    }
-    return 0;
+    const pages = this.rowPages[this.rowIndexAtY(docY)];
+    return pages && pages.length > 0 ? pages[pages.length - 1] : 0;
+  }
+
+  private rowIndexAtY(docY: number): number {
+    if (this.rowTops.length === 0) return 0;
+    const firstPast = lowerBound(this.rowTops.length, (row) => this.rowTops[row] > docY);
+    return Math.max(0, firstPast - 1);
   }
 
   /**

--- a/rhwp-studio/tests/canvas-view-page-arrangement.test.ts
+++ b/rhwp-studio/tests/canvas-view-page-arrangement.test.ts
@@ -110,7 +110,7 @@ test('가로 쪽 이동은 배치와 함께 한 번에 전환하고 가로 가�
   );
   assert.match(
     canvasViewSource,
-    /getVisiblePages\([\s\S]*?scrollX,[\s\S]*?vpWidth/,
+    /getVisibilitySnapshot\([\s\S]*?scrollX,[\s\S]*?vpWidth/,
   );
   const method = classMethodSource('setPageViewSettings', 'getViewportManager');
   assert.match(method, /resolvePageViewSettings/);

--- a/rhwp-studio/tests/page-render-scheduler.test.ts
+++ b/rhwp-studio/tests/page-render-scheduler.test.ts
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import {
+  PageRenderScheduler,
+  syncVisibleRenderBudget,
+  type SchedulerHost,
+} from '../src/view/page-render-scheduler.ts';
+
+test('단일·두 쪽 첫 페인트는 보이는 쪽을 한 프레임에서 모두 그린다', () => {
+  assert.equal(syncVisibleRenderBudget(1, 1), 1);
+  assert.equal(syncVisibleRenderBudget(2, 2), 2);
+  assert.equal(syncVisibleRenderBudget(4, 4), 1, '한 행 여러 쪽은 slice');
+  assert.equal(syncVisibleRenderBudget(4, 0), 0);
+});
+
+test('새 스크롤 generation은 남은 visible slice를 버리고 render를 호출하지 않는다', () => {
+  const frames: Array<(time: number) => void> = [];
+  const host: SchedulerHost = {
+    requestAnimationFrame(callback) {
+      frames.push(callback);
+      return frames.length;
+    },
+    cancelAnimationFrame() {
+      frames.length = 0;
+    },
+  };
+  const scheduler = new PageRenderScheduler(host);
+  const rendered: number[] = [];
+  const gen1 = scheduler.beginFrame();
+  scheduler.scheduleVisible([10, 11, 12], gen1, (pageIdx) => rendered.push(pageIdx));
+
+  assert.equal(frames.length, 1);
+  frames[0](0);
+  assert.deepEqual(rendered, [10]);
+  assert.equal(scheduler.pendingVisibleCount(), 2);
+
+  const gen2 = scheduler.beginFrame();
+  assert.equal(scheduler.pendingVisibleCount(), 0);
+  assert.notEqual(gen2, gen1);
+
+  scheduler.scheduleVisible([20], gen2, (pageIdx) => rendered.push(pageIdx));
+  assert.equal(frames.length, 1);
+  frames[0](0);
+  assert.deepEqual(rendered, [10, 20]);
+});
+
+test('일반 휠은 Ctrl/Meta 없이 zoom을 바꾸지 않는다', () => {
+  const source = readFileSync(new URL('../src/view/viewport-manager.ts', import.meta.url), 'utf8');
+  const wheel = source.slice(source.indexOf('private onWheel'), source.indexOf('private wheelDeltaPixels'));
+  assert.match(wheel, /if \(!e\.ctrlKey && !e\.metaKey\)/);
+  const zoomCall = wheel.indexOf('smoothZoomTo');
+  const modifierReturn = wheel.indexOf('return;');
+  assert.ok(zoomCall > modifierReturn, 'Ctrl/Meta가 없는 경로는 zoom 호출 전에 return해야 한다');
+});

--- a/rhwp-studio/tests/page-surface-lru.test.ts
+++ b/rhwp-studio/tests/page-surface-lru.test.ts
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  estimateSurfaceBytes,
+  pageSurfaceCacheKey,
+  PageSurfaceLru,
+  quantizeRenderScaleTier,
+  TOTAL_SURFACE_PIXEL_BUDGET,
+} from '../src/view/page-surface-lru.ts';
+
+test('같은 page/revision/backend/tier 왕복은 render 없이 cache hit가 난다', () => {
+  const lru = new PageSurfaceLru(10_000);
+  const evicted: number[] = [];
+  const onEvict = (pageIdx: number) => evicted.push(pageIdx);
+  const key = (pageIdx: number, revision = 1, scale = 2) => pageSurfaceCacheKey({
+    pageIdx,
+    revision,
+    backend: 'canvas2d',
+    renderScaleTier: quantizeRenderScaleTier(scale),
+  });
+
+  lru.put(4, key(4), 1000, onEvict);
+  lru.put(5, key(5), 1000, onEvict);
+  assert.equal(lru.touch(4, key(4)), true);
+  assert.equal(lru.touch(5, key(5)), true);
+  assert.equal(lru.touch(4, key(4, 2)), false, 'revision이 바뀌면 miss');
+  assert.equal(lru.touch(4, key(4, 1, 3)), false, 'renderScale tier가 바뀌면 miss');
+  assert.deepEqual(evicted, []);
+  assert.equal(lru.stats().hits, 2);
+  assert.equal(lru.stats().misses, 2);
+});
+
+test('eviction은 고정 행 수가 아니라 surface 픽셀 예산을 따른다', () => {
+  const lru = new PageSurfaceLru(3_000);
+  const evicted: number[] = [];
+  const keyOf = (pageIdx: number) => pageSurfaceCacheKey({
+    pageIdx,
+    revision: 1,
+    backend: 'canvaskit',
+    renderScaleTier: 1,
+  });
+
+  lru.put(0, keyOf(0), 1000, (pageIdx) => evicted.push(pageIdx), new Set([2]));
+  lru.put(1, keyOf(1), 1000, (pageIdx) => evicted.push(pageIdx), new Set([2]));
+  lru.put(2, keyOf(2), 1000, (pageIdx) => evicted.push(pageIdx), new Set([2]));
+  lru.put(3, keyOf(3), 1000, (pageIdx) => evicted.push(pageIdx), new Set([2]));
+
+  assert.ok(evicted.includes(0) || evicted.includes(1) || evicted.includes(3));
+  assert.equal(evicted.includes(2), false, 'visible 페이지는 예산이 넘어도 유지');
+  assert.ok(lru.stats().pixels <= 3_000 || lru.has(2, keyOf(2)));
+  assert.equal(estimateSurfaceBytes(1000), 4000);
+  assert.equal(TOTAL_SURFACE_PIXEL_BUDGET, 67_108_864);
+});
+
+test('문서 변경 키와 dispose clear는 이전 표면을 버린다', () => {
+  const lru = new PageSurfaceLru(8_000);
+  const key1 = pageSurfaceCacheKey({
+    pageIdx: 0, revision: 1, backend: 'canvas2d', renderScaleTier: 1,
+  });
+  const key2 = pageSurfaceCacheKey({
+    pageIdx: 0, revision: 2, backend: 'canvas2d', renderScaleTier: 1,
+  });
+  lru.put(0, key1, 1000, () => {});
+  assert.equal(lru.has(0, key1), true);
+  lru.put(0, key2, 1000, () => {});
+  assert.equal(lru.has(0, key1), false);
+  assert.equal(lru.has(0, key2), true);
+  lru.clear();
+  assert.equal(lru.has(0, key2), false);
+  assert.equal(lru.stats().size, 0);
+});

--- a/rhwp-studio/tests/page-visibility-snapshot.test.ts
+++ b/rhwp-studio/tests/page-visibility-snapshot.test.ts
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import {
+  uniqueRowIndices,
+  VirtualScroll,
+} from '../src/view/virtual-scroll.ts';
+
+function pages(n: number, width = 800, height = 1000) {
+  return Array.from({ length: n }, () => ({ width, height })) as never;
+}
+
+test('행 인덱스 이진 탐색은 100쪽 그리드에서 전체 페이지를 선형 스캔하지 않는다', () => {
+  const scroll = new VirtualScroll(10);
+  scroll.setPageDimensions(
+    pages(100),
+    0.4,
+    4000,
+    { kind: 'multiple', columns: 4, rows: 2 },
+  );
+  assert.equal(scroll.getColumns(), 4);
+  assert.equal(scroll.getRowCount(), 25);
+
+  const rowHeight = scroll.getPageHeight(0) + scroll.getPageGap();
+  const snapshot = scroll.getVisibilitySnapshot(rowHeight * 10, 200, 0, 4000);
+
+  assert.deepEqual(snapshot.visiblePages, [40, 41, 42, 43]);
+  assert.deepEqual(snapshot.visibleRows, [10]);
+  assert.ok(snapshot.probedRows < 20, `행 이진 탐색이어야 한다 (실제 ${snapshot.probedRows})`);
+  assert.ok(snapshot.probedPages < 20, `보이는 행의 페이지만 조사해야 한다 (실제 ${snapshot.probedPages})`);
+  assert.equal(snapshot.computed, true);
+});
+
+test('같은 뷰포트 키의 getVisiblePages·getPrefetchPages는 스냅샷을 재사용한다', () => {
+  const scroll = new VirtualScroll(10);
+  scroll.setPageDimensions(pages(40), 0.4, 4000, { kind: 'multiple', columns: 4, rows: 2 });
+
+  const first = scroll.getVisibilitySnapshot(0, 200, 0, 4000);
+  const visible = scroll.getVisiblePages(0, 200, 0, 4000);
+  const prefetch = scroll.getPrefetchPages(0, 200, 0, 4000);
+  const second = scroll.getVisibilitySnapshot(0, 200, 0, 4000);
+
+  assert.deepEqual(visible, [0, 1, 2, 3]);
+  assert.deepEqual(visible, first.visiblePages);
+  assert.deepEqual(prefetch, first.prefetchPages);
+  assert.equal(second.computed, false);
+  assert.equal(second.probedPages, first.probedPages);
+  assert.deepEqual(prefetch, [0, 1, 2, 3, 4, 5, 6, 7]);
+});
+
+test('스크롤 방향 작업 집합은 진행 쪽 prefetch를 앞에 둔다', () => {
+  const scroll = new VirtualScroll(10);
+  scroll.setPageDimensions(pages(12), 0.4, 4000, { kind: 'multiple', columns: 4, rows: 2 });
+  const snapshot = scroll.getVisibilitySnapshot(0, 200, 0, 4000);
+  assert.deepEqual(snapshot.visiblePages, [0, 1, 2, 3]);
+
+  const down = scroll.getWorkSet(snapshot, 1);
+  const up = scroll.getWorkSet(snapshot, -1);
+  assert.deepEqual(down.visible, [0, 1, 2, 3]);
+  assert.deepEqual(down.prefetch, [4, 5, 6, 7]);
+  assert.deepEqual(up.prefetch, [4, 5, 6, 7]);
+});
+
+test('uniqueRowIndices는 그리드 한 행의 열 중복을 한 번으로 접는다', () => {
+  assert.deepEqual(uniqueRowIndices([2, 2, 2, 2, 3, 3]), [2, 3]);
+});
+
+test('getPageAtY 행 이진 탐색은 행의 마지막 쪽을 유지한다', () => {
+  const scroll = new VirtualScroll(10);
+  scroll.setPageDimensions(pages(9), 0.4, 4000, { kind: 'multiple', columns: 3, rows: 2 });
+  const y = scroll.getPageOffset(3);
+  assert.equal(scroll.getPageAtY(y), 5);
+  assert.equal(scroll.getRowFirstPageAtY(y), 3);
+});
+
+test('CanvasView는 가시성 스냅샷과 행 단위 세로 눈금자를 쓴다', () => {
+  const view = readFileSync(new URL('../src/view/canvas-view.ts', import.meta.url), 'utf8');
+  const ruler = readFileSync(new URL('../src/view/ruler.ts', import.meta.url), 'utf8');
+  assert.match(view, /getVisibilitySnapshot\(/);
+  assert.match(view, /pageSurfaceLru/);
+  assert.match(view, /pageRenderScheduler/);
+  assert.match(view, /syncVisibleRenderBudget/);
+  assert.doesNotMatch(view, /prefetchSet\.has\(pageIdx\)/);
+  assert.match(view, /for \(const pageIdx of visiblePages\)/);
+  assert.match(view, /this\.schedulePrefetchPages\(prefetchPages\.filter/);
+  assert.match(view, /requestIdleCallback\(run, \{ timeout: 1000 \}\)/);
+  assert.match(view, /cancelPendingPrefetch\(\)/);
+  assert.match(ruler, /uniqueRowIndices/);
+  assert.match(ruler, /peekVisibilitySnapshot/);
+});


### PR DESCRIPTION
## 요약

페이지가 많은 문서를 한 행 여러 쪽으로 스크롤할 때 새 행의 여러 페이지를 한 번에 동기 렌더하고, 화면 밖으로 나간 Canvas를 즉시 버려 짧은 왕복마다 다시 래스터하던 경로를 고칩니다. 새 캔버스 엔진을 만들지 않고 기존 `VirtualScroll`·`CanvasPool`·`CanvasView` 위에 행 인덱스·표면 LRU·스케줄러만 얹었습니다.

## 변경

- `VirtualScroll`이 행 top/height 인덱스를 유지하고 첫/마지막 visible row를 이진 탐색합니다. `getVisiblePages`/`getPrefetchPages`는 같은 프레임의 `getVisibilitySnapshot()`을 공유합니다.
- 작업 집합을 `visible` / 진행 방향 `prefetch` / LRU `retention`으로 나눕니다. 화면 밖 페이지를 prefetch ±1행 밖으로 나가자마자 제거하지 않습니다.
- 페이지·revision·backend·renderScale tier를 키로 하는 표면 LRU를 둡니다. eviction은 고정 행 수가 아니라 `clampRenderScale`과 같은 67,108,864 픽셀 예산을 따릅니다.
- 단일/두 쪽은 보이는 쪽을 한 프레임에서 모두 그려 첫 페인트를 유지하고, 3열 이상은 한 slice에 1페이지만 동기 렌더한 뒤 나머지는 rAF로 나눕니다.
- prefetch는 idle callback마다 한 페이지만 진행합니다. 새 스크롤은 generation을 올려 stale slice/prefetch를 취소하며, 취소된 작업은 zoom을 바꾸지 않습니다.
- 세로 눈금자는 공유 스냅샷의 행을 `uniqueRowIndices`로 접어 같은 visible row를 열 수만큼 그리지 않고, 기하는 포커스 쪽(#6107)을 유지합니다.
- Ctrl/Meta가 없는 일반 휠은 기존처럼 문서 zoom을 변경하지 않습니다.

## 수용 기준

- [x] 가시성 판정은 전체 페이지 중복 선형 탐색이 아니라 행 인덱스 한 번
- [x] warm-up 후 같은 page/revision/backend/tier 왕복은 cache hit, `renderPage` 반복 없음
- [x] 한 행 여러 쪽의 새 행 진입은 scheduler budget으로 분할
- [x] 새 스크롤이 stale prefetch보다 우선, 취소된 작업이 zoom을 바꾸지 않음
- [x] Ctrl/Meta 없는 일반 스크롤은 문서 zoom을 변경하지 않음
- [x] 세로 눈금자는 동일 visible row를 중복 렌더하지 않음
- [x] 단일 쪽/두 쪽의 초기 동기 `renderPage` 수는 기준선과 같거나 더 적음

## 검증

- [x] `cargo fmt --all -- --check` — 해당 없음 (TypeScript/studio만, rustc 없음)
- [x] `node --experimental-strip-types --test` 관련 스튜디오 테스트 57건 통과

Closes #6042
