### PR TITLE
ci: 문서 전용 병합 후 worker 재사용

### DIFF
--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -220,6 +220,16 @@ jobs:
               }
               const requireFullLaneEvidence = ["ci.yml", "codeql.yml"]
                 .includes(process.env.WORKFLOW_FILE);
+              const reviewOnlyWorker = {
+                "proptest-roundtrip.yml": {
+                  preflight: "Proptest preflight",
+                  worker: "prop roundtrip",
+                },
+                "adapter-diff.yml": {
+                  preflight: "adapter inter-diff preflight",
+                  worker: "adapter inter-diff",
+                },
+              }[process.env.WORKFLOW_FILE];
               const fullLaneRunIds = [];
               if (requireFullLaneEvidence) {
                 for (const workflowRun of workflowRuns) {
@@ -253,6 +263,31 @@ jobs:
                   }
                 }
               }
+              const reviewOnlyFastPassRunIds = [];
+              if (reviewOnlyWorker) {
+                for (const workflowRun of workflowRuns) {
+                  if (workflowRun.status !== "completed" || workflowRun.conclusion !== "success") {
+                    continue;
+                  }
+                  const jobs = await github.paginate(
+                    github.rest.actions.listJobsForWorkflowRun,
+                    { owner, repo, run_id: workflowRun.id, per_page: 100 },
+                  );
+                  const preflightSucceeded = jobs.some((job) => (
+                    job.name === reviewOnlyWorker.preflight
+                    && job.status === "completed"
+                    && job.conclusion === "success"
+                  ));
+                  const workerSkipped = jobs.some((job) => (
+                    job.name === reviewOnlyWorker.worker
+                    && job.status === "completed"
+                    && job.conclusion === "skipped"
+                  ));
+                  if (preflightSucceeded && workerSkipped) {
+                    reviewOnlyFastPassRunIds.push(String(workflowRun.id));
+                  }
+                }
+              }
               const evidence = {
                 mergeCommit,
                 pullRequests,
@@ -264,6 +299,9 @@ jobs:
               };
               if (requireFullLaneEvidence) {
                 evidence.fullLaneRunIds = fullLaneRunIds;
+              }
+              if (reviewOnlyWorker) {
+                evidence.reviewOnlyFastPassRunIds = reviewOnlyFastPassRunIds;
               }
               return evidence;
             }

--- a/mydocs/manual/pr_review/review_only_fast_pass.md
+++ b/mydocs/manual/pr_review/review_only_fast_pass.md
@@ -107,6 +107,21 @@ all-review-only-no-code-impact fast-pass를 즉시 선택한다. candidate의 �
 
 따라서 순수 문서·review 기준 자료 PR에 A 경로의 candidate-check 조회 조건을 잘못 적용하지 않는다.
 
+### B.1 `devel` 병합 후 worker 재사용
+
+Adapter inter-diff와 Proptest roundtrip은 `devel` push에도 required check 이름을 유지한다. PR event가
+아닌 push에는 PR payload가 없으므로, 일반 preflight는 단독으로 review-only 판정을 하지 않고 Full로
+닫힌다. 다만 trusted post-merge controller가 아래를 모두 확인한 같은 저장소 PR이면 worker를 다시
+실행하지 않는다.
+
+1. merge commit이 유일한 `devel` 대상 PR에 대응하고, merge tree와 PR head tree가 일치한다.
+2. PR 전체 파일과 linear PR commit이 모두 B 경로 허용 범위다.
+3. 해당 PR head의 성공한 `pull_request` workflow run에서 해당 preflight는 success이고 worker는
+   실제로 `skipped`였다.
+
+direct push, fork PR, PR 식별 불명확, merge tree 불일치, workflow·CI policy 변경, 비허용 파일, merge
+commit 또는 worker-skip 증거 누락은 재사용하지 않고 Full 실행한다.
+
 ## Full CI fallback
 
 다음 중 하나면 fast-pass로 단정하지 않고 workflow의 full CI 결과를 기다린다.

--- a/mydocs/working/task_m100_6457_stage1_postmerge_review_only_reuse.md
+++ b/mydocs/working/task_m100_6457_stage1_postmerge_review_only_reuse.md
@@ -1,0 +1,36 @@
+---
+kind: working
+status: complete
+issue: 6457
+last_verified: 2026-08-30
+---
+
+# #6457 병합 후 review-only worker 재사용
+
+## 관측
+
+PR #6456은 `mydocs/` 3개 파일만 변경했고 PR preflight에서 Proptest와 Adapter worker가 모두
+`skipped`였다. 그러나 squash merge `7592e9c99dab3e359c41a86a1b5e1608afc861a5`의 `devel` push는
+PR payload가 없어서 두 일반 preflight가 각각 `non-pull-request:push`와
+`full-non-devel-pr:push`로 Full worker를 실행했다.
+
+- Proptest post-merge run: 33300506177, worker 성공, 약 3분
+- Adapter post-merge run: 33300506178, worker 성공, 약 3분
+
+## 구현 경계
+
+`trusted-postmerge-ci-reuse`에서 다음 조건을 모두 만족한 직접 review-only PR만 재사용한다.
+
+1. 기존의 same-repository PR, 유일한 merge mapping, merge tree=head tree, enforcement surface 불변
+   검사를 통과한다.
+2. PR 전체 파일과 linear commit history가 review-only 허용 범위다.
+3. 정확한 PR workflow run이 성공했고, 해당 preflight는 success이며 해당 heavy worker는 `skipped`다.
+
+이 증거가 없으면 기존처럼 Full로 닫는다. code candidate 또는 trailing review-only 경로의 기존 판정은
+변경하지 않는다.
+
+## 검증 계획
+
+- direct review-only post-merge 재사용과 worker-skip 증거 누락 fail-closed Node 단위 테스트
+- CI impact, policy, trusted reuse Node 계약 묶음
+- Python workflow 계약 전체와 `actionlint`

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -76,6 +76,17 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
         self.assertIn("Download trusted PR Archive B duration measurement", ci)
         self.assertIn("Download trusted PR Archive C duration measurement", ci)
 
+    def test_direct_review_only_reuse_requires_the_exact_skipped_worker(self) -> None:
+        workflow = REUSABLE.read_text(encoding="utf-8")
+        self.assertIn("reviewOnlyFastPassRunIds", workflow)
+        self.assertIn('"proptest-roundtrip.yml"', workflow)
+        self.assertIn('preflight: "Proptest preflight"', workflow)
+        self.assertIn('worker: "prop roundtrip"', workflow)
+        self.assertIn('"adapter-diff.yml"', workflow)
+        self.assertIn('preflight: "adapter inter-diff preflight"', workflow)
+        self.assertIn('worker: "adapter inter-diff"', workflow)
+        self.assertIn('job.conclusion === "skipped"', workflow)
+
     def test_trusted_reuse_evaluator_contracts_are_invoked_by_ci(self) -> None:
         ci = CI_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn(

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
@@ -101,6 +101,41 @@ test("reuses the preceding full CI through a linear review-only tail", () => {
   });
 });
 
+test("reuses an exact direct review-only PR fast pass after merge", () => {
+  const result = evaluateTrustedPostMergeReuse(input({
+    pullFiles: [
+      { filename: "mydocs/pr/archives/pr_6456_review.md", status: "added" },
+      { filename: "mydocs/orders/20260830.md", status: "modified" },
+    ],
+    prCommits: [{
+      sha: head,
+      parents: [{ sha: base }],
+      files: [{ filename: "mydocs/pr/archives/pr_6456_review.md", status: "added" }],
+    }],
+    reviewOnlyFastPassRunIds: ["123"],
+  }));
+  assert.deepEqual(result, {
+    reuse: true,
+    reason: "direct-review-only-pr-fast-pass-reused",
+    sourceRunId: "123",
+    pullNumber: "42",
+  });
+});
+
+test("fails closed when a direct review-only PR lacks worker-skip evidence", () => {
+  const result = evaluateTrustedPostMergeReuse(input({
+    pullFiles: [{ filename: "mydocs/orders/20260830.md", status: "modified" }],
+    prCommits: [{
+      sha: head,
+      parents: [{ sha: base }],
+      files: [{ filename: "mydocs/orders/20260830.md", status: "modified" }],
+    }],
+    reviewOnlyFastPassRunIds: [],
+  }));
+  assert.equal(result.reuse, false);
+  assert.equal(result.reason, "direct-review-only-pr-fast-pass-evidence-unavailable");
+});
+
 test("prefers the final PR head when code and review evidence passed together", () => {
   const result = evaluateTrustedPostMergeReuse(input({
     prCommits: [

--- a/scripts/verify-trusted-postmerge-ci-reuse.mjs
+++ b/scripts/verify-trusted-postmerge-ci-reuse.mjs
@@ -100,6 +100,34 @@ export function selectTrustedPostMergeCandidate(pullRequest, prCommits) {
   return null;
 }
 
+function isDirectReviewOnlyPullRequest(pullRequest, pullFiles, prCommits) {
+  if (
+    !validSha(pullRequest?.head?.sha)
+    || !Array.isArray(pullFiles)
+    || pullFiles.length === 0
+    || !pullFiles.every(allowedReviewOnlyFile)
+    || !Array.isArray(prCommits)
+    || prCommits.length === 0
+  ) {
+    return false;
+  }
+
+  let expectedSha = pullRequest.head.sha;
+  for (let index = prCommits.length - 1; index >= 0; index -= 1) {
+    const commit = prCommits[index];
+    if (commit?.sha !== expectedSha) {
+      return false;
+    }
+    const classification = classifyReviewOnlyCommit(commit);
+    if (classification.kind !== "review") {
+      return false;
+    }
+    expectedSha = classification.parentSha;
+  }
+
+  return true;
+}
+
 function latestCandidateRun(runs, pullRequest, repository, candidateSha) {
   const createdAt = timestamp(pullRequest.created_at);
   const mergedAt = timestamp(pullRequest.merged_at);
@@ -136,6 +164,13 @@ function hasFullLaneEvidence(input, run) {
   }
   const runId = String(run?.id || "");
   return runId !== "" && input.fullLaneRunIds.some((id) => String(id) === runId);
+}
+
+function hasReviewOnlyFastPassEvidence(input, run) {
+  const runId = String(run?.id || "");
+  return Array.isArray(input?.reviewOnlyFastPassRunIds)
+    && runId !== ""
+    && input.reviewOnlyFastPassRunIds.some((id) => String(id) === runId);
 }
 
 export function evaluateTrustedPostMergeReuse(input) {
@@ -187,6 +222,35 @@ export function evaluateTrustedPostMergeReuse(input) {
   }
   if (enforcementPathChanged(input.pullFiles)) {
     return denied("pr-changes-ci-enforcement-surface");
+  }
+
+  // A direct review-only PR has no code candidate. It is safe to reuse only
+  // when this worker's exact PR run proves that preflight skipped the worker.
+  if (isDirectReviewOnlyPullRequest(pullRequest, input.pullFiles, input.prCommits)) {
+    const finalHeadCandidate = latestCandidateRun(
+      input.workflowRuns,
+      pullRequest,
+      input.repository,
+      pullRequest.head.sha,
+    );
+    if (!finalHeadCandidate) {
+      return denied("direct-review-only-pr-workflow-unavailable");
+    }
+    if (
+      finalHeadCandidate.status !== "completed"
+      || finalHeadCandidate.conclusion !== "success"
+    ) {
+      return denied("direct-review-only-pr-workflow-not-successful");
+    }
+    if (!hasReviewOnlyFastPassEvidence(input, finalHeadCandidate)) {
+      return denied("direct-review-only-pr-fast-pass-evidence-unavailable");
+    }
+    return {
+      reuse: true,
+      reason: "direct-review-only-pr-fast-pass-reused",
+      sourceRunId: String(finalHeadCandidate.id),
+      pullNumber: String(pullRequest.number),
+    };
   }
 
   const candidateSource = selectTrustedPostMergeCandidate(pullRequest, input.prCommits);


### PR DESCRIPTION
## 변경 요약

문서-only PR이 `devel`에 병합된 뒤 Proptest roundtrip과 Adapter inter-diff worker가 다시 실행되던 경로를 보정합니다.

- 동일 저장소의 유일한 devel 병합 PR, 동일 merge tree, review-only 파일과 linear history를 다시 확인합니다.
- 정확한 PR workflow run에서 preflight success 및 해당 worker `skipped`를 증거로 요구합니다.
- direct push, fork, CI enforcement 변경, tree/history 불일치, 증거 누락은 기존대로 Full 실행합니다.

## 관련 이슈

Refs #6457

## 테스트

- [x] `git diff --check`
- [x] `actionlint .github/workflows/trusted-postmerge-ci-reuse.yml`
- [x] CI impact/policy 및 trusted post-merge Node 계약 87개
- [x] Python workflow 계약 169개
- [x] Rust 변경 없음: Cargo lint/test 미실행

## 성능 영향

#6456과 같은 순수 review-only PR은 merge 뒤 Proptest와 Adapter의 약 3분 worker 재실행을 생략합니다. 코드·workflow·증거 경계가 불명확한 병합은 Full 실행을 유지합니다.