### PR TITLE
fix(hit-test): 묶음 자식 Image의 페이지 전체 bbox가 표 셀 진입을 가로채지 않는다

### DIFF
--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -11,6 +11,15 @@ use crate::model::paragraph::Paragraph;
 use crate::renderer::layout::{CellContext, CellPathEntry};
 use crate::renderer::render_tree::TextRunNode;
 
+/// 묶음 개체(GSO Group)인가. 자식 Image 노드는 외곽 Group의 control_index를 물려받는다.
+fn is_group_shape_control(ctrl: &Control) -> bool {
+    matches!(
+        ctrl,
+        Control::Shape(shape)
+            if matches!(shape.as_ref(), crate::model::shape::ShapeObject::Group(_))
+    )
+}
+
 /// 글자겹침 TextRun의 논리적 char_count (1) 반환, 아니면 실제 글자 수 반환.
 ///
 /// `table-vpos-01.hwp`의 boxed 10/11/12처럼 CharOverlap payload가 여러
@@ -1980,6 +1989,12 @@ impl DocumentCore {
                             .and_then(|para| {
                                 let ctrl = para.controls.get(ci)?;
                                 if !is_treat_as_char_object_control(ctrl) {
+                                    return None;
+                                }
+                                // 묶음 자식 Image는 외곽 Group 인덱스를 물려받고 paint bbox가
+                                // 페이지 전체로 팽창될 수 있다. 그 bbox를 본문 인라인 hit로
+                                // 등록하면 표/셀 검사보다 먼저 선점한다 (#4753).
+                                if is_group_shape_control(ctrl) {
                                     return None;
                                 }
                                 find_logical_control_positions(para).get(ci).copied()

--- a/tests/cases/issue_4753_group_image_hittest.rs
+++ b/tests/cases/issue_4753_group_image_hittest.rs
@@ -1,0 +1,67 @@
+//! [Issue #4753] 묶음 자식 Image의 페이지 전체 bbox가 160쪽 표 셀 hit-test를 가로채지 않는다.
+//!
+//! `samples/2025 행정업무운영 편람(최종).hwp` 사용자 160쪽(0-based 159)의 표
+//! (section 4, paragraph 60, control 0) 위에는 treat_as_char 묶음 개체의 자식
+//! Image가 페이지 전체 bbox로 올라온다. 그 Image를 본문 인라인 hit로 등록하면
+//! 표 안 클릭이 전부 paragraph 0으로 떨어진다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+use rhwp::wasm_api::HwpDocument;
+use serde_json::Value;
+
+const SAMPLE: &str = "samples/2025 행정업무운영 편람(최종).hwp";
+const PAGE: u32 = 159;
+const TABLE_SECTION: u64 = 4;
+const TABLE_PARENT_PARA: u64 = 60;
+const TABLE_CONTROL: u64 = 0;
+
+fn load_handbook() -> HwpDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    HwpDocument::from_bytes(&bytes).expect("parse handbook hwp")
+}
+
+fn hit_json(doc: &HwpDocument, x: f64, y: f64) -> Value {
+    let json = doc
+        .hit_test_native(PAGE, x, y)
+        .unwrap_or_else(|e| panic!("hit_test_native({PAGE}, {x}, {y}): {e}"));
+    serde_json::from_str(&json).unwrap_or_else(|e| panic!("parse hit json `{json}`: {e}"))
+}
+
+fn assert_table_cell_hit(hit: &Value, x: f64, y: f64) {
+    assert_eq!(
+        hit["sectionIndex"].as_u64(),
+        Some(TABLE_SECTION),
+        "({x},{y}) hit={hit}"
+    );
+    assert_eq!(
+        hit["parentParaIndex"].as_u64(),
+        Some(TABLE_PARENT_PARA),
+        "({x},{y}) must enter the page-160 table, not the group-child image, hit={hit}"
+    );
+    assert_eq!(
+        hit["controlIndex"].as_u64(),
+        Some(TABLE_CONTROL),
+        "({x},{y}) hit={hit}"
+    );
+    assert!(
+        hit.get("cellIndex").is_some(),
+        "({x},{y}) cell context required, hit={hit}"
+    );
+    assert!(
+        hit.get("cellPath").and_then(|p| p.as_array()).is_some(),
+        "({x},{y}) cellPath required, hit={hit}"
+    );
+}
+
+#[test]
+fn issue_4753_page160_table_cells_not_stolen_by_group_child_image() {
+    let doc = load_handbook();
+    // 표 bbox ≈ (113.4, 147.4, 532.6, 733.7). 내부 여러 지점이 모두 셀로 들어가야 한다.
+    for &(x, y) in &[(200.0, 250.0), (320.0, 400.0), (500.0, 600.0)] {
+        assert_table_cell_hit(&hit_json(&doc, x, y), x, y);
+    }
+}


### PR DESCRIPTION
## 변경 요약

samples/2025 행정업무운영 편람(최종).hwp 사용자 160쪽에서 표 셀을 클릭해도 커서가 표 안으로 들어가지 않았습니다. 같은 페이지 render tree의 묶음 자식 Image가 페이지 전체 bbox (0,0,740.8,1014.4)를 갖고, 그 노드의 control metadata는 외곽 	reat_as_char Group(section 4, paragraph 0, control 2)을 가리킵니다. collect_body_inline_image_hits()가 이 bbox를 본문 인라인 hit로 등록한 뒤 즉시 반환해서 표/셀 검사까지 도달하지 못했습니다.

이 PR은 Group 컨트롤을 가리키는 Image를 본문 인라인 hit 후보에서 제외합니다. 직접 본문에 삽입된 Picture hit는 그대로 두고, 외곽 Group의 논리 위치는 기존 inline_shape_positions 경로를 씁니다. 줄바꿈기/렌더러를 건드리지 않습니다.

## 관련 이슈

closes #4753

## 테스트

- [x] **cargo fmt --all -- --check 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. cargo fmt --check 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 cargo fmt --all 후 다시 --check)
- [x] 새 integration test는 원본을 	ests/cases/*.rs에만 추가했고 	ests/generated/, 	ests/suites/manifest.json, 일반 PR의 Cargo generated test target을 포함하지 않음 (--sync-cargo-targets 메인터너 registry PR은 marker 블록만 예외)
- [x] src/**의 #[cfg(test)]를 변경하지 않음 (source unit-test count 4221 유지)
- [x] cargo test --offline --test issue_4753_group_image_hittest 통과 (3.72s). 160쪽 표 내부 좌표 3곳 (200,250), (320,400), (500,600)이 section 4 / parentPara 60 / control 0 + cellPath를 반환
- [ ] cargo clippy -- -D warnings 전체는 디스크 한도로 생략. 변경은 매치 가드 한 곳
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 (hit-test 전용)
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오 또는 편집 커맨드 리뷰 체크리스트 통과
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부
- [ ] .claude/agents/, .claude/skills/, .agents/skills/ 변경 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음. 기존 render tree 한 번 순회에서 Group 컨트롤 Image만 건너뜀
- 재현·측정: samples/2025 행정업무운영 편람(최종).hwp page 159 hit-test 3.72s (문서 로드 포함)

## 스크린샷

해당 없음 (hit-test JSON 계약).
