### PR TITLE
문서: HWPX 양식 사전 차단과 재시작 대응 안내

### DIFF
--- a/mydocs/manual/mcp_hwp2024Convert_usage.md
+++ b/mydocs/manual/mcp_hwp2024Convert_usage.md
@@ -262,6 +262,20 @@ status의 terminal 상태는 `succeeded`, `failed`, `expired`다. `succeeded`일
 `failed` 또는 `expired`이면 result blob과 local output은 없으므로 download하지 않는다.
 비동기 start에는 local `output_dir`을 전달하지 않으며 download 단계에서 지정한다.
 
+### 비성공 terminal 상태 대응
+
+`failed`는 입력 문서의 손상만을 뜻하지 않는다. `status`의 `phase`와 `error`를 함께 확인하고,
+같은 `job_id`를 성공으로 가정하거나 결과 저장에 사용하지 않는다.
+
+- `phase: failed`와 `input preflight rejected ...` 오류는 한컴 worker를 시작하기 전에 입력 계약 또는
+  무인 호환성 문제를 발견한 경우다. 아래 사전 차단 절의 종류별 대응을 따른다.
+- `phase: service_restarted`는 service가 queued/running/succeeded job의 결과 blob을 안전하게
+  보관·복구하기 전에 재시작된 경우다. 같은 `job_id`를 반복 조회하거나 download하지 말고, 원본 local
+  input blob으로 새 `start` 요청을 제출한다.
+- 여러 service endpoint를 병렬로 쓰는 client wrapper는 `start`에 성공한 endpoint를 해당 job의
+  `status`와 `download`까지 고정해야 한다. 서로 다른 endpoint에 상태 조회나 결과 저장을 보내면
+  그 서버에는 job journal과 result blob이 없어 `job_id was not found or has expired`가 반환될 수 있다.
+
 ## VS Code MCP 등록
 
 VS Code Chat에서 tool을 사용할 때만 stdio bridge를 등록한다. terminal에서 bridge를 미리 실행해 두지
@@ -494,6 +508,26 @@ input preflight rejected the document: script-enabled HWP with an OnDocument_Ope
 `OnDocument_New`만 있는 문서는 이 정책으로 차단하지 않는다. 이 오류는 파일 구조 손상을 뜻하지 않는다.
 `timeout_seconds`나 engine을 바꿔 재시도하거나 script 실행을 승인하지 말고, 원본 제공자에게 스크립트 없는
 사본을 요청하거나 보안 검토가 가능한 별도 대화형 환경에서 문서 코드를 확인한다.
+
+## HWPX 양식 컨트롤 사전 차단
+
+HWPX의 `Contents/*.xml`에 `checkBtn`, `radioBtn`, `comboBox`, `edit` 양식 컨트롤이 있으면 현재
+배포된 무인 HOffice120/HOffice130 runtime에서 `OpenDocument` access violation이 재현된다. 이 HWPX는
+ZIP·XML 형식이 유효하더라도 손상 문서로 분류하지 않는다. service는 한컴 DLL/WPF를 시작하기 전에
+다음 오류로 job을 끝낸다.
+
+```text
+input preflight rejected the document: HWPX form controls are incompatible with the installed Hancom unattended runtime
+```
+
+암호 HWPX는 password preparation 뒤 평문 temporary package를 다시 검사한다. 이 차단은 HWP 형식의
+양식 컨트롤이나 일반 HWPX에 적용되지 않는다.
+
+이 경우 비동기 job은 `terminal: true`, `status: failed`, `phase: failed`, `output_bytes: 0`이며
+result blob과 local output을 만들지 않는다. `download`를 호출하지 말고, `timeout_seconds` 증가나
+다른 engine으로 같은 HWPX를 재시도하지 않는다. 한컴 runtime 업데이트 뒤 두 engine에서 실제
+open·PDF smoke가 통과하기 전까지는 원본 제공자에게 양식 없는 사본을 요청하거나, 보안 검토가 가능한
+대화형 한컴 환경에서 처리한다.
 
 ## 성공 확인
 

--- a/mydocs/orders/20260830.md
+++ b/mydocs/orders/20260830.md
@@ -52,3 +52,15 @@ date: 2026-08-30
   `Shape(Picture)`·Endnote 해석, verification 증적, 고정 fixture 자기서술을 보정했다. 최신
   `upstream/devel@2deb3dd61` 기준 focused 5/5·CLI catalog 20/20·전체 8,686/8,686과 새 Rust lint 묶음을
   통과했으며 code candidate는 `d8ab820b0`이다.
+
+## HWPX 양식 컨트롤과 비동기 재시작 대응 가이드
+
+- [x] 최신 `upstream/devel@a71ebf214` 위에서 [PR #6456](https://github.com/edwardkim/rhwp/pull/6456)을
+  생성했다. HWPX 양식 컨트롤이 현재 무인 runtime과 호환되지 않아 worker 시작 전 `failed`로 끝나는
+  계약과 암호 HWPX 재검사를 사용자 가이드에 반영했다.
+- [x] `service_restarted`에서는 같은 job ID의 polling/download 대신 원본 local input으로 새 비동기
+  start를 제출하고, 병렬 endpoint wrapper는 start/status/download endpoint를 고정해야 함을 명시했다.
+- [x] 단일 사용자 가이드의 `git diff --check`, 링크·문서 메타데이터 검사와
+  `cargo fmt --all -- --check`를 통과했다. self-review는
+  [PR #6456 검토 문서](../pr/archives/pr_6456_review.md)에 기록했으며, 최신 trailing head의
+  review-only CI와 mergeability를 확인한 뒤 user 승인에 따라 squash merge한다.

--- a/mydocs/pr/archives/pr_6456_review.md
+++ b/mydocs/pr/archives/pr_6456_review.md
@@ -1,0 +1,54 @@
+---
+kind: pr-review
+status: pending-ci
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-30
+pr: 6456
+issue: null
+author: jangster77
+---
+
+# PR #6456 review - HWPX 양식 사전 차단과 재시작 대응 안내
+
+## 라우팅과 metadata
+
+- PR: [#6456](https://github.com/edwardkim/rhwp/pull/6456), base: `devel`.
+- base route: `collaborator_self_merge.md`; modifiers: `intake_and_review.md`,
+  `local_validation.md`, `review_only_fast_pass.md`.
+- 작성자·self-review: `jangster77`; collaborator 본인 PR이므로 reviewer request는 등록하지 않았다.
+- 기준: `upstream/devel@a71ebf2141ae3bd1ca3b5d3ea438bbe3454edaf9`.
+- code candidate: `bd3241519a594778743137c1f93a39fe18c4bd96`.
+- 작성 시점 참고값: Open non-draft, `MERGEABLE`, 1 file, `+34/-0`.
+  `mergeStateStatus=BLOCKED`는 required CI 대기 상태이며, CI 결과와 mergeability는 merge 직전에
+  다시 확인한다.
+
+## 변경 범위와 판단
+
+`mydocs/manual/mcp_hwp2024Convert_usage.md`만 수정한 review-only PR이다.
+
+- HWPX의 `checkBtn`, `radioBtn`, `comboBox`, `edit` 양식 컨트롤은 현재 무인 HOffice120/HOffice130
+  runtime에서 access violation을 재현하지만, 손상 문서가 아니라는 점을 분리했다.
+- 해당 입력은 한컴 worker 전에 `failed`로 끝나며 결과 blob·local output이 없고 download를 호출하지
+  않아야 한다는 계약을 추가했다. 암호 HWPX의 password preparation 후 재검사도 안내한다.
+- `service_restarted`는 같은 job의 반복 polling·download가 아니라 원본 local input으로 새 `start`를
+  제출해야 하는 실패임을 명시했다. 여러 endpoint를 병렬 사용하는 wrapper의 start/status/download
+  endpoint 고정 규칙도 포함했다.
+- server/client source, service 설정, 인증 정보, fixture, PDF 산출물은 변경하지 않는다.
+
+## 로컬 검증
+
+- `git diff --check`: 통과.
+- `python scripts/check_markdown_links.py mydocs/manual/mcp_hwp2024Convert_usage.md`: 통과.
+- `python scripts/check_document_metadata.py`: 통과.
+- `cargo fmt --all`, `cargo fmt --all -- --check`: 통과.
+- 문서 전용 변경이므로 Cargo test, MCP 변환 smoke, visual sweep은 실행하지 않았다. 이번 PR은 runtime
+  동작을 변경하지 않으며, 배포된 service의 실제 비동기 smoke는 별도 `hwp-convert-2024` 작업에서 확인했다.
+
+## 최종 권고와 후속 조건
+
+**조건부 수용.** HWPX 양식 입력을 손상·timeout·일반 재시도와 혼동하지 않도록 하고, service 재시작 뒤
+job 회수 불가 시의 client 동작을 실제 계약에 맞게 설명한다.
+
+- trailing review 기록을 포함한 최신 head의 review-only fast-pass CI와 required aggregate가 성공해야 한다.
+- merge 직전에 최신 head의 `MERGEABLE/CLEAN` 상태를 다시 확인한다.
+- 작업지시자 승인에 따라 squash merge한 뒤 `upstream/devel` 동기화와 브랜치 정리를 수행한다.


### PR DESCRIPTION
## 변경 요약

- HWPX 양식 컨트롤의 무인 runtime 호환성 사전 차단과 결과 대응을 안내합니다.
- 비동기 job의 `service_restarted` 실패 시 재제출 방법과 endpoint 고정 규칙을 명시합니다.

## 검증

- `git diff --check`
- `python scripts/check_markdown_links.py mydocs/manual/mcp_hwp2024Convert_usage.md`
- `python scripts/check_document_metadata.py`
- `cargo fmt --all -- --check`

## 범위

`mydocs/manual/mcp_hwp2024Convert_usage.md`만 수정한 docs-only PR입니다. server/client 동작과 접근 정보는 변경하지 않습니다.
