### PR TITLE
머리말/꼬리말 편집 API와 이벤트 계약 정리

### DIFF
--- a/mydocs/pr/archives/pr_6461_review.md
+++ b/mydocs/pr/archives/pr_6461_review.md
@@ -2,7 +2,7 @@
 kind: pr-review
 status: pending-ci
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-08-30
+last_verified: 2026-08-31
 pr: 6461
 issue: 6453
 author: postmelee
@@ -22,10 +22,11 @@ author: postmelee
   `mydocs/manual/pr_review/intake_and_review.md`, `mydocs/manual/pr_review/local_validation.md`,
   `mydocs/manual/codex/docs_and_git_workflow.md`.
 - 작성자·self-review: `postmelee`; collaborator 본인 PR이므로 reviewer request는 등록하지 않았다.
-- 검토 대상 base는 `devel`, 로컬 code candidate는
-  `4ab7d5f798277175b349f23f4593a6fbebadef02`이다. 보정 전 원격 head
-  `575e7c88e97903a5693baae102460c996a57d279`의 required checks는 모두 성공했고,
-  이 문서를 포함한 trailing head의 CI는 push 뒤 다시 확인해야 한다.
+- 검토 대상 code candidate는 `4ab7d5f798277175b349f23f4593a6fbebadef02`,
+  검증된 trailing 원격 head는 `c0603b9f139266e3ca59afcdf8e6ac9e98a2d291`이다.
+  [해당 head CI](https://github.com/edwardkim/rhwp/actions/runs/33306122565)의
+  Build & Test, lint, 전체 Rust archive, Native Skia와 package gate가 성공했다.
+  [Canvas visual diff](https://github.com/edwardkim/rhwp/actions/runs/33306122461)도 성공했다.
 
 ## 변경 범위와 판단
 
@@ -67,11 +68,25 @@ author: postmelee
 - 실제 Chrome E2E에서 HF 진입, 선택·치환·IME, 반복 페이지 투영, 홀짝 target 전환을 확인했다.
   E2E가 만든 ignored screenshot과 HTML report는 검증 산출물이며 stage하지 않았다.
 
+## 2026-08-31 병합 전 재확인
+
+- 최신 `devel` `3afbb066fe93724ab44309163a2e04efb954bf18`과의 merge simulation은 clean이다.
+- #6460 충돌 해소 후보 `5846201178a62d5019b0858c881bd3655eb1ac4b` 위에 이 PR을
+  누적한 merge simulation도 clean이며, 결과 tree는
+  `f14d5b8f820372cff958726dd38cf816f34ea910`이다.
+- 누적 tree에서 canonical HF resolver와 대표 preview cache, 페이지별·전체·부분 캐시 무효화가
+  함께 유지되는 것을 코드로 확인했다. 이 tree 자체를 실행 검증했다는 의미는 아니다.
+- source 변경 없이 #6453 Studio 계약 테스트 3/3, `npx tsc --noEmit`, `git diff --check`를
+  다시 통과했다. 전체 Rust·Native Skia 검증은 위 녹색 code-head CI 근거를 재사용한다.
+- GitHub 상태는 `OPEN`, `MERGEABLE/CLEAN`이다. #6460을 먼저 병합한다면 변경된 base에서
+  이 PR의 mergeable 상태와 최신 required checks를 다시 확인해야 한다.
+
 ## 최종 권고와 후속 조건
 
-**조건부 수용.** 대표 페이지와 텍스트 변경 이벤트 계약을 자동 검증했고, 리뷰의 주석 동기화와 IME
+**승인.** 대표 페이지와 텍스트 변경 이벤트 계약을 자동 검증했고, 리뷰의 주석 동기화와 IME
 우회 경로도 보정했다. 문단 split/merge 이벤트 식별은 비차단 후속 설계 항목이다.
+이 판정은 기술 검토 결과이며 원격 push·merge 실행 승인이 아니다.
 
-- 이 self-review를 trailing 문서 commit으로 같은 branch에 추가한다.
-- 최신 PR head의 required checks가 모두 성공하고 `MERGEABLE/CLEAN`인지 확인한다.
+- 갱신한 self-review를 trailing 문서 commit으로 같은 branch에 추가한다.
+- push 후 최신 trailing PR head의 required checks와 `MERGEABLE/CLEAN`을 다시 확인한다.
 - merge는 작업지시자의 별도 승인 뒤 수행하며, #6453은 PR 본문의 `closes #6453`에 따라 merge 시 닫는다.

--- a/mydocs/pr/archives/pr_6461_review.md
+++ b/mydocs/pr/archives/pr_6461_review.md
@@ -1,0 +1,77 @@
+---
+kind: pr-review
+status: pending-ci
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-30
+pr: 6461
+issue: 6453
+author: postmelee
+---
+
+# PR #6461 review - 머리말/꼬리말 편집 API와 이벤트 계약 정리
+
+## 라우팅과 metadata
+
+- PR: [#6461](https://github.com/edwardkim/rhwp/pull/6461), 관련 이슈:
+  [#6453](https://github.com/edwardkim/rhwp/issues/6453).
+- base route: `collaborator_self_merge.md`; modifiers: `intake_and_review.md`,
+  `local_validation.md`.
+- loaded documents: `AGENTS.md`, `CLAUDE.md`, `mydocs/manual/codex/MEMORY.md`,
+  `mydocs/README.md`, `mydocs/manual/pr_review_workflow.md`,
+  `mydocs/manual/pr_review/README.md`, `mydocs/manual/pr_review/collaborator_self_merge.md`,
+  `mydocs/manual/pr_review/intake_and_review.md`, `mydocs/manual/pr_review/local_validation.md`,
+  `mydocs/manual/codex/docs_and_git_workflow.md`.
+- 작성자·self-review: `postmelee`; collaborator 본인 PR이므로 reviewer request는 등록하지 않았다.
+- 검토 대상 base는 `devel`, 로컬 code candidate는
+  `4ab7d5f798277175b349f23f4593a6fbebadef02`이다. 보정 전 원격 head
+  `575e7c88e97903a5693baae102460c996a57d279`의 required checks는 모두 성공했고,
+  이 문서를 포함한 trailing head의 CI는 push 뒤 다시 확인해야 한다.
+
+## 변경 범위와 판단
+
+- `applyFrom`/`applyTo` 변환과 HF control 탐색을 canonical helper로 통합해 편집 command와
+  renderer가 같은 정의를 선택한다.
+- Studio의 대표 편집 페이지를 `previewPage` 계약으로 통일하고 공개 커서 API는 문단·문자 좌표와
+  명시적 preview page를 받는다.
+- HF 삽입·삭제·범위 치환을 `HeaderFooterTextReplaced` 원자 이벤트로 기록해 실제 clamp된 편집 전
+  반열린 범위와 편집 후 `insertedEnd`를 제공한다.
+- 저장 형식과 사용자 UI는 바꾸지 않으며 내부 resolver, bridge, 이벤트 payload의 모호성을 줄이는
+  계약 정리로 범위가 통제되어 있다.
+
+## 리뷰 보정
+
+- 체크인한 `rhwp-studio/public/rhwp.d.ts`의 `preview_page_hint` 설명을 Rust 생성 원본과 축자
+  일치하도록 `4ab7d5f79`에서 보정했다. 다음 WASM package 갱신 때 발생할 주석 churn을 제거했다.
+- IME 조합 시작의 HF caret 계산도 `getRect()?.pageIndex` 우회 대신 `hfPreviewPage`를 직접 전달하도록
+  같은 후보에서 보정했고, source guard test로 계약을 고정했다.
+- HF 문단 split/merge가 범용 `ParagraphSplit`/`ParagraphMerged` 이벤트를 계속 사용하는 점은 유효한
+  후속 설계 항목이다. 이번 이슈가 정리한 텍스트 replace 이벤트와 별개의 variant 확장이고, 현재
+  Studio 소비자가 해당 범용 이벤트를 HF/본문 판별에 사용하지 않아 blocker는 아니다. 각주 등 다른
+  편집 컨텍스트까지 포함한 이벤트 식별 계약으로 별도 이슈에서 다루는 것이 적절하다.
+
+## 로컬 검증
+
+- `git diff --check`: 통과.
+- #6453 Studio source contract test: 3/3 통과.
+- `npx tsc --noEmit`: 통과.
+- Studio 전체 `npm test`: 1,312 passed, 1 skipped.
+- Studio production build: 244 modules, 통과.
+- 실제 Google Chrome `npm run e2e:issue-4121`: 56/56 통과.
+- Rust source는 보정 전 원격 head와 동일하다. 해당 head에서 CI의 lint 묶음, 전체 Rust archive,
+  Native Skia, Canvas visual diff, CodeQL과 package gate가 모두 성공했다.
+
+## 시각 영향과 증적
+
+- d.ts 문서와 IME 대표 페이지 전달 경로만 보정하며 UI 모양과 renderer 출력은 바꾸지 않는다.
+  새 기준 이미지, PDF/SVG visual sweep과 screenshot 갱신은 필요하지 않다.
+- 실제 Chrome E2E에서 HF 진입, 선택·치환·IME, 반복 페이지 투영, 홀짝 target 전환을 확인했다.
+  E2E가 만든 ignored screenshot과 HTML report는 검증 산출물이며 stage하지 않았다.
+
+## 최종 권고와 후속 조건
+
+**조건부 수용.** 대표 페이지와 텍스트 변경 이벤트 계약을 자동 검증했고, 리뷰의 주석 동기화와 IME
+우회 경로도 보정했다. 문단 split/merge 이벤트 식별은 비차단 후속 설계 항목이다.
+
+- 이 self-review를 trailing 문서 commit으로 같은 branch에 추가한다.
+- 최신 PR head의 required checks가 모두 성공하고 `MERGEABLE/CLEAN`인지 확인한다.
+- merge는 작업지시자의 별도 승인 뒤 수행하며, #6453은 PR 본문의 `closes #6453`에 따라 merge 시 닫는다.

--- a/rhwp-studio/e2e/header-footer-selection-issue4121.test.mjs
+++ b/rhwp-studio/e2e/header-footer-selection-issue4121.test.mjs
@@ -84,12 +84,12 @@ runTest('#4121 HF 선택 반복 페이지 scroll-in 투영', async ({ page }) =>
       target.applyTo,
       startPage,
     );
-    handler.cursor.setHfCursorPosition(0, 0, startPage);
+    handler.cursor.setHfCursorPosition(0, 0);
     handler.eventBus.emit('headerFooterModeChanged', {
       mode: 'header',
       sectionIdx: handler.cursor.hfSectionIdx,
       applyTo: handler.cursor.hfApplyTo,
-      previewPage: handler.cursor.hfPreferredPage,
+      previewPage: handler.cursor.hfPreviewPage,
     });
     handler.viewportManager.setZoom(0.7);
     handler.focus();
@@ -122,7 +122,7 @@ runTest('#4121 HF 선택 반복 페이지 scroll-in 투영', async ({ page }) =>
       cursor.hfApplyTo,
       0,
     ));
-    const pageNum = cursor.hfPreferredPage;
+    const pageNum = cursor.hfPreviewPage;
     const start = wasm.getCursorRectInHeaderFooter(
       cursor.hfSectionIdx, true, cursor.hfApplyTo, 0, 1, pageNum,
     );
@@ -267,11 +267,11 @@ runTest('#4121 HF 선택 반복 페이지 scroll-in 투영', async ({ page }) =>
     return {
       length: info.charCount,
       selection: handler.cursor.getHeaderFooterSelectionOrdered(),
-      page: handler.cursor.hfPreferredPage,
+      page: handler.cursor.hfPreviewPage,
     };
   });
   assert(cutUndo.length === 13 && cutUndo.selection !== null && cutUndo.page === setup.startPage,
-    'cut Undo는 내용·HF 선택·preferredPage를 복원한다');
+    'cut Undo는 내용·HF 선택·previewPage를 복원한다');
 
   await page.evaluate(() => window.__inputHandler.performRedo());
   await settle(page, 250);
@@ -514,12 +514,12 @@ runTest('#4121 HF 선택 반복 페이지 scroll-in 투영', async ({ page }) =>
     handler.viewportManager.setZoom(0.55);
     handler.afterEdit();
     handler.cursor.enterHeaderFooterMode(true, sectionIdx, 0, pages[0]);
-    handler.cursor.setHfCursorPosition(0, 0, pages[0]);
+    handler.cursor.setHfCursorPosition(0, 0);
     handler.eventBus.emit('headerFooterModeChanged', {
       mode: 'header',
       sectionIdx: handler.cursor.hfSectionIdx,
       applyTo: handler.cursor.hfApplyTo,
-      previewPage: handler.cursor.hfPreferredPage,
+      previewPage: handler.cursor.hfPreviewPage,
     });
     handler.updateCaret();
     handler.focus();
@@ -741,15 +741,15 @@ runTest('#4121 HF 선택 반복 페이지 scroll-in 투영', async ({ page }) =>
   await page.evaluate(({ sectionIdx, startPage }) => {
     const handler = window.__inputHandler;
     handler.cursor.switchHeaderFooterTarget(false, sectionIdx, 1, startPage);
-    handler.cursor.setHfCursorPosition(0, 0, startPage);
+    handler.cursor.setHfCursorPosition(0, 0);
     handler.eventBus.emit('headerFooterModeChanged', {
       mode: 'footer',
       sectionIdx: handler.cursor.hfSectionIdx,
       applyTo: handler.cursor.hfApplyTo,
-      previewPage: handler.cursor.hfPreferredPage,
+      previewPage: handler.cursor.hfPreviewPage,
     });
     handler.viewportManager.setScrollTop(
-      handler.virtualScroll.getPageOffset(handler.cursor.hfPreferredPage),
+      handler.virtualScroll.getPageOffset(handler.cursor.hfPreviewPage),
     );
     handler.focus();
   }, { sectionIdx: matrixSetup.sectionIdx, startPage: activeParity[0].pageNum });
@@ -757,10 +757,10 @@ runTest('#4121 HF 선택 반복 페이지 scroll-in 투영', async ({ page }) =>
   const representativeEditing = await page.evaluate(() => {
     const handler = window.__inputHandler;
     const layer = document.querySelector(
-      `[data-rhwp-hf-edit-page="${handler.cursor.hfPreferredPage}"].is-representative`,
+      `[data-rhwp-hf-edit-page="${handler.cursor.hfPreviewPage}"].is-representative`,
     );
     return {
-      preferredPage: handler.cursor.hfPreferredPage,
+      previewPage: handler.cursor.hfPreviewPage,
       expectedPreviewPage: handler.wasm.getHeaderFooterPreviewPage(handler.cursor.hfSectionIdx),
       label: document.querySelector('.tb-hf-label')?.textContent || '',
       badge: layer?.querySelector('.hf-edit-badge')?.textContent || '',
@@ -769,8 +769,8 @@ runTest('#4121 HF 선택 반복 페이지 scroll-in 투영', async ({ page }) =>
     };
   });
   assert(
-    representativeEditing.preferredPage === representativeEditing.expectedPreviewPage
-      && representativeEditing.preferredPage === matrixSetup.pages[0],
+    representativeEditing.previewPage === representativeEditing.expectedPreviewPage
+      && representativeEditing.previewPage === matrixSetup.pages[0],
     `짝수 꼬리말도 구역 첫 페이지에서 대표 편집한다 (${JSON.stringify(representativeEditing)})`,
   );
   assert(
@@ -790,7 +790,7 @@ runTest('#4121 HF 선택 반복 페이지 scroll-in 투영', async ({ page }) =>
   assert(paritySelection?.start.applyTo === 1 && paritySelection.end.charOffset === 7,
     'Shift+End가 짝수 쪽 꼬리말 선택을 만든다');
   assert(
-    await visibleSelectionProjectsToPage(page, representativeEditing.preferredPage),
+    await visibleSelectionProjectsToPage(page, representativeEditing.previewPage),
     '짝수 쪽 꼬리말 선택이 대표 편집 페이지에 투영된다',
   );
 
@@ -808,7 +808,7 @@ runTest('#4121 HF 선택 반복 페이지 scroll-in 투영', async ({ page }) =>
     assert(related, `짝수 쪽 ${target.pageNum + 1}쪽은 실제 적용 영역으로 연관 표시된다`);
   }
   for (const target of otherParity) {
-    if (target.pageNum === representativeEditing.preferredPage) continue;
+    if (target.pageNum === representativeEditing.previewPage) continue;
     await page.evaluate((pageNum) => {
       const handler = window.__inputHandler;
       handler.viewportManager.setScrollTop(handler.virtualScroll.getPageOffset(pageNum));
@@ -819,7 +819,7 @@ runTest('#4121 HF 선택 반복 페이지 scroll-in 투영', async ({ page }) =>
   }
 
   const switchTarget = otherParity.find(
-    target => target.pageNum !== representativeEditing.preferredPage,
+    target => target.pageNum !== representativeEditing.previewPage,
   );
   assert(Boolean(switchTarget), '대표 페이지 밖에 홀수 꼬리말 적용 쪽이 있다');
   await page.evaluate((pageNum) => {
@@ -842,7 +842,7 @@ runTest('#4121 HF 선택 반복 페이지 scroll-in 투영', async ({ page }) =>
     return {
       mode: handler.cursor.headerFooterMode,
       applyTo: handler.cursor.hfApplyTo,
-      page: handler.cursor.hfPreferredPage,
+      page: handler.cursor.hfPreviewPage,
       previewPage: handler.wasm.getHeaderFooterPreviewPage(handler.cursor.hfSectionIdx),
       label: document.querySelector('.tb-hf-label')?.textContent || '',
       selection: handler.cursor.getHeaderFooterSelectionOrdered(),
@@ -860,7 +860,7 @@ runTest('#4121 HF 선택 반복 페이지 scroll-in 투영', async ({ page }) =>
 
   const actualPreviewTarget = await page.evaluate(() => {
     const handler = window.__inputHandler;
-    return handler.wasm.getHeaderFooterEditTarget(handler.cursor.hfPreferredPage, false);
+    return handler.wasm.getHeaderFooterEditTarget(handler.cursor.hfPreviewPage, false);
   });
   await page.click('[data-cmd="page:headerfooter-close"]');
   await settle(page, 250);

--- a/rhwp-studio/public/rhwp.d.ts
+++ b/rhwp-studio/public/rhwp.d.ts
@@ -485,10 +485,10 @@ export class HwpDocument {
     /**
      * 머리말/꼬리말 내 커서 위치의 픽셀 좌표를 반환한다.
      *
-     * preferred_page: 선호 페이지 (더블클릭한 페이지). -1이면 첫 번째 발견 페이지 사용.
+     * preview_page_hint: 편집 정의를 투영할 대표 페이지 힌트. 음수이면 실제 적용 페이지를 찾는다.
      * 반환: JSON `{"pageIndex":N,"x":F,"y":F,"height":F}`
      */
-    getCursorRectInHeaderFooter(section_idx: number, is_header: boolean, apply_to: number, hf_para_idx: number, char_offset: number, preferred_page: number): string;
+    getCursorRectInHeaderFooter(section_idx: number, is_header: boolean, apply_to: number, hf_para_idx: number, char_offset: number, preview_page_hint: number): string;
     /**
      * 각주/미주 내부 커서 렉트 계산
      */

--- a/rhwp-studio/public/rhwp.d.ts
+++ b/rhwp-studio/public/rhwp.d.ts
@@ -485,7 +485,8 @@ export class HwpDocument {
     /**
      * 머리말/꼬리말 내 커서 위치의 픽셀 좌표를 반환한다.
      *
-     * preview_page_hint: 편집 정의를 투영할 대표 페이지 힌트. 음수이면 실제 적용 페이지를 찾는다.
+     * preview_page_hint: 편집 정의를 투영할 대표 페이지 힌트. Studio는 구역의 첫 페이지를
+     * 전달한다. 음수이면 호환 경로로 실제 적용 페이지를 앞에서부터 찾는다.
      * 반환: JSON `{"pageIndex":N,"x":F,"y":F,"height":F}`
      */
     getCursorRectInHeaderFooter(section_idx: number, is_header: boolean, apply_to: number, hf_para_idx: number, char_offset: number, preview_page_hint: number): string;

--- a/rhwp-studio/src/command/commands/page.ts
+++ b/rhwp-studio/src/command/commands/page.ts
@@ -95,7 +95,7 @@ function insertHfField(
     sectionIdx: cursor.hfSectionIdx,
     isHeader,
     applyTo: cursor.hfApplyTo,
-    preferredPage: cursor.hfPreferredPage,
+    previewPage: cursor.hfPreviewPage,
   };
   const paraIdx = cursor.hfParaIdx;
   const charOffset = cursor.hfCharOffset;

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -3127,9 +3127,10 @@ export class WasmBridge {
     );
   }
 
-  getCursorRectInHeaderFooter(sec: number, isHeader: boolean, applyTo: number, hfParaIdx: number, charOffset: number, preferredPage = -1): CursorRect {
+  /** 구역 첫 페이지에 투영된 대표 HF 편집 표면의 캐럿 좌표를 반환한다. */
+  getCursorRectInHeaderFooter(sec: number, isHeader: boolean, applyTo: number, hfParaIdx: number, charOffset: number, previewPage: number): CursorRect {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
-    return JSON.parse(this.doc.getCursorRectInHeaderFooter(sec, isHeader, applyTo, hfParaIdx, charOffset, preferredPage));
+    return JSON.parse(this.doc.getCursorRectInHeaderFooter(sec, isHeader, applyTo, hfParaIdx, charOffset, previewPage));
   }
 
   getSelectionRectsInHeaderFooter(

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -76,7 +76,7 @@ export type EditContext =
       readonly applyTo: number;
       readonly paraIdx: number;
       readonly charOffset: number;
-      readonly preferredPage: number;
+      readonly previewPage: number;
     }
   | {
       readonly mode: 'footnote';
@@ -100,7 +100,7 @@ export type HeaderFooterSelectionSnapshot = {
   readonly mode: 'headerFooter';
   readonly start: HeaderFooterTextPosition;
   readonly end: HeaderFooterTextPosition;
-  readonly preferredPage: number;
+  readonly previewPage: number;
 };
 
 export type EditSelectionSnapshot = BodySelectionSnapshot | HeaderFooterSelectionSnapshot;
@@ -1294,7 +1294,8 @@ export interface HeaderFooterEditTarget {
   readonly sectionIdx: number;
   readonly isHeader: boolean;
   readonly applyTo: number;
-  readonly preferredPage: number;
+  /** 구역 첫 페이지에 마련된 대표 HF 편집 표면 */
+  readonly previewPage: number;
 }
 
 export interface FootnoteEditTarget {
@@ -1310,7 +1311,7 @@ export interface FootnoteEditTarget {
 function hfEditContext(t: HeaderFooterEditTarget, paraIdx: number, charOffset: number): EditContext {
   return {
     mode: 'headerFooter', sectionIdx: t.sectionIdx, isHeader: t.isHeader,
-    applyTo: t.applyTo, paraIdx, charOffset, preferredPage: t.preferredPage,
+    applyTo: t.applyTo, paraIdx, charOffset, previewPage: t.previewPage,
   };
 }
 

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -61,8 +61,8 @@ export class CursorState {
   private _hfApplyTo = 0; // 0=Both, 1=Even, 2=Odd
   private _hfParaIdx = 0;
   private _hfCharOffset = 0;
-  /** 머리말/꼬리말이 위치한 선호 페이지 (더블클릭한 페이지) */
-  private _hfPreferredPage = -1;
+  /** 머리말/꼬리말 정의를 투영해 편집하는 구역 첫 페이지 */
+  private _hfPreviewPage = -1;
   /** 편집 모드 진입 전 본문 커서 위치 (탈출 시 복원용) */
   private _savedBodyPosition: DocumentPosition | null = null;
 
@@ -175,15 +175,15 @@ export class CursorState {
   getHeaderFooterSelectionOrdered(): {
     start: HeaderFooterTextPosition;
     end: HeaderFooterTextPosition;
-    preferredPage: number;
+    previewPage: number;
   } | null {
     if (!this.hfAnchor || this._headerFooterMode === 'none') return null;
     const focus = this.currentHeaderFooterTextPosition();
     if (!CursorState.sameHeaderFooterTarget(this.hfAnchor, focus)) return null;
     const cmp = CursorState.compareHeaderFooterPositions(this.hfAnchor, focus);
     return cmp <= 0
-      ? { start: { ...this.hfAnchor }, end: focus, preferredPage: this._hfPreferredPage }
-      : { start: focus, end: { ...this.hfAnchor }, preferredPage: this._hfPreferredPage };
+      ? { start: { ...this.hfAnchor }, end: focus, previewPage: this._hfPreviewPage }
+      : { start: focus, end: { ...this.hfAnchor }, previewPage: this._hfPreviewPage };
   }
 
   /** 현재 위치를 anchor로 설정 (선택 시작) */
@@ -223,7 +223,7 @@ export class CursorState {
   selectHeaderFooterRange(
     start: HeaderFooterTextPosition,
     end: HeaderFooterTextPosition,
-    preferredPage: number,
+    previewPage: number,
   ): boolean {
     if (this._headerFooterMode === 'none') return false;
     const current = this.currentHeaderFooterTextPosition();
@@ -257,7 +257,12 @@ export class CursorState {
     this.hfAnchor = { ...start };
     this._hfParaIdx = end.paraIdx;
     this._hfCharOffset = end.charOffset;
-    if (preferredPage >= 0) this._hfPreferredPage = preferredPage;
+    if (previewPage >= 0) {
+      this._hfPreviewPage = this.resolveHeaderFooterPreviewPage(
+        this._hfSectionIdx,
+        previewPage,
+      );
+    }
     this.updateRect();
     return true;
   }
@@ -1294,7 +1299,7 @@ export class CursorState {
         const isHeader = this._headerFooterMode === 'header';
         this.rect = this.wasm.getCursorRectInHeaderFooter(
           this._hfSectionIdx, isHeader, this._hfApplyTo,
-          this._hfParaIdx, this._hfCharOffset, this._hfPreferredPage,
+          this._hfParaIdx, this._hfCharOffset, this._hfPreviewPage,
         );
         return;
       }
@@ -1902,8 +1907,8 @@ export class CursorState {
   get hfParaIdx(): number { return this._hfParaIdx; }
   /** 머리말/꼬리말 내 문자 오프셋 */
   get hfCharOffset(): number { return this._hfCharOffset; }
-  /** 머리말/꼬리말 캐럿을 표시할 선호 페이지 */
-  get hfPreferredPage(): number { return this._hfPreferredPage; }
+  /** 머리말/꼬리말 정의를 투영해 편집하는 구역 첫 페이지 */
+  get hfPreviewPage(): number { return this._hfPreviewPage; }
 
   /** 머리말/꼬리말 편집 모드인지 반환 */
   isInHeaderFooter(): boolean { return this._headerFooterMode !== 'none'; }
@@ -1921,7 +1926,7 @@ export class CursorState {
   }
 
   /** 머리말/꼬리말 편집 모드에 진입한다. */
-  enterHeaderFooterMode(isHeader: boolean, sectionIdx: number, applyTo: number, preferredPage = -1): void {
+  enterHeaderFooterMode(isHeader: boolean, sectionIdx: number, applyTo: number, sourcePage = -1): void {
     // 현재 본문 커서 위치 저장
     this._savedBodyPosition = { ...this.position };
 
@@ -1930,9 +1935,9 @@ export class CursorState {
     this._hfApplyTo = applyTo;
     this._hfParaIdx = 0;
     this._hfCharOffset = 0;
-    this._hfPreferredPage = this.resolveHeaderFooterPreviewPage(
+    this._hfPreviewPage = this.resolveHeaderFooterPreviewPage(
       sectionIdx,
-      preferredPage >= 0 ? preferredPage : (this.rect?.pageIndex ?? 0),
+      sourcePage >= 0 ? sourcePage : (this.rect?.pageIndex ?? 0),
     );
 
     // 선택 해제
@@ -1964,31 +1969,25 @@ export class CursorState {
   }
 
   /** 다른 머리말/꼬리말로 직접 전환한다 (exit→enter 사이의 updateRect 호출을 피함). */
-  switchHeaderFooterTarget(isHeader: boolean, sectionIdx: number, applyTo: number, targetPage = -1): void {
+  switchHeaderFooterTarget(isHeader: boolean, sectionIdx: number, applyTo: number, sourcePage = -1): void {
     if (this._headerFooterMode === 'none') return;
     this._headerFooterMode = isHeader ? 'header' : 'footer';
     this._hfSectionIdx = sectionIdx;
     this._hfApplyTo = applyTo;
     this._hfParaIdx = 0;
     this._hfCharOffset = 0;
-    this._hfPreferredPage = this.resolveHeaderFooterPreviewPage(
+    this._hfPreviewPage = this.resolveHeaderFooterPreviewPage(
       sectionIdx,
-      targetPage >= 0 ? targetPage : (this.rect?.pageIndex ?? this._hfPreferredPage),
+      sourcePage >= 0 ? sourcePage : (this.rect?.pageIndex ?? this._hfPreviewPage),
     );
     this.clearSelection();
     this.updateRect();
   }
 
   /** 머리말/꼬리말 내 커서 위치를 설정한다. */
-  setHfCursorPosition(paraIdx: number, charOffset: number, preferredPage = -1): void {
+  setHfCursorPosition(paraIdx: number, charOffset: number): void {
     this._hfParaIdx = paraIdx;
     this._hfCharOffset = charOffset;
-    if (preferredPage >= 0) {
-      this._hfPreferredPage = this.resolveHeaderFooterPreviewPage(
-        this._hfSectionIdx,
-        preferredPage,
-      );
-    }
     this.updateRect();
   }
 
@@ -2015,7 +2014,7 @@ export class CursorState {
       return this.selectHeaderFooterRange(
         { ...target, paraIdx: 0, charOffset: 0 },
         { ...target, paraIdx: lastPara, charOffset: Number(lastInfo.charCount) },
-        this._hfPreferredPage,
+        this._hfPreviewPage,
       );
     } catch (e) {
       console.warn('[CursorState] selectAllInHeaderFooter 실패:', e);
@@ -2226,7 +2225,6 @@ export class CursorState {
         ) {
           this._hfParaIdx = hit.paraIndex;
           this._hfCharOffset = hit.charOffset;
-          this._hfPreferredPage = pageNum;
           this.updateRect();
           return;
         }

--- a/rhwp-studio/src/engine/header-footer-mode.ts
+++ b/rhwp-studio/src/engine/header-footer-mode.ts
@@ -24,7 +24,7 @@ export function headerFooterModeState(cursor: CursorState): HeaderFooterModeChan
     mode: cursor.headerFooterMode === 'header' ? 'header' : 'footer',
     sectionIdx: cursor.hfSectionIdx,
     applyTo: cursor.hfApplyTo,
-    previewPage: cursor.hfPreferredPage,
+    previewPage: cursor.hfPreviewPage,
   };
 }
 

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -897,7 +897,7 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       try {
         const target = {
           sectionIdx: this.cursor.hfSectionIdx, isHeader, applyTo: this.cursor.hfApplyTo,
-          preferredPage: this.cursor.hfPreferredPage,
+          previewPage: this.cursor.hfPreviewPage,
         };
         const paraIdx = this.cursor.hfParaIdx;
         const charOffset = this.cursor.hfCharOffset;
@@ -916,7 +916,7 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       try {
         const target = {
           sectionIdx: this.cursor.hfSectionIdx, isHeader, applyTo: this.cursor.hfApplyTo,
-          preferredPage: this.cursor.hfPreferredPage,
+          previewPage: this.cursor.hfPreviewPage,
         };
         const paraIdx = this.cursor.hfParaIdx;
         const charOffset = this.cursor.hfCharOffset;

--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -813,7 +813,7 @@ export function onClick(this: any, e: MouseEvent): void {
         // 본문 hitTest로 계속 진행
       } else {
         const clickedIsHeader = hfHit.isHeader ?? (this.cursor.headerFooterMode === 'header');
-        const isPreviewSurface = pageIdx === this.cursor.hfPreferredPage
+        const isPreviewSurface = pageIdx === this.cursor.hfPreviewPage
           && clickedIsHeader === (this.cursor.headerFooterMode === 'header');
         const clickedSection = isPreviewSurface
           ? this.cursor.hfSectionIdx
@@ -879,7 +879,7 @@ export function onClick(this: any, e: MouseEvent): void {
           ) {
             if (e.shiftKey && sameTarget) this.cursor.setHfAnchor();
             else this.cursor.clearSelection();
-            this.cursor.setHfCursorPosition(inHfHit.paraIndex, inHfHit.charOffset, pageIdx);
+            this.cursor.setHfCursorPosition(inHfHit.paraIndex, inHfHit.charOffset);
             if (!e.shiftKey || !sameTarget) this.cursor.setHfAnchor();
             this.active = true;
             this.startTextSelectionDrag(e);

--- a/rhwp-studio/src/engine/input-handler-text.ts
+++ b/rhwp-studio/src/engine/input-handler-text.ts
@@ -228,7 +228,7 @@ export function handleBackspace(this: any, pos: DocumentPosition, inCell: boolea
     const hfOff = this.cursor.hfCharOffset;
     const target = {
       sectionIdx: this.cursor.hfSectionIdx, isHeader, applyTo: this.cursor.hfApplyTo,
-      preferredPage: this.cursor.hfPreferredPage,
+      previewPage: this.cursor.hfPreviewPage,
     };
     const paraIdx = this.cursor.hfParaIdx;
     if (hfOff > 0) {
@@ -297,7 +297,7 @@ export function handleDelete(this: any, pos: DocumentPosition, inCell: boolean):
     const isHeader = this.cursor.headerFooterMode === 'header';
     const target = {
       sectionIdx: this.cursor.hfSectionIdx, isHeader, applyTo: this.cursor.hfApplyTo,
-      preferredPage: this.cursor.hfPreferredPage,
+      previewPage: this.cursor.hfPreviewPage,
     };
     try {
       const paraIdx = this.cursor.hfParaIdx;
@@ -468,7 +468,7 @@ export function onCompositionEnd(this: any): void {
           sectionIdx: this.cursor.hfSectionIdx,
           isHeader: this.cursor.headerFooterMode === 'header',
           applyTo: this.cursor.hfApplyTo,
-          preferredPage: this.cursor.hfPreferredPage,
+          previewPage: this.cursor.hfPreviewPage,
         };
         this.executeOperation({ kind: 'record', command: new InsertTextInHeaderFooterCommand(target, this.cursor.hfParaIdx, anchor.charOffset, composed) });
       }
@@ -682,7 +682,7 @@ export function onInput(this: any, e?: InputEvent): void {
       }
       const target = {
         sectionIdx: this.cursor.hfSectionIdx, isHeader, applyTo: this.cursor.hfApplyTo,
-        preferredPage: this.cursor.hfPreferredPage,
+        previewPage: this.cursor.hfPreviewPage,
       };
       const paraIdx = this.cursor.hfParaIdx;
       const charOffset = this.cursor.hfCharOffset;

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -3518,7 +3518,7 @@ export class InputHandler {
             const isHeader = this.cursor.headerFooterMode === 'header';
             startRect = this.wasm.getCursorRectInHeaderFooter(
               this.cursor.hfSectionIdx, isHeader, this.cursor.hfApplyTo,
-              this.cursor.hfParaIdx, anchor.charOffset, this.cursor.getRect()?.pageIndex ?? 0,
+              this.cursor.hfParaIdx, anchor.charOffset, this.cursor.hfPreviewPage,
             )!;
           } else if (this.cursor.isInFootnote()) {
             startRect = this.wasm.getCursorRectInFootnote(

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -1565,7 +1565,6 @@ export class InputHandler {
         this.cursor.setHfCursorPosition(
           hfHit.hit.paraIndex,
           hfHit.hit.charOffset,
-          hfHit.pageIdx,
         );
         this.updateCaretDuringDrag();
       }
@@ -2009,7 +2008,7 @@ export class InputHandler {
       applyTo: ordered.end.applyTo,
       paraIdx: this.cursor.hfParaIdx,
       charOffset: this.cursor.hfCharOffset,
-      preferredPage: ordered.preferredPage,
+      previewPage: ordered.previewPage,
     };
     const bodyPosition = this.cursor.getPosition();
     this.executeOperation({
@@ -2307,7 +2306,7 @@ export class InputHandler {
           applyTo,
           paraIdx: hfParaIdx,
           charOffset: hfCharOffset,
-          preferredPage: cur.hfPreferredPage,
+          previewPage: cur.hfPreviewPage,
         },
         operation: (wasm) => {
           wasm.applyParaFormatInHf(sectionIdx, isHeader, applyTo, hfParaIdx, propsJson);
@@ -2668,7 +2667,7 @@ export class InputHandler {
       mode: 'headerFooter',
       start: { ...selection.start },
       end: { ...selection.end },
-      preferredPage: selection.preferredPage,
+      previewPage: selection.previewPage,
     };
   }
 
@@ -2704,13 +2703,13 @@ export class InputHandler {
     };
     const start = ordered?.start ?? collapsed;
     const end = ordered?.end ?? collapsed;
-    const preferredPage = this.cursor.hfPreferredPage;
+    const previewPage = this.cursor.hfPreviewPage;
     const contextBefore: EditContext = {
       mode: 'headerFooter',
       ...target,
       paraIdx: this.cursor.hfParaIdx,
       charOffset: this.cursor.hfCharOffset,
-      preferredPage,
+      previewPage,
     };
     const selectionBefore = ordered && options.restoreSelectionOnUndo
       ? this.headerFooterSelectionSnapshot(ordered)
@@ -2732,7 +2731,7 @@ export class InputHandler {
             ...target,
             paraIdx: result.hfParaIndex,
             charOffset: result.charOffset,
-            preferredPage,
+            previewPage,
           };
         },
         selectionBefore,
@@ -2758,7 +2757,7 @@ export class InputHandler {
         this.cursor.selectHeaderFooterRange(
           ordered.start,
           ordered.end,
-          ordered.preferredPage,
+          ordered.previewPage,
         );
       }
       console.warn('[InputHandler] HF 범위 치환 실패:', err);
@@ -2789,7 +2788,7 @@ export class InputHandler {
       applyTo: this.cursor.hfApplyTo,
       paraIdx: this.cursor.hfParaIdx,
       charOffset: this.cursor.hfCharOffset,
-      preferredPage: this.cursor.hfPreferredPage,
+      previewPage: this.cursor.hfPreviewPage,
     });
     return true;
   }
@@ -2893,20 +2892,20 @@ export class InputHandler {
             ctx.isHeader,
             ctx.sectionIdx,
             ctx.applyTo,
-            ctx.preferredPage,
+            ctx.previewPage,
           );
         } else {
           this.cursor.enterHeaderFooterMode(
             ctx.isHeader,
             ctx.sectionIdx,
             ctx.applyTo,
-            ctx.preferredPage,
+            ctx.previewPage,
           );
         }
         // 진입/전환 양쪽 모두 mode-change 를 알려 툴바/오버레이가 stale 하지 않게 한다.
         emitHeaderFooterModeChanged(this.eventBus, this.cursor);
       }
-      this.cursor.setHfCursorPosition(ctx.paraIdx, ctx.charOffset, ctx.preferredPage);
+      this.cursor.setHfCursorPosition(ctx.paraIdx, ctx.charOffset);
       return;
     }
 
@@ -2992,7 +2991,7 @@ export class InputHandler {
     if (!range) return;
     if ('mode' in range) {
       if (range.mode === 'headerFooter') {
-        this.cursor.selectHeaderFooterRange(range.start, range.end, range.preferredPage);
+        this.cursor.selectHeaderFooterRange(range.start, range.end, range.previewPage);
       }
       return;
     }
@@ -3011,7 +3010,7 @@ export class InputHandler {
     const range = cmd?.selectionAfter?.();
     if (!range) return;
     if ('mode' in range && range.mode === 'headerFooter') {
-      this.cursor.selectHeaderFooterRange(range.start, range.end, range.preferredPage);
+      this.cursor.selectHeaderFooterRange(range.start, range.end, range.previewPage);
     }
   }
 

--- a/rhwp-studio/tests/issue-4121-header-footer-editing.test.ts
+++ b/rhwp-studio/tests/issue-4121-header-footer-editing.test.ts
@@ -18,8 +18,9 @@ test('#4121 history 복원용 HF 선택은 현재 target과 문단 경계를 다
     const wasm = {
       getCursorRectInHeaderFooter: (
         _sec: number, _header: boolean, _apply: number,
-        paraIdx: number, charOffset: number, preferredPage: number,
-      ) => ({ pageIndex: preferredPage, x: charOffset * 8, y: paraIdx * 20, height: 12 }),
+        paraIdx: number, charOffset: number, previewPage: number,
+      ) => ({ pageIndex: previewPage, x: charOffset * 8, y: paraIdx * 20, height: 12 }),
+      getHeaderFooterPreviewPage: () => 4,
       getHeaderFooterParaInfo: (_sec: number, _header: boolean, _apply: number, paraIdx: number) =>
         JSON.stringify({ paraCount: 2, charCount: paraIdx === 0 ? 5 : 4 }),
     };
@@ -31,7 +32,7 @@ test('#4121 history 복원용 HF 선택은 현재 target과 문단 경계를 다
       { sectionIdx: 2, isHeader: true, applyTo: 1, paraIdx: 1, charOffset: 3 },
       6,
     ), true);
-    assert.equal(cursor.getHeaderFooterSelectionOrdered()?.preferredPage, 6);
+    assert.equal(cursor.getHeaderFooterSelectionOrdered()?.previewPage, 4);
 
     cursor.clearSelection();
     assert.equal(cursor.selectHeaderFooterRange(
@@ -59,17 +60,17 @@ test('#4121 HF snapshot command는 undo/redo 문맥과 선택 정책을 분리�
     };
     const before = {
       mode: 'headerFooter', sectionIdx: 0, isHeader: true, applyTo: 0,
-      paraIdx: 1, charOffset: 3, preferredPage: 4,
+      paraIdx: 1, charOffset: 3, previewPage: 4,
     };
     const after = {
       mode: 'headerFooter', sectionIdx: 0, isHeader: true, applyTo: 0,
-      paraIdx: 0, charOffset: 2, preferredPage: 4,
+      paraIdx: 0, charOffset: 2, previewPage: 4,
     };
     const selection = {
       mode: 'headerFooter',
       start: { sectionIdx: 0, isHeader: true, applyTo: 0, paraIdx: 0, charOffset: 2 },
       end: { sectionIdx: 0, isHeader: true, applyTo: 0, paraIdx: 1, charOffset: 3 },
-      preferredPage: 4,
+      previewPage: 4,
     };
     const body = { sectionIndex: 0, paragraphIndex: 0, charOffset: 0 };
     const cmd = new SubmodeSelectionSnapshotCommand(

--- a/rhwp-studio/tests/issue-4121-header-footer-selection.test.ts
+++ b/rhwp-studio/tests/issue-4121-header-footer-selection.test.ts
@@ -18,22 +18,22 @@ test('#4121 HF anchor는 본문·각주와 독립된 target 소유 범위를 만
     const wasm = {
       getCursorRectInHeaderFooter: (
         _sec: number, _header: boolean, _apply: number,
-        paraIdx: number, charOffset: number, preferredPage: number,
-      ) => ({ pageIndex: preferredPage, x: charOffset * 8, y: paraIdx * 20, height: 12 }),
+        paraIdx: number, charOffset: number, previewPage: number,
+      ) => ({ pageIndex: previewPage, x: charOffset * 8, y: paraIdx * 20, height: 12 }),
       getHeaderFooterParaInfo: (_sec: number, _header: boolean, _apply: number, paraIdx: number) =>
         JSON.stringify({ paraCount: 2, charCount: paraIdx === 0 ? 5 : 4 }),
     };
     const cursor: any = new CursorState(wasm);
     cursor.enterHeaderFooterMode(true, 2, 1, 4);
-    cursor.setHfCursorPosition(0, 4, 4);
+    cursor.setHfCursorPosition(0, 4);
     cursor.setHfAnchor();
-    cursor.setHfCursorPosition(1, 2, 6);
+    cursor.setHfCursorPosition(1, 2);
 
     assert.equal(cursor.hasSelection(), true);
     assert.deepEqual(cursor.getHeaderFooterSelectionOrdered(), {
       start: { sectionIdx: 2, isHeader: true, applyTo: 1, paraIdx: 0, charOffset: 4 },
       end: { sectionIdx: 2, isHeader: true, applyTo: 1, paraIdx: 1, charOffset: 2 },
-      preferredPage: 6,
+      previewPage: 4,
     });
 
     cursor.switchHeaderFooterTarget(true, 2, 2, 7);
@@ -55,9 +55,9 @@ test('#4121 HF 역방향 범위는 문단·문자 사전식으로 정렬된다',
     };
     const cursor: any = new CursorState(wasm);
     cursor.enterHeaderFooterMode(false, 0, 0, 3);
-    cursor.setHfCursorPosition(1, 6, 3);
+    cursor.setHfCursorPosition(1, 6);
     cursor.setHfAnchor();
-    cursor.setHfCursorPosition(0, 2, 3);
+    cursor.setHfCursorPosition(0, 2);
 
     const selection = cursor.getHeaderFooterSelectionOrdered();
     assert.deepEqual(selection?.start, {
@@ -80,8 +80,8 @@ test('#4121 HF 위아래 이동은 같은 resolved target의 시각 줄만 따�
     const wasm = {
       getCursorRectInHeaderFooter: (
         _sec: number, _header: boolean, _apply: number,
-        paraIdx: number, charOffset: number, preferredPage: number,
-      ) => ({ pageIndex: preferredPage, x: charOffset * 8, y: paraIdx * 20, height: 12 }),
+        paraIdx: number, charOffset: number, previewPage: number,
+      ) => ({ pageIndex: previewPage, x: charOffset * 8, y: paraIdx * 20, height: 12 }),
       getHeaderFooterParaInfo: () => JSON.stringify({ paraCount: 2, charCount: 8 }),
       hitTestInHeaderFooter: () => ({
         hit: true, sectionIndex: 0, applyTo: 2, paraIndex: 1, charOffset: 3,
@@ -89,13 +89,13 @@ test('#4121 HF 위아래 이동은 같은 resolved target의 시각 줄만 따�
     };
     const cursor: any = new CursorState(wasm);
     cursor.enterHeaderFooterMode(true, 0, 2, 5);
-    cursor.setHfCursorPosition(0, 2, 5);
+    cursor.setHfCursorPosition(0, 2);
     cursor.setHfAnchor();
     cursor.moveVerticalInHf(1);
 
     assert.equal(cursor.hfParaIdx, 1);
     assert.equal(cursor.hfCharOffset, 3);
-    assert.equal(cursor.getHeaderFooterSelectionOrdered()?.preferredPage, 5);
+    assert.equal(cursor.getHeaderFooterSelectionOrdered()?.previewPage, 5);
   } finally {
     await vite.close();
   }
@@ -111,14 +111,14 @@ test('#4121 HF 단어·문단·target 경계 이동은 HF 좌표계를 유지한
     const wasm = {
       getCursorRectInHeaderFooter: (
         _sec: number, _header: boolean, _apply: number,
-        paraIdx: number, charOffset: number, preferredPage: number,
-      ) => ({ pageIndex: preferredPage, x: charOffset * 8, y: paraIdx * 20, height: 12 }),
+        paraIdx: number, charOffset: number, previewPage: number,
+      ) => ({ pageIndex: previewPage, x: charOffset * 8, y: paraIdx * 20, height: 12 }),
       getHeaderFooterParaInfo: (_sec: number, _header: boolean, _apply: number, paraIdx: number) =>
         JSON.stringify({ paraCount: texts.length, charCount: Array.from(texts[paraIdx]).length, text: texts[paraIdx] }),
     };
     const cursor: any = new CursorState(wasm);
     cursor.enterHeaderFooterMode(true, 0, 0, 2);
-    cursor.setHfCursorPosition(0, 10, 2);
+    cursor.setHfCursorPosition(0, 10);
 
     cursor.moveToWordBoundaryInHf(-1);
     assert.equal(cursor.hfCharOffset, 6, 'Option+Left는 이전 단어 시작으로 이동');
@@ -149,14 +149,14 @@ test('#4121 macOS HF Option+Shift·Command+Shift 탐색은 실제 선택 범위�
     const wasm = {
       getCursorRectInHeaderFooter: (
         _sec: number, _header: boolean, _apply: number,
-        paraIdx: number, charOffset: number, preferredPage: number,
-      ) => ({ pageIndex: preferredPage, x: charOffset * 8, y: paraIdx * 20, height: 12 }),
+        paraIdx: number, charOffset: number, previewPage: number,
+      ) => ({ pageIndex: previewPage, x: charOffset * 8, y: paraIdx * 20, height: 12 }),
       getHeaderFooterParaInfo: (_sec: number, _header: boolean, _apply: number, paraIdx: number) =>
         JSON.stringify({ paraCount: texts.length, charCount: Array.from(texts[paraIdx]).length, text: texts[paraIdx] }),
     };
     const cursor: any = new CursorState(wasm);
     cursor.enterHeaderFooterMode(true, 0, 0, 2);
-    cursor.setHfCursorPosition(0, 10, 2);
+    cursor.setHfCursorPosition(0, 10);
     let caretUpdates = 0;
     const handler: any = {
       active: true,
@@ -183,11 +183,11 @@ test('#4121 macOS HF Option+Shift·Command+Shift 탐색은 실제 선택 범위�
     assert.deepEqual(cursor.getHeaderFooterSelectionOrdered(), {
       start: { sectionIdx: 0, isHeader: true, applyTo: 0, paraIdx: 0, charOffset: 6 },
       end: { sectionIdx: 0, isHeader: true, applyTo: 0, paraIdx: 0, charOffset: 10 },
-      preferredPage: 2,
+      previewPage: 2,
     });
 
     cursor.clearSelection();
-    cursor.setHfCursorPosition(1, 3, 2);
+    cursor.setHfCursorPosition(1, 3);
     onKeyDown.call(handler, key('ArrowUp', { metaKey: true, shiftKey: true }));
     assert.deepEqual(cursor.getHeaderFooterSelectionOrdered()?.start, {
       sectionIdx: 0, isHeader: true, applyTo: 0, paraIdx: 0, charOffset: 0,
@@ -210,8 +210,8 @@ test('#4121 HF 모두 선택은 메뉴와 Ctrl/Cmd+A 모두 현재 정의만 대
     const wasm = {
       getCursorRectInHeaderFooter: (
         _sec: number, _header: boolean, _apply: number,
-        paraIdx: number, charOffset: number, preferredPage: number,
-      ) => ({ pageIndex: preferredPage, x: charOffset * 8, y: paraIdx * 20, height: 12 }),
+        paraIdx: number, charOffset: number, previewPage: number,
+      ) => ({ pageIndex: previewPage, x: charOffset * 8, y: paraIdx * 20, height: 12 }),
       getHeaderFooterParaInfo: (_sec: number, _header: boolean, _apply: number, paraIdx: number) =>
         JSON.stringify({
           paraCount: texts.length,
@@ -221,7 +221,7 @@ test('#4121 HF 모두 선택은 메뉴와 Ctrl/Cmd+A 모두 현재 정의만 대
     };
     const cursor: any = new CursorState(wasm);
     cursor.enterHeaderFooterMode(true, 1, 2, 3);
-    cursor.setHfCursorPosition(0, 2, 3);
+    cursor.setHfCursorPosition(0, 2);
     let caretUpdates = 0;
     let dispatched = '';
     const handler: any = {
@@ -243,7 +243,7 @@ test('#4121 HF 모두 선택은 메뉴와 Ctrl/Cmd+A 모두 현재 정의만 대
     assert.deepEqual(cursor.getHeaderFooterSelectionOrdered(), {
       start: { sectionIdx: 1, isHeader: true, applyTo: 2, paraIdx: 0, charOffset: 0 },
       end: { sectionIdx: 1, isHeader: true, applyTo: 2, paraIdx: 1, charOffset: 16 },
-      preferredPage: 3,
+      previewPage: 3,
     });
     assert.equal(cursor.getSelectionOrdered(), null, '본문 anchor는 만들지 않는다');
 

--- a/rhwp-studio/tests/issue-6453-header-footer-contract.test.ts
+++ b/rhwp-studio/tests/issue-6453-header-footer-contract.test.ts
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'vite';
+import { functionBodyFrom } from './support/source-guard.ts';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+
+test('#6453 HF 커서 위치 API는 대표 편집 페이지를 바꾸지 않는다', async () => {
+  const vite = await createServer({
+    root: rootDir, appType: 'custom', logLevel: 'silent', server: { middlewareMode: true },
+  });
+  try {
+    const { CursorState } = await vite.ssrLoadModule('/src/engine/cursor.ts');
+    const wasm = {
+      getHeaderFooterPreviewPage: () => 2,
+      getCursorRectInHeaderFooter: (
+        _sec: number, _header: boolean, _apply: number,
+        paraIdx: number, charOffset: number, previewPage: number,
+      ) => ({ pageIndex: previewPage, x: charOffset * 8, y: paraIdx * 20, height: 12 }),
+      getHeaderFooterParaInfo: () => JSON.stringify({ paraCount: 1, charCount: 8 }),
+    };
+    const cursor: any = new CursorState(wasm);
+
+    cursor.enterHeaderFooterMode(true, 0, 1, 9);
+    assert.equal(cursor.hfPreviewPage, 2, '진입 쪽과 무관하게 구역 대표 페이지를 사용한다');
+
+    cursor.setHfCursorPosition(0, 4);
+    assert.equal(cursor.hfPreviewPage, 2, '텍스트 위치 변경은 대표 페이지를 바꾸지 않는다');
+
+    assert.equal(cursor.selectHeaderFooterRange(
+      { sectionIdx: 0, isHeader: true, applyTo: 1, paraIdx: 0, charOffset: 1 },
+      { sectionIdx: 0, isHeader: true, applyTo: 1, paraIdx: 0, charOffset: 4 },
+      9,
+    ), true);
+    assert.equal(cursor.getHeaderFooterSelectionOrdered()?.previewPage, 2,
+      'history의 이전 페이지 힌트도 현재 대표 페이지로 정규화한다');
+  } finally {
+    await vite.close();
+  }
+});
+
+test('#6453 HF 공개 커서 위치 API는 문단·문자 좌표만 받는다', () => {
+  const cursor = src('src/engine/cursor.ts');
+  const setPosition = functionBodyFrom(cursor, 'setHfCursorPosition(');
+
+  assert.match(cursor, /setHfCursorPosition\(paraIdx: number, charOffset: number\): void/);
+  assert.doesNotMatch(setPosition, /page|resolveHeaderFooterPreviewPage/);
+});

--- a/rhwp-studio/tests/issue-6453-header-footer-contract.test.ts
+++ b/rhwp-studio/tests/issue-6453-header-footer-contract.test.ts
@@ -50,3 +50,17 @@ test('#6453 HF 공개 커서 위치 API는 문단·문자 좌표만 받는다', 
   assert.match(cursor, /setHfCursorPosition\(paraIdx: number, charOffset: number\): void/);
   assert.doesNotMatch(setPosition, /page|resolveHeaderFooterPreviewPage/);
 });
+
+test('#6453 IME 조합 캐럿도 HF 대표 편집 페이지를 직접 사용한다', () => {
+  const handler = src('src/engine/input-handler.ts');
+  const updateCaret = functionBodyFrom(handler, 'private updateCaret(');
+
+  assert.match(
+    updateCaret,
+    /getCursorRectInHeaderFooter\([\s\S]*?this\.cursor\.hfPreviewPage/,
+  );
+  assert.doesNotMatch(
+    updateCaret,
+    /getCursorRectInHeaderFooter\([\s\S]*?this\.cursor\.getRect\(\)\?\.pageIndex/,
+  );
+});

--- a/src/bin/rhwp-q-kit/cursor_in_hf.rs
+++ b/src/bin/rhwp-q-kit/cursor_in_hf.rs
@@ -24,7 +24,7 @@ pub fn run(args: &[String]) -> i32 {
         opts.apply_to,
         opts.para,
         opts.offset,
-        opts.preferred_page,
+        opts.preview_page_hint,
     ) {
         Ok(s) => s,
         Err(e) => {
@@ -43,7 +43,8 @@ pub fn run(args: &[String]) -> i32 {
         "applyTo": opts.apply_to,
         "para": opts.para,
         "offset": opts.offset,
-        "preferredPage": opts.preferred_page,
+        // 기존 JSON 소비자를 위해 키 이름은 유지한다. 값의 의미는 대표 페이지 힌트다.
+        "preferredPage": opts.preview_page_hint,
     });
     merge_object(&mut payload, native);
     if opts.json {
@@ -61,7 +62,7 @@ struct Opts {
     apply_to: u8,
     para: usize,
     offset: usize,
-    preferred_page: i32,
+    preview_page_hint: i32,
 }
 
 fn parse(args: &[String]) -> Result<Opts, i32> {
@@ -116,7 +117,7 @@ fn parse(args: &[String]) -> Result<Opts, i32> {
         apply_to: require(apply_to, "--apply-to")?,
         para: require(para, "--para")?,
         offset: require(offset, "--offset")?,
-        preferred_page: page.map(|p| p as i32).unwrap_or(-1),
+        preview_page_hint: page.map(|p| p as i32).unwrap_or(-1),
     })
 }
 

--- a/src/document_core/commands/header_footer_ops.rs
+++ b/src/document_core/commands/header_footer_ops.rs
@@ -8,7 +8,9 @@ use crate::document_core::helpers::{
     build_tab_def_from_json, json_has_border_keys, json_has_tab_keys, parse_char_shape_mods,
     parse_json_i16_array, parse_para_shape_mods,
 };
-use crate::document_core::{ClipboardData, DocumentCore};
+use crate::document_core::{
+    header_footer_apply_from_u8, header_footer_apply_to_u8, ClipboardData, DocumentCore,
+};
 use crate::error::HwpError;
 use crate::model::control::Control;
 use crate::model::event::DocumentEvent;
@@ -16,24 +18,6 @@ use crate::model::header_footer::{Footer, Header, HeaderFooterApply};
 use crate::model::paragraph::{ParaMeta, Paragraph};
 use crate::renderer::composer::{reflow_line_segs, ParagraphBox};
 use crate::renderer::style_resolver::resolve_styles_for_document;
-
-/// applyTo u8 값 → HeaderFooterApply 변환
-fn apply_from_u8(v: u8) -> HeaderFooterApply {
-    match v {
-        1 => HeaderFooterApply::Even,
-        2 => HeaderFooterApply::Odd,
-        _ => HeaderFooterApply::Both,
-    }
-}
-
-/// HeaderFooterApply → u8 변환
-fn apply_to_u8(a: HeaderFooterApply) -> u8 {
-    match a {
-        HeaderFooterApply::Both => 0,
-        HeaderFooterApply::Even => 1,
-        HeaderFooterApply::Odd => 2,
-    }
-}
 
 /// HeaderFooterApply → 표시 레이블
 fn apply_label(a: HeaderFooterApply) -> &'static str {
@@ -59,31 +43,6 @@ impl DocumentCore {
         ))
     }
 
-    /// 구역의 문단들에서 특정 apply_to의 머리말 또는 꼬리말 컨트롤 위치를 찾는다.
-    /// 반환: (para_index, control_index)
-    fn find_header_footer_control(
-        &self,
-        section_idx: usize,
-        is_header: bool,
-        apply_to: HeaderFooterApply,
-    ) -> Option<(usize, usize)> {
-        let section = self.document.sections.get(section_idx)?;
-        for (pi, para) in section.paragraphs.iter().enumerate() {
-            for (ci, ctrl) in para.controls.iter().enumerate() {
-                match ctrl {
-                    Control::Header(h) if is_header && h.apply_to == apply_to => {
-                        return Some((pi, ci));
-                    }
-                    Control::Footer(f) if !is_header && f.apply_to == apply_to => {
-                        return Some((pi, ci));
-                    }
-                    _ => {}
-                }
-            }
-        }
-        None
-    }
-
     /// 머리말/꼬리말 조회 — JSON 반환
     ///
     /// 존재하면: `{"ok":true,"exists":true,"applyTo":0,"paraCount":N,"text":"..."}`
@@ -101,7 +60,7 @@ impl DocumentCore {
                 self.document.sections.len()
             )));
         }
-        let apply = apply_from_u8(apply_to);
+        let apply = header_footer_apply_from_u8(apply_to);
         if let Some((pi, ci)) = self.find_header_footer_control(section_idx, is_header, apply) {
             let section = &self.document.sections[section_idx];
             let ctrl = &section.paragraphs[pi].controls[ci];
@@ -119,7 +78,7 @@ impl DocumentCore {
             let label = apply_label(at);
             Ok(format!(
                 "{{\"ok\":true,\"exists\":true,\"kind\":\"{}\",\"applyTo\":{},\"label\":\"{}\",\"paraIndex\":{},\"controlIndex\":{},\"paraCount\":{},\"text\":\"{}\"}}",
-                kind, apply_to_u8(at), label, pi, ci, paragraphs.len(),
+                kind, header_footer_apply_to_u8(at), label, pi, ci, paragraphs.len(),
                 super::super::helpers::json_escape(&text)
             ))
         } else {
@@ -144,7 +103,7 @@ impl DocumentCore {
                 self.document.sections.len()
             )));
         }
-        let apply = apply_from_u8(apply_to);
+        let apply = header_footer_apply_from_u8(apply_to);
         if self
             .find_header_footer_control(section_idx, is_header, apply)
             .is_some()
@@ -219,7 +178,7 @@ impl DocumentCore {
         apply_to: u8,
         hf_para_idx: usize,
     ) -> Result<&mut Paragraph, HwpError> {
-        let apply = apply_from_u8(apply_to);
+        let apply = header_footer_apply_from_u8(apply_to);
         let (pi, ci) = self
             .find_header_footer_control(section_idx, is_header, apply)
             .ok_or_else(|| {
@@ -267,7 +226,7 @@ impl DocumentCore {
         apply_to: u8,
         hf_para_idx: usize,
     ) -> Option<&Paragraph> {
-        let apply = apply_from_u8(apply_to);
+        let apply = header_footer_apply_from_u8(apply_to);
         let (pi, ci) = self.find_header_footer_control(section_idx, is_header, apply)?;
         let ctrl = &self.document.sections[section_idx].paragraphs[pi].controls[ci];
         match ctrl {
@@ -284,7 +243,7 @@ impl DocumentCore {
         is_header: bool,
         apply_to: u8,
     ) -> Result<&[Paragraph], HwpError> {
-        let apply = apply_from_u8(apply_to);
+        let apply = header_footer_apply_from_u8(apply_to);
         let (pi, ci) = self
             .find_header_footer_control(section_idx, is_header, apply)
             .ok_or_else(|| {
@@ -306,7 +265,7 @@ impl DocumentCore {
         is_header: bool,
         apply_to: u8,
     ) -> Result<&mut Vec<Paragraph>, HwpError> {
-        let apply = apply_from_u8(apply_to);
+        let apply = header_footer_apply_from_u8(apply_to);
         let (pi, ci) = self
             .find_header_footer_control(section_idx, is_header, apply)
             .ok_or_else(|| {
@@ -341,7 +300,7 @@ impl DocumentCore {
 
         let hf_para = self.get_hf_paragraph_mut(section_idx, is_header, apply_to, hf_para_idx)?;
         let new_chars_count = text.chars().count();
-        hf_para.insert_text_at(char_offset, text);
+        let inserted_at = hf_para.insert_text_at(char_offset, text);
 
         // 리플로우 (머리말/꼬리말 영역 폭 기반)
         self.reflow_hf_paragraph(section_idx, is_header, apply_to, hf_para_idx);
@@ -351,13 +310,19 @@ impl DocumentCore {
         self.mark_section_dirty(section_idx);
         self.paginate_if_needed();
 
-        let new_offset = char_offset + new_chars_count;
-        self.event_log.push(DocumentEvent::TextInserted {
-            section: section_idx,
-            para: 0,
-            offset: char_offset,
-            len: new_chars_count,
-        });
+        let new_offset = inserted_at + new_chars_count;
+        self.event_log
+            .push(DocumentEvent::HeaderFooterTextReplaced {
+                section: section_idx,
+                is_header,
+                apply_to,
+                start_para: hf_para_idx,
+                start_offset: inserted_at,
+                end_para: hf_para_idx,
+                end_offset: inserted_at,
+                inserted_end_para: hf_para_idx,
+                inserted_end_offset: new_offset,
+            });
         Ok(super::super::helpers::json_ok_with(&format!(
             "\"charOffset\":{}",
             new_offset
@@ -386,8 +351,14 @@ impl DocumentCore {
         // [Task #2337] undo 재삽입용으로 삭제될 텍스트를 먼저 확보한다. char 단위 슬라이스는
         // delete_text_at 의 클램핑(text_len - char_offset)과 동일 범위이며, Rust char 경계로
         // 잘라 studio(UTF-16) 측 조인 모호성을 피한다. 역연산 삭제 커맨드가 재삽입에 쓴다.
-        let deleted_text: String = hf_para.text.chars().skip(char_offset).take(count).collect();
-        hf_para.delete_text_at(char_offset, count);
+        let actual_offset = char_offset.min(hf_para.text.chars().count());
+        let deleted_text: String = hf_para
+            .text
+            .chars()
+            .skip(actual_offset)
+            .take(count)
+            .collect();
+        hf_para.delete_text_at(actual_offset, count);
 
         // 리플로우
         self.reflow_hf_paragraph(section_idx, is_header, apply_to, hf_para_idx);
@@ -397,15 +368,22 @@ impl DocumentCore {
         self.mark_section_dirty(section_idx);
         self.paginate_if_needed();
 
-        self.event_log.push(DocumentEvent::TextDeleted {
-            section: section_idx,
-            para: 0,
-            offset: char_offset,
-            count,
-        });
+        let deleted_count = deleted_text.chars().count();
+        self.event_log
+            .push(DocumentEvent::HeaderFooterTextReplaced {
+                section: section_idx,
+                is_header,
+                apply_to,
+                start_para: hf_para_idx,
+                start_offset: actual_offset,
+                end_para: hf_para_idx,
+                end_offset: actual_offset + deleted_count,
+                inserted_end_para: hf_para_idx,
+                inserted_end_offset: actual_offset,
+            });
         Ok(super::super::helpers::json_ok_with(&format!(
             "\"charOffset\":{},\"deletedText\":\"{}\"",
-            char_offset,
+            actual_offset,
             super::super::helpers::json_escape(&deleted_text)
         )))
     }
@@ -427,7 +405,7 @@ impl DocumentCore {
             )));
         }
 
-        let apply = apply_from_u8(apply_to);
+        let apply = header_footer_apply_from_u8(apply_to);
         let (pi, ci) = self
             .find_header_footer_control(section_idx, is_header, apply)
             .ok_or_else(|| {
@@ -507,7 +485,7 @@ impl DocumentCore {
             ));
         }
 
-        let apply = apply_from_u8(apply_to);
+        let apply = header_footer_apply_from_u8(apply_to);
         let (pi, ci) = self
             .find_header_footer_control(section_idx, is_header, apply)
             .ok_or_else(|| {
@@ -568,7 +546,7 @@ impl DocumentCore {
                 section_idx
             )));
         }
-        let apply = apply_from_u8(apply_to);
+        let apply = header_footer_apply_from_u8(apply_to);
         let (pi, ci) = self
             .find_header_footer_control(section_idx, is_header, apply)
             .ok_or_else(|| {
@@ -691,24 +669,18 @@ impl DocumentCore {
         }
         self.document.sections[section_idx].raw_stream = None;
         self.rebuild_section(section_idx);
-        self.event_log.push(DocumentEvent::TextDeleted {
-            section: section_idx,
-            para: start_para,
-            offset: start_offset,
-            count: if start_para == end_para {
-                end_offset.saturating_sub(start_offset)
-            } else {
-                0
-            },
-        });
-        if !normalized.is_empty() {
-            self.event_log.push(DocumentEvent::TextInserted {
+        self.event_log
+            .push(DocumentEvent::HeaderFooterTextReplaced {
                 section: section_idx,
-                para: start_para,
-                offset: start_offset,
-                len: normalized.chars().count(),
+                is_header,
+                apply_to,
+                start_para,
+                start_offset,
+                end_para,
+                end_offset,
+                inserted_end_para: cursor_para,
+                inserted_end_offset: cursor_offset,
             });
-        }
 
         Ok(super::super::helpers::json_ok_with(&format!(
             "\"hfParaIndex\":{},\"charOffset\":{}",
@@ -922,7 +894,7 @@ impl DocumentCore {
                 self.document.sections.len()
             )));
         }
-        let apply = apply_from_u8(apply_to);
+        let apply = header_footer_apply_from_u8(apply_to);
         let (pi, ci) = self
             .find_header_footer_control(section_idx, is_header, apply)
             .ok_or_else(|| {
@@ -962,7 +934,7 @@ impl DocumentCore {
     ) -> Result<String, HwpError> {
         let mut items = Vec::new();
         let mut current_index: i32 = -1;
-        let current_apply = apply_from_u8(current_apply_to);
+        let current_apply = header_footer_apply_from_u8(current_apply_to);
 
         for (si, section) in self.document.sections.iter().enumerate() {
             for (pi, para) in section.paragraphs.iter().enumerate() {
@@ -974,7 +946,7 @@ impl DocumentCore {
                     };
                     let kind = if is_header { "머리말" } else { "꼬리말" };
                     let label = apply_label(apply);
-                    let at = apply_to_u8(apply);
+                    let at = header_footer_apply_to_u8(apply);
 
                     if si == current_section_idx
                         && is_header == current_is_header
@@ -1056,8 +1028,8 @@ impl DocumentCore {
                         if let Some(para) = section.paragraphs.get(para_idx) {
                             if let Some(ctrl) = para.controls.get(ctrl_idx) {
                                 match ctrl {
-                                    Control::Header(h) => apply_to_u8(h.apply_to),
-                                    Control::Footer(f) => apply_to_u8(f.apply_to),
+                                    Control::Header(h) => header_footer_apply_to_u8(h.apply_to),
+                                    Control::Footer(f) => header_footer_apply_to_u8(f.apply_to),
                                     _ => 0,
                                 }
                             } else {
@@ -1152,7 +1124,7 @@ impl DocumentCore {
         let final_width = (available_width - margin_left - margin_right).max(0.0);
 
         // 가변 참조로 리플로우 실행
-        let apply = apply_from_u8(apply_to);
+        let apply = header_footer_apply_from_u8(apply_to);
         if let Some((pi, ci)) = self.find_header_footer_control(section_idx, is_header, apply) {
             let ctrl = &mut self.document.sections[section_idx].paragraphs[pi].controls[ci];
             let paragraphs = match ctrl {
@@ -1296,12 +1268,18 @@ impl DocumentCore {
         self.paginate_if_needed();
 
         let new_offset = inserted_at + 1;
-        self.event_log.push(DocumentEvent::TextInserted {
-            section: section_idx,
-            para: 0,
-            offset: inserted_at,
-            len: 1,
-        });
+        self.event_log
+            .push(DocumentEvent::HeaderFooterTextReplaced {
+                section: section_idx,
+                is_header,
+                apply_to,
+                start_para: hf_para_idx,
+                start_offset: inserted_at,
+                end_para: hf_para_idx,
+                end_offset: inserted_at,
+                inserted_end_para: hf_para_idx,
+                inserted_end_offset: new_offset,
+            });
         Ok(super::super::helpers::json_ok_with(&format!(
             "\"charOffset\":{},\"insertedAt\":{},\"insertedLength\":1",
             new_offset, inserted_at
@@ -1338,7 +1316,7 @@ impl DocumentCore {
             )));
         }
 
-        let apply = apply_from_u8(apply_to);
+        let apply = header_footer_apply_from_u8(apply_to);
 
         // 1) 기존 HF가 있으면 삭제
         if self
@@ -1894,8 +1872,8 @@ mod tests {
                         if let Some(para) = section.paragraphs.get(pi) {
                             if let Some(ctrl) = para.controls.get(ci) {
                                 let apply_to = match ctrl {
-                                    Control::Header(h) => apply_to_u8(h.apply_to),
-                                    Control::Footer(f) => apply_to_u8(f.apply_to),
+                                    Control::Header(h) => header_footer_apply_to_u8(h.apply_to),
+                                    Control::Footer(f) => header_footer_apply_to_u8(f.apply_to),
                                     _ => 255,
                                 };
                                 eprintln!(

--- a/src/document_core/mod.rs
+++ b/src/document_core/mod.rs
@@ -15,8 +15,10 @@ pub mod table_calc;
 pub mod text_security;
 pub mod validation;
 
+use crate::model::control::Control;
 use crate::model::document::Document;
 use crate::model::event::DocumentEvent;
+use crate::model::header_footer::HeaderFooterApply;
 use crate::model::paragraph::Paragraph;
 use crate::model::table::TableTransposeData;
 use crate::renderer::composer::ComposedParagraph;
@@ -35,6 +37,26 @@ use std::sync::Arc;
 /// 기본 폰트 fallback 경로
 pub const DEFAULT_FALLBACK_FONT: &str = "/usr/share/fonts/truetype/nanum/NanumGothic.ttf";
 pub(crate) const TABLE_CAPTION_CELL_SENTINEL: usize = 65_534;
+
+/// Studio/WASM의 `applyTo` 숫자를 core 열거형으로 변환한다.
+///
+/// 공개 API의 기존 호환 규칙대로 1=짝수, 2=홀수, 나머지는 양쪽이다.
+pub(crate) fn header_footer_apply_from_u8(value: u8) -> HeaderFooterApply {
+    match value {
+        1 => HeaderFooterApply::Even,
+        2 => HeaderFooterApply::Odd,
+        _ => HeaderFooterApply::Both,
+    }
+}
+
+/// core 열거형을 Studio/WASM의 `applyTo` 숫자로 변환한다.
+pub(crate) fn header_footer_apply_to_u8(value: HeaderFooterApply) -> u8 {
+    match value {
+        HeaderFooterApply::Both => 0,
+        HeaderFooterApply::Even => 1,
+        HeaderFooterApply::Odd => 2,
+    }
+}
 
 /// 내부 클립보드 데이터
 pub(crate) struct ClipboardData {
@@ -232,6 +254,34 @@ pub struct DocumentCore {
     /// HWPX 비표준 감지 등 문서 검증 경고.
     /// `from_bytes` 에서 자동 생성되며, 사용자 고지·선택적 reflow 에 사용 (#177).
     pub(crate) validation_report: validation::ValidationReport,
+}
+
+impl DocumentCore {
+    /// 구역에서 지정한 머리말/꼬리말 정의의 원본 control 위치를 찾는다.
+    ///
+    /// 편집 command와 대표 페이지 renderer가 반드시 이 resolver를 공유해야 한다
+    /// (#6453). 먼저 발견된 동일 종류·적용 범위 control이 canonical target이다.
+    pub(crate) fn find_header_footer_control(
+        &self,
+        section_idx: usize,
+        is_header: bool,
+        apply_to: HeaderFooterApply,
+    ) -> Option<(usize, usize)> {
+        let section = self.document.sections.get(section_idx)?;
+        for (para_index, para) in section.paragraphs.iter().enumerate() {
+            for (control_index, control) in para.controls.iter().enumerate() {
+                let matches = match control {
+                    Control::Header(header) => is_header && header.apply_to == apply_to,
+                    Control::Footer(footer) => !is_header && footer.apply_to == apply_to,
+                    _ => false,
+                };
+                if matches {
+                    return Some((para_index, control_index));
+                }
+            }
+        }
+        None
+    }
 }
 
 /// `DocumentCore` 는 스레드 경계 너머로 소유될 수 있어야 한다 — native 소비자(MCP 서버,

--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -4,7 +4,7 @@ use super::super::helpers::{
     find_char_at_x, find_logical_control_positions, is_treat_as_char_object_control,
     navigable_text_len, LineInfoResult,
 };
-use crate::document_core::DocumentCore;
+use crate::document_core::{header_footer_apply_to_u8, DocumentCore};
 use crate::error::HwpError;
 use crate::model::control::Control;
 use crate::model::paragraph::Paragraph;
@@ -4286,6 +4286,10 @@ impl DocumentCore {
 
     /// 머리말/꼬리말 내 커서 좌표를 반환한다.
     ///
+    /// `preview_page_hint`가 구역 대표 페이지이면 그 페이지에 요청한 정의를 투영한다.
+    /// 그 밖의 유효한 페이지는 실제 적용 정의가 일치할 때만 사용하며, 음수이면 실제 적용
+    /// 페이지를 앞에서부터 찾는 CLI·구버전 호출부 호환 경로로 동작한다.
+    ///
     /// 반환: JSON `{"pageIndex":N,"x":F,"y":F,"height":F}`
     pub fn get_cursor_rect_in_header_footer_native(
         &self,
@@ -4294,7 +4298,7 @@ impl DocumentCore {
         apply_to: u8,
         hf_para_idx: usize,
         char_offset: usize,
-        preferred_page: i32,
+        preview_page_hint: i32,
     ) -> Result<String, HwpError> {
         use crate::renderer::layout::compute_char_positions;
         use crate::renderer::render_tree::{RenderNode, RenderNodeType};
@@ -4389,20 +4393,22 @@ impl DocumentCore {
             None
         }
 
-        // preferred_page가 지정되면 해당 페이지를 먼저 탐색
+        // 대표 페이지 힌트가 지정되면 해당 페이지를 먼저 탐색한다. 대표 페이지가 아닌
+        // 힌트에서는 실제 적용 정의가 일치해야 하므로 클릭 페이지가 편집 surface를 바꾸지 않는다.
         let total_pages = self.page_count();
-        let page_order: Vec<u32> = if preferred_page >= 0 && (preferred_page as u32) < total_pages {
-            let pref = preferred_page as u32;
-            std::iter::once(pref)
-                .chain((0..total_pages).filter(move |&p| p != pref))
-                .collect()
-        } else {
-            (0..total_pages).collect()
-        };
+        let page_order: Vec<u32> =
+            if preview_page_hint >= 0 && (preview_page_hint as u32) < total_pages {
+                let preview = preview_page_hint as u32;
+                std::iter::once(preview)
+                    .chain((0..total_pages).filter(move |&page| page != preview))
+                    .collect()
+            } else {
+                (0..total_pages).collect()
+            };
         for page_num in page_order {
             let actual_target = self.resolve_header_footer_target(page_num, is_header);
-            let is_preview_page = preferred_page >= 0
-                && page_num == preferred_page as u32
+            let is_preview_page = preview_page_hint >= 0
+                && page_num == preview_page_hint as u32
                 && self
                     .header_footer_preview_page_for_section(section_idx)
                     .is_ok_and(|preview| preview == page_num);
@@ -4547,8 +4553,6 @@ impl DocumentCore {
 
     /// 해당 페이지에서 활성화된 머리말/꼬리말의 (source_section_index, apply_to)를 반환한다.
     fn get_active_hf_info(&self, page_num: u32, is_header: bool) -> Option<(usize, u8)> {
-        use crate::model::header_footer::HeaderFooterApply;
-
         let mut offset = 0u32;
         for (_si, pr) in self.pagination.iter().enumerate() {
             let count = pr.pages.len() as u32;
@@ -4566,16 +4570,8 @@ impl DocumentCore {
                         if let Some(para) = section.paragraphs.get(r.para_index) {
                             if let Some(ctrl) = para.controls.get(r.control_index) {
                                 let apply_to = match ctrl {
-                                    Control::Header(h) => match h.apply_to {
-                                        HeaderFooterApply::Both => 0,
-                                        HeaderFooterApply::Even => 1,
-                                        HeaderFooterApply::Odd => 2,
-                                    },
-                                    Control::Footer(f) => match f.apply_to {
-                                        HeaderFooterApply::Both => 0,
-                                        HeaderFooterApply::Even => 1,
-                                        HeaderFooterApply::Odd => 2,
-                                    },
+                                    Control::Header(h) => header_footer_apply_to_u8(h.apply_to),
+                                    Control::Footer(f) => header_footer_apply_to_u8(f.apply_to),
                                     _ => 0,
                                 };
                                 return Some((source_sec, apply_to));

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -2,8 +2,8 @@
 
 use super::super::helpers::color_ref_to_css;
 use crate::document_core::{
-    DeferredPaginationJobState, DeferredPaginationStepResult, DeferredPaginationTargetStatus,
-    DocumentCore, PendingPaginationJob,
+    header_footer_apply_from_u8, DeferredPaginationJobState, DeferredPaginationStepResult,
+    DeferredPaginationTargetStatus, DocumentCore, PendingPaginationJob,
 };
 use crate::error::HwpError;
 use crate::model::control::Control;
@@ -6790,37 +6790,21 @@ impl DocumentCore {
         is_header: bool,
         apply_to: u8,
     ) -> Result<HeaderFooterRef, HwpError> {
-        let apply_to = match apply_to {
-            1 => HeaderFooterApply::Even,
-            2 => HeaderFooterApply::Odd,
-            _ => HeaderFooterApply::Both,
-        };
-        let section = self
-            .document
-            .sections
-            .get(section_idx)
-            .ok_or_else(|| HwpError::RenderError(format!("구역 {} 범위 초과", section_idx)))?;
-        for (para_index, para) in section.paragraphs.iter().enumerate() {
-            for (control_index, control) in para.controls.iter().enumerate() {
-                let matches_target = match control {
-                    Control::Header(header) => is_header && header.apply_to == apply_to,
-                    Control::Footer(footer) => !is_header && footer.apply_to == apply_to,
-                    _ => false,
-                };
-                if matches_target {
-                    return Ok(HeaderFooterRef {
-                        para_index,
-                        control_index,
-                        source_section_index: section_idx,
-                        table_path: Vec::new(),
-                    });
-                }
-            }
-        }
-        Err(HwpError::RenderError(format!(
-            "머리말/꼬리말 편집 target을 찾을 수 없습니다: sec={}, is_header={}, apply_to={}",
-            section_idx, is_header, apply_to as u8
-        )))
+        let apply = header_footer_apply_from_u8(apply_to);
+        let (para_index, control_index) = self
+            .find_header_footer_control(section_idx, is_header, apply)
+            .ok_or_else(|| {
+                HwpError::RenderError(format!(
+                    "머리말/꼬리말 편집 target을 찾을 수 없습니다: sec={}, is_header={}, apply_to={}",
+                    section_idx, is_header, apply_to
+                ))
+            })?;
+        Ok(HeaderFooterRef {
+            para_index,
+            control_index,
+            source_section_index: section_idx,
+            table_path: Vec::new(),
+        })
     }
 
     /// 구역 첫 페이지에 요청한 HF 정의를 임시로 투영한 비캐시 렌더 트리.

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -19,6 +19,22 @@ pub enum DocumentEvent {
         offset: usize,
         count: usize,
     },
+    /// 머리말/꼬리말의 반열린 범위 `[start, end)`를 원자적으로 치환했다.
+    ///
+    /// `start`/`end`는 변경 전 HF 로컬 좌표이고 `inserted_end`는 변경 후 삽입 범위의
+    /// 끝 좌표다. 따라서 collapsed range는 삽입, 같은 inserted end는 삭제, 나머지는
+    /// 치환으로 손실 없이 구분할 수 있다 (#6453).
+    HeaderFooterTextReplaced {
+        section: usize,
+        is_header: bool,
+        apply_to: u8,
+        start_para: usize,
+        start_offset: usize,
+        end_para: usize,
+        end_offset: usize,
+        inserted_end_para: usize,
+        inserted_end_offset: usize,
+    },
     ParagraphSplit {
         section: usize,
         para: usize,
@@ -161,6 +177,28 @@ impl DocumentEvent {
             } => format!(
                 r#"{{"type":"TextDeleted","section":{},"para":{},"offset":{},"count":{}}}"#,
                 section, para, offset, count
+            ),
+            DocumentEvent::HeaderFooterTextReplaced {
+                section,
+                is_header,
+                apply_to,
+                start_para,
+                start_offset,
+                end_para,
+                end_offset,
+                inserted_end_para,
+                inserted_end_offset,
+            } => format!(
+                r#"{{"type":"HeaderFooterTextReplaced","section":{},"isHeader":{},"applyTo":{},"start":{{"para":{},"offset":{}}},"end":{{"para":{},"offset":{}}},"insertedEnd":{{"para":{},"offset":{}}}}}"#,
+                section,
+                is_header,
+                apply_to,
+                start_para,
+                start_offset,
+                end_para,
+                end_offset,
+                inserted_end_para,
+                inserted_end_offset
             ),
             DocumentEvent::ParagraphSplit {
                 section,

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -2896,7 +2896,8 @@ impl HwpDocument {
 
     /// 머리말/꼬리말 내 커서 위치의 픽셀 좌표를 반환한다.
     ///
-    /// preferred_page: 선호 페이지 (더블클릭한 페이지). -1이면 첫 번째 발견 페이지 사용.
+    /// `preview_page_hint`: 편집 정의를 투영할 대표 페이지 힌트. Studio는 구역의 첫 페이지를
+    /// 전달한다. 음수이면 호환 경로로 실제 적용 페이지를 앞에서부터 찾는다.
     /// 반환: JSON `{"pageIndex":N,"x":F,"y":F,"height":F}`
     #[wasm_bindgen(js_name = getCursorRectInHeaderFooter)]
     pub fn get_cursor_rect_in_header_footer(
@@ -2906,7 +2907,7 @@ impl HwpDocument {
         apply_to: u8,
         hf_para_idx: u32,
         char_offset: u32,
-        preferred_page: i32,
+        preview_page_hint: i32,
     ) -> Result<String, JsValue> {
         self.get_cursor_rect_in_header_footer_native(
             section_idx as usize,
@@ -2914,7 +2915,7 @@ impl HwpDocument {
             apply_to,
             hf_para_idx as usize,
             char_offset as usize,
-            preferred_page,
+            preview_page_hint,
         )
         .map_err(|e| e.into())
     }

--- a/tests/cases/issue_6453_header_footer_contract.rs
+++ b/tests/cases/issue_6453_header_footer_contract.rs
@@ -1,0 +1,170 @@
+//! [#6453] 머리말/꼬리말 편집 resolver와 원자 text event 계약.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::wasm_api::HwpDocument;
+
+fn header_with_text(text: &str) -> HwpDocument {
+    let mut doc = HwpDocument::create_empty();
+    doc.create_blank_document_native().expect("blank2010 생성");
+    doc.create_header_footer_native(0, true, 0)
+        .expect("양쪽 머리말 생성");
+    doc.insert_text_in_header_footer_native(0, true, 0, 0, 0, text)
+        .expect("머리말 입력");
+    doc
+}
+
+fn only_event(raw: &str) -> serde_json::Value {
+    let value: serde_json::Value = serde_json::from_str(raw).expect("event log JSON");
+    let events = value["events"].as_array().expect("events array");
+    assert_eq!(
+        events.len(),
+        1,
+        "text mutation은 원자 event 하나여야 함: {raw}"
+    );
+    events[0].clone()
+}
+
+fn assert_range_event(
+    event: &serde_json::Value,
+    start: (usize, usize),
+    end: (usize, usize),
+    inserted_end: (usize, usize),
+) {
+    assert_eq!(event["type"], "HeaderFooterTextReplaced");
+    assert_eq!(event["section"], 0);
+    assert_eq!(event["isHeader"], true);
+    assert_eq!(event["applyTo"], 0);
+    assert_eq!(event["start"]["para"], start.0);
+    assert_eq!(event["start"]["offset"], start.1);
+    assert_eq!(event["end"]["para"], end.0);
+    assert_eq!(event["end"]["offset"], end.1);
+    assert_eq!(event["insertedEnd"]["para"], inserted_end.0);
+    assert_eq!(event["insertedEnd"]["offset"], inserted_end.1);
+}
+
+#[test]
+fn edit_query_and_preview_renderer_resolve_the_same_hf_definition() {
+    let mut doc = HwpDocument::create_empty();
+    doc.create_blank_document_native().expect("blank2010 생성");
+    for (apply_to, text) in [(1, "E"), (2, "ODD-LONG")] {
+        doc.create_header_footer_native(0, false, apply_to)
+            .expect("홀짝 꼬리말 생성");
+        doc.insert_text_in_header_footer_native(0, false, apply_to, 0, 0, text)
+            .expect("홀짝 꼬리말 입력");
+    }
+    let preview_page: serde_json::Value = serde_json::from_str(
+        &doc.get_header_footer_preview_page_native(0)
+            .expect("대표 페이지 조회"),
+    )
+    .expect("대표 페이지 JSON");
+    let preview_page = preview_page["pageIndex"].as_u64().expect("pageIndex") as u32;
+
+    let mut widths = Vec::new();
+    for (apply_to, expected_text) in [(1, "E"), (2, "ODD-LONG")] {
+        let edit_query: serde_json::Value = serde_json::from_str(
+            &doc.get_header_footer_native(0, false, apply_to)
+                .expect("편집 command resolver 조회"),
+        )
+        .expect("HF JSON");
+        assert_eq!(edit_query["text"], expected_text);
+
+        let rendered: serde_json::Value = serde_json::from_str(
+            &doc.get_selection_rects_in_header_footer_native(
+                0,
+                false,
+                apply_to,
+                preview_page,
+                0,
+                0,
+                0,
+                expected_text.chars().count(),
+            )
+            .expect("대표 페이지 renderer resolver 조회"),
+        )
+        .expect("selection rect JSON");
+        widths.push(rendered[0]["width"].as_f64().expect("selection width"));
+    }
+    assert!(
+        widths[1] > widths[0],
+        "편집 조회와 renderer가 각각 요청한 동일 HF 정의를 사용해야 함: {widths:?}"
+    );
+}
+
+#[test]
+fn single_paragraph_insert_delete_and_replace_events_are_exact() {
+    let mut insertion = header_with_text("AB");
+    insertion.begin_batch_native().expect("event log 초기화");
+    insertion
+        .replace_range_in_header_footer_native(0, true, 0, 0, 1, 0, 1, "X")
+        .expect("단일 문단 삽입");
+    let event = only_event(&insertion.end_batch_native().expect("삽입 event log"));
+    assert_range_event(&event, (0, 1), (0, 1), (0, 2));
+
+    let mut deletion = header_with_text("AB");
+    deletion.begin_batch_native().expect("event log 초기화");
+    deletion
+        .replace_range_in_header_footer_native(0, true, 0, 0, 0, 0, 1, "")
+        .expect("단일 문단 삭제");
+    let event = only_event(&deletion.end_batch_native().expect("삭제 event log"));
+    assert_range_event(&event, (0, 0), (0, 1), (0, 0));
+
+    let mut replacement = header_with_text("AB");
+    replacement.begin_batch_native().expect("event log 초기화");
+    replacement
+        .replace_range_in_header_footer_native(0, true, 0, 0, 0, 0, 1, "XY")
+        .expect("단일 문단 치환");
+    let event = only_event(&replacement.end_batch_native().expect("치환 event log"));
+    assert_range_event(&event, (0, 0), (0, 1), (0, 2));
+}
+
+#[test]
+fn direct_insert_and_delete_events_report_the_actual_clamped_range() {
+    let mut insertion = header_with_text("AB");
+    insertion.begin_batch_native().expect("event log 초기화");
+    insertion
+        .insert_text_in_header_footer_native(0, true, 0, 0, 99, "X")
+        .expect("문단 끝에 삽입");
+    let event = only_event(&insertion.end_batch_native().expect("삽입 event log"));
+    assert_range_event(&event, (0, 2), (0, 2), (0, 3));
+
+    let mut deletion = header_with_text("AB");
+    deletion.begin_batch_native().expect("event log 초기화");
+    deletion
+        .delete_text_in_header_footer_native(0, true, 0, 0, 1, 99)
+        .expect("문단 끝까지 삭제");
+    let event = only_event(&deletion.end_batch_native().expect("삭제 event log"));
+    assert_range_event(&event, (0, 1), (0, 2), (0, 1));
+}
+
+#[test]
+fn multi_paragraph_insert_delete_and_replace_events_are_exact() {
+    let mut insertion = header_with_text("AB");
+    insertion.begin_batch_native().expect("event log 초기화");
+    insertion
+        .replace_range_in_header_footer_native(0, true, 0, 0, 1, 0, 1, "X\nY")
+        .expect("다문단 삽입");
+    let event = only_event(&insertion.end_batch_native().expect("삽입 event log"));
+    assert_range_event(&event, (0, 1), (0, 1), (1, 1));
+
+    let mut deletion = header_with_text("AB");
+    deletion
+        .split_paragraph_in_header_footer_native(0, true, 0, 0, 1, None)
+        .expect("삭제용 문단 분할");
+    deletion.begin_batch_native().expect("event log 초기화");
+    deletion
+        .replace_range_in_header_footer_native(0, true, 0, 0, 1, 1, 1, "")
+        .expect("다문단 삭제");
+    let event = only_event(&deletion.end_batch_native().expect("삭제 event log"));
+    assert_range_event(&event, (0, 1), (1, 1), (0, 1));
+
+    let mut replacement = header_with_text("ABCD");
+    replacement
+        .split_paragraph_in_header_footer_native(0, true, 0, 0, 2, None)
+        .expect("치환용 문단 분할");
+    replacement.begin_batch_native().expect("event log 초기화");
+    replacement
+        .replace_range_in_header_footer_native(0, true, 0, 0, 1, 1, 1, "X\nYZ")
+        .expect("다문단 치환");
+    let event = only_event(&replacement.end_batch_native().expect("치환 event log"));
+    assert_range_event(&event, (0, 1), (1, 1), (1, 2));
+}


### PR DESCRIPTION
## 변경 요약

머리말/꼬리말 편집의 내부 resolver, 대표 페이지 API, 변경 이벤트 계약을 하나의 명확한 규칙으로 정리합니다.

- `applyFrom`/`applyTo` 변환과 HF control 탐색을 canonical helper로 통합해 편집 command와 renderer가 같은 정의를 선택하게 했습니다.
- Studio 내부 대표 페이지 명칭을 `previewPage`로 통일하고, 공개 커서 위치 API는 문단·문자 좌표만 받도록 정리했습니다.
- 진입/복원 시 전달된 쪽은 fallback 힌트로만 쓰고 구역 대표 편집 페이지로 정규화합니다.
- HF 삽입·삭제·치환을 `HeaderFooterTextReplaced` 원자 이벤트 하나로 기록하며, 편집 전 반열린 범위와 편집 후 `insertedEnd`를 정확히 제공합니다.
- 범위를 벗어난 직접 삽입·삭제도 실제로 clamp된 위치를 이벤트에 기록합니다.

## 관련 이슈

closes #6453

## 테스트

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --locked --test regression_suite_015 issue_6453_header_footer_contract --target-dir target/pr-review` (4 passed)
- [x] 기존 #4121 HF 회귀 테스트 7건 통과
- [x] `npm test` in `rhwp-studio` (1,311 passed, 1 existing skip)
- [x] WASM package 생성 후 `npx tsc --noEmit`
- [x] native Clippy, WASM Clippy, workspace build, workspace all-target Clippy (`-D warnings`)
- [x] `node scripts/rust-test-suite-manifest.mjs --prepare` 후 `--check`
- [x] `node scripts/rust-unit-test-tiers.mjs --check` (4,221 tests 정책 확인)
- [x] 새 integration test 원본은 `tests/cases/`에만 추가했고 파생 suite/manifest는 stage하지 않음
- [x] 변경한 #4121 E2E 스크립트 `node --check` 통과
- [ ] 스크린샷 — 사용자에게 보이는 UI 변경이 없는 API·이벤트 계약 정리라 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음
- 재현·측정: 성능 경로 변경 없음. resolver 중복 제거와 이벤트 payload 정확성에 한정됩니다.

## 병합 메모

#6452와 기능 의존성은 없습니다. 다만 일부 HF core 파일이 겹치므로 #6452가 먼저 병합되면 이 PR을 최신 `devel`에 재배치하겠습니다.
