### PR TITLE
fix(studio): 자동 쪽 배치의 열 선택과 중앙 정렬을 바로잡는다

### DIFF
--- a/mydocs/orders/20260830.md
+++ b/mydocs/orders/20260830.md
@@ -266,6 +266,6 @@ date: 2026-08-30
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| [#6040](https://github.com/edwardkim/rhwp/issues/6040) | 자동 쪽 배치의 줌 토폴로지 commit·중앙 정렬·Canvas 교체 안정화 | 진행중 | [Stage 1](../working/task_m100_6040_stage1.md) `63fa3d0cf` 재구성과 기존 줌 재검증을 승인받았다. 문서 commit 뒤 줌 경로와 분리된 눈금자 끝 라벨 처리(Stage 1.1)를 진행한다. |
+| [#6040](https://github.com/edwardkim/rhwp/issues/6040) | 자동 쪽 배치의 줌 토폴로지 commit·중앙 정렬·Canvas 교체 안정화 | 진행중 | [Stage 1](../working/task_m100_6040_stage1.md) 재구성 문서를 `354b2d417`로 고정했다. [Stage 1.1](../working/task_m100_6040_stage1_1.md) 눈금자 끝 라벨 구현도 승인받아 별도 commit으로 고정하며, 폐기한 Stage 2·3은 재개하지 않는다. |
 | [#6041](https://github.com/edwardkim/rhwp/issues/6041) | 다중 쪽·개요 보기의 적응형 render scale과 Canvas surface 예산 | 대기 | #6040 결과 승인·commit 뒤 그 head에서 native stack 중간 branch를 만들고 별도 수행·구현 계획 승인을 받는다. |
 | [#6042](https://github.com/edwardkim/rhwp/issues/6042) | 다중 페이지 스크롤의 행 가상화·페이지 LRU·프리페치 scheduler | 대기 | #6041 결과 승인·commit 뒤 그 head에서 native stack 상단 branch를 만들고 별도 수행·구현 계획 승인을 받는다. |

--- a/mydocs/orders/20260830.md
+++ b/mydocs/orders/20260830.md
@@ -266,6 +266,6 @@ date: 2026-08-30
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| [#6040](https://github.com/edwardkim/rhwp/issues/6040) | 자동 쪽 배치의 줌 토폴로지 commit·중앙 정렬·Canvas 교체 안정화 | 진행중 | 이슈 갱신·담당자 지정과 native stack 하단 초기화를 마쳤다. 작업지시자가 [수행 계획](../plans/task_m100_6040.md)과 [구현 계획](../plans/task_m100_6040_impl.md)을 승인해 Stage 1 자동 열·점유 중앙 정렬을 진행한다. |
+| [#6040](https://github.com/edwardkim/rhwp/issues/6040) | 자동 쪽 배치의 줌 토폴로지 commit·중앙 정렬·Canvas 교체 안정화 | 진행중 | 작업지시자가 [Stage 1](../working/task_m100_6040_stage1.md) 결과를 승인해 commit하고, Stage 2 줌 preview와 topology commit 분리를 진행한다. |
 | [#6041](https://github.com/edwardkim/rhwp/issues/6041) | 다중 쪽·개요 보기의 적응형 render scale과 Canvas surface 예산 | 대기 | #6040 결과 승인·commit 뒤 그 head에서 native stack 중간 branch를 만들고 별도 수행·구현 계획 승인을 받는다. |
 | [#6042](https://github.com/edwardkim/rhwp/issues/6042) | 다중 페이지 스크롤의 행 가상화·페이지 LRU·프리페치 scheduler | 대기 | #6041 결과 승인·commit 뒤 그 head에서 native stack 상단 branch를 만들고 별도 수행·구현 계획 승인을 받는다. |

--- a/mydocs/orders/20260830.md
+++ b/mydocs/orders/20260830.md
@@ -233,7 +233,6 @@ date: 2026-08-30
   `cargo fmt --all -- --check`를 통과했다. self-review는
   [PR #6456 검토 문서](../pr/archives/pr_6456_review.md)에 기록했으며, 최신 trailing head의
   review-only CI와 mergeability를 확인한 뒤 user 승인에 따라 squash merge한다.
-
 ## Kevin PR #6398-#6446 통합 검토 후보
 
 - [x] `upstream/devel@bd78a53122e4b532eeee330b2788cbc858dad2b0` 위에 #6398, #6399, #6400,
@@ -262,3 +261,11 @@ date: 2026-08-30
 - #6445는 source-vpos를 현행 float/typeset API에 연결했고, #6471은 devel의 기존 Zoom 계약을 유지하면서 고유 CMYK JPEG 정규화만 남겼다.
 - focused 회귀 19건과 최종 #6310 계약 4건, native·WASM·workspace clippy, workspace build, manifest와 format 검증을 통과했다.
 - 원 PR별 기록은 `mydocs/pr/archives/pr_6413_review.md` 외 7건에 분리했다. 통합 PR latest-head CI와 Render Diff 성공 전에는 최종 수용·원 PR close를 수행하지 않는다.
+
+## M100 — 다중 페이지 렌더링 성능·정합성 stacked PR
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| [#6040](https://github.com/edwardkim/rhwp/issues/6040) | 자동 쪽 배치의 줌 토폴로지 commit·중앙 정렬·Canvas 교체 안정화 | 진행중 | 이슈 갱신·담당자 지정과 native stack 하단 초기화를 마쳤다. 작업지시자가 [수행 계획](../plans/task_m100_6040.md)과 [구현 계획](../plans/task_m100_6040_impl.md)을 승인해 Stage 1 자동 열·점유 중앙 정렬을 진행한다. |
+| [#6041](https://github.com/edwardkim/rhwp/issues/6041) | 다중 쪽·개요 보기의 적응형 render scale과 Canvas surface 예산 | 대기 | #6040 결과 승인·commit 뒤 그 head에서 native stack 중간 branch를 만들고 별도 수행·구현 계획 승인을 받는다. |
+| [#6042](https://github.com/edwardkim/rhwp/issues/6042) | 다중 페이지 스크롤의 행 가상화·페이지 LRU·프리페치 scheduler | 대기 | #6041 결과 승인·commit 뒤 그 head에서 native stack 상단 branch를 만들고 별도 수행·구현 계획 승인을 받는다. |

--- a/mydocs/orders/20260830.md
+++ b/mydocs/orders/20260830.md
@@ -266,6 +266,6 @@ date: 2026-08-30
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| [#6040](https://github.com/edwardkim/rhwp/issues/6040) | 자동 쪽 배치의 줌 토폴로지 commit·중앙 정렬·Canvas 교체 안정화 | 진행중 | [Stage 1](../working/task_m100_6040_stage1.md) 재구성 문서를 `354b2d417`로 고정했다. [Stage 1.1](../working/task_m100_6040_stage1_1.md) 눈금자 끝 라벨 구현도 승인받아 별도 commit으로 고정하며, 폐기한 Stage 2·3은 재개하지 않는다. |
+| [#6040](https://github.com/edwardkim/rhwp/issues/6040) | 자동 쪽 배치의 줌 토폴로지 commit·중앙 정렬·Canvas 교체 안정화 | 진행중 | 최신 `upstream/devel@7592e9c99`에 재배치한 code head `049683ee9`의 전체·browser 검증을 통과했다. [Stage 1](../working/task_m100_6040_stage1.md)과 [Stage 1.1](../working/task_m100_6040_stage1_1.md)만 유지하며 Draft PR 본문 검토를 기다린다. |
 | [#6041](https://github.com/edwardkim/rhwp/issues/6041) | 다중 쪽·개요 보기의 적응형 render scale과 Canvas surface 예산 | 대기 | #6040 결과 승인·commit 뒤 그 head에서 native stack 중간 branch를 만들고 별도 수행·구현 계획 승인을 받는다. |
 | [#6042](https://github.com/edwardkim/rhwp/issues/6042) | 다중 페이지 스크롤의 행 가상화·페이지 LRU·프리페치 scheduler | 대기 | #6041 결과 승인·commit 뒤 그 head에서 native stack 상단 branch를 만들고 별도 수행·구현 계획 승인을 받는다. |

--- a/mydocs/orders/20260830.md
+++ b/mydocs/orders/20260830.md
@@ -266,6 +266,6 @@ date: 2026-08-30
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| [#6040](https://github.com/edwardkim/rhwp/issues/6040) | 자동 쪽 배치의 줌 토폴로지 commit·중앙 정렬·Canvas 교체 안정화 | 진행중 | 작업지시자가 [Stage 1](../working/task_m100_6040_stage1.md) 결과를 승인해 commit하고, Stage 2 줌 preview와 topology commit 분리를 진행한다. |
+| [#6040](https://github.com/edwardkim/rhwp/issues/6040) | 자동 쪽 배치의 줌 토폴로지 commit·중앙 정렬·Canvas 교체 안정화 | 진행중 | [Stage 1](../working/task_m100_6040_stage1.md) `63fa3d0cf` 재구성과 기존 줌 재검증을 승인받았다. 문서 commit 뒤 줌 경로와 분리된 눈금자 끝 라벨 처리(Stage 1.1)를 진행한다. |
 | [#6041](https://github.com/edwardkim/rhwp/issues/6041) | 다중 쪽·개요 보기의 적응형 render scale과 Canvas surface 예산 | 대기 | #6040 결과 승인·commit 뒤 그 head에서 native stack 중간 branch를 만들고 별도 수행·구현 계획 승인을 받는다. |
 | [#6042](https://github.com/edwardkim/rhwp/issues/6042) | 다중 페이지 스크롤의 행 가상화·페이지 LRU·프리페치 scheduler | 대기 | #6041 결과 승인·commit 뒤 그 head에서 native stack 상단 branch를 만들고 별도 수행·구현 계획 승인을 받는다. |

--- a/mydocs/orders/20260830.md
+++ b/mydocs/orders/20260830.md
@@ -266,6 +266,6 @@ date: 2026-08-30
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| [#6040](https://github.com/edwardkim/rhwp/issues/6040) | 자동 쪽 배치의 줌 토폴로지 commit·중앙 정렬·Canvas 교체 안정화 | 진행중 | 최신 `upstream/devel@7592e9c99`에 재배치한 code head `049683ee9`의 전체·browser 검증을 통과했다. [Stage 1](../working/task_m100_6040_stage1.md)과 [Stage 1.1](../working/task_m100_6040_stage1_1.md)만 유지하며 Draft PR 본문 검토를 기다린다. |
+| [#6040](https://github.com/edwardkim/rhwp/issues/6040) | 자동 쪽 배치의 줌 토폴로지 commit·중앙 정렬·Canvas 교체 안정화 | 진행중 | [Draft PR #6458](https://github.com/edwardkim/rhwp/pull/6458)을 stack bottom으로 생성했다. 제출 기준 `upstream/devel@7592e9c99`에 재배치한 code candidate `afb33b50e`의 전체·browser 검증을 통과했고 [self-review](../pr/archives/pr_6458_review.md)를 기록했다. #6040의 미포함 성능 기준은 열어두고 trailing head CI 뒤 #6041 layer를 시작한다. |
 | [#6041](https://github.com/edwardkim/rhwp/issues/6041) | 다중 쪽·개요 보기의 적응형 render scale과 Canvas surface 예산 | 대기 | #6040 결과 승인·commit 뒤 그 head에서 native stack 중간 branch를 만들고 별도 수행·구현 계획 승인을 받는다. |
 | [#6042](https://github.com/edwardkim/rhwp/issues/6042) | 다중 페이지 스크롤의 행 가상화·페이지 LRU·프리페치 scheduler | 대기 | #6041 결과 승인·commit 뒤 그 head에서 native stack 상단 branch를 만들고 별도 수행·구현 계획 승인을 받는다. |

--- a/mydocs/orders/20260901.md
+++ b/mydocs/orders/20260901.md
@@ -157,3 +157,17 @@
 | Issue | 타스크 | 상태 | 비고 |
 | --- | --- | --- | --- |
 | #6187 | 눈금자 상시 표시·resize 무깜빡임 PR #6570 self-review | 완료 | code candidate `88ca4d1bf` 로컬·사용자 Stage 3·CI 통과, 판정 `승인`; trailing 기록과 정상 merge 뒤 #6432 정리 |
+
+## #6458 최신 devel 통합 및 live hysteresis 보정
+
+- 최신 `upstream/devel@0d1540931`을 merge commit `a19020085`로 통합하고 maintainer가 차단한 live auto
+  열 commit 누락을 Stage 1.2에서 보정했다.
+- `VirtualScroll`이 이전 auto 열을 소유·전달하고 fixed/horizontal/문서 교체에서 reset한다. 기존 settled
+  Canvas 반환·재할당은 유지해 #6438의 pool/DOM 이중 소유권 문제를 가져오지 않았다.
+- resize 뒤 캐럿·선택 overlay를 확정 페이지 좌표에 재투영했다. actual CanvasView/CanvasPool test와
+  focused 34/34, Studio 1,351 pass·1 skip, TypeScript·build를 통과했다.
+- 77쪽 `kps-ai.hwp` 77%에서 폭 왕복 결과는 `1→1→2→2→1열`, DOM canvas/고유 slot 일치,
+  캐럿·눈금자·hit-test 정상이다.
+- code candidate `333fa8f5d`; 원격 #6458은 아직 이전 Draft head이므로 push·required CI·설명 댓글을 다음
+  gate로 남긴다. #6438은 원격 후보 게시 뒤 credit-preserving handoff comment와 함께 닫는다.
+- 기록: `mydocs/working/task_m100_6040_stage1_2.md`, `mydocs/pr/archives/pr_6458_review.md`.

--- a/mydocs/orders/20260901.md
+++ b/mydocs/orders/20260901.md
@@ -160,14 +160,18 @@
 
 ## #6458 최신 devel 통합 및 live hysteresis 보정
 
-- 최신 `upstream/devel@0d1540931`을 merge commit `a19020085`로 통합하고 maintainer가 차단한 live auto
-  열 commit 누락을 Stage 1.2에서 보정했다.
+- `upstream/devel@0d1540931`을 `a19020085`로 통합한 뒤, 첫 push 직후 병합된 #6570까지
+  `upstream/devel@b9d408f0d`을 `db1a15fb1`로 다시 통합했다. 오늘 작업 기록 충돌은 양쪽을 보존했다.
+- maintainer가 차단한 live auto 열 commit 누락을 Stage 1.2에서 보정했다.
 - `VirtualScroll`이 이전 auto 열을 소유·전달하고 fixed/horizontal/문서 교체에서 reset한다. 기존 settled
   Canvas 반환·재할당은 유지해 #6438의 pool/DOM 이중 소유권 문제를 가져오지 않았다.
-- resize 뒤 캐럿·선택 overlay를 확정 페이지 좌표에 재투영했다. actual CanvasView/CanvasPool test와
-  focused 34/34, Studio 1,351 pass·1 skip, TypeScript·build를 통과했다.
+- resize 뒤 캐럿·선택 overlay를 확정 페이지 좌표에 재투영했다. actual CanvasView/CanvasPool과 최신
+  Ruler harness focused 45/45, Studio 1,360 pass·1 skip, TypeScript·build를 통과했다.
+- #6570의 Canvas mock에는 Stage 1.1이 쓰는 `measureText()`가 없어 통합 test가 실패했다. 실제 숫자
+  라벨 폭을 반환하는 최소 fake를 추가한 `afa32ef18`에서 Ruler pointer·resize 계약을 복구했다.
 - 77쪽 `kps-ai.hwp` 77%에서 폭 왕복 결과는 `1→1→2→2→1열`, DOM canvas/고유 slot 일치,
   캐럿·눈금자·hit-test 정상이다.
-- code candidate `333fa8f5d`; 원격 #6458은 아직 이전 Draft head이므로 push·required CI·설명 댓글을 다음
-  gate로 남긴다. #6438은 원격 후보 게시 뒤 credit-preserving handoff comment와 함께 닫는다.
+- Stage code candidate `333fa8f5d`, latest integration candidate `afa32ef18`; 첫 push와 설명 댓글은
+  게시됐고, 최신 devel 재통합 head의 두 번째 push·required CI를 다음 gate로 남긴다. #6438은 원격 후보
+  게시 뒤 credit-preserving handoff comment와 함께 닫는다.
 - 기록: `mydocs/working/task_m100_6040_stage1_2.md`, `mydocs/pr/archives/pr_6458_review.md`.

--- a/mydocs/orders/20260901.md
+++ b/mydocs/orders/20260901.md
@@ -171,7 +171,8 @@
   라벨 폭을 반환하는 최소 fake를 추가한 `afa32ef18`에서 Ruler pointer·resize 계약을 복구했다.
 - 77쪽 `kps-ai.hwp` 77%에서 폭 왕복 결과는 `1→1→2→2→1열`, DOM canvas/고유 slot 일치,
   캐럿·눈금자·hit-test 정상이다.
-- Stage code candidate `333fa8f5d`, latest integration candidate `afa32ef18`; 첫 push와 설명 댓글은
-  게시됐고, 최신 devel 재통합 head의 두 번째 push·required CI를 다음 gate로 남긴다. #6438은 원격 후보
-  게시 뒤 credit-preserving handoff comment와 함께 닫는다.
+- Stage code candidate `333fa8f5d`, latest integration candidate `afa32ef18`, remote review head
+  `dff556c8e`. Draft #6458은 `MERGEABLE/CLEAN`, 18 success·15 skip·1 neutral·failure/pending 0이다.
+- #6438은 contributor credit·source head·Canvas ownership 검토 조건을 인계 댓글로 보존하고 superseded로
+  닫았다. merge하지 않았다. 다음 gate는 #6454 측정·결정 계획이고 그 뒤 #6467을 restack한다.
 - 기록: `mydocs/working/task_m100_6040_stage1_2.md`, `mydocs/pr/archives/pr_6458_review.md`.

--- a/mydocs/plans/task_m100_6040.md
+++ b/mydocs/plans/task_m100_6040.md
@@ -1,0 +1,113 @@
+# 수행 계획 — Task M100 #6040
+
+- **이슈**: [#6040](https://github.com/edwardkim/rhwp/issues/6040)
+- **브랜치**: `codex/issue-6040-zoom-topology`
+- **기준 commit**: `upstream/devel` `2deb3dd61`
+- **작성일**: 2026-08-30 KST
+- **절차 상태**: 수행·구현 계획 승인 완료, Stage 1 진행
+
+## 절차 상태와 native stack 경계
+
+- 2026-08-30 작업지시자가 #6040·#6041·#6042를 GitHub native stacked PR로 진행하도록 요청했다.
+- #6040 본문에 자동 모드의 실제 점유 묶음 중앙 정렬과 50% gate로 2열을 건너뛰는 현상을 추가하고,
+  갱신 알림 댓글을 게시했다. GitHub 직접 첨부만 남은 네 이미지는 본문의 명시적 placeholder로 보존했다.
+- 세 이슈의 열린 선점 PR이 없음을 확인하고 GitHub 계정 `postmelee`를 모두 담당자로 지정했다.
+- 다른 작업이 있는 원본 worktree는 건드리지 않고 최신 `upstream/devel@2deb3dd61`에서 독립 worktree와
+  stack 하단 branch를 만들었다.
+- 이 문서는 코드 변경 전 계획이다. 구현은 작업지시자가 수행 계획과 구현 계획을 승인한 뒤 시작한다.
+- 2026-08-30 작업지시자가 수행 계획과 구현 계획을 승인하고 Stage 1 진행을 지시했다.
+- stack trunk는 `devel`이다. #6040은 bottom, #6041은 #6040을 직접 base로 하는 middle, #6042는
+  #6041을 직접 base로 하는 top PR이다.
+- 각 이슈는 독립 계획 승인과 Stage 결과 승인·commit을 완료한 뒤 다음 branch를 만든다. 세 layer의
+  검증이 끝나기 전에는 remote push와 `gh stack submit`을 실행하지 않는다.
+
+## 목표
+
+1. 자동 모드의 열 후보를 표시 페이지 폭·page gap·편집 영역 폭으로 계산하고 실제 페이지 수로 제한한다.
+2. 빈 열이 아니라 실제 점유 페이지 묶음을 편집 영역 가운데에 놓는다.
+3. 줌 제스처 중에는 commit된 행·열 토폴로지를 고정하고 기존 화면을 preview로 사용한다.
+4. 제스처 정착 시 최종 후보를 한 번 commit하고 기준 페이지의 정규화 앵커를 보존한다.
+5. 정착만을 이유로 활성 Canvas를 일괄 제거하지 않고 새 렌더가 준비된 페이지부터 교체한다.
+6. 자동 외의 고정 쪽 배치와 기존 그리드 클릭·현재 쪽·행 이동·가로 팬 계약을 보존한다.
+
+## 범위
+
+### 포함
+
+- 자동 열 순수 후보 계산: `viewportWidth`, 표시된 최대 페이지 폭, page gap, page count
+- 자동 열 commit 정책과 경계 흔들림 방지
+- 실제 점유 열 수 기준 중앙 정렬; 마지막 미완성 행의 기존 시작 열 규칙은 유지
+- 줌 제스처 snapshot, preview, 최종 topology commit, 기준 페이지/페이지 내부 앵커 복원
+- 줌 정착 시 visible/retained active Canvas의 점진적 교체
+- 줌·resize가 동일 후보 계산을 사용하는 회귀 테스트와 진단 계측
+
+### 제외
+
+- `effectiveDpr`, render scale tier, 총 surface pixel/byte 예산: #6041
+- 행 인덱스, visibility snapshot 공유, page LRU, eviction, prefetch scheduler: #6042
+- 쪽 모양 UI·상태 모델: #6039에서 완료된 계약을 소비만 한다.
+- 마지막 미완성 행의 한글 2024 정렬 규칙 변경: 추가 실측 전에는 현재 열 시작 규칙을 유지한다.
+- print/PDF/SVG/high-quality export 출력
+
+## 단계와 산출물
+
+1. **Stage 1 — 자동 열·실제 점유 중앙 정렬의 순수 계약**
+   - 50% 전역 gate를 제거하고 열 후보를 폭과 page count로 계산한다.
+   - 실제 페이지보다 많은 빈 열이 그리드 폭에 포함되지 않게 한다.
+   - fixed arrangement와 가로 쪽 이동이 영향받지 않는 focused test를 추가한다.
+   - 완료 기록: `mydocs/working/task_m100_6040_stage1.md`
+2. **Stage 2 — 줌 preview와 topology commit 분리**
+   - 제스처 시작 snapshot과 정착 commit 상태를 CanvasView에 도입한다.
+   - 애니메이션 프레임에서는 전체 `VirtualScroll` 재계산과 최종 품질 render를 하지 않는다.
+   - 최종 frame에서 레이아웃을 한 번 계산하고 기준 페이지의 정규화 앵커를 복원한다.
+   - 완료 기록: `mydocs/working/task_m100_6040_stage2.md`
+3. **Stage 3 — 활성 Canvas 점진적 교체와 계측**
+   - 줌 정착 시 `releaseAllRenderedPages()`를 호출하는 경로를 페이지 단위 교체로 바꾼다.
+   - visible 우선으로 새 결과를 준비하고 성공한 페이지만 교체하며 실패·취소 시 기존 결과를 유지한다.
+   - #6042의 LRU·scheduler를 선행 구현하지 않고 현재 active working set 안에서만 동작한다.
+   - 완료 기록: `mydocs/working/task_m100_6040_stage3.md`
+4. **Stage 4 — 통합 회귀·실제 브라우저 검증**
+   - 자동 1/2/3쪽 이상, 51%→50%, 27%·17%, 줌 왕복·resize·고정 배치 매트릭스를 검증한다.
+   - TypeScript·Studio 전체 test·build와 실제 Chrome 계측을 수행한다.
+   - 최종 보고서: `mydocs/report/task_m100_6040_report.md`
+
+각 Stage는 focused 검증과 working 보고 뒤 작업지시자의 결과 승인을 받고 commit한 다음에만 다음
+Stage로 이동한다.
+
+## 검증 계획
+
+- `node --test`로 자동 열·중앙 정렬·CanvasView 줌 preview/commit·기존 앵커 회귀 focused test 실행
+- `(cd rhwp-studio && npx tsc --noEmit)`
+- `npm --prefix rhwp-studio test`
+- `npm --prefix rhwp-studio run build`
+- 실제 Chrome에서 A4 3쪽·6쪽 문서의 자동 51%/50%/27%/17%, 줌 인/아웃 왕복, resize 검증
+- 실제 브라우저 진단값으로 제스처당 layout commit·전체 release·page render 호출 수와 앵커 오차 기록
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+Studio 화면 전용 TypeScript 변경이므로 Rust source/test가 바뀌지 않는 한 Rust Clippy 묶음과 Native
+Skia·WASM 전체 빌드는 기본 범위에서 제외한다. 렌더 엔진 출력은 바꾸지 않으므로 PDF/SVG sweep 대신
+실제 browser 기능·성능 검증을 권위 근거로 사용한다.
+
+## 위험과 완화
+
+| 위험 | 완화 |
+| --- | --- |
+| 50% gate 제거로 핀치 중 열 수가 더 자주 변함 | 후보 계산과 실제 commit을 분리하고 제스처 정착 시 한 번만 commit한다. |
+| 페이지 수 cap이 fixed/facing의 의도적 빈 슬롯까지 없앰 | cap과 실제 점유 중앙 정렬은 `auto`에만 적용하고 fixed topology 회귀 테스트를 둔다. |
+| 미완성 마지막 행 정렬이 함께 바뀜 | 첫 행 전체가 실제 page count보다 작은 경우만 문제를 닫고 마지막 미완성 행의 열 시작 규칙은 유지한다. |
+| preview 중 클릭·캐럿 좌표가 commit 좌표와 섞임 | VirtualScroll 좌표는 제스처 동안 commit snapshot에 고정하고 정착 후 한 번에 교체한다. |
+| 기존 Canvas 교체 중 화면이 비거나 stale 작업이 덮어씀 | render epoch를 확인해 성공한 최신 결과만 원자 교체하고 실패·취소 시 기존 Canvas를 유지한다. |
+| #6041·#6042 기능이 #6040에 섞임 | 해상도 선택과 캐시/scheduler는 hook·계측 경계만 두고 정책은 후속 layer로 남긴다. |
+| public preview native stack 동작 변화 | 제출 직전 공식 문서·`gh stack view`·branch base를 재확인하고 세 PR을 bottom-up으로 병합한다. |
+
+## 승인 게이트
+
+1. 작업지시자가 이 수행 계획과 구현 계획을 승인한다.
+2. 승인 뒤 Stage 1을 구현·검증하고 결과 승인을 기다린다.
+3. Stage 1 승인·commit 뒤 Stage 2, 같은 방식으로 Stage 3과 Stage 4를 진행한다.
+4. #6040 최종 결과 승인·commit 뒤에만 #6041 branch와 별도 계획을 만든다.
+5. #6041 최종 결과 승인·commit 뒤에만 #6042 branch와 별도 계획을 만든다.
+6. 세 branch의 전체 검증과 PR 초안 검토 뒤 remote push·`gh stack submit` 승인을 별도로 받는다.
+7. 게시된 stack은 #6040→#6041→#6042 순서로 review·merge하고 각 하단 merge 후 상단의 재base CI를
+   다시 확인한다.

--- a/mydocs/plans/task_m100_6040.md
+++ b/mydocs/plans/task_m100_6040.md
@@ -2,7 +2,7 @@
 
 - **이슈**: [#6040](https://github.com/edwardkim/rhwp/issues/6040)
 - **브랜치**: `codex/issue-6040-zoom-topology`
-- **PR 기준 commit**: `upstream/devel` `0d1540931`
+- **PR 기준 commit**: `upstream/devel` `b9d408f0d`
 - **최초 구현 기준**: `upstream/devel` `2deb3dd61`
 - **작성일**: 2026-08-30 KST
 - **절차 상태**: Stage 1·1.1 유지, Stage 1.2 live 자동 열 commit 보정, Stage 2·3 폐기
@@ -49,6 +49,9 @@
   Stage 1.2에서 live commit 소유·reset과 resize 뒤 캐럿/선택 오버레이 재투영을 보정했다.
 - Stage 1.2는 기존 settled `releaseAllRenderedPages() → updateVisiblePages()` 경로를 유지한다. PR #6438의
   progressive Canvas 교체에서 지적된 pool/DOM 이중 소유권과 장시간 동기 렌더를 포함하지 않는다.
+- 첫 push 직후 `devel`에 #6570 눈금자 resize/paint 변경이 병합돼 PR이 `DIRTY`가 됐다. 최신
+  `upstream/devel@b9d408f0d`을 merge commit `db1a15fb1`로 다시 통합하고 오늘 작업 기록 양쪽을 보존했다.
+  새 Ruler 실제 동작 harness에는 Stage 1.1의 라벨 경계 판정이 쓰는 `measureText()` fake만 보완했다.
 
 ## 목표
 

--- a/mydocs/plans/task_m100_6040.md
+++ b/mydocs/plans/task_m100_6040.md
@@ -2,7 +2,8 @@
 
 - **이슈**: [#6040](https://github.com/edwardkim/rhwp/issues/6040)
 - **브랜치**: `codex/issue-6040-zoom-topology`
-- **기준 commit**: `upstream/devel` `2deb3dd61`
+- **PR 기준 commit**: `upstream/devel` `7592e9c99`
+- **최초 구현 기준**: `upstream/devel` `2deb3dd61`
 - **작성일**: 2026-08-30 KST
 - **절차 상태**: Stage 1 기준 재구성·기존 줌 재검증 완료, Stage 2·3 폐기, 성능 재설계 보류
 
@@ -32,6 +33,13 @@
   commit으로 고정한 뒤, 기존 줌 경로를 변경하지 않는 Stage 1.1 눈금자 끝 라벨 처리만 진행한다.
 - 2026-08-30 작업지시자가 Stage 1.1을 직접 검증하고 이 구현으로 확정했다. Stage 1과 Stage 1.1만
   #6040의 구현 결과로 유지하며, 폐기한 Stage 2·3 설계는 재개하지 않는다.
+- 2026-08-30 PR 준비에서 승인 head를
+  `codex/issue-6040-pre-submit-20260830@1d597e81b`에 보존하고 최신
+  `upstream/devel@7592e9c99` 위로 네 commit을 재배치했다. range-diff에서 source·test patch는
+  동일했고, 오늘할일 충돌은 최신 기록과 M100 섹션을 모두 보존했다.
+- rebased code head `049683ee9`에서 TypeScript, Studio 1,278건, production build 243 modules,
+  `cargo fmt --all -- --check`와 실제 Chromium 자동 60% 2열·50% 3열·155% 눈금자를 통과했다.
+  GitHub `viewerPermission=WRITE`이며 동일 head의 열린 PR은 없다.
 - stack trunk는 `devel`이다. #6040은 bottom, #6041은 #6040을 직접 base로 하는 middle, #6042는
   #6041을 직접 base로 하는 top PR이다.
 - 각 이슈는 독립 계획 승인과 Stage 결과 승인·commit을 완료한 뒤 다음 branch를 만든다. 세 layer의

--- a/mydocs/plans/task_m100_6040.md
+++ b/mydocs/plans/task_m100_6040.md
@@ -30,6 +30,8 @@
   2→3열 전환을 통과했다. 성능 경로는 단일 공유 좌표 모델의 새 계획 승인 전까지 구현하지 않는다.
 - 2026-08-30 작업지시자가 Stage 1 기준 재구성과 기존 줌 재검증 결과를 승인했다. 재구성 문서를 별도
   commit으로 고정한 뒤, 기존 줌 경로를 변경하지 않는 Stage 1.1 눈금자 끝 라벨 처리만 진행한다.
+- 2026-08-30 작업지시자가 Stage 1.1을 직접 검증하고 이 구현으로 확정했다. Stage 1과 Stage 1.1만
+  #6040의 구현 결과로 유지하며, 폐기한 Stage 2·3 설계는 재개하지 않는다.
 - stack trunk는 `devel`이다. #6040은 bottom, #6041은 #6040을 직접 base로 하는 middle, #6042는
   #6041을 직접 base로 하는 top PR이다.
 - 각 이슈는 독립 계획 승인과 Stage 결과 승인·commit을 완료한 뒤 다음 branch를 만든다. 세 layer의
@@ -73,20 +75,25 @@
    - 실제 페이지보다 많은 빈 열이 그리드 폭에 포함되지 않게 한다.
    - fixed arrangement와 가로 쪽 이동이 영향받지 않는 focused test를 추가한다.
    - 완료 기록: `mydocs/working/task_m100_6040_stage1.md`
-2. **Stage 2 — 줌 preview와 topology commit 분리**
+2. **Stage 1.1 — 수평 눈금자 끝 라벨 경계 처리**
+   - Stage 1 재구성의 수동 검증에서 확인한 기존 표시 결함만 다룬다.
+   - 종이 끝 경계선과 tick은 유지하고, 가운데 정렬된 숫자의 실제 폭이 종이 범위를 넘으면 라벨만 숨긴다.
+   - 줌·`VirtualScroll`·Canvas 배치 경로는 변경하지 않는다.
+   - 완료 기록: `mydocs/working/task_m100_6040_stage1_1.md`
+3. **Stage 2 — 줌 preview와 topology commit 분리**
    - **폐기**: `VirtualScroll`을 고정하고 Canvas만 별도 CSS 좌표로 움직이는 구현은 기존 화면 요소의
      단일 좌표 계약을 깨므로 현재 branch에서 제거했다.
    - 제스처 시작 snapshot과 정착 commit 상태를 CanvasView에 도입한다.
    - 애니메이션 프레임에서는 전체 `VirtualScroll` 재계산과 최종 품질 render를 하지 않는다.
    - 최종 frame에서 레이아웃을 한 번 계산하고 기준 페이지의 정규화 앵커를 복원한다.
    - 완료 기록: `mydocs/working/task_m100_6040_stage2.md`
-3. **Stage 3 — 활성 Canvas 점진적 교체와 계측**
+4. **Stage 3 — 활성 Canvas 점진적 교체와 계측**
    - **폐기**: Stage 2 좌표 모델에 의존한 구현을 현재 branch에서 제거했다.
    - 줌 정착 시 `releaseAllRenderedPages()`를 호출하는 경로를 페이지 단위 교체로 바꾼다.
    - visible 우선으로 새 결과를 준비하고 성공한 페이지만 교체하며 실패·취소 시 기존 결과를 유지한다.
    - #6042의 LRU·scheduler를 선행 구현하지 않고 현재 active working set 안에서만 동작한다.
    - 완료 기록: `mydocs/working/task_m100_6040_stage3.md`
-4. **Stage 4 — 통합 회귀·실제 브라우저 검증**
+5. **Stage 4 — 통합 회귀·실제 브라우저 검증**
    - **종료**: 폐기된 Stage 2·3의 통합 검증 대신 Stage 1 기준 기존 줌 동작을 재검증했다.
    - 자동 1/2/3쪽 이상, 51%→50%, 27%·17%, 줌 왕복·resize·고정 배치 매트릭스를 검증한다.
    - TypeScript·Studio 전체 test·build와 실제 Chrome 계측을 수행한다.

--- a/mydocs/plans/task_m100_6040.md
+++ b/mydocs/plans/task_m100_6040.md
@@ -4,7 +4,7 @@
 - **브랜치**: `codex/issue-6040-zoom-topology`
 - **기준 commit**: `upstream/devel` `2deb3dd61`
 - **작성일**: 2026-08-30 KST
-- **절차 상태**: Stage 1 결과 승인·commit 준비, Stage 2 진행
+- **절차 상태**: Stage 1 기준 재구성·기존 줌 재검증 완료, Stage 2·3 폐기, 성능 재설계 보류
 
 ## 절차 상태와 native stack 경계
 
@@ -19,12 +19,26 @@
 - 2026-08-30 Stage 1 자동 열·실제 점유 중앙 정렬 구현과 focused·Studio 전체 검증을 완료하고 결과
   승인을 기다린다.
 - 2026-08-30 작업지시자가 Stage 1 결과를 승인하고 Stage 2 진행을 지시했다.
+- 2026-08-30 Stage 2·3 구현 뒤 줌 중 고정된 `VirtualScroll`과 Canvas 전용 CSS preview가 서로 다른
+  좌표계를 만들었다. 좌우·상하 jump와 눈금자 지연이 같은 원인에서 파생됐고, 캐럿·선택·hit-test에도
+  같은 위험이 있음을 기준 commit부터 재분석했다.
+- 2026-08-30 작업지시자 동의 아래 전체 상태를
+  `codex/issue-6040-zoom-topology-backup-20260830@d97307cab`에 보존하고 작업 branch를 Stage 1
+  `63fa3d0cf`로 재구성했다. Stage 2·3과 후속 회귀 수정은 현재 branch에 포함하지 않는다.
+- 2026-08-30 `CanvasView`·`Ruler`·`ViewportManager`·caret/input 경로가 기준 `2deb3dd61`과 동일함을
+  확인했다. focused 69건, 전체 Studio 1,246건, TypeScript·build와 실제 Chromium의 눈금자·캐럿·자동
+  2→3열 전환을 통과했다. 성능 경로는 단일 공유 좌표 모델의 새 계획 승인 전까지 구현하지 않는다.
+- 2026-08-30 작업지시자가 Stage 1 기준 재구성과 기존 줌 재검증 결과를 승인했다. 재구성 문서를 별도
+  commit으로 고정한 뒤, 기존 줌 경로를 변경하지 않는 Stage 1.1 눈금자 끝 라벨 처리만 진행한다.
 - stack trunk는 `devel`이다. #6040은 bottom, #6041은 #6040을 직접 base로 하는 middle, #6042는
   #6041을 직접 base로 하는 top PR이다.
 - 각 이슈는 독립 계획 승인과 Stage 결과 승인·commit을 완료한 뒤 다음 branch를 만든다. 세 layer의
   검증이 끝나기 전에는 remote push와 `gh stack submit`을 실행하지 않는다.
 
 ## 목표
+
+현재 branch의 승인된 실행 범위는 아래 1·2·6번이다. 3~5번은 폐기한 Stage 2·3 설계의 목표로서,
+눈금자·캐럿·선택·hit-test까지 같은 preview geometry를 소비하는 새 계획을 승인하기 전에는 재개하지 않는다.
 
 1. 자동 모드의 열 후보를 표시 페이지 폭·page gap·편집 영역 폭으로 계산하고 실제 페이지 수로 제한한다.
 2. 빈 열이 아니라 실제 점유 페이지 묶음을 편집 영역 가운데에 놓는다.
@@ -60,16 +74,20 @@
    - fixed arrangement와 가로 쪽 이동이 영향받지 않는 focused test를 추가한다.
    - 완료 기록: `mydocs/working/task_m100_6040_stage1.md`
 2. **Stage 2 — 줌 preview와 topology commit 분리**
+   - **폐기**: `VirtualScroll`을 고정하고 Canvas만 별도 CSS 좌표로 움직이는 구현은 기존 화면 요소의
+     단일 좌표 계약을 깨므로 현재 branch에서 제거했다.
    - 제스처 시작 snapshot과 정착 commit 상태를 CanvasView에 도입한다.
    - 애니메이션 프레임에서는 전체 `VirtualScroll` 재계산과 최종 품질 render를 하지 않는다.
    - 최종 frame에서 레이아웃을 한 번 계산하고 기준 페이지의 정규화 앵커를 복원한다.
    - 완료 기록: `mydocs/working/task_m100_6040_stage2.md`
 3. **Stage 3 — 활성 Canvas 점진적 교체와 계측**
+   - **폐기**: Stage 2 좌표 모델에 의존한 구현을 현재 branch에서 제거했다.
    - 줌 정착 시 `releaseAllRenderedPages()`를 호출하는 경로를 페이지 단위 교체로 바꾼다.
    - visible 우선으로 새 결과를 준비하고 성공한 페이지만 교체하며 실패·취소 시 기존 결과를 유지한다.
    - #6042의 LRU·scheduler를 선행 구현하지 않고 현재 active working set 안에서만 동작한다.
    - 완료 기록: `mydocs/working/task_m100_6040_stage3.md`
 4. **Stage 4 — 통합 회귀·실제 브라우저 검증**
+   - **종료**: 폐기된 Stage 2·3의 통합 검증 대신 Stage 1 기준 기존 줌 동작을 재검증했다.
    - 자동 1/2/3쪽 이상, 51%→50%, 27%·17%, 줌 왕복·resize·고정 배치 매트릭스를 검증한다.
    - TypeScript·Studio 전체 test·build와 실제 Chrome 계측을 수행한다.
    - 최종 보고서: `mydocs/report/task_m100_6040_report.md`

--- a/mydocs/plans/task_m100_6040.md
+++ b/mydocs/plans/task_m100_6040.md
@@ -2,10 +2,10 @@
 
 - **이슈**: [#6040](https://github.com/edwardkim/rhwp/issues/6040)
 - **브랜치**: `codex/issue-6040-zoom-topology`
-- **PR 기준 commit**: `upstream/devel` `7592e9c99`
+- **PR 기준 commit**: `upstream/devel` `0d1540931`
 - **최초 구현 기준**: `upstream/devel` `2deb3dd61`
 - **작성일**: 2026-08-30 KST
-- **절차 상태**: Stage 1 기준 재구성·기존 줌 재검증 완료, Stage 2·3 폐기, 성능 재설계 보류
+- **절차 상태**: Stage 1·1.1 유지, Stage 1.2 live 자동 열 commit 보정, Stage 2·3 폐기
 
 ## 절차 상태와 native stack 경계
 
@@ -44,6 +44,11 @@
   #6041을 직접 base로 하는 top PR이다.
 - 각 이슈는 독립 계획 승인과 Stage 결과 승인·commit을 완료한 뒤 다음 branch를 만든다. 세 layer의
   검증이 끝나기 전에는 remote push와 `gh stack submit`을 실행하지 않는다.
+- 2026-09-01 maintainer review에서 순수 helper의 `committedColumns`가 실제 `VirtualScroll` 연속 호출에
+  전달되지 않는 점을 확인했다. 최신 `upstream/devel@0d1540931`을 merge commit `a19020085`로 통합하고,
+  Stage 1.2에서 live commit 소유·reset과 resize 뒤 캐럿/선택 오버레이 재투영을 보정했다.
+- Stage 1.2는 기존 settled `releaseAllRenderedPages() → updateVisiblePages()` 경로를 유지한다. PR #6438의
+  progressive Canvas 교체에서 지적된 pool/DOM 이중 소유권과 장시간 동기 렌더를 포함하지 않는다.
 
 ## 목표
 
@@ -88,20 +93,27 @@
    - 종이 끝 경계선과 tick은 유지하고, 가운데 정렬된 숫자의 실제 폭이 종이 범위를 넘으면 라벨만 숨긴다.
    - 줌·`VirtualScroll`·Canvas 배치 경로는 변경하지 않는다.
    - 완료 기록: `mydocs/working/task_m100_6040_stage1_1.md`
-3. **Stage 2 — 줌 preview와 topology commit 분리**
+3. **Stage 1.2 — live 자동 열 commit과 overlay 재투영**
+   - `VirtualScroll`이 이전 auto 열 commit을 소유하고 연속 zoom/resize 후보에 전달한다.
+   - horizontal·고정 배치·문서 교체에서 이전 auto commit을 지운다.
+   - resize 레이아웃 확정 뒤 캐럿·선택 overlay를 같은 authoritative 좌표에 다시 놓는다.
+   - 기존 settled Canvas 반환·재할당 경로는 유지하고 actual CanvasView/CanvasPool test로 단일 소유권을
+     검증한다.
+   - 완료 기록: `mydocs/working/task_m100_6040_stage1_2.md`
+4. **Stage 2 — 줌 preview와 topology commit 분리**
    - **폐기**: `VirtualScroll`을 고정하고 Canvas만 별도 CSS 좌표로 움직이는 구현은 기존 화면 요소의
      단일 좌표 계약을 깨므로 현재 branch에서 제거했다.
    - 제스처 시작 snapshot과 정착 commit 상태를 CanvasView에 도입한다.
    - 애니메이션 프레임에서는 전체 `VirtualScroll` 재계산과 최종 품질 render를 하지 않는다.
    - 최종 frame에서 레이아웃을 한 번 계산하고 기준 페이지의 정규화 앵커를 복원한다.
    - 완료 기록: `mydocs/working/task_m100_6040_stage2.md`
-4. **Stage 3 — 활성 Canvas 점진적 교체와 계측**
+5. **Stage 3 — 활성 Canvas 점진적 교체와 계측**
    - **폐기**: Stage 2 좌표 모델에 의존한 구현을 현재 branch에서 제거했다.
    - 줌 정착 시 `releaseAllRenderedPages()`를 호출하는 경로를 페이지 단위 교체로 바꾼다.
    - visible 우선으로 새 결과를 준비하고 성공한 페이지만 교체하며 실패·취소 시 기존 결과를 유지한다.
    - #6042의 LRU·scheduler를 선행 구현하지 않고 현재 active working set 안에서만 동작한다.
    - 완료 기록: `mydocs/working/task_m100_6040_stage3.md`
-5. **Stage 4 — 통합 회귀·실제 브라우저 검증**
+6. **Stage 4 — 통합 회귀·실제 브라우저 검증**
    - **종료**: 폐기된 Stage 2·3의 통합 검증 대신 Stage 1 기준 기존 줌 동작을 재검증했다.
    - 자동 1/2/3쪽 이상, 51%→50%, 27%·17%, 줌 왕복·resize·고정 배치 매트릭스를 검증한다.
    - TypeScript·Studio 전체 test·build와 실제 Chrome 계측을 수행한다.

--- a/mydocs/plans/task_m100_6040.md
+++ b/mydocs/plans/task_m100_6040.md
@@ -4,7 +4,7 @@
 - **브랜치**: `codex/issue-6040-zoom-topology`
 - **기준 commit**: `upstream/devel` `2deb3dd61`
 - **작성일**: 2026-08-30 KST
-- **절차 상태**: 수행·구현 계획 승인 완료, Stage 1 진행
+- **절차 상태**: Stage 1 결과 승인·commit 준비, Stage 2 진행
 
 ## 절차 상태와 native stack 경계
 
@@ -16,6 +16,9 @@
   stack 하단 branch를 만들었다.
 - 이 문서는 코드 변경 전 계획이다. 구현은 작업지시자가 수행 계획과 구현 계획을 승인한 뒤 시작한다.
 - 2026-08-30 작업지시자가 수행 계획과 구현 계획을 승인하고 Stage 1 진행을 지시했다.
+- 2026-08-30 Stage 1 자동 열·실제 점유 중앙 정렬 구현과 focused·Studio 전체 검증을 완료하고 결과
+  승인을 기다린다.
+- 2026-08-30 작업지시자가 Stage 1 결과를 승인하고 Stage 2 진행을 지시했다.
 - stack trunk는 `devel`이다. #6040은 bottom, #6041은 #6040을 직접 base로 하는 middle, #6042는
   #6041을 직접 base로 하는 top PR이다.
 - 각 이슈는 독립 계획 승인과 Stage 결과 승인·commit을 완료한 뒤 다음 branch를 만든다. 세 layer의

--- a/mydocs/plans/task_m100_6040_impl.md
+++ b/mydocs/plans/task_m100_6040_impl.md
@@ -2,10 +2,11 @@
 
 - **이슈**: [#6040](https://github.com/edwardkim/rhwp/issues/6040)
 - **브랜치**: `codex/issue-6040-zoom-topology`
-- **기준 commit**: `upstream/devel` `2deb3dd61`
+- **PR 기준 commit**: `upstream/devel` `7592e9c99`
+- **최초 구현 기준**: `upstream/devel` `2deb3dd61`
 - **문서 성격**: 구현 전 파일·상태 전이 설계
 - **계획 승인**: 2026-08-30 작업지시자 승인, Stage 1 진행
-- **현재 상태**: Stage 2·3 구현 폐기·Stage 1 `63fa3d0cf` 재구성 완료. 아래 줌 상태 전이 설계는
+- **현재 상태**: Stage 2·3 구현 폐기·Stage 1 `a135cc266` 재구성 완료. 아래 줌 상태 전이 설계는
   역사적 폐기안이며 새 공유 좌표 계획 승인 전에는 구현하지 않는다.
 
 ## 자동 열 계약
@@ -37,9 +38,9 @@ candidate = clamp(fitColumns, 1, pageCount)
 ## 줌 상태 전이
 
 > **폐기된 설계**: 이 절의 Canvas 전용 preview는 눈금자·캐럿·선택·hit-test와 다른 좌표계를 만들어
-> 회귀를 일으켰다. 현재 branch의 `CanvasView`·`Ruler`·`ViewportManager`·caret/input 경로는 기준
-> `2deb3dd61`과 동일하다. 후속 설계는 모든 소비자가 하나의 authoritative preview geometry를
-> 사용하거나, 기존처럼 매 프레임 같은 `VirtualScroll`을 소비해야 한다.
+> 회귀를 일으켰다. 현재 branch는 최신 PR 기준 대비 `CanvasView`·`ViewportManager`·caret/input 경로를
+> 변경하지 않으며, `Ruler`는 Stage 1.1의 끝 라벨 경계 처리만 포함한다. 후속 설계는 모든 소비자가 하나의
+> authoritative preview geometry를 사용하거나, 기존처럼 매 프레임 같은 `VirtualScroll`을 소비해야 한다.
 
 ```text
 idle

--- a/mydocs/plans/task_m100_6040_impl.md
+++ b/mydocs/plans/task_m100_6040_impl.md
@@ -2,7 +2,7 @@
 
 - **이슈**: [#6040](https://github.com/edwardkim/rhwp/issues/6040)
 - **브랜치**: `codex/issue-6040-zoom-topology`
-- **PR 기준 commit**: `upstream/devel` `0d1540931`
+- **PR 기준 commit**: `upstream/devel` `b9d408f0d`
 - **최초 구현 기준**: `upstream/devel` `2deb3dd61`
 - **문서 성격**: 구현 전 파일·상태 전이 설계
 - **계획 승인**: 2026-08-30 작업지시자 승인, Stage 1 진행

--- a/mydocs/plans/task_m100_6040_impl.md
+++ b/mydocs/plans/task_m100_6040_impl.md
@@ -1,0 +1,158 @@
+# 구현 계획 — Task M100 #6040
+
+- **이슈**: [#6040](https://github.com/edwardkim/rhwp/issues/6040)
+- **브랜치**: `codex/issue-6040-zoom-topology`
+- **기준 commit**: `upstream/devel` `2deb3dd61`
+- **문서 성격**: 구현 전 파일·상태 전이 설계
+- **계획 승인**: 2026-08-30 작업지시자 승인, Stage 1 진행
+
+## 자동 열 계약
+
+### 후보 계산
+
+자동 열 후보는 이미 zoom이 적용된 표시 폭을 입력으로 받아 다음 의미를 갖는다.
+
+```text
+fitColumns = floor((viewportWidth + pageGap) / (maxDisplayedPageWidth + pageGap))
+candidate = clamp(fitColumns, 1, pageCount)
+```
+
+- 페이지가 없으면 1열의 빈 레이아웃, 한 쪽이면 1열을 반환한다.
+- invalid/0 viewport와 invalid page width는 안전하게 1열로 수렴한다.
+- 50%라는 절대 배율은 입력과 분기에서 제거한다.
+- zoom과 resize는 동일 순수 계산을 호출한다.
+- 같은 경계의 미세한 왕복 입력에는 현재 commit 열 수와 CSS px 단위 히스테리시스 여유를 함께 전달해
+  candidate가 즉시 되돌아가지 않게 한다.
+
+### 점유 그리드 중앙 정렬
+
+- `auto`의 commit 열 수는 page count보다 클 수 없으므로 3쪽 문서의 첫 행이 3쪽이면 점유 열도 3이다.
+- 중앙 정렬 폭은 `occupiedColumns × maxPageWidth + gaps`를 사용한다.
+- 페이지별 폭이 다른 경우 각 slot 안의 기존 중앙 정렬을 유지한다.
+- `double`, `facing`, `multiple`은 지정 topology 자체가 의미이므로 의도적인 빈 slot을 유지한다.
+- 마지막 미완성 행은 이 작업에서 별도 가운데 정렬하지 않고 기존 `pageIdx % columns` 규칙을 보존한다.
+
+## 줌 상태 전이
+
+```text
+idle
+  └─ 첫 animation zoom event → preview(snapshot)
+preview
+  ├─ animation frame → committed topology 유지 + active element CSS preview
+  └─ settled event → commit(final candidate, one layout pass, anchor restore)
+commit
+  └─ visible active Canvas를 새 품질로 점진 교체 → idle
+```
+
+snapshot에는 최소한 다음 값을 둔다.
+
+- 시작 zoom과 committed topology key/columns
+- 기준 페이지와 그 페이지 안의 정규화된 x/y 앵커
+- 시작 viewport와 scrollLeft/scrollTop
+- active page별 기존 rendered zoom/epoch
+
+애니메이션 프레임은 전체 page array의 `setPageDimensions()`를 다시 호출하지 않는다. committed
+VirtualScroll 좌표와 snapshot으로 현재 active Canvas·overlay에만 preview box를 적용하고 배율 표시는 계속
+갱신한다. 정착 event는 final zoom의 candidate로 `recalcLayout()`을 정확히 한 번 호출하고 새 page box에서
+정규화 앵커를 복원한다.
+
+## 파일별 구현
+
+### `rhwp-studio/src/view/virtual-scroll.ts`
+
+- `GRID_ZOOM_THRESHOLD`와 그 분기를 제거한다.
+- auto candidate/commit에 필요한 순수 helper 또는 작은 value object를 추가한다.
+- `setPageDimensions()`가 auto의 이전 committed columns 또는 명시적 commit 값을 받을 수 있게 하되 fixed
+  arrangement 호출 계약은 바꾸지 않는다.
+- `getLayoutTopologyKey()`에 commit된 auto columns만 반영해 preview 후보가 topology 변경으로 보이지 않게
+  한다.
+- auto의 grid width와 margin은 실제 점유 열을 사용한다.
+
+### `rhwp-studio/src/view/canvas-view.ts`
+
+- `ZoomLayoutPreviewSession` 상태와 render epoch를 관리한다.
+- `onZoomChanged()`를 animation preview와 settled commit 경로로 분리한다.
+- preview 경로에서는 `recalcLayout()`, `renderPage()`, `releaseAllRenderedPages()`를 호출하지 않는다.
+- settled 경로는 final candidate를 commit한 뒤 한 번만 레이아웃을 계산하고 snapshot의 기준 페이지/정규화
+  앵커로 scroll을 복원한다.
+- resize는 같은 candidate resolver를 사용하되 독립적인 단일 commit으로 처리한다.
+- fixed arrangement에서는 topology key가 바뀌지 않으므로 좌표 재배치와 품질 교체만 수행한다.
+
+### `rhwp-studio/src/view/canvas-pool.ts`
+
+- 현재 page→Canvas 소유권을 유지한 채 교체 후보 Canvas를 준비하고 성공 시 swap하는 최소 API를 둔다.
+- swap 전까지 기존 Canvas는 DOM과 pool의 active entry로 남는다.
+- 취소·실패한 후보는 DOM에 노출하지 않고 available pool로 돌린다.
+- page 결과를 viewport 밖에 보존하는 LRU/eviction은 추가하지 않는다.
+
+### `rhwp-studio/src/view/page-renderer.ts`
+
+- 필요한 경우 staging Canvas 렌더가 기존 페이지 layer를 먼저 제거하지 않도록 render/commit 경계를
+  분리한다.
+- 최신 render epoch의 성공 결과만 Canvas와 부속 layer를 commit한다.
+- render scale 계산은 현재 `zoom × rawDpr`와 `clampRenderScale()`을 그대로 사용한다. tier·surface 예산은
+  #6041에서 구현한다.
+
+### 진단 경로
+
+- 기존 DEV 진단 패턴을 따라 제스처당 preview frame, layout commit, candidate change, full release,
+  page replacement 횟수와 anchor CSS px 오차를 관찰 가능하게 한다.
+- production 동작이나 공개 문서 모델에는 진단 상태를 저장하지 않는다.
+
+## 테스트
+
+### `virtual-scroll-page-arrangement.test.ts`
+
+- 51%에서도 폭이 두 쪽만 허용하면 2열, 세 쪽을 허용하면 3열
+- 50% 전후가 동일 geometry에서 동일 candidate
+- 3쪽 27%·17%에서 columns=3이고 묶음 중심 오차 ≤1 CSS px
+- page count보다 큰 fitColumns의 cap
+- invalid/0 viewport의 1열 fallback
+- single/double/facing/multiple과 horizontal movement의 topology 불변
+- 페이지 폭이 다른 auto slot의 내부 중앙 정렬
+
+### 줌 preview/commit focused test
+
+- animation N frame에서 전체 layout commit 0, settled event에서 1
+- animation frame에서 final-quality `renderPage`와 `releaseAllRenderedPages` 0
+- 경계 하나를 넘는 제스처의 topology commit 1 이하
+- 기준 페이지/정규화 앵커 오차 ≤2 CSS px
+- zoom in/out 왕복과 resize가 같은 최종 candidate를 선택
+- stale render epoch가 새 Canvas를 덮어쓰지 않고 실패 시 기존 Canvas 유지
+
+### 기존 회귀
+
+- #685, #689, #2560의 grid hit/current-page/row navigation
+- #3244, #3245, #3246, #3591의 zoom sensitivity/anchor/horizontal pan
+- page arrangement transaction이 최종 `recalcLayout()` 한 번만 수행하는 계약
+- Canvas2D와 CanvasKit의 기존 render 성공·fallback 경로
+
+## Stage별 예상 변경 경계
+
+1. Stage 1: `virtual-scroll.ts`와 자동 배치 focused test, working 보고서
+2. Stage 2: `canvas-view.ts` 줌 상태 전이와 앵커 focused test, working 보고서
+3. Stage 3: `canvas-pool.ts`/필요한 `page-renderer.ts` 최소 교체 API와 계측 test, working 보고서
+4. Stage 4: 통합 test·build·browser evidence와 최종 보고서
+
+각 Stage 결과 승인 뒤 해당 source·test·보고 문서를 하나의 검토 가능한 commit으로 고정한다. 실제 조사에서
+파일 책임이 달라지면 source를 수정하기 전에 이 구현 계획과 승인 기록부터 갱신한다.
+
+## native stacked PR 연결 계획
+
+1. #6040의 네 Stage와 최종 승인을 마치고 bottom head를 고정한다.
+2. 그 head에서 `codex/issue-6041-adaptive-render-scale`을 만들고 #6041 수행·구현 계획 승인을 받는다.
+3. #6041 완료 head에서 `codex/issue-6042-page-virtualization`을 만들고 #6042 수행·구현 계획 승인을 받는다.
+4. `gh stack view`에서 `devel ← #6040 ← #6041 ← #6042` 순서와 각 layer diff를 확인한다.
+5. 세 head의 범위별·누적 검증, 한국어 PR 제목·본문·stack map을 사용자에게 보고하고 게시 승인을 받는다.
+6. `gh stack submit --remote upstream`은 push와 PR 생성을 함께 수행하므로 승인 뒤 한 번 실행한다.
+7. GitHub native stack public preview의 cascading rebase 뒤에는 영향받은 상단 head를 다시 동기화·검증한다.
+
+## 커밋 경계 후보
+
+1. `docs(studio): #6040 자동 줌 토폴로지 계획을 기록한다`
+2. `fix(studio): 자동 페이지 열과 점유 그리드 정렬을 바로잡는다`
+3. `perf(studio): 줌 preview와 토폴로지 commit을 분리한다`
+4. `perf(studio): 줌 정착 Canvas를 점진 교체한다`
+5. `docs(test): #6040 통합 검증 결과를 기록한다`
+
+#6041의 render scale tier와 #6042의 LRU·scheduler 변경은 이 branch에 포함하지 않는다.

--- a/mydocs/plans/task_m100_6040_impl.md
+++ b/mydocs/plans/task_m100_6040_impl.md
@@ -5,6 +5,8 @@
 - **기준 commit**: `upstream/devel` `2deb3dd61`
 - **문서 성격**: 구현 전 파일·상태 전이 설계
 - **계획 승인**: 2026-08-30 작업지시자 승인, Stage 1 진행
+- **현재 상태**: Stage 2·3 구현 폐기·Stage 1 `63fa3d0cf` 재구성 완료. 아래 줌 상태 전이 설계는
+  역사적 폐기안이며 새 공유 좌표 계획 승인 전에는 구현하지 않는다.
 
 ## 자동 열 계약
 
@@ -33,6 +35,11 @@ candidate = clamp(fitColumns, 1, pageCount)
 - 마지막 미완성 행은 이 작업에서 별도 가운데 정렬하지 않고 기존 `pageIdx % columns` 규칙을 보존한다.
 
 ## 줌 상태 전이
+
+> **폐기된 설계**: 이 절의 Canvas 전용 preview는 눈금자·캐럿·선택·hit-test와 다른 좌표계를 만들어
+> 회귀를 일으켰다. 현재 branch의 `CanvasView`·`Ruler`·`ViewportManager`·caret/input 경로는 기준
+> `2deb3dd61`과 동일하다. 후속 설계는 모든 소비자가 하나의 authoritative preview geometry를
+> 사용하거나, 기존처럼 매 프레임 같은 `VirtualScroll`을 소비해야 한다.
 
 ```text
 idle

--- a/mydocs/plans/task_m100_6040_impl.md
+++ b/mydocs/plans/task_m100_6040_impl.md
@@ -2,12 +2,12 @@
 
 - **이슈**: [#6040](https://github.com/edwardkim/rhwp/issues/6040)
 - **브랜치**: `codex/issue-6040-zoom-topology`
-- **PR 기준 commit**: `upstream/devel` `7592e9c99`
+- **PR 기준 commit**: `upstream/devel` `0d1540931`
 - **최초 구현 기준**: `upstream/devel` `2deb3dd61`
 - **문서 성격**: 구현 전 파일·상태 전이 설계
 - **계획 승인**: 2026-08-30 작업지시자 승인, Stage 1 진행
-- **현재 상태**: Stage 2·3 구현 폐기·Stage 1 `a135cc266` 재구성 완료. 아래 줌 상태 전이 설계는
-  역사적 폐기안이며 새 공유 좌표 계획 승인 전에는 구현하지 않는다.
+- **현재 상태**: Stage 2·3 구현 폐기, Stage 1·1.1 유지, Stage 1.2 live 자동 열 commit 보정. 아래 줌
+  상태 전이 설계는 역사적 폐기안이며 새 공유 좌표 계획 승인 전에는 구현하지 않는다.
 
 ## 자동 열 계약
 
@@ -70,13 +70,19 @@ VirtualScroll 좌표와 snapshot으로 현재 active Canvas·overlay에만 previ
 
 - `GRID_ZOOM_THRESHOLD`와 그 분기를 제거한다.
 - auto candidate/commit에 필요한 순수 helper 또는 작은 value object를 추가한다.
-- `setPageDimensions()`가 auto의 이전 committed columns 또는 명시적 commit 값을 받을 수 있게 하되 fixed
-  arrangement 호출 계약은 바꾸지 않는다.
+- `VirtualScroll` 인스턴스가 auto의 이전 committed columns를 보존하고 다음 `setPageDimensions()` 계산에
+  전달한다. horizontal·고정 배치·문서 교체에서는 이를 reset하며 fixed arrangement 호출 계약은 바꾸지
+  않는다.
 - `getLayoutTopologyKey()`에 commit된 auto columns만 반영해 preview 후보가 topology 변경으로 보이지 않게
   한다.
 - auto의 grid width와 margin은 실제 점유 열을 사용한다.
 
 ### `rhwp-studio/src/view/canvas-view.ts`
+
+- **Stage 1.2 실제 변경**: `reset()`이 `VirtualScroll.resetAutoColumnCommit()`을 호출해 이전 문서의
+  경계 상태를 제거한다. settled zoom의 기존 전체 반환·재할당 경로는 변경하지 않는다.
+
+아래 항목은 폐기된 Stage 2 설계이며 현재 code candidate에 포함되지 않는다.
 
 - `ZoomLayoutPreviewSession` 상태와 render epoch를 관리한다.
 - `onZoomChanged()`를 animation preview와 settled commit 경로로 분리한다.
@@ -106,6 +112,12 @@ VirtualScroll 좌표와 snapshot으로 현재 active Canvas·overlay에만 previ
 - 기존 DEV 진단 패턴을 따라 제스처당 preview frame, layout commit, candidate change, full release,
   page replacement 횟수와 anchor CSS px 오차를 관찰 가능하게 한다.
 - production 동작이나 공개 문서 모델에는 진단 상태를 저장하지 않는다.
+
+### `rhwp-studio/src/engine/input-handler.ts`
+
+- **Stage 1.2 실제 변경**: 기존 zoom overlay 갱신을 공통 메서드로 모으고, viewport resize에서는
+  CanvasView가 레이아웃을 확정한 다음 tick에 캐럿·필드·텍스트/셀 선택·그림/표 선택을 다시 투영한다.
+- 별도 preview 좌표를 만들지 않고 기존 cursor/VirtualScroll authoritative geometry만 소비한다.
 
 ## 테스트
 
@@ -138,9 +150,11 @@ VirtualScroll 좌표와 snapshot으로 현재 active Canvas·overlay에만 previ
 ## Stage별 예상 변경 경계
 
 1. Stage 1: `virtual-scroll.ts`와 자동 배치 focused test, working 보고서
-2. Stage 2: `canvas-view.ts` 줌 상태 전이와 앵커 focused test, working 보고서
-3. Stage 3: `canvas-pool.ts`/필요한 `page-renderer.ts` 최소 교체 API와 계측 test, working 보고서
-4. Stage 4: 통합 test·build·browser evidence와 최종 보고서
+2. Stage 1.1: 수평 눈금자 끝 라벨 경계 처리와 실제 브라우저 검증
+3. Stage 1.2: live auto commit·문서 reset·resize overlay 재투영과 actual CanvasView/CanvasPool test
+4. Stage 2: **폐기**, Canvas 전용 줌 상태 전이와 앵커 설계를 현재 branch에서 제거
+5. Stage 3: **폐기**, 점진 Canvas 교체와 계측을 현재 branch에서 제거
+6. Stage 4: Stage 1~1.2 통합 test·build·browser evidence와 최종 보고서
 
 각 Stage 결과 승인 뒤 해당 source·test·보고 문서를 하나의 검토 가능한 commit으로 고정한다. 실제 조사에서
 파일 책임이 달라지면 source를 수정하기 전에 이 구현 계획과 승인 기록부터 갱신한다.

--- a/mydocs/pr/archives/pr_6458_review.md
+++ b/mydocs/pr/archives/pr_6458_review.md
@@ -1,6 +1,6 @@
 ---
 kind: pr-review
-status: pending-push
+status: draft-ci-green
 canonical: mydocs/manual/pr_review_workflow.md
 last_verified: 2026-09-01
 pr: 6458
@@ -32,13 +32,13 @@ author: postmelee
 | devel merge commit | `a19020085`, `db1a15fb1` |
 | Stage 1.2 code candidate | `333fa8f5d` |
 | local integration candidate | `afa32ef18` |
-| remote head | `0a6e6e2a320611ec5f2bb64483f927242597c251` |
-| 누적 규모 | 20 files, `+1153/-51`, 11 commits |
-| 원격 상태 | Draft, local candidate push·required CI 대기 |
+| remote head | `dff556c8ef91df233291454a69bcac4a66673709` |
+| 누적 규모 | 20 files, `+1177/-51`, 12 commits |
+| 원격 상태 | Draft, `MERGEABLE/CLEAN`, required checks 완료 |
 
-PR #6458은 GitHub native stack의 bottom PR이다. 현재 로컬 후보는 최신 `upstream/devel`을 merge commit으로
-통합했으며, 원격 Draft head는 maintainer review 이전 후보에 머물러 있다. 따라서 아래 Stage 1.2 해결 근거는
-push 전 로컬 판정이고 원격 required checks의 성공을 주장하지 않는다.
+PR #6458은 GitHub native stack의 bottom PR이다. 최신 `upstream/devel` 통합과 Stage 1.2 해결 근거가
+remote Draft head에 게시됐고 required checks까지 완료됐다. Ready 전환은 stack 전체를 완성한 뒤 별도
+승인 gate에서 처리한다.
 
 현재 code candidate가 포함하는 범위는 다음과 같다.
 
@@ -95,6 +95,13 @@ Rust source·test·fixture·renderer/export 출력은 바꾸지 않으므로 Rus
 실행하지 않았다. Studio 화면 배치와 overlay 동작은 actual method test와 실제 browser 결과를 권위
 근거로 사용한다.
 
+remote head `dff556c8e`의 34 checks는 18 success, 15 scope-based skip, 1 neutral, failure·pending 0으로
+완료됐다. [CI run 33499726401](https://github.com/edwardkim/rhwp/actions/runs/33499726401),
+[CodeQL run 33499726503](https://github.com/edwardkim/rhwp/actions/runs/33499726503),
+[Render Diff run 33499726189](https://github.com/edwardkim/rhwp/actions/runs/33499726189),
+[Adapter inter-diff run 33499726498](https://github.com/edwardkim/rhwp/actions/runs/33499726498),
+[Proptest run 33499726475](https://github.com/edwardkim/rhwp/actions/runs/33499726475)이 성공했다.
+
 ## 실제 브라우저·시각 검증
 
 Canvas2D로 77쪽 `kps-ai.hwp`를 열고 자동 배치 77%에서 편집 viewport 폭을 왕복했다.
@@ -121,8 +128,9 @@ Stage 1.1의 기존 브라우저 근거도 유지된다. 6쪽 문서 자동 60%�
 
 - #6444는 contributor credit과 source head 계보를 댓글로 남기고 #6458→#6467→#6042에 인계한 뒤
   2026-09-01 닫았다.
-- #6438은 이 local candidate를 #6458 원격에 push해 maintainer가 대체 구현을 확인할 수 있게 한 뒤,
-  contributor credit·검토에서 얻은 Canvas ownership 조건을 명시하고 닫는다.
+- #6438은 contributor `kevin9327`의 source head `29b37abec`와 Canvas ownership·visible/prefetch 검토
+  조건을 [인계 댓글](https://github.com/edwardkim/rhwp/pull/6438#issuecomment-5492945930)로 보존하고,
+  #6458 required checks가 성공한 뒤 superseded 상태로 닫았다. merge하지 않았다.
 - #6454에서 공유 frame 좌표계의 비용·효과를 먼저 측정한다. 그 결정 전에 #6467을 새 bottom head 위로
   반복 restack하지 않는다.
 - #6454 결정 뒤 #6467을 #6458 위에 restack하고 layer diff·CI·34/50/100% 시각 증적을 다시 검증한다.
@@ -130,7 +138,7 @@ Stage 1.1의 기존 브라우저 근거도 유지된다. 6쪽 문서 자동 60%�
 
 ## 최종 권고
 
-**Stage 1.2 local candidate는 push 가능한 상태지만 PR은 Draft로 유지한다.** Maintainer가 지적한 live
-hysteresis, actual CanvasView 경로, Canvas 단일 소유권, 브라우저 caret/ruler/hit-test, 최신 devel 통합은
-로컬에서 해결·검증했다. 다음 절차는 local candidate push와 #6458 설명 댓글, 새 required CI 확인이다.
-그 뒤 #6438을 인계·종료하고 하이퍼워터폴 다음 gate인 #6454 측정 계획으로 이동한다.
+**Stage 1.2는 원격 제출·CI까지 완료됐고 PR은 Draft로 유지한다.** Maintainer가 지적한 live hysteresis,
+actual CanvasView 경로, Canvas 단일 소유권, 브라우저 caret/ruler/hit-test, 최신 devel 통합을 해결·검증했다.
+#6438 인계·종료도 완료했다. 하이퍼워터폴 다음 gate는 #6454 공유 frame 좌표계의 측정·결정 계획이며,
+그 결과 뒤에 #6467을 restack한다.

--- a/mydocs/pr/archives/pr_6458_review.md
+++ b/mydocs/pr/archives/pr_6458_review.md
@@ -1,8 +1,8 @@
 ---
 kind: pr-review
-status: pending-ci
+status: pending-push
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-08-30
+last_verified: 2026-09-01
 pr: 6458
 issue: 6040
 author: postmelee
@@ -23,98 +23,105 @@ author: postmelee
 
 ## metadata와 범위
 
-| 항목 | 작성 시점 참고값 |
+| 항목 | 2026-09-01 로컬 후보 |
 | --- | --- |
 | PR | [#6458](https://github.com/edwardkim/rhwp/pull/6458) |
 | 관련 issue | [#6040](https://github.com/edwardkim/rhwp/issues/6040) |
 | base / head | `devel` / `codex/issue-6040-zoom-topology` |
-| 제출 기준 devel | `7592e9c99a1ca7c13604a33a9a22eb141b04973d` |
-| code candidate | `afb33b50edfcef7cc59e3169c294c35137bad7f2` |
-| 규모 | 12 files, `+695/-21`, 5 commits |
-| 원격 상태 | Draft, `MERGEABLE`, `mergeStateStatus=BLOCKED`; code candidate required CI 성공 |
+| 최신 통합 devel | `0d1540931d59a8712c27f339fcbb71e1c00fd4b1` |
+| devel merge commit | `a19020085e7074ecc06f343f457e2d455811ec96` |
+| local code candidate | `333fa8f5d` |
+| remote head | `dfe27e18884cd067b0f4ccd0ed9141e20640fac5` |
+| 누적 규모 | 18 files, `+1131/-51`, 8 commits |
+| 원격 상태 | Draft, local candidate push·required CI 대기 |
 
-PR 생성 뒤 `upstream/devel`은 `d3b40a3d7c3ecb5d0f014ce604b99fda17b2bd9b`까지 24 commits
-전진했다. 작성 시점의 최신 base와 code candidate는 `git merge-tree --write-tree upstream/devel HEAD`에서
-충돌 없이 tree `d7c220a889846ebe7b0997fc17eee2e4f1d7f1a4`를 만들었다. review-only 기록만을 위해 source를
-merge하거나 rebase하지 않으며, merge 전 최신 base와 mergeability를 다시 확인한다.
+PR #6458은 GitHub native stack의 bottom PR이다. 현재 로컬 후보는 최신 `upstream/devel`을 merge commit으로
+통합했으며, 원격 Draft head는 maintainer review 이전 후보에 머물러 있다. 따라서 아래 Stage 1.2 해결 근거는
+push 전 로컬 판정이고 원격 required checks의 성공을 주장하지 않는다.
 
-이 PR은 GitHub native stack의 bottom PR이다. #6041은 이 source branch를 base로, #6042는 #6041
-source branch를 base로 추가한다. 자동 쪽 배치가 다음 계약을 지키도록 고친다.
+현재 code candidate가 포함하는 범위는 다음과 같다.
 
 - 고정 50% gate 대신 표시 페이지 폭·쪽 간격·편집 viewport 폭으로 자동 열 수를 고른다.
 - 열 수를 실제 페이지 수로 제한하고, 빈 grid slot이 아니라 실제 점유 페이지 묶음을 가운데에 둔다.
+- 이전 auto 열 commit을 live `VirtualScroll` 경로가 보존·전달해 경계에서 히스테리시스를 적용한다.
+- horizontal·고정 배치·문서 교체에서 이전 auto commit을 reset한다.
+- resize 레이아웃 확정 뒤 캐럿·선택 overlay를 같은 authoritative 좌표에 다시 투영한다.
 - 155% A4 수평 눈금자에서 종이 밖으로 넘는 `21` 라벨만 숨기고 끝 tick과 종이 경계는 유지한다.
-- 기존 `VirtualScroll` 기반 줌·눈금자·캐럿 좌표 경로는 유지한다.
 
-PR 본문은 `Refs #6040`을 사용한다. #6040 본문의 CSS zoom preview, topology commit, 점진적 Canvas
-교체 성능 수용 기준은 이 code candidate에 포함되지 않으므로 이 PR로 issue를 닫지 않는다.
+PR 본문은 `Refs #6040`을 사용한다. #6040 본문의 폐기된 CSS zoom preview·점진 Canvas 교체와 #6041
+render scale, #6042 LRU·scheduler는 포함하지 않으므로 이 PR로 issue를 닫지 않는다.
 
-## self-review와 범위 결정
+## maintainer blocker와 로컬 해결 판정
 
-**현재 Stage 1·1.1 범위는 조건부 수용 권고한다.** 표시 geometry에서 열 수를 계산하고 실제 점유
-묶음을 별도로 가운데에 두는 경계는 2열 누락과 저배율 좌측 쏠림을 직접 해결한다. 눈금자 라벨은
-canvas text bounds가 종이 안에 완전히 들어오는 경우에만 그려 끝 tick·경계 계산을 바꾸지 않는다.
+Maintainer는 [review comment](https://github.com/edwardkim/rhwp/pull/6458#issuecomment-5487030630)에서
+순수 helper만 `committedColumns`를 받고 live 경로가 이전 commit을 전달하지 않는 점을 차단했다.
 
-초기 계획의 Canvas 전용 CSS zoom preview와 점진적 Canvas 교체 Stage 2·3도 로컬에서 구현했으나,
-기존 `VirtualScroll` 좌표와 preview 좌표가 병행되면서 좌우·상하 jump, 눈금자 반영 지연, 캐럿·선택·
-hit-test 회귀 위험이 확인됐다. 해당 구현은 안전 branch에만 보존하고 이 PR에서 제거했다. 사용자는
-Stage 1 기준 재구성과 눈금자 끝 라벨 처리를 직접 확인해 현재 범위로 결정했다.
+| 요청 | 로컬 후보 판정 |
+| --- | --- |
+| live auto 경로가 이전 commit 소유·전달 | `VirtualScroll.committedAutoColumns`로 해결 |
+| 동일 VirtualScroll 연속 입력 test | `800→814→806→818→806→801px`, `1→1→1→2→2→1열` 통과 |
+| 실제 `CanvasView.onZoomChanged()` test | Vite SSR actual method 실행, zoom event당 layout commit 1회 확인 |
+| Canvas pool/DOM 소유권 | 매 settled zoom에서 active page·DOM canvas·고유 slot 1:1 확인 |
+| 실제 browser 경계 zoom·resize | 77쪽 `kps-ai.hwp`의 1↔2열 왕복과 ruler·caret·hit-test 확인 |
+| 최신 devel 통합 | `upstream/devel@0d1540931`을 `a19020085`로 통합 |
+| 내부 review 현행화 | 이 문서와 Stage 1.2 보고서를 local candidate 기준으로 갱신 |
+| child #6467 restack | #6454 측정·결정 gate 뒤 수행하도록 보류 |
 
-별도 `pr_6458_review_impl.md`는 만들지 않는다. maintainer 보정이나 conflict 해결이 없고, 구현·rollback과
-후속 stack 순서는 [수행 계획](../../plans/task_m100_6040.md)과
-[구현 계획](../../plans/task_m100_6040_impl.md)에 이미 기록돼 있다.
+PR #6438의 progressive Canvas 교체는 active pool을 새 Canvas로 덮고 기존 DOM Canvas를 orphan으로
+남기는 문제와 동기 렌더 장시간 작업이 review에서 확인됐다. 이 후보는 해당 경로를 가져오지 않고 기존
+settled `releaseAllRenderedPages() → updateVisiblePages()`를 보존한다. actual CanvasPool test는 이 결정이
+매 zoom 뒤 단일 소유권을 유지함을 고정한다.
 
 ## 완료한 로컬 검증
 
-제출 기준 `devel@7592e9c99`에 재배치한 code candidate에서 다음 검증을 완료했다.
+local code candidate `333fa8f5d`에서 다음을 완료했다.
 
 | 검증 | 결과 |
 | --- | --- |
+| focused | 34/34 pass |
 | TypeScript | `npx tsc --noEmit` 통과 |
-| Studio test | 1,278건 중 1,277 pass, 1 skip, 0 fail |
-| Studio build | 243 modules 빌드 통과, 기존 대형 chunk 경고만 확인 |
-| Rust format | 파생 regression suite 준비 뒤 `cargo fmt --all -- --check` 통과 |
-| diff·문서 | `git diff --check`, 변경 Markdown 상대 링크 검사 통과 |
-| 최신 base 병합 | `devel@d3b40a3d7`과 자동 merge tree 생성 통과 |
+| Studio test | 1,352건 중 1,351 pass, 1 policy skip, 0 fail |
+| Studio build | 246 modules 빌드 통과, 기존 browser externalize·대형 chunk 경고만 확인 |
+| WASM binding | 공식 `scripts/wasm-pack-locked.sh`로 최신 devel binding 생성 확인, tracked diff 없음 |
+| diff | `git diff --check` 통과 |
 
-Rust source·test·fixture·renderer/export 출력은 바꾸지 않으므로 Cargo test와 Clippy, PDF/SVG visual
-sweep은 실행하지 않았다. 파생 `tests/generated/`와 `tests/suites/manifest.json`은 ignored 검증 산출물로
-PR에 포함하지 않았다.
+Rust source·test·fixture·renderer/export 출력은 바꾸지 않으므로 Rust Clippy 묶음과 PDF/SVG visual sweep은
+실행하지 않았다. Studio 화면 배치와 overlay 동작은 actual method test와 실제 browser 결과를 권위
+근거로 사용한다.
 
 ## 실제 브라우저·시각 검증
 
-`http://127.0.0.1:4176/?renderer=canvas2d`의 6쪽 문서를 실제 브라우저에서 열어 확인했다.
+Canvas2D로 77쪽 `kps-ai.hwp`를 열고 자동 배치 77%에서 편집 viewport 폭을 왕복했다.
 
-- 편집 viewport 1260px에서 자동 60%는 2열이고 점유 묶음 중심 오차는 0.14px였다.
-- 같은 문서의 자동 50%는 3열이고 점유 묶음 중심 오차는 0.07px였다.
-- A4 155%에서 20cm 라벨은 보이고 21cm 라벨은 숨겨졌으며 끝 tick·종이 경계는 남았다.
-- 브라우저 warning/error log는 0건이었다.
-- 작업지시자는 반복 zoom 영상 비교로 Stage 2·3 회귀를 확인했고, 제거 뒤 Stage 1 기준 재구성과
-  Stage 1.1 결과를 직접 검증해 현재 범위에 동의했다.
+| 편집 viewport 폭 | 1225px | 1235px | 1240px | 1235px | 1220px |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 확정 열 수 | 1 | 1 | 2 | 2 | 1 |
+| DOM canvas / 고유 page slot | 3/3 | 3/3 | 4/4 | 4/4 | 3/3 |
+| 현재 쪽 | 2/77 | 2/77 | 2/77 | 2/77 | 2/77 |
 
-이번 변경은 Studio viewport의 페이지 배치와 ruler overlay 동작이며 HWP/HWPX/PDF renderer 결과나
-fixture를 바꾸지 않는다. 따라서 기준 PDF visual sweep 대신 자동 geometry 회귀와 실제 browser 동작을
-직접 판정했다. #6040 이슈의 사용자 재현 이미지는 참고 근거이며 별도 제품 출력 기준 asset으로 승격하지
-않는다.
+- 증가·감소 dead band 안에서는 기존 열 commit을 유지하고 경계 밖에서만 1↔2열로 전환했다.
+- 캐럿은 매 단계 2쪽 안에 있었고 1열로 돌아오면 처음 좌표로 복귀했다.
+- 수평 눈금자 canvas 폭은 매 단계 편집 viewport 폭과 정확히 일치했다.
+- 2쪽 클릭 hit-test 뒤 현재 쪽이 2/77로 유지됐다.
+- DOM canvas 수와 고유 page slot 수가 항상 같아 orphan/중복 Canvas가 없었다.
 
-## 위험과 후속 조건
+Stage 1.1의 기존 브라우저 근거도 유지된다. 6쪽 문서 자동 60%는 2열, 50%는 3열이며 A4 155%에서
+20cm 라벨은 보이고 21cm 라벨만 숨겨진다. 끝 tick과 종이 경계는 남는다.
 
-- 이 PR은 #6040의 성능 최적화 전체가 아니라 검증된 배치 정합성 범위만 포함한다. 남은 Stage 2·3은
-  기존 좌표계와 단일 소유권을 보장하는 별도 설계 없이는 다시 추가하지 않는다.
-- #6041·#6042는 각각 직전 PR source branch를 base로 삼되, 각 layer의 diff·검증·승인 기록을 분리한다.
-- code candidate의 required checks는 17 success, 15 scope-based skip, 0 failure·pending으로 완료됐다.
-  [CI run 33301044206](https://github.com/edwardkim/rhwp/actions/runs/33301044206)의 Frontend package
-  gate와 Build & Test aggregate,
-  [CodeQL run 33301044201](https://github.com/edwardkim/rhwp/actions/runs/33301044201),
-  [Render Diff run 33301044144](https://github.com/edwardkim/rhwp/actions/runs/33301044144),
-  [Adapter inter-diff run 33301044199](https://github.com/edwardkim/rhwp/actions/runs/33301044199),
-  [Proptest roundtrip run 33301044191](https://github.com/edwardkim/rhwp/actions/runs/33301044191)이 성공했다.
-- review-only trailing head를 push한 뒤 exact code candidate의 녹색 결과 재사용 여부와 최신 required
-  aggregate, mergeability를 확인한다.
-- Draft 해제와 실제 merge는 stack 완성 상태를 공유한 뒤 작업지시자의 별도 승인을 받는다.
+## 외부 PR 인계와 stack 후속 조건
+
+- #6444는 contributor credit과 source head 계보를 댓글로 남기고 #6458→#6467→#6042에 인계한 뒤
+  2026-09-01 닫았다.
+- #6438은 이 local candidate를 #6458 원격에 push해 maintainer가 대체 구현을 확인할 수 있게 한 뒤,
+  contributor credit·검토에서 얻은 Canvas ownership 조건을 명시하고 닫는다.
+- #6454에서 공유 frame 좌표계의 비용·효과를 먼저 측정한다. 그 결정 전에 #6467을 새 bottom head 위로
+  반복 restack하지 않는다.
+- #6454 결정 뒤 #6467을 #6458 위에 restack하고 layer diff·CI·34/50/100% 시각 증적을 다시 검증한다.
+- #6042는 그 stack이 안정된 뒤 재개한다.
 
 ## 최종 권고
 
-**Draft bottom PR로 조건부 수용.** 현재 Stage 1·1.1 구현과 로컬·브라우저 검증은 #6040의 배치 정합성
-범위를 충족한다. 다만 code candidate와 trailing review-only head의 required checks가 모두 성공하고,
-최신 base에 대한 mergeability를 다시 확인하기 전에는 Ready 전환이나 merge를 권고하지 않는다.
+**Stage 1.2 local candidate는 push 가능한 상태지만 PR은 Draft로 유지한다.** Maintainer가 지적한 live
+hysteresis, actual CanvasView 경로, Canvas 단일 소유권, 브라우저 caret/ruler/hit-test, 최신 devel 통합은
+로컬에서 해결·검증했다. 다음 절차는 local candidate push와 #6458 설명 댓글, 새 required CI 확인이다.
+그 뒤 #6438을 인계·종료하고 하이퍼워터폴 다음 gate인 #6454 측정 계획으로 이동한다.

--- a/mydocs/pr/archives/pr_6458_review.md
+++ b/mydocs/pr/archives/pr_6458_review.md
@@ -1,0 +1,120 @@
+---
+kind: pr-review
+status: pending-ci
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-30
+pr: 6458
+issue: 6040
+author: postmelee
+---
+
+# PR #6458 review - 자동 쪽 배치 열 선택과 점유 중앙 정렬
+
+## 라우팅
+
+- base route: `collaborator_self_merge.md`
+- modifiers: `intake_and_review.md`, `local_validation.md`,
+  `visual_fixture_evidence.md`, `review_only_fast_pass.md`
+- loaded documents: `pr_review_workflow.md`, `pr_review/README.md`,
+  `pr_review/collaborator_self_merge.md`, `pr_review/intake_and_review.md`,
+  `pr_review/local_validation.md`, `pr_review/visual_fixture_evidence.md`,
+  `pr_review/review_only_fast_pass.md`, `codex/docs_and_git_workflow.md`
+- 작성자·self-review: `postmelee`; collaborator 본인 PR이므로 reviewer request는 등록하지 않았다.
+
+## metadata와 범위
+
+| 항목 | 작성 시점 참고값 |
+| --- | --- |
+| PR | [#6458](https://github.com/edwardkim/rhwp/pull/6458) |
+| 관련 issue | [#6040](https://github.com/edwardkim/rhwp/issues/6040) |
+| base / head | `devel` / `codex/issue-6040-zoom-topology` |
+| 제출 기준 devel | `7592e9c99a1ca7c13604a33a9a22eb141b04973d` |
+| code candidate | `afb33b50edfcef7cc59e3169c294c35137bad7f2` |
+| 규모 | 12 files, `+695/-21`, 5 commits |
+| 원격 상태 | Draft, `MERGEABLE`, `mergeStateStatus=BLOCKED`; code candidate required CI 성공 |
+
+PR 생성 뒤 `upstream/devel`은 `d3b40a3d7c3ecb5d0f014ce604b99fda17b2bd9b`까지 24 commits
+전진했다. 작성 시점의 최신 base와 code candidate는 `git merge-tree --write-tree upstream/devel HEAD`에서
+충돌 없이 tree `d7c220a889846ebe7b0997fc17eee2e4f1d7f1a4`를 만들었다. review-only 기록만을 위해 source를
+merge하거나 rebase하지 않으며, merge 전 최신 base와 mergeability를 다시 확인한다.
+
+이 PR은 GitHub native stack의 bottom PR이다. #6041은 이 source branch를 base로, #6042는 #6041
+source branch를 base로 추가한다. 자동 쪽 배치가 다음 계약을 지키도록 고친다.
+
+- 고정 50% gate 대신 표시 페이지 폭·쪽 간격·편집 viewport 폭으로 자동 열 수를 고른다.
+- 열 수를 실제 페이지 수로 제한하고, 빈 grid slot이 아니라 실제 점유 페이지 묶음을 가운데에 둔다.
+- 155% A4 수평 눈금자에서 종이 밖으로 넘는 `21` 라벨만 숨기고 끝 tick과 종이 경계는 유지한다.
+- 기존 `VirtualScroll` 기반 줌·눈금자·캐럿 좌표 경로는 유지한다.
+
+PR 본문은 `Refs #6040`을 사용한다. #6040 본문의 CSS zoom preview, topology commit, 점진적 Canvas
+교체 성능 수용 기준은 이 code candidate에 포함되지 않으므로 이 PR로 issue를 닫지 않는다.
+
+## self-review와 범위 결정
+
+**현재 Stage 1·1.1 범위는 조건부 수용 권고한다.** 표시 geometry에서 열 수를 계산하고 실제 점유
+묶음을 별도로 가운데에 두는 경계는 2열 누락과 저배율 좌측 쏠림을 직접 해결한다. 눈금자 라벨은
+canvas text bounds가 종이 안에 완전히 들어오는 경우에만 그려 끝 tick·경계 계산을 바꾸지 않는다.
+
+초기 계획의 Canvas 전용 CSS zoom preview와 점진적 Canvas 교체 Stage 2·3도 로컬에서 구현했으나,
+기존 `VirtualScroll` 좌표와 preview 좌표가 병행되면서 좌우·상하 jump, 눈금자 반영 지연, 캐럿·선택·
+hit-test 회귀 위험이 확인됐다. 해당 구현은 안전 branch에만 보존하고 이 PR에서 제거했다. 사용자는
+Stage 1 기준 재구성과 눈금자 끝 라벨 처리를 직접 확인해 현재 범위로 결정했다.
+
+별도 `pr_6458_review_impl.md`는 만들지 않는다. maintainer 보정이나 conflict 해결이 없고, 구현·rollback과
+후속 stack 순서는 [수행 계획](../../plans/task_m100_6040.md)과
+[구현 계획](../../plans/task_m100_6040_impl.md)에 이미 기록돼 있다.
+
+## 완료한 로컬 검증
+
+제출 기준 `devel@7592e9c99`에 재배치한 code candidate에서 다음 검증을 완료했다.
+
+| 검증 | 결과 |
+| --- | --- |
+| TypeScript | `npx tsc --noEmit` 통과 |
+| Studio test | 1,278건 중 1,277 pass, 1 skip, 0 fail |
+| Studio build | 243 modules 빌드 통과, 기존 대형 chunk 경고만 확인 |
+| Rust format | 파생 regression suite 준비 뒤 `cargo fmt --all -- --check` 통과 |
+| diff·문서 | `git diff --check`, 변경 Markdown 상대 링크 검사 통과 |
+| 최신 base 병합 | `devel@d3b40a3d7`과 자동 merge tree 생성 통과 |
+
+Rust source·test·fixture·renderer/export 출력은 바꾸지 않으므로 Cargo test와 Clippy, PDF/SVG visual
+sweep은 실행하지 않았다. 파생 `tests/generated/`와 `tests/suites/manifest.json`은 ignored 검증 산출물로
+PR에 포함하지 않았다.
+
+## 실제 브라우저·시각 검증
+
+`http://127.0.0.1:4176/?renderer=canvas2d`의 6쪽 문서를 실제 브라우저에서 열어 확인했다.
+
+- 편집 viewport 1260px에서 자동 60%는 2열이고 점유 묶음 중심 오차는 0.14px였다.
+- 같은 문서의 자동 50%는 3열이고 점유 묶음 중심 오차는 0.07px였다.
+- A4 155%에서 20cm 라벨은 보이고 21cm 라벨은 숨겨졌으며 끝 tick·종이 경계는 남았다.
+- 브라우저 warning/error log는 0건이었다.
+- 작업지시자는 반복 zoom 영상 비교로 Stage 2·3 회귀를 확인했고, 제거 뒤 Stage 1 기준 재구성과
+  Stage 1.1 결과를 직접 검증해 현재 범위에 동의했다.
+
+이번 변경은 Studio viewport의 페이지 배치와 ruler overlay 동작이며 HWP/HWPX/PDF renderer 결과나
+fixture를 바꾸지 않는다. 따라서 기준 PDF visual sweep 대신 자동 geometry 회귀와 실제 browser 동작을
+직접 판정했다. #6040 이슈의 사용자 재현 이미지는 참고 근거이며 별도 제품 출력 기준 asset으로 승격하지
+않는다.
+
+## 위험과 후속 조건
+
+- 이 PR은 #6040의 성능 최적화 전체가 아니라 검증된 배치 정합성 범위만 포함한다. 남은 Stage 2·3은
+  기존 좌표계와 단일 소유권을 보장하는 별도 설계 없이는 다시 추가하지 않는다.
+- #6041·#6042는 각각 직전 PR source branch를 base로 삼되, 각 layer의 diff·검증·승인 기록을 분리한다.
+- code candidate의 required checks는 17 success, 15 scope-based skip, 0 failure·pending으로 완료됐다.
+  [CI run 33301044206](https://github.com/edwardkim/rhwp/actions/runs/33301044206)의 Frontend package
+  gate와 Build & Test aggregate,
+  [CodeQL run 33301044201](https://github.com/edwardkim/rhwp/actions/runs/33301044201),
+  [Render Diff run 33301044144](https://github.com/edwardkim/rhwp/actions/runs/33301044144),
+  [Adapter inter-diff run 33301044199](https://github.com/edwardkim/rhwp/actions/runs/33301044199),
+  [Proptest roundtrip run 33301044191](https://github.com/edwardkim/rhwp/actions/runs/33301044191)이 성공했다.
+- review-only trailing head를 push한 뒤 exact code candidate의 녹색 결과 재사용 여부와 최신 required
+  aggregate, mergeability를 확인한다.
+- Draft 해제와 실제 merge는 stack 완성 상태를 공유한 뒤 작업지시자의 별도 승인을 받는다.
+
+## 최종 권고
+
+**Draft bottom PR로 조건부 수용.** 현재 Stage 1·1.1 구현과 로컬·브라우저 검증은 #6040의 배치 정합성
+범위를 충족한다. 다만 code candidate와 trailing review-only head의 required checks가 모두 성공하고,
+최신 base에 대한 mergeability를 다시 확인하기 전에는 Ready 전환이나 merge를 권고하지 않는다.

--- a/mydocs/pr/archives/pr_6458_review.md
+++ b/mydocs/pr/archives/pr_6458_review.md
@@ -28,11 +28,12 @@ author: postmelee
 | PR | [#6458](https://github.com/edwardkim/rhwp/pull/6458) |
 | 관련 issue | [#6040](https://github.com/edwardkim/rhwp/issues/6040) |
 | base / head | `devel` / `codex/issue-6040-zoom-topology` |
-| 최신 통합 devel | `0d1540931d59a8712c27f339fcbb71e1c00fd4b1` |
-| devel merge commit | `a19020085e7074ecc06f343f457e2d455811ec96` |
-| local code candidate | `333fa8f5d` |
-| remote head | `dfe27e18884cd067b0f4ccd0ed9141e20640fac5` |
-| 누적 규모 | 18 files, `+1131/-51`, 8 commits |
+| 최신 통합 devel | `b9d408f0d` |
+| devel merge commit | `a19020085`, `db1a15fb1` |
+| Stage 1.2 code candidate | `333fa8f5d` |
+| local integration candidate | `afa32ef18` |
+| remote head | `0a6e6e2a320611ec5f2bb64483f927242597c251` |
+| 누적 규모 | 20 files, `+1153/-51`, 11 commits |
 | 원격 상태 | Draft, local candidate push·required CI 대기 |
 
 PR #6458은 GitHub native stack의 bottom PR이다. 현재 로컬 후보는 최신 `upstream/devel`을 merge commit으로
@@ -63,7 +64,7 @@ Maintainer는 [review comment](https://github.com/edwardkim/rhwp/pull/6458#issue
 | 실제 `CanvasView.onZoomChanged()` test | Vite SSR actual method 실행, zoom event당 layout commit 1회 확인 |
 | Canvas pool/DOM 소유권 | 매 settled zoom에서 active page·DOM canvas·고유 slot 1:1 확인 |
 | 실제 browser 경계 zoom·resize | 77쪽 `kps-ai.hwp`의 1↔2열 왕복과 ruler·caret·hit-test 확인 |
-| 최신 devel 통합 | `upstream/devel@0d1540931`을 `a19020085`로 통합 |
+| 최신 devel 통합 | 첫 통합 뒤 전진한 `upstream/devel@b9d408f0d`까지 `db1a15fb1`로 재통합 |
 | 내부 review 현행화 | 이 문서와 Stage 1.2 보고서를 local candidate 기준으로 갱신 |
 | child #6467 restack | #6454 측정·결정 gate 뒤 수행하도록 보류 |
 
@@ -74,16 +75,21 @@ settled `releaseAllRenderedPages() → updateVisiblePages()`를 보존한다. ac
 
 ## 완료한 로컬 검증
 
-local code candidate `333fa8f5d`에서 다음을 완료했다.
+latest integration candidate `afa32ef18`에서 다음을 완료했다.
 
 | 검증 | 결과 |
 | --- | --- |
-| focused | 34/34 pass |
+| focused | Stage 1.2 + 최신 Ruler actual harness 45/45 pass |
 | TypeScript | `npx tsc --noEmit` 통과 |
-| Studio test | 1,352건 중 1,351 pass, 1 policy skip, 0 fail |
+| Studio test | 1,361건 중 1,360 pass, 1 policy skip, 0 fail |
 | Studio build | 246 modules 빌드 통과, 기존 browser externalize·대형 chunk 경고만 확인 |
 | WASM binding | 공식 `scripts/wasm-pack-locked.sh`로 최신 devel binding 생성 확인, tracked diff 없음 |
 | diff | `git diff --check` 통과 |
+
+첫 push 직후 #6570이 `devel`에 병합돼 오늘 작업 기록 한 파일이 충돌했다. 양쪽 기록을 모두 보존해
+재통합했다. 제품 source는 자동 병합됐고, #6570의 실제 Ruler harness Canvas mock에 Stage 1.1이 사용하는
+`measureText()`가 없어서 통합 test만 실패했다. 숫자 라벨의 양수 폭을 반환하는 fake를 한 줄 추가한 뒤
+Ruler pointer·resize wrapper와 전체 Studio를 다시 통과시켰다.
 
 Rust source·test·fixture·renderer/export 출력은 바꾸지 않으므로 Rust Clippy 묶음과 PDF/SVG visual sweep은
 실행하지 않았다. Studio 화면 배치와 overlay 동작은 actual method test와 실제 browser 결과를 권위
@@ -104,6 +110,9 @@ Canvas2D로 77쪽 `kps-ai.hwp`를 열고 자동 배치 77%에서 편집 viewport
 - 수평 눈금자 canvas 폭은 매 단계 편집 viewport 폭과 정확히 일치했다.
 - 2쪽 클릭 hit-test 뒤 현재 쪽이 2/77로 유지됐다.
 - DOM canvas 수와 고유 page slot 수가 항상 같아 orphan/중복 Canvas가 없었다.
+
+위 표는 최신 `devel@b9d408f0d` 통합 뒤 다시 얻은 결과다. #6570 눈금자 resize/paint 변경 뒤에도 ruler
+bitmap/client 폭은 각 단계 `1225, 1235, 1240, 1235, 1220px`로 viewport와 정확히 일치했다.
 
 Stage 1.1의 기존 브라우저 근거도 유지된다. 6쪽 문서 자동 60%는 2열, 50%는 3열이며 A4 155%에서
 20cm 라벨은 보이고 21cm 라벨만 숨겨진다. 끝 tick과 종이 경계는 남는다.

--- a/mydocs/pr/archives/pr_6458_review.md
+++ b/mydocs/pr/archives/pr_6458_review.md
@@ -1,8 +1,8 @@
 ---
 kind: pr-review
-status: draft-ci-green
+status: approved-pending-ci
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-09-01
+last_verified: 2026-09-03
 pr: 6458
 issue: 6040
 author: postmelee
@@ -23,22 +23,19 @@ author: postmelee
 
 ## metadata와 범위
 
-| 항목 | 2026-09-01 로컬 후보 |
+| 항목 | 2026-09-03 Ready 재자격화 |
 | --- | --- |
 | PR | [#6458](https://github.com/edwardkim/rhwp/pull/6458) |
 | 관련 issue | [#6040](https://github.com/edwardkim/rhwp/issues/6040) |
 | base / head | `devel` / `codex/issue-6040-zoom-topology` |
-| 최신 통합 devel | `b9d408f0d` |
-| devel merge commit | `a19020085`, `db1a15fb1` |
+| 최신 통합 devel | `eb2ea3add` |
 | Stage 1.2 code candidate | `333fa8f5d` |
-| local integration candidate | `afa32ef18` |
-| remote head | `dff556c8ef91df233291454a69bcac4a66673709` |
-| 누적 규모 | 20 files, `+1177/-51`, 12 commits |
-| 원격 상태 | Draft, `MERGEABLE/CLEAN`, required checks 완료 |
+| 2026-09-03 restack code candidate | `4f977ef4154c441b17e76bf349190a257e0c7829` |
+| 원격 상태 | Draft, restack push·exact-head CI 대기 |
 
-PR #6458은 GitHub native stack의 bottom PR이다. 최신 `upstream/devel` 통합과 Stage 1.2 해결 근거가
-remote Draft head에 게시됐고 required checks까지 완료됐다. Ready 전환은 stack 전체를 완성한 뒤 별도
-승인 gate에서 처리한다.
+PR #6458은 GitHub native stack의 bottom PR이다. 2026-09-03 최신 `upstream/devel` 위로 세 레이어를
+cascading rebase했고, 제품 충돌 없이 선형성을 회복했다. 아래 exact-head 로컬 게이트와 원격 CI가 모두
+통과하면 이 bottom만 먼저 Ready로 전환하고, merge 직전 사용자 승인을 별도로 받는다.
 
 현재 code candidate가 포함하는 범위는 다음과 같다.
 
@@ -124,21 +121,22 @@ bitmap/client 폭은 각 단계 `1225, 1235, 1240, 1235, 1220px`로 viewport와 
 Stage 1.1의 기존 브라우저 근거도 유지된다. 6쪽 문서 자동 60%는 2열, 50%는 3열이며 A4 155%에서
 20cm 라벨은 보이고 21cm 라벨만 숨겨진다. 끝 tick과 종이 경계는 남는다.
 
-## 외부 PR 인계와 stack 후속 조건
+## 외부 PR 인계와 stack 진행 상태
 
 - #6444는 contributor credit과 source head 계보를 댓글로 남기고 #6458→#6467→#6042에 인계한 뒤
   2026-09-01 닫았다.
 - #6438은 contributor `kevin9327`의 source head `29b37abec`와 Canvas ownership·visible/prefetch 검토
   조건을 [인계 댓글](https://github.com/edwardkim/rhwp/pull/6438#issuecomment-5492945930)로 보존하고,
   #6458 required checks가 성공한 뒤 superseded 상태로 닫았다. merge하지 않았다.
-- #6454에서 공유 frame 좌표계의 비용·효과를 먼저 측정한다. 그 결정 전에 #6467을 새 bottom head 위로
-  반복 restack하지 않는다.
-- #6454 결정 뒤 #6467을 #6458 위에 restack하고 layer diff·CI·34/50/100% 시각 증적을 다시 검증한다.
-- #6042는 그 stack이 안정된 뒤 재개한다.
+- #6454 공유 frame 좌표계는 진입 gate를 통과하지 못해 제품 변경 없이 `NOT_PLANNED`로 종료했다.
+- #6467과 #6637 구현·검증을 완료했고, native stack #6640을 최신 `devel` 위에 bottom-first로 재적층했다.
+- merge는 #6458 → #6467 → #6637 순서로 진행한다. 각 단계는 직접 base가 `devel`이 된 exact head의
+  required checks를 확인하고 Ready 전환 뒤 사용자 승인을 받는다.
 
 ## 최종 권고
 
-**Stage 1.2는 원격 제출·CI까지 완료됐고 PR은 Draft로 유지한다.** Maintainer가 지적한 live hysteresis,
-actual CanvasView 경로, Canvas 단일 소유권, 브라우저 caret/ruler/hit-test, 최신 devel 통합을 해결·검증했다.
-#6438 인계·종료도 완료했다. 하이퍼워터폴 다음 gate는 #6454 공유 frame 좌표계의 측정·결정 계획이며,
-그 결과 뒤에 #6467을 restack한다.
+**승인.** Maintainer가 지적한 live hysteresis, actual CanvasView 경로, Canvas 단일 소유권,
+브라우저 caret/ruler/hit-test를 해결했고, 최신 `devel@eb2ea3add` 재적층 뒤 TypeScript, Studio 전체
+1,373건(1,372 pass·1 policy skip), production build 247 modules, E2E manifest 126/126,
+`git diff --check`를 통과했다. 제품·test 충돌은 없었다. restack push 뒤 #6458 exact-head required
+checks가 통과하면 Ready로 전환할 수 있으며, merge는 사용자 승인 전까지 수행하지 않는다.

--- a/mydocs/working/task_m100_6040_stage1.md
+++ b/mydocs/working/task_m100_6040_stage1.md
@@ -2,8 +2,10 @@
 
 - **이슈**: [#6040](https://github.com/edwardkim/rhwp/issues/6040)
 - **브랜치**: `codex/issue-6040-zoom-topology`
-- **기준 commit**: `upstream/devel` `2deb3dd61`
-- **계획 commit**: `5b98fb684`
+- **PR 기준 commit**: `upstream/devel` `7592e9c99`
+- **최초 구현 기준**: `upstream/devel` `2deb3dd61`
+- **계획 commit**: `d5cd2e387` (재배치 전 `5b98fb684`)
+- **Stage 1 commit**: `a135cc266` (재배치 전 `63fa3d0cf`)
 - **결과 승인**: 2026-08-30 작업지시자 승인; 2026-08-30 Stage 2·3 폐기 뒤 이 commit으로 재구성
 - **Stage 범위**: 자동 열 순수 계산·page count cap·중앙 정렬·히스테리시스 계약. 줌 preview와
   topology commit 분리는 Stage 2에 유지
@@ -77,7 +79,7 @@ tests 46, pass 46, fail 0
 
 Stage 2·3의 Canvas 전용 preview 설계는 기존 단일 좌표 계약을 깨는 회귀 때문에 폐기했다. 전체 상태는
 `codex/issue-6040-zoom-topology-backup-20260830@d97307cab`에 보존했고, 작업 branch는 이 Stage 1
-commit `63fa3d0cf`로 재구성했다.
+commit `a135cc266`으로 재구성했다(재배치 전 `63fa3d0cf`).
 
 ## Stage 1 재구성 뒤 기존 줌 재검증
 

--- a/mydocs/working/task_m100_6040_stage1.md
+++ b/mydocs/working/task_m100_6040_stage1.md
@@ -1,0 +1,85 @@
+# Task M100 #6040 Stage 1 완료 보고 — 자동 열과 실제 점유 중앙 정렬
+
+- **이슈**: [#6040](https://github.com/edwardkim/rhwp/issues/6040)
+- **브랜치**: `codex/issue-6040-zoom-topology`
+- **기준 commit**: `upstream/devel` `2deb3dd61`
+- **계획 commit**: `5b98fb684`
+- **결과 승인**: 2026-08-30 작업지시자 승인, Stage 2 진행
+- **Stage 범위**: 자동 열 순수 계산·page count cap·중앙 정렬·히스테리시스 계약. 줌 preview와
+  topology commit 분리는 Stage 2에 유지
+
+## 구현 결과
+
+- 자동 모드의 `zoom <= 0.5` 전역 gate를 제거했다.
+- 표시된 최대 페이지 폭, 현재 CSS page gap, 편집 영역 폭만으로 들어가는 열 수를 계산한다.
+- 후보 열 수를 `1..pageCount`로 제한해 존재하지 않는 빈 열이 그리드 중앙 정렬 폭에 포함되지 않게 했다.
+- candidate가 1열이면 기존 단일 열 CSS 중앙 정렬을, 2열 이상이면 기존 그리드 좌표 계약을 사용한다.
+- 이전 commit 열 수를 선택적으로 받는 순수 `resolveAutoPageColumns()`를 추가했다. 열 경계 양쪽에 8 CSS
+  px dead band를 두어 Stage 2의 zoom commit과 resize가 같은 계산·히스테리시스를 재사용할 수 있다.
+- `single`, `double`, `facing`, `multiple`, 가로 쪽 이동과 마지막 미완성 행의 시작 열 규칙은 바꾸지 않았다.
+
+## 문제 시나리오 측정
+
+800×1000 쪽, CSS gap 6px 조건에서 확인한 결과다.
+
+| 문서·편집 영역 | 배율 | 이전 핵심 증상 | Stage 1 결과 |
+| --- | ---: | --- | --- |
+| 6쪽·폭 900px | 51% | 전역 gate로 1열 | 2열, 묶음 중심 450px = viewport 중심 450px |
+| 6쪽·폭 900px | 50% | 폭 계산이 갑자기 활성화 | 2열 유지 |
+| 6쪽·폭 900px | 49% | 경계 직후 열 topology 변화 | 2열 유지 |
+| 3쪽·폭 2000px | 27% | 빈 열 때문에 왼쪽 치우침 | 3열, 좌우 670~1330px, 중심 오차 0px |
+| 3쪽·폭 2000px | 17% | 축소할수록 왼쪽 치우침 확대 | 3열, 좌우 790~1210px, 중심 오차 0px |
+
+## focused 검증
+
+다음 여섯 suite에서 자동 배치와 기존 좌표·행 이동·가로 팬 계약 46건이 모두 통과했다.
+
+```text
+node --test \
+  rhwp-studio/tests/virtual-scroll-page-arrangement.test.ts \
+  rhwp-studio/tests/virtual-scroll-grid-page.test.ts \
+  rhwp-studio/tests/virtual-scroll-horizontal-pan.test.ts \
+  rhwp-studio/tests/active-page-integration.test.ts \
+  rhwp-studio/tests/page-scroll-step.test.ts \
+  rhwp-studio/tests/canvas-view-page-arrangement.test.ts
+
+tests 46, pass 46, fail 0
+```
+
+추가한 회귀 범위는 다음과 같다.
+
+- 51%·50%·49%에서 2쪽 폭이면 모두 2열
+- 27%·17% 3쪽 문서의 열 수 cap과 실제 묶음 중심 오차 ≤1 CSS px
+- invalid/0 geometry의 1열 fallback
+- 1↔2열 경계의 ±8px 히스테리시스
+- 고정 쪽 배치와 가로 쪽 이동 불변
+
+## 전체·정적 검증
+
+- `(cd rhwp-studio && npx tsc --noEmit)`: 통과
+  - 격리 worktree에는 생성형 `pkg/rhwp.js`가 없어서 원본 작업공간의 동일 WASM 산출물을 로컬 symlink로
+    연결해 검사·build한 뒤 즉시 제거했다. source와 Git 변경에는 포함되지 않는다.
+- `npm --prefix rhwp-studio test`: 1,246건 중 1,245 pass·1 skip·0 fail
+- `npm --prefix rhwp-studio run build`: 239 modules production build 통과
+- `git diff --check`: 통과
+
+`npm ci`는 잠금파일 기준 382 packages를 설치했고 기존 lock 기준 3 vulnerabilities(1 low·2 high)를
+보고했다. 의존성이나 lockfile은 변경하지 않았다.
+
+## 범위 감사
+
+- 수정한 source는 `rhwp-studio/src/view/virtual-scroll.ts` 한 파일이다.
+- 테스트는 자동 배치 계약과 기존 임계값을 설명하던 주석만 변경했다.
+- `CanvasView`, `CanvasPool`, `PageRenderer`는 아직 변경하지 않았다.
+- render scale tier·surface 예산(#6041), 행 인덱스·LRU·scheduler(#6042)는 추가하지 않았다.
+
+## 다음 게이트
+
+작업지시자가 Stage 1 결과를 승인하면 이 source·test·보고 문서를 commit하고 Stage 2에서만 다음 작업을
+진행한다.
+
+1. 줌 제스처 시작 시 commit topology와 기준 페이지/정규화 앵커 snapshot
+2. animation frame의 전체 `recalcLayout()` 제거와 active element CSS preview
+3. settled event의 최종 후보 단일 commit과 앵커 복원
+
+Stage 2 승인 전에는 활성 Canvas 점진 교체(Stage 3)를 구현하지 않는다.

--- a/mydocs/working/task_m100_6040_stage1.md
+++ b/mydocs/working/task_m100_6040_stage1.md
@@ -4,7 +4,7 @@
 - **브랜치**: `codex/issue-6040-zoom-topology`
 - **기준 commit**: `upstream/devel` `2deb3dd61`
 - **계획 commit**: `5b98fb684`
-- **결과 승인**: 2026-08-30 작업지시자 승인, Stage 2 진행
+- **결과 승인**: 2026-08-30 작업지시자 승인; 2026-08-30 Stage 2·3 폐기 뒤 이 commit으로 재구성
 - **Stage 범위**: 자동 열 순수 계산·page count cap·중앙 정렬·히스테리시스 계약. 줌 preview와
   topology commit 분리는 Stage 2에 유지
 
@@ -75,11 +75,24 @@ tests 46, pass 46, fail 0
 
 ## 다음 게이트
 
-작업지시자가 Stage 1 결과를 승인하면 이 source·test·보고 문서를 commit하고 Stage 2에서만 다음 작업을
-진행한다.
+Stage 2·3의 Canvas 전용 preview 설계는 기존 단일 좌표 계약을 깨는 회귀 때문에 폐기했다. 전체 상태는
+`codex/issue-6040-zoom-topology-backup-20260830@d97307cab`에 보존했고, 작업 branch는 이 Stage 1
+commit `63fa3d0cf`로 재구성했다.
 
-1. 줌 제스처 시작 시 commit topology와 기준 페이지/정규화 앵커 snapshot
-2. animation frame의 전체 `recalcLayout()` 제거와 active element CSS preview
-3. settled event의 최종 후보 단일 commit과 앵커 복원
+## Stage 1 재구성 뒤 기존 줌 재검증
 
-Stage 2 승인 전에는 활성 Canvas 점진 교체(Stage 3)를 구현하지 않는다.
+- 기준 `2deb3dd61` 대비 `canvas-view.ts`, `ruler.ts`, `viewport-manager.ts`, `caret-renderer.ts`,
+  `input-handler.ts` diff 0
+- 자동 배치·줌·눈금자 focused: 69건 중 69 pass
+- 전체 Studio: 1,246건 중 1,245 pass·1 skip·0 fail
+- TypeScript no-emit·239 modules production build·`git diff --check`: 통과
+- Chromium, 편집 viewport `1260px`, 6쪽 자동 배치:
+  - 60% 2열, 점유 묶음 중심 오차 0.14px
+  - 50% 3열, 점유 묶음 중심 오차 0.07px
+  - 100→90%에서 content와 종이 폭이 매 frame 함께 변하고 중간 92%에서도 눈금자 경계 일치
+  - 50→60% 3→2열 전환 전 frame에서 caret의 page-local X 비율 `0.1428`, Y `0.1178~0.1179`
+  - warning/error 0건
+
+성능 최적화는 눈금자·캐럿·선택·hit-test까지 같은 preview geometry를 소비하는 새 구현 계획을 별도로
+승인하기 전에는 재개하지 않는다. 작업지시자가 2026-08-30 재검증 결과를 승인했으므로 이 재구성 문서를
+별도 commit으로 고정하고, #6040의 다음 범위는 줌 경로와 분리된 눈금자 끝 라벨 처리(Stage 1.1)만 진행한다.

--- a/mydocs/working/task_m100_6040_stage1_1.md
+++ b/mydocs/working/task_m100_6040_stage1_1.md
@@ -1,0 +1,45 @@
+# 작업 기록 — Task M100 #6040 Stage 1.1
+
+- **이슈**: [#6040](https://github.com/edwardkim/rhwp/issues/6040)
+- **브랜치**: `codex/issue-6040-zoom-topology`
+- **부모 commit**: Stage 1 재구성 문서 `354b2d417`
+- **작성일**: 2026-08-30 KST
+- **결과 승인**: 2026-08-30 작업지시자 승인
+- **Stage 범위**: 수평 눈금자 끝 라벨의 종이 경계 초과만 억제. 종이 경계·끝 tick과 기존 줌·배치 경로는 유지
+
+## 문제와 판단
+
+A4 155%에서 21cm 라벨은 중심이 종이 오른쪽 끝에 놓여 글자의 오른쪽 절반이 종이 밖 경계와 겹쳤다.
+21cm 위치 자체와 끝 tick은 올바르므로 tick을 제거하거나 A4 길이를 예외 처리하지 않고, 가운데 정렬된
+라벨의 실제 글자 폭이 현재 종이 범위에 온전히 들어오는지만 판정한다.
+
+이 결함은 Stage 1 이전 기준 commit에도 있던 표시 문제다. Stage 1 재구성의 수동 검증에서 발견했으므로
+#6040의 작은 후속 polish로 포함하되, 줌 좌표·`VirtualScroll`·Canvas 배치에는 손대지 않는다.
+
+## 변경
+
+- `ruler-label-geometry.ts`: 라벨 중심·실제 폭·종이 왼쪽·표시 폭으로 종이 내부 여부를 계산하는 순수 함수를 추가했다.
+- `ruler.ts`: 수평 숫자 라벨을 그리기 직전에 `measureText()` 결과로 판정한다. 경계선과 모든 tick은 기존대로 그린다.
+- `ruler-label-geometry.test.ts`: A4 155%의 20cm 표시·21cm 숨김, 경계 교차, 비정상 입력을 고정했다.
+
+## 검증
+
+- 눈금자 focused: 17건 중 17 pass
+- TypeScript `npx tsc --noEmit`: 통과
+- 전체 Studio: 1,249건 중 1,248 pass·1 skip·0 fail
+- production build: 240 modules, 통과. 기존 대형 chunk 경고만 확인
+- 실제 Chromium, 6쪽 복구 문서, 자동 모드 155%:
+  - 20cm 라벨 표시
+  - 21cm 라벨 숨김
+  - 종이 오른쪽 경계선과 끝 tick 유지
+  - warning/error 0건
+- `git diff --check`: 통과
+
+## 범위 감사와 다음 게이트
+
+Stage 1.1 source 변경은 수평 눈금자 그리기 한 지점과 순수 라벨 판정 함수뿐이다. `CanvasView`,
+`VirtualScroll`, `ViewportManager`, caret/input 경로는 변경하지 않는다.
+
+작업지시자가 직접 검증한 뒤 이 구현으로 확정했다. source·test·이 보고서를 별도 commit으로 고정하고,
+#6040에서는 폐기한 Stage 2·3 설계를 재개하지 않는다. #6040의 제출 준비와 #6041 stack branch는 이
+commit 뒤에만 진행한다.

--- a/mydocs/working/task_m100_6040_stage1_1.md
+++ b/mydocs/working/task_m100_6040_stage1_1.md
@@ -2,7 +2,8 @@
 
 - **이슈**: [#6040](https://github.com/edwardkim/rhwp/issues/6040)
 - **브랜치**: `codex/issue-6040-zoom-topology`
-- **부모 commit**: Stage 1 재구성 문서 `354b2d417`
+- **부모 commit**: Stage 1 재구성 문서 `ce3402e52` (재배치 전 `354b2d417`)
+- **구현 commit**: `049683ee9` (재배치 전 `1d597e81b`)
 - **작성일**: 2026-08-30 KST
 - **결과 승인**: 2026-08-30 작업지시자 승인
 - **Stage 범위**: 수평 눈금자 끝 라벨의 종이 경계 초과만 억제. 종이 경계·끝 tick과 기존 줌·배치 경로는 유지
@@ -26,13 +27,16 @@ A4 155%에서 21cm 라벨은 중심이 종이 오른쪽 끝에 놓여 글자의 
 
 - 눈금자 focused: 17건 중 17 pass
 - TypeScript `npx tsc --noEmit`: 통과
-- 전체 Studio: 1,249건 중 1,248 pass·1 skip·0 fail
-- production build: 240 modules, 통과. 기존 대형 chunk 경고만 확인
+- 전체 Studio: 1,278건 중 1,277 pass·1 skip·0 fail
+- production build: 243 modules, 통과. 기존 대형 chunk 경고만 확인
+- `cargo fmt --all -- --check`: 파생 regression suite 준비 뒤 통과. 파생 파일은 PR에 포함하지 않음
 - 실제 Chromium, 6쪽 복구 문서, 자동 모드 155%:
   - 20cm 라벨 표시
   - 21cm 라벨 숨김
   - 종이 오른쪽 경계선과 끝 tick 유지
   - warning/error 0건
+- 같은 문서 자동 60%: 2열, 점유 묶음 중심 오차 0.14px
+- 같은 문서 자동 50%: 3열, 점유 묶음 중심 오차 0.07px
 - `git diff --check`: 통과
 
 ## 범위 감사와 다음 게이트

--- a/mydocs/working/task_m100_6040_stage1_2.md
+++ b/mydocs/working/task_m100_6040_stage1_2.md
@@ -1,0 +1,73 @@
+# 작업 기록 — Task M100 #6040 Stage 1.2
+
+- **이슈**: [#6040](https://github.com/edwardkim/rhwp/issues/6040)
+- **PR**: [#6458](https://github.com/edwardkim/rhwp/pull/6458)
+- **브랜치**: `codex/issue-6040-zoom-topology`
+- **최신 기준**: `upstream/devel@0d1540931`
+- **최신 devel 통합 commit**: `a19020085`
+- **작성일**: 2026-09-01 KST
+- **Stage 범위**: live 자동 열 commit 연결, 문서·배치 경계 reset, resize 뒤 오버레이 재투영
+
+## 문제와 판단
+
+Stage 1의 순수 `resolveAutoPageColumns()`는 이전 확정 열을 입력받아 히스테리시스를 적용했지만,
+실제 `VirtualScroll.setPageDimensions()` 호출은 그 값을 보존하거나 전달하지 않았다. 따라서 같은
+인스턴스에 `814 → 806 → 818 → 806px` 같은 경계 입력이 연속되면 순수 helper의 계약과 달리 열 수가
+매 호출의 단발 후보로 다시 계산될 수 있었다.
+
+최신 devel을 통합한 뒤 실제 브라우저에서 resize를 반복하자 페이지와 눈금자는 새 행·열 좌표를 사용하지만
+캐럿 오버레이는 이전 슬롯에 남는 별도 회귀도 확인됐다. 열 commit은 `VirtualScroll`이 소유하고,
+CanvasView의 기존 settled 재레이아웃·Canvas 반환 경로는 유지한다. 캐럿·선택 오버레이는 CanvasView가
+같은 `viewport-resize` 이벤트에서 레이아웃을 확정한 다음 tick에 authoritative 좌표를 다시 읽는다.
+
+PR #6438에서 지적된 progressive Canvas 교체와 active pool/DOM 이중 소유권 문제를 되살리지 않기 위해
+`releaseAllRenderedPages() → updateVisiblePages()` 계약은 변경하지 않는다.
+
+## 변경
+
+- `VirtualScroll`이 마지막 자동 열 commit을 보존하고 다음 auto 계산에 전달한다.
+- horizontal 또는 명시 배치로 전환하면 자동 열 commit을 지운다.
+- `CanvasView.reset()`에서 문서 교체 전 commit을 지워 새 문서의 첫 후보에 섞이지 않게 한다.
+- 기존 zoom 오버레이 갱신을 한 메서드로 모으고, viewport resize에서는 레이아웃 확정 다음 tick에
+  캐럿·필드·텍스트/셀 선택·그림/표 선택을 같은 좌표로 재투영한다.
+- 실제 `CanvasView.onZoomChanged()`를 Vite SSR로 실행해 zoom event당 레이아웃 commit 1회와
+  CanvasPool active page/DOM canvas의 단일 소유권을 검증한다.
+
+## 자동화 검증
+
+- 자동 열 focused test: 같은 `VirtualScroll`에서 `800 → 814 → 806 → 818 → 806 → 801px`를 넣어
+  `1 → 1 → 1 → 2 → 2 → 1열`로만 확정되는 계약을 고정했다.
+- 명시 배치 전환과 문서 reset이 이전 auto commit을 제거하는 회귀 test를 추가했다.
+- 실제 CanvasView zoom test에서 1→2열 경계를 왕복하고, 초기 1회와 zoom event당 1회만 레이아웃을
+  commit하며 매 정착 뒤 DOM canvas 수·고유 page slot·CanvasPool active page가 일치함을 확인했다.
+- InputHandler source contract test로 zoom과 resize가 같은 overlay 재투영 경로를 사용함을 고정했다.
+- focused test: 34/34 pass
+- TypeScript `npx tsc --noEmit`: 통과
+- 전체 Studio: 1,352건 중 1,351 pass·1 policy skip·0 fail
+- production build: 246 modules, 통과. 기존 CanvasKit browser externalize와 대형 chunk 경고만 확인
+- `git diff --check`: 통과
+
+## 실제 브라우저 검증
+
+77쪽 `kps-ai.hwp`를 Canvas2D, 자동 배치, 77%에서 열고 뷰포트 폭을 왕복했다.
+
+| 편집 viewport 폭 | 1225px | 1235px | 1240px | 1235px | 1220px |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 확정 열 수 | 1 | 1 | 2 | 2 | 1 |
+| DOM canvas / 고유 page slot | 3/3 | 3/3 | 4/4 | 4/4 | 3/3 |
+| 현재 쪽 | 2/77 | 2/77 | 2/77 | 2/77 | 2/77 |
+
+- 증가·감소 경계 안에서는 기존 열 commit이 유지되고 dead band 밖에서만 1↔2열로 전환됐다.
+- 캐럿은 매 단계에서 현재 2쪽 안에 있었고 1열로 돌아오면 처음 좌표로 복귀했다.
+- 수평 눈금자 canvas 폭은 매 단계 편집 viewport 폭과 정확히 일치했다.
+- 클릭 hit-test 뒤 현재 쪽은 2/77로 유지됐다.
+- DOM canvas 수와 고유 page slot 수가 항상 같아 orphan/중복 Canvas가 없었다.
+
+## 범위 감사와 다음 게이트
+
+이 Stage는 live 열 commit과 오버레이 좌표 동기화만 보정한다. 폐기된 Canvas 전용 zoom preview,
+점진 Canvas 교체, #6041 render scale, #6042 LRU·scheduler는 포함하지 않는다.
+
+#6444는 contributor credit과 head 계보를 남기고 #6458→#6467→#6042로 인계한 뒤 닫았다. #6438은
+이 Stage를 원격 #6458에 게시해 maintainer가 대체 구현을 볼 수 있게 한 뒤 같은 방식으로 인계·종료한다.
+그 전에는 contributor PR을 닫지 않는다.

--- a/mydocs/working/task_m100_6040_stage1_2.md
+++ b/mydocs/working/task_m100_6040_stage1_2.md
@@ -3,8 +3,8 @@
 - **이슈**: [#6040](https://github.com/edwardkim/rhwp/issues/6040)
 - **PR**: [#6458](https://github.com/edwardkim/rhwp/pull/6458)
 - **브랜치**: `codex/issue-6040-zoom-topology`
-- **최신 기준**: `upstream/devel@0d1540931`
-- **최신 devel 통합 commit**: `a19020085`
+- **최신 기준**: `upstream/devel@b9d408f0d`
+- **최신 devel 통합 commit**: `a19020085`, `db1a15fb1`
 - **작성일**: 2026-09-01 KST
 - **Stage 범위**: live 자동 열 commit 연결, 문서·배치 경계 reset, resize 뒤 오버레이 재투영
 
@@ -41,11 +41,15 @@ PR #6438에서 지적된 progressive Canvas 교체와 active pool/DOM 이중 소
 - 실제 CanvasView zoom test에서 1→2열 경계를 왕복하고, 초기 1회와 zoom event당 1회만 레이아웃을
   commit하며 매 정착 뒤 DOM canvas 수·고유 page slot·CanvasPool active page가 일치함을 확인했다.
 - InputHandler source contract test로 zoom과 resize가 같은 overlay 재투영 경로를 사용함을 고정했다.
-- focused test: 34/34 pass
+- Stage 1.2와 최신 Ruler actual harness focused test: 45/45 pass
 - TypeScript `npx tsc --noEmit`: 통과
-- 전체 Studio: 1,352건 중 1,351 pass·1 policy skip·0 fail
+- 전체 Studio: 1,361건 중 1,360 pass·1 policy skip·0 fail
 - production build: 246 modules, 통과. 기존 CanvasKit browser externalize와 대형 chunk 경고만 확인
 - `git diff --check`: 통과
+
+첫 push 뒤 병합된 #6570의 Ruler actual harness는 Stage 1.1의 `ctx.measureText()`를 fake하지 않아 통합
+focused test가 실패했다. 브라우저 숫자 라벨 폭을 반환하는 최소 Canvas mock을 추가해 pointer 1건과
+resize 19건 wrapper를 포함한 Ruler 계약을 다시 통과시켰다. 제품 코드는 추가 변경하지 않았다.
 
 ## 실제 브라우저 검증
 
@@ -62,6 +66,10 @@ PR #6438에서 지적된 progressive Canvas 교체와 active pool/DOM 이중 소
 - 수평 눈금자 canvas 폭은 매 단계 편집 viewport 폭과 정확히 일치했다.
 - 클릭 hit-test 뒤 현재 쪽은 2/77로 유지됐다.
 - DOM canvas 수와 고유 page slot 수가 항상 같아 orphan/중복 Canvas가 없었다.
+
+최신 `devel@b9d408f0d` 통합 뒤 같은 문서·배율·폭 순서로 다시 실행해 동일한 열·Canvas·캐럿 결과를
+확인했다. #6570 눈금자 변경 뒤에도 매 단계 ruler bitmap 폭과 client 폭이 각각
+`1225, 1235, 1240, 1235, 1220px`로 viewport와 정확히 일치했다.
 
 ## 범위 감사와 다음 게이트
 

--- a/mydocs/working/task_m100_6040_stage1_2.md
+++ b/mydocs/working/task_m100_6040_stage1_2.md
@@ -76,6 +76,6 @@ resize 19건 wrapper를 포함한 Ruler 계약을 다시 통과시켰다. 제품
 이 Stage는 live 열 commit과 오버레이 좌표 동기화만 보정한다. 폐기된 Canvas 전용 zoom preview,
 점진 Canvas 교체, #6041 render scale, #6042 LRU·scheduler는 포함하지 않는다.
 
-#6444는 contributor credit과 head 계보를 남기고 #6458→#6467→#6042로 인계한 뒤 닫았다. #6438은
-이 Stage를 원격 #6458에 게시해 maintainer가 대체 구현을 볼 수 있게 한 뒤 같은 방식으로 인계·종료한다.
-그 전에는 contributor PR을 닫지 않는다.
+#6444는 contributor credit과 head 계보를 남기고 #6458→#6467→#6042로 인계한 뒤 닫았다. #6438도
+#6458 remote head `dff556c8e`의 required checks가 성공한 뒤 source head와 maintainer가 발견한 Canvas
+ownership 조건을 댓글로 보존하고 superseded 상태로 닫았다. 두 PR 모두 merge하지 않았다.

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -660,34 +660,8 @@ export class InputHandler {
     this.textarea.addEventListener('cut', this.onCutBound);
     this.textarea.addEventListener('paste', this.onPasteBound);
 
-    // 줌 변경 시 캐럿/선택 마커 위치 갱신
-    eventBus.on('zoom-changed', () => {
-      if (this.active) {
-        const rect = this.cursor.getRect();
-        if (rect) {
-          this.caret.updatePosition(this.viewportManager.getZoom());
-        }
-        // 필드 마커도 줌에 맞게 갱신
-        if (this.fieldMarker.isVisible) {
-          this.updateFieldMarkers();
-        }
-      }
-      // 텍스트 블럭 선택 줌 동기화
-      if (this.cursor.hasSelection()) {
-        this.updateSelection();
-      }
-      // F5 셀 선택 줌 동기화
-      if (this.cursor.isInCellSelectionMode()) {
-        this.updateCellSelection();
-      }
-      // 도형/표 선택 핸들 줌 동기화
-      if (this.cursor.isInPictureObjectSelection()) {
-        this.renderPictureObjectSelection();
-      }
-      if (this.cursor.isInTableObjectSelection()) {
-        this.renderTableObjectSelection();
-      }
-    });
+    // 배율이나 자동 열 수가 바뀌면 페이지 기준 오버레이도 같은 확정 좌표로 옮긴다.
+    eventBus.on('zoom-changed', () => this.updateViewportOverlayPositions());
 
     eventBus.on('document-view-changed', () => {
       if (!this.active) return;
@@ -709,7 +683,8 @@ export class InputHandler {
       if (this.cursor.getHeaderFooterSelectionOrdered()) this.updateSelection();
     });
     eventBus.on('viewport-resize', () => {
-      if (this.cursor.getHeaderFooterSelectionOrdered()) this.updateSelection();
+      // CanvasView가 같은 이벤트에서 VirtualScroll을 먼저 확정한 다음 그 좌표를 읽는다.
+      window.setTimeout(() => this.updateViewportOverlayPositions(), 0);
     });
 
     // 표 객체 선택 변경 시 렌더링
@@ -752,6 +727,18 @@ export class InputHandler {
       // 서식바 조작으로 빠진 포커스를 항상 복원
       this.focusTextarea();
     });
+  }
+
+  /** 줌·resize 뒤 VirtualScroll 확정 좌표에 캐럿과 선택 오버레이를 다시 투영한다. */
+  private updateViewportOverlayPositions(): void {
+    // updatePosition은 CaretRenderer가 현재 rect를 보유하지 않으면 no-op이고 display도 바꾸지
+    // 않는다. textarea focus가 순간 빠진 상태에서도 화면에 남은 캐럿은 새 쪽 슬롯을 따라야 한다.
+    this.caret.updatePosition(this.viewportManager.getZoom());
+    if (this.active && this.fieldMarker.isVisible) this.updateFieldMarkers();
+    if (this.cursor.hasSelection()) this.updateSelection();
+    if (this.cursor.isInCellSelectionMode()) this.updateCellSelection();
+    if (this.cursor.isInPictureObjectSelection()) this.renderPictureObjectSelection();
+    if (this.cursor.isInTableObjectSelection()) this.renderTableObjectSelection();
   }
 
   /** 클릭 이벤트 처리 — hitTest로 커서 배치 */

--- a/rhwp-studio/src/view/canvas-view.ts
+++ b/rhwp-studio/src/view/canvas-view.ts
@@ -1253,6 +1253,7 @@ export class CanvasView {
     this.headerFooterEditState = null;
     this.pageRenderer.setPageMarginGuideEdges('both');
     this.activePageSnapshot = null;
+    this.virtualScroll.resetAutoColumnCommit();
     if (hadActivePage) this.eventBus.emit('active-page-changed', null);
     if (hadFocusedPage) this.eventBus.emit('focused-page-changed', null);
     this.pages = [];

--- a/rhwp-studio/src/view/ruler-label-geometry.ts
+++ b/rhwp-studio/src/view/ruler-label-geometry.ts
@@ -1,0 +1,20 @@
+/**
+ * 가운데 정렬된 눈금자 라벨이 용지 범위 안에 온전히 들어오는지 판정한다.
+ *
+ * 용지 끝 tick과 경계선은 그대로 그리되, 끝점에 중심을 둔 숫자가 용지 밖으로
+ * 넘치는 경우 라벨만 숨기기 위한 순수 좌표 계약이다.
+ */
+export function isRulerLabelInsidePage(
+  centerX: number,
+  labelWidth: number,
+  pageLeft: number,
+  pageWidth: number,
+): boolean {
+  if (![centerX, labelWidth, pageLeft, pageWidth].every(Number.isFinite)) return false;
+  if (labelWidth < 0 || pageWidth < 0) return false;
+
+  const halfLabelWidth = labelWidth / 2;
+  const pageRight = pageLeft + pageWidth;
+  return centerX - halfLabelWidth >= pageLeft
+    && centerX + halfLabelWidth <= pageRight;
+}

--- a/rhwp-studio/src/view/ruler.ts
+++ b/rhwp-studio/src/view/ruler.ts
@@ -20,6 +20,7 @@ import {
   type ActivePageSnapshot,
 } from './active-page.ts';
 import { resolveRulerScale } from './ruler-scale.ts';
+import { isRulerLabelInsidePage } from './ruler-label-geometry.ts';
 
 export type { RulerPinCommit };
 
@@ -668,7 +669,15 @@ export class Ruler {
         // 숫자는 cm 단위. 저배율에서는 5cm·10cm처럼 더 큰 단계만 남는다.
         const cm = mm / 10;
         if (cm > 0) {
-          ctx.fillText(`${cm}`, x, 1);
+          const label = `${cm}`;
+          if (isRulerLabelInsidePage(
+            x,
+            ctx.measureText(label).width,
+            pageScreenLeft,
+            pageDisplayWidth,
+          )) {
+            ctx.fillText(label, x, 1);
+          }
         }
       } else if (tickIndex % middleEvery === 0) {
         tickH = 6;

--- a/rhwp-studio/src/view/virtual-scroll.ts
+++ b/rhwp-studio/src/view/virtual-scroll.ts
@@ -91,6 +91,7 @@ export class VirtualScroll {
   private columns = 1;
   private gridMode = false;
   private horizontalMode = false;
+  private committedAutoColumns: number | undefined;
   private readonly pageGapAt100Percent: number;
   private pageGap: number;
 
@@ -115,12 +116,14 @@ export class VirtualScroll {
 
     this.horizontalMode = movement === 'horizontal';
     if (this.horizontalMode) {
+      this.committedAutoColumns = undefined;
       this.gridMode = false;
       this.layoutHorizontalRow(viewportWidth, viewportHeight);
       return;
     }
 
     const normalized = normalizePageArrangement(arrangement);
+    if (normalized.kind !== 'auto') this.committedAutoColumns = undefined;
     switch (normalized.kind) {
       case 'single':
         this.gridMode = false;
@@ -148,7 +151,9 @@ export class VirtualScroll {
             viewportWidth,
             displayedPageWidth: this.maxPageWidth,
             pageGap: this.pageGap,
+            committedColumns: this.committedAutoColumns,
           });
+          this.committedAutoColumns = columns;
           this.gridMode = columns > 1;
           if (this.gridMode) {
             this.layoutUniformGrid(viewportWidth, columns);
@@ -159,6 +164,11 @@ export class VirtualScroll {
         break;
     }
     this.applyHorizontalPanSpace(viewportWidth);
+  }
+
+  /** 문서 교체 시 이전 문서의 자동 열 commit이 새 문서 경계 판단에 섞이지 않게 한다. */
+  resetAutoColumnCommit(): void {
+    this.committedAutoColumns = undefined;
   }
 
   /** 한컴 가로 쪽 이동: 한 쪽 배치의 모든 페이지를 왼쪽에서 오른쪽으로 잇는다. */

--- a/rhwp-studio/src/view/virtual-scroll.ts
+++ b/rhwp-studio/src/view/virtual-scroll.ts
@@ -7,13 +7,75 @@ import {
 import type { PageMovementDirection } from './page-movement.ts';
 import { resolvePageGap } from './page-gap.ts';
 
-/** 그리드 모드 전환 줌 임계값 */
-const GRID_ZOOM_THRESHOLD = 0.5;
+/** 자동 열 경계에서 resize/zoom 미세 입력이 왕복하지 않게 하는 CSS px 여유. */
+const AUTO_COLUMN_HYSTERESIS_PX = 8;
 
 /** [#3591] 가로 팬 여백 = clamp(창 폭 × 비율, 하한, 상한). 상한이 큰 화면에서의 증가를 끊는다. */
 const PAN_SPACE_RATIO = 0.25;
 const MIN_PAN_SPACE = 80;
 const MAX_PAN_SPACE = 240;
+
+export interface AutoPageColumnMetrics {
+  pageCount: number;
+  viewportWidth: number;
+  displayedPageWidth: number;
+  pageGap: number;
+  committedColumns?: number;
+  hysteresisPx?: number;
+}
+
+/**
+ * 자동 쪽 배치의 가로 열 수를 표시 geometry만으로 결정한다.
+ *
+ * `committedColumns`를 생략하면 현재 폭에 들어가는 열 수를 바로 반환한다. 이전 commit을
+ * 전달하면 인접 열 경계 양쪽에 작은 dead band를 두어 resize/zoom의 sub-pixel 흔들림으로
+ * 열 수가 왕복하지 않게 한다.
+ */
+export function resolveAutoPageColumns({
+  pageCount,
+  viewportWidth,
+  displayedPageWidth,
+  pageGap,
+  committedColumns,
+  hysteresisPx = AUTO_COLUMN_HYSTERESIS_PX,
+}: AutoPageColumnMetrics): number {
+  const safePageCount = Number.isFinite(pageCount)
+    ? Math.max(1, Math.floor(pageCount))
+    : 1;
+  const safeViewportWidth = Number.isFinite(viewportWidth) && viewportWidth > 0
+    ? viewportWidth
+    : 0;
+  const safePageWidth = Number.isFinite(displayedPageWidth) && displayedPageWidth > 0
+    ? displayedPageWidth
+    : 0;
+  const safeGap = Number.isFinite(pageGap) && pageGap >= 0 ? pageGap : 0;
+
+  if (safeViewportWidth === 0 || safePageWidth === 0) return 1;
+
+  const fitColumns = Math.max(
+    1,
+    Math.floor((safeViewportWidth + safeGap) / (safePageWidth + safeGap)),
+  );
+  const candidate = Math.min(safePageCount, fitColumns);
+  if (committedColumns === undefined || !Number.isFinite(committedColumns)) return candidate;
+
+  const committed = Math.min(
+    safePageCount,
+    Math.max(1, Math.floor(committedColumns)),
+  );
+  if (candidate === committed) return committed;
+
+  const hysteresis = Number.isFinite(hysteresisPx)
+    ? Math.max(0, hysteresisPx)
+    : AUTO_COLUMN_HYSTERESIS_PX;
+  if (candidate > committed) {
+    const nextBoundary = (committed + 1) * safePageWidth + committed * safeGap;
+    return safeViewportWidth >= nextBoundary + hysteresis ? candidate : committed;
+  }
+
+  const currentBoundary = committed * safePageWidth + (committed - 1) * safeGap;
+  return safeViewportWidth < currentBoundary - hysteresis ? candidate : committed;
+}
 
 export class VirtualScroll {
   private pageOffsets: number[] = [];
@@ -78,16 +140,21 @@ export class VirtualScroll {
         break;
       case 'auto':
       default:
-        // 기존 자동 동작: 50% 이하에서만 뷰포트에 들어가는 최대 열 수를 쓴다.
-        this.gridMode = zoom <= GRID_ZOOM_THRESHOLD && viewportWidth > 0 && pages.length > 1;
-        if (this.gridMode) {
-          const columns = Math.max(
-            1,
-            Math.floor((viewportWidth + this.pageGap) / (this.maxPageWidth + this.pageGap)),
-          );
-          this.layoutUniformGrid(viewportWidth, columns);
-        } else {
-          this.layoutSingleColumn();
+        // 자동은 절대 배율 gate가 아니라 실제 표시 폭과 뷰포트 폭으로 열 수를 고른다.
+        // pageCount cap은 존재하지 않는 빈 열이 중앙 정렬 폭에 포함되는 것도 막는다.
+        {
+          const columns = resolveAutoPageColumns({
+            pageCount: pages.length,
+            viewportWidth,
+            displayedPageWidth: this.maxPageWidth,
+            pageGap: this.pageGap,
+          });
+          this.gridMode = columns > 1;
+          if (this.gridMode) {
+            this.layoutUniformGrid(viewportWidth, columns);
+          } else {
+            this.layoutSingleColumn();
+          }
         }
         break;
     }
@@ -230,8 +297,8 @@ export class VirtualScroll {
   private horizontalPanSpace(viewportWidth: number, contentWidth: number): number {
     // 그리드는 layoutGrid 의 marginLeft 가 이미 중앙을 잡고, base 가 항상 창 폭 이상
     // (`max(gridWidth + marginLeft*2, viewportWidth)`)이라 팬 조건이 경계에서 참이 될 수
-    // 있다. 그리드 첫 진입(zoom 0.5)에서만 팬이 붙어 스크롤 여지가 생기고 문서가 중앙에서
-    // 밀리는 현상이 그것이다. 그리드에는 팬을 주지 않는다.
+    // 있다. 자동 열 수가 1→다중 열로 바뀌는 순간 팬이 붙으면 스크롤 여지가 생기고 문서가
+    // 중앙에서 밀린다. 그리드에는 팬을 주지 않는다.
     if (this.gridMode) return 0;
     if (contentWidth <= viewportWidth) return 0;
     const ratio = viewportWidth * PAN_SPACE_RATIO;

--- a/rhwp-studio/tests/canvas-view-page-arrangement.test.ts
+++ b/rhwp-studio/tests/canvas-view-page-arrangement.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { createServer } from 'vite';
 
 import { VirtualScroll } from '../src/view/virtual-scroll.ts';
 
@@ -10,8 +11,8 @@ const canvasViewSource = readFileSync(
   'utf8',
 );
 
-function pages(n: number) {
-  return Array.from({ length: n }, () => ({ width: 800, height: 1000 })) as never;
+function pages(n: number, width = 800, height = 1000) {
+  return Array.from({ length: n }, () => ({ width, height })) as never;
 }
 
 function classMethodSource(name: string, nextName: string): string {
@@ -115,4 +116,142 @@ test('가로 쪽 이동은 배치와 함께 한 번에 전환하고 가로 가�
   const method = classMethodSource('setPageViewSettings', 'getViewportManager');
   assert.match(method, /resolvePageViewSettings/);
   assert.doesNotMatch(method, /document-(?:changed|mutated)/);
+});
+
+test('실제 CanvasView zoom 경로는 자동 열 commit과 Canvas pool 단일 소유권을 유지한다', async () => {
+  const studioRoot = fileURLToPath(new URL('..', import.meta.url));
+  const vite = await createServer({
+    root: studioRoot,
+    appType: 'custom',
+    logLevel: 'silent',
+    server: { middlewareMode: true },
+  });
+  const previousDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
+
+  try {
+    const { CanvasView } = await vite.ssrLoadModule('/src/view/canvas-view.ts');
+    const { CanvasPool } = await vite.ssrLoadModule('/src/view/canvas-pool.ts');
+    const children: HTMLCanvasElement[] = [];
+    let removeCount = 0;
+    const scrollContent = {
+      style: {},
+      classList: { toggle: () => undefined },
+      appendChild: (canvas: HTMLCanvasElement) => {
+        children.push(canvas);
+        (canvas as unknown as { parentElement: HTMLElement | null }).parentElement =
+          scrollContent as unknown as HTMLElement;
+        return canvas;
+      },
+      removeChild: (canvas: HTMLCanvasElement) => {
+        const index = children.indexOf(canvas);
+        assert.ok(index >= 0, 'DOM에 있는 Canvas만 제거해야 한다');
+        children.splice(index, 1);
+        (canvas as unknown as { parentElement: HTMLElement | null }).parentElement = null;
+        removeCount += 1;
+        return canvas;
+      },
+      querySelectorAll: () => [],
+    };
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: {
+        createElement: (tagName: string) => {
+          assert.equal(tagName, 'canvas');
+          return {
+            classList: { add: () => undefined },
+            dataset: {},
+            parentElement: null,
+            style: {},
+          } as unknown as HTMLCanvasElement;
+        },
+      },
+    });
+
+    const virtualScroll = new VirtualScroll(10);
+    const originalSetPageDimensions = virtualScroll.setPageDimensions.bind(virtualScroll);
+    let layoutCommitCount = 0;
+    virtualScroll.setPageDimensions = (...args: Parameters<VirtualScroll['setPageDimensions']>) => {
+      layoutCommitCount += 1;
+      originalSetPageDimensions(...args);
+    };
+
+    let zoom = 1.01;
+    let scrollLeft = 0;
+    let scrollTop = 0;
+    const viewportManager = {
+      getZoom: () => zoom,
+      getViewportSize: () => ({ width: 817, height: 600 }),
+      getScrollX: () => scrollLeft,
+      getScrollY: () => scrollTop,
+      setScrollLeft: (value: number) => { scrollLeft = value; },
+      setScrollTop: (value: number) => { scrollTop = value; },
+      isZoomAnimating: () => false,
+    };
+    const canvasPool = new CanvasPool();
+    const view = Object.create(CanvasView.prototype) as Record<string, unknown>;
+    view.virtualScroll = virtualScroll;
+    view.canvasPool = canvasPool;
+    view.viewportManager = viewportManager;
+    view.pages = pages(3, 400, 600);
+    view.pageArrangement = { kind: 'auto' };
+    view.pageMovement = { direction: 'vertical', wheelHorizontal: false };
+    view.scrollContent = scrollContent;
+    view.eventBus = { emit: () => undefined };
+    view.pageRenderer = {
+      cancelAll: () => undefined,
+      resetImageRetryState: () => undefined,
+      removeAllPageLayers: () => undefined,
+    };
+    view.cancelPendingTextEditRefresh = () => undefined;
+    view.cancelTextEditStaticLayerVerification = () => undefined;
+    view.removeHeaderFooterEditOverlays = () => undefined;
+    view.removeAllGridOverlays = () => undefined;
+    view.updateVisiblePages = () => {
+      const canvas = canvasPool.acquire(0);
+      (scrollContent.appendChild as (canvas: HTMLCanvasElement) => HTMLCanvasElement)(canvas);
+    };
+
+    const initialCanvas = canvasPool.acquire(0);
+    (scrollContent.appendChild as (canvas: HTMLCanvasElement) => HTMLCanvasElement)(initialCanvas);
+
+    const invoke = (name: string, ...args: unknown[]): unknown => {
+      const method = view[name];
+      assert.equal(typeof method, 'function', `${name} 메서드가 있어야 한다`);
+      return (method as (...values: unknown[]) => unknown).apply(view, args);
+    };
+    const assertSingleCanvasOwnership = (): void => {
+      assert.deepEqual(canvasPool.activePages, [0]);
+      assert.equal(children.length, canvasPool.activePages.length);
+      assert.equal(new Set(canvasPool.activePages).size, canvasPool.activePages.length);
+      assert.equal(canvasPool.getCanvas(0), children[0]);
+    };
+
+    invoke('recalcLayout');
+    assert.equal(virtualScroll.getColumns(), 1);
+
+    zoom = 1;
+    invoke('onZoomChanged', zoom, { x: 0.5, y: 0.5 });
+    assert.equal(virtualScroll.getColumns(), 1, '증가 dead band 안에서는 1열 유지');
+    assertSingleCanvasOwnership();
+
+    zoom = 0.99;
+    invoke('onZoomChanged', zoom, { x: 0.5, y: 0.5 });
+    assert.equal(virtualScroll.getColumns(), 2, 'dead band를 지난 뒤 2열 commit');
+    assertSingleCanvasOwnership();
+
+    zoom = 1;
+    invoke('onZoomChanged', zoom, { x: 0.5, y: 0.5 });
+    assert.equal(virtualScroll.getColumns(), 2, '반대 방향 dead band 안에서는 2열 유지');
+    assertSingleCanvasOwnership();
+
+    assert.equal(layoutCommitCount, 4, '초기 1회와 zoom event당 1회만 레이아웃 commit');
+    assert.equal(removeCount, 3, 'settled zoom마다 기존 Canvas를 반환한 뒤 하나만 다시 할당');
+  } finally {
+    if (previousDocument) {
+      Object.defineProperty(globalThis, 'document', previousDocument);
+    } else {
+      Reflect.deleteProperty(globalThis, 'document');
+    }
+    await vite.close();
+  }
 });

--- a/rhwp-studio/tests/ruler-label-geometry.test.ts
+++ b/rhwp-studio/tests/ruler-label-geometry.test.ts
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isRulerLabelInsidePage } from '../src/view/ruler-label-geometry.ts';
+
+const PX_PER_MM = 96 / 25.4;
+
+test('A4 155%에서 20cm 라벨은 보이고 21cm 끝 라벨은 숨긴다', () => {
+  const zoom = 1.55;
+  const pageLeft = 248;
+  const pageWidth = 210 * PX_PER_MM * zoom;
+  const labelWidth = 11;
+
+  assert.equal(
+    isRulerLabelInsidePage(pageLeft + 200 * PX_PER_MM * zoom, labelWidth, pageLeft, pageWidth),
+    true,
+  );
+  assert.equal(
+    isRulerLabelInsidePage(pageLeft + 210 * PX_PER_MM * zoom, labelWidth, pageLeft, pageWidth),
+    false,
+  );
+});
+
+test('끝 tick 안쪽이라도 라벨 폭이 용지 경계를 넘으면 숨긴다', () => {
+  assert.equal(isRulerLabelInsidePage(98, 6, 0, 100), false);
+  assert.equal(isRulerLabelInsidePage(97, 6, 0, 100), true);
+});
+
+test('잘못된 좌표나 음수 크기는 표시하지 않는다', () => {
+  assert.equal(isRulerLabelInsidePage(Number.NaN, 6, 0, 100), false);
+  assert.equal(isRulerLabelInsidePage(50, -1, 0, 100), false);
+  assert.equal(isRulerLabelInsidePage(50, 6, 0, -1), false);
+});

--- a/rhwp-studio/tests/support/ruler-harness.mjs
+++ b/rhwp-studio/tests/support/ruler-harness.mjs
@@ -66,6 +66,7 @@ class FakeCanvas extends FakeTarget {
       stroke: () => this.paint.strokes++,
       fill: () => this.paint.fills++,
       fillText: text => this.paint.labels.push(text),
+      measureText: text => ({ width: String(text).length * 5 }),
     };
   }
   get width() { return this.bitmapSize.width; }

--- a/rhwp-studio/tests/viewport-manager-smooth-zoom.test.ts
+++ b/rhwp-studio/tests/viewport-manager-smooth-zoom.test.ts
@@ -472,3 +472,20 @@ test('CanvasView scales existing pages during zoom and rerenders only after sett
   );
   assert.match(source, /dataset\.rhwpRenderedZoom = String\(zoom\)/);
 });
+
+test('InputHandler는 zoom과 resize에서 같은 확정 페이지 좌표로 캐럿·선택을 다시 투영한다', () => {
+  const source = readFileSync(new URL('../src/engine/input-handler.ts', import.meta.url), 'utf8');
+
+  assert.match(
+    source,
+    /eventBus\.on\('zoom-changed', \(\) => this\.updateViewportOverlayPositions\(\)\)/,
+  );
+  assert.match(
+    source,
+    /eventBus\.on\('viewport-resize', \(\) => \{[\s\S]*?window\.setTimeout\(\(\) => this\.updateViewportOverlayPositions\(\), 0\);[\s\S]*?\}\)/,
+  );
+  assert.match(
+    source,
+    /private updateViewportOverlayPositions\(\): void \{[\s\S]*?this\.caret\.updatePosition\(this\.viewportManager\.getZoom\(\)\)[\s\S]*?this\.updateSelection\(\)[\s\S]*?this\.updateCellSelection\(\)[\s\S]*?this\.renderPictureObjectSelection\(\)[\s\S]*?this\.renderTableObjectSelection\(\)/,
+  );
+});

--- a/rhwp-studio/tests/virtual-scroll-grid-page.test.ts
+++ b/rhwp-studio/tests/virtual-scroll-grid-page.test.ts
@@ -21,7 +21,7 @@ function pages(n: number, width = 800, height = 1000) {
   return Array.from({ length: n }, () => ({ width, height })) as never;
 }
 
-/** 3열 그리드가 되도록 충분히 넓은 뷰포트. zoom 0.4 < 0.5 임계값. */
+/** 표시 geometry가 3열 이상이 되도록 충분히 넓은 뷰포트와 배율. */
 const ZOOM = 0.4;
 const VIEWPORT = 2000;
 

--- a/rhwp-studio/tests/virtual-scroll-horizontal-pan.test.ts
+++ b/rhwp-studio/tests/virtual-scroll-horizontal-pan.test.ts
@@ -118,7 +118,7 @@ test('pointer anchor remains representable across the viewport-width boundary', 
 });
 
 // [#3591] 그리드는 layoutGrid 가 중앙을 잡으므로 팬을 주지 않는다.
-// 그리드 첫 진입(zoom 0.5)에서만 팬이 붙어 스크롤 여지가 생기고 문서가 밀리던 회귀 가드.
+// 자동 열 수가 1→다중 열로 바뀔 때 팬이 붙어 스크롤 여지가 생기고 문서가 밀리던 회귀 가드.
 test('grid mode never receives pan space at any zoom', () => {
   const scroll = new VirtualScroll();
   const gridPages = Array.from({ length: 5 }, () => ({ width: 794, height: 1123 })) as never;

--- a/rhwp-studio/tests/virtual-scroll-page-arrangement.test.ts
+++ b/rhwp-studio/tests/virtual-scroll-page-arrangement.test.ts
@@ -1,21 +1,95 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { VirtualScroll } from '../src/view/virtual-scroll.ts';
+import {
+  resolveAutoPageColumns,
+  VirtualScroll,
+} from '../src/view/virtual-scroll.ts';
 
 function pages(n: number, width = 800, height = 1000) {
   return Array.from({ length: n }, () => ({ width, height })) as never;
 }
 
-test('자동은 기존 50% 임계값과 뷰포트 최대 열 계산을 보존한다', () => {
+test('자동은 절대 배율 gate 없이 표시 geometry로 열 수를 계산한다', () => {
   const scroll = new VirtualScroll(10);
   scroll.setPageDimensions(pages(6), 0.4, 2000, { kind: 'auto' });
   assert.equal(scroll.getColumns(), 6);
   assert.equal(scroll.getPageOffset(0), scroll.getPageOffset(5));
 
   scroll.setPageDimensions(pages(6), 0.51, 2000, { kind: 'auto' });
-  assert.equal(scroll.getColumns(), 1);
-  assert.notEqual(scroll.getPageOffset(0), scroll.getPageOffset(1));
+  assert.equal(scroll.getColumns(), 4);
+  assert.equal(scroll.getPageOffset(0), scroll.getPageOffset(3));
+  assert.notEqual(scroll.getPageOffset(0), scroll.getPageOffset(4));
+});
+
+test('자동은 50% 위에서도 두 쪽 폭이면 2열을 선택하고 50% 전후에 1열을 끼우지 않는다', () => {
+  const scroll = new VirtualScroll(10);
+  for (const zoom of [0.51, 0.5, 0.49]) {
+    scroll.setPageDimensions(pages(6), zoom, 900, { kind: 'auto' });
+    assert.equal(scroll.getColumns(), 2, `zoom ${zoom}`);
+    assert.equal(scroll.getPageOffset(0), scroll.getPageOffset(1));
+  }
+});
+
+test('자동 열 후보는 실제 페이지 수를 넘지 않고 실제 점유 묶음을 중앙 정렬한다', () => {
+  const viewportWidth = 2000;
+  for (const zoom of [0.27, 0.17]) {
+    const scroll = new VirtualScroll(10);
+    scroll.setPageDimensions(pages(3), zoom, viewportWidth, { kind: 'auto' });
+
+    assert.equal(scroll.getColumns(), 3, `zoom ${zoom}`);
+    const groupLeft = scroll.getPageLeft(0);
+    const groupRight = scroll.getPageLeft(2) + scroll.getPageWidth(2);
+    assert.ok(
+      Math.abs((groupLeft + groupRight) / 2 - viewportWidth / 2) <= 1,
+      `zoom ${zoom}: 실제 3쪽 묶음이 viewport 중앙이어야 한다`,
+    );
+  }
+});
+
+test('자동 열 후보는 잘못된 geometry에 1열로 수렴하고 열 경계에 hysteresis를 적용한다', () => {
+  assert.equal(resolveAutoPageColumns({
+    pageCount: 3,
+    viewportWidth: 0,
+    displayedPageWidth: 400,
+    pageGap: 6,
+  }), 1);
+  assert.equal(resolveAutoPageColumns({
+    pageCount: 3,
+    viewportWidth: 1000,
+    displayedPageWidth: 0,
+    pageGap: 6,
+  }), 1);
+
+  const boundary = 2 * 400 + 6;
+  assert.equal(resolveAutoPageColumns({
+    pageCount: 3,
+    viewportWidth: boundary + 4,
+    displayedPageWidth: 400,
+    pageGap: 6,
+    committedColumns: 1,
+  }), 1, '증가 경계 +8px 안에서는 기존 1열 commit 유지');
+  assert.equal(resolveAutoPageColumns({
+    pageCount: 3,
+    viewportWidth: boundary + 8,
+    displayedPageWidth: 400,
+    pageGap: 6,
+    committedColumns: 1,
+  }), 2, '증가 경계 +8px에서 2열 commit 허용');
+  assert.equal(resolveAutoPageColumns({
+    pageCount: 3,
+    viewportWidth: boundary - 4,
+    displayedPageWidth: 400,
+    pageGap: 6,
+    committedColumns: 2,
+  }), 2, '감소 경계 -8px 안에서는 기존 2열 commit 유지');
+  assert.equal(resolveAutoPageColumns({
+    pageCount: 3,
+    viewportWidth: boundary - 9,
+    displayedPageWidth: 400,
+    pageGap: 6,
+    committedColumns: 2,
+  }), 1, '감소 경계 -8px를 벗어나면 1열 commit');
 });
 
 test('한 쪽은 낮은 배율에서도 한 행 한 쪽과 중앙 정렬을 유지한다', () => {

--- a/rhwp-studio/tests/virtual-scroll-page-arrangement.test.ts
+++ b/rhwp-studio/tests/virtual-scroll-page-arrangement.test.ts
@@ -92,6 +92,39 @@ test('자동 열 후보는 잘못된 geometry에 1열로 수렴하고 열 경계
   }), 1, '감소 경계 -8px를 벗어나면 1열 commit');
 });
 
+test('같은 VirtualScroll의 자동 열 commit은 연속 zoom/resize 경계 입력에서 왕복하지 않는다', () => {
+  const scroll = new VirtualScroll(10);
+  const setViewport = (viewportWidth: number): number => {
+    scroll.setPageDimensions(pages(3, 400, 600), 1, viewportWidth, { kind: 'auto' });
+    return scroll.getColumns();
+  };
+
+  assert.equal(setViewport(800), 1);
+  assert.equal(setViewport(814), 1, '증가 dead band 안에서는 1열 유지');
+  assert.equal(setViewport(806), 1, '경계를 되짚어도 1열 유지');
+  assert.equal(setViewport(818), 2, '증가 dead band를 지난 뒤에만 2열 commit');
+  assert.equal(setViewport(806), 2, '감소 dead band 안에서는 2열 유지');
+  assert.equal(setViewport(801), 1, '감소 dead band를 벗어나면 1열 commit');
+});
+
+test('명시 배치와 문서 교체는 이전 자동 열 commit을 다음 자동 계산에 넘기지 않는다', () => {
+  const scroll = new VirtualScroll(10);
+  const samplePages = pages(3, 400, 600);
+
+  scroll.setPageDimensions(samplePages, 1, 800, { kind: 'auto' });
+  assert.equal(scroll.getColumns(), 1);
+
+  scroll.setPageDimensions(samplePages, 1, 814, { kind: 'double' });
+  scroll.setPageDimensions(samplePages, 1, 814, { kind: 'auto' });
+  assert.equal(scroll.getColumns(), 2, '명시 배치를 거치면 자동 배치는 현재 geometry에서 다시 시작');
+
+  scroll.setPageDimensions(samplePages, 1, 806, { kind: 'auto' });
+  assert.equal(scroll.getColumns(), 2, '감소 dead band 안에서는 기존 2열 commit 유지');
+  scroll.resetAutoColumnCommit();
+  scroll.setPageDimensions(samplePages, 1, 806, { kind: 'auto' });
+  assert.equal(scroll.getColumns(), 1, '문서 교체 reset 뒤에는 현재 geometry 후보를 즉시 commit');
+});
+
 test('한 쪽은 낮은 배율에서도 한 행 한 쪽과 중앙 정렬을 유지한다', () => {
   const scroll = new VirtualScroll(10);
   scroll.setPageDimensions(pages(3), 0.25, 1200, { kind: 'single' });


### PR DESCRIPTION
## 변경 요약

- 자동 쪽 배치의 50% 전역 gate를 제거하고, 표시 페이지 폭·쪽 간격·편집 영역 폭으로 열 수를 계산합니다.
- 자동 열 수를 실제 페이지 수로 제한하고 빈 slot이 아닌 실제 점유 페이지 묶음을 편집 영역 가운데에 놓습니다.
- A4 155% 수평 눈금자에서 종이 밖으로 넘는 `21` 라벨만 숨기고 끝 tick과 종이 경계는 유지합니다.
- 기존 `VirtualScroll` 기반 줌·눈금자·캐럿 좌표 경로는 유지합니다.

### 범위 결정

초기 계획의 Canvas 전용 CSS zoom preview와 점진적 Canvas 교체를 로컬에서 구현했지만, 기존
`VirtualScroll` 좌표와 별도 preview 좌표가 공존하면서 좌우·상하 jump, 눈금자 지연과 캐럿·선택·hit-test
회귀 위험이 확인됐습니다. 해당 Stage 2·3 구현은 이 PR에서 제거했고, 이 PR은 검증된 자동 열·점유 중앙
정렬과 눈금자 끝 라벨 수정만 포함합니다.

## 관련 이슈

Refs #6040

- GitHub native stack의 bottom PR이며 trunk는 `devel`입니다.
- 후속 #6041은 이 PR branch를 base로, #6042는 #6041 branch를 base로 추가할 예정입니다.
- #6040 본문의 CSS preview·topology commit·점진적 Canvas 교체 성능 수용 기준은 이 PR로 닫지 않습니다.

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** — 파생 regression suite 준비 뒤 실행했고 파생 파일은 PR에 포함하지 않음
- [x] 새 integration test 등록 규칙 — 해당 없음(Rust integration test 변경 없음)
- [x] `src/**`의 `#[cfg(test)]` policy 검사 — 해당 없음(Rust source 변경 없음)
- [x] `cargo test` — Studio-only 변경이므로 변경 범위별 기본 검증에서 제외
- [x] `cargo clippy -- -D warnings` — Rust source/test 변경이 없어 제외
- [x] 관련 샘플 SVG 내보내기 — renderer/export 출력 변경이 없어 제외
- [x] 웹(WASM) 렌더링 확인
  - 6쪽 자동 60%: 2열, 점유 묶음 중심 오차 0.14px
  - 6쪽 자동 50%: 3열, 점유 묶음 중심 오차 0.07px
  - A4 155%: 20cm 라벨 표시, 21cm 라벨 숨김, 끝 tick·종이 경계 유지
  - browser warning/error 0건
- [x] rhwp-studio UI 회귀 검증
  - `npx tsc --noEmit`
  - `npm test`: 1,278건 중 1,277 pass·1 skip·0 fail
  - `npm run build`: 243 modules, 기존 대형 chunk 경고만 확인
  - focused 자동 배치·눈금자 회귀와 실제 browser 동작 확인
  - 작업 기록: [Stage 1](https://github.com/edwardkim/rhwp/blob/codex/issue-6040-zoom-topology/mydocs/working/task_m100_6040_stage1.md), [Stage 1.1](https://github.com/edwardkim/rhwp/blob/codex/issue-6040-zoom-topology/mydocs/working/task_m100_6040_stage1_1.md)
- [ ] 에이전트 작업 증빙 캡슐 — 이번 작업은 source test·전체 Studio 회귀·실제 browser 증적으로 검증했으며 별도 capsule은 만들지 않음

## 성능 영향 및 측정 결과

- 예상 영향: 자동 열 선택의 정합성 개선. 이 PR 자체는 zoom 성능 최적화를 포함하지 않습니다.
- 재현·측정: 편집 viewport 1260px, 6쪽 A4 문서에서 자동 60% 2열과 50% 3열의 점유 묶음 중심 오차가 각각 0.14px, 0.07px였습니다.
- 열 후보는 절대 배율이 아니라 표시 geometry를 사용하며, 순수 회귀 테스트에서 51%·50%·49% 2열 유지와 27%·17% 3쪽 점유 중앙 정렬을 고정했습니다.

## 스크린샷

- #6040 이슈 본문에 27%·17% 중앙 정렬과 51%·50% 열 전환 사용자 재현 시나리오가 정리되어 있습니다.
- Draft 생성 뒤 필요하면 기존 사용자 재현 이미지와 최신 155% 눈금자 검증 이미지를 첨부합니다.
