### PR TITLE
수정(renderer): Gmail류 웹메일 서명 붙여넣기가 서식 없이 raw HTML 태그로 삽입되는 결함 수정

### DIFF
--- a/mydocs/working/issue_6463_html_paste_raw_tags.md
+++ b/mydocs/working/issue_6463_html_paste_raw_tags.md
@@ -1,0 +1,58 @@
+# #6463 Gmail류 웹메일 서명 붙여넣기가 서식 없이 raw HTML 태그로 삽입되는 문제 수정
+
+## 무엇을
+
+사용자가 실제로 Gmail에서 복사한 회사 연락처 서명 블록("🇰🇷 서울 사무소 (한국 지사)" 제목 +
+전화번호/이메일/주소 목록)을 rhwp-studio에 붙여넣었을 때, 서식 있는 문서로 렌더링되지 않고
+`jscontroller`, `jsaction`, `data-copy-service-computed-style` 같은 속성값과 `<span>`,
+`<strong>`, HTML 주석이 그대로 문자로 삽입됐다.
+
+## 왜 (원인)
+
+`src/document_core/commands/html_import.rs`의 `parse_html_to_paragraphs`(최상위 파서)는
+`<table>`/`<img>`/`<p>`/`<div>`/`<br>`만 블록으로 인식한다.
+
+1. **`<span>`이 `<p>` 밖에 바로 올 때** — 예전 코드는 span 내부(중첩 `<u>`/`<strong>`/주석
+   포함)를 여는 태그의 `>` 뒤부터 그대로 `pending_text`에 밀어 넣었다. 실측 문서의 제목은
+   `<div><span>...<u><span>...서울 사무소...</span></u></span></div>` 구조라, 바깥 `<span>`이
+   이 경로를 타 태그가 그대로 노출됐다.
+2. **`<ul>`/`<li>`가 전혀 인식되지 않음** — "기타 태그 무시"로 태그만 건너뛰어 목록 항목이
+   문단으로 분리되지 않고, 1번 버그와 겹쳐 항목 전체가 raw 텍스트가 됐다.
+
+## 어떻게 (변경)
+
+- 최상위 `<span>` 처리를 `<p>`와 같은 패턴으로 바꿨다: span 내용을 `parse_inline_content`
+  (중첩 `<strong>`/`<b>`/`<em>` 등 서식 해석 가능한 기존 함수)에 넘겨 문단으로 만든다.
+- `<ul>`/`<ol>`을 `<div>`처럼 컨테이너로 재귀 처리(`parse_html_to_paragraphs` 재호출)하고,
+  `<li>`는 내부 전체(중첩 태그 포함)를 `parse_inline_content`로 한 번에 파싱해 "• " 글머리
+  기호를 붙인 문단으로 만든다. 글머리 기호만큼 `char_shapes`의 `start_pos`(UTF-16 코드유닛
+  단위)를 밀어 서식 위치를 맞춘다.
+
+## 검증
+
+실제 사용자가 붙여넣은 HTML(1207자, Gmail 클립보드 원본)로 확인:
+
+**수정 전**: 문단 하나에 원본 raw HTML 전체가 텍스트로 삽입 (jscontroller 등 속성 그대로 노출).
+
+**수정 후**:
+```
+para[0] = "🇰🇷 서울 사무소 (한국 지사)"
+para[1] = "• 전화번호: 02-2135-3428"
+para[2] = "• 이메일: koreacs@trungnguyenlegend.com"
+para[3] = "• 주소: 서울특별시 강남구 도산대로 145 인우빌딩 408호 (우: 06036)"
+```
+"전화번호:"/"이메일:"/"주소:" 라벨은 `<strong>` 인식으로 굵게 `char_shape`도 정확한 위치에
+적용됨(각 문단 `start_pos=2`, 글머리 기호 "• " 2 UTF-16 코드유닛 뒤).
+
+### 무회귀
+
+- `cargo test --lib -p rhwp` 3889 passed / 0 failed — 기존 HTML 붙여넣기 단위 테스트
+  34개(스타일/표/colspan-rowspan/다중 문단) 포함 전부 통과.
+- `cargo fmt --check`, `cargo clippy --lib -- -D warnings` 통과.
+- `wasm-pack build --target web`로 rhwp-studio용 WASM 재빌드.
+
+## 참고
+
+같은 문서에서 붙여넣기가 "응답 없음"으로 멈추는 별개 증상(#6449)이 보고됐으나, 그건 빈
+문서·큰 문서(382쪽) 양쪽 모두에서 재현되지 않아 사용자의 특정 문서(자동복구 파일) 상태
+특이점으로 추정된다. 이 PR은 그와 무관하게 항상 재현되는 서식 손실만 다룬다.

--- a/src/document_core/commands/html_import.rs
+++ b/src/document_core/commands/html_import.rs
@@ -556,6 +556,75 @@ impl DocumentCore {
                     paragraphs.extend(sub_paras);
                     pos = div_end;
                     continue;
+                } else if tag_lower.starts_with("<ul") || tag_lower.starts_with("<ol") {
+                    // [Gmail 등 웹메일 서명 붙여넣기가 raw 태그로 나오던 결함] 목록 태그
+                    // 자체는 컨테이너일 뿐이라 <div>처럼 내부를 재귀 처리한다 — <li> 각각이
+                    // 실제 항목 문단이 된다.
+                    if !pending_text.trim().is_empty() {
+                        self.flush_text_to_paragraphs(&mut paragraphs, &pending_text);
+                        pending_text.clear();
+                    }
+                    let list_tag_name = if tag_lower.starts_with("<ul") {
+                        "ul"
+                    } else {
+                        "ol"
+                    };
+                    let list_content_start = tag_end + 1;
+                    let list_end = find_closing_tag_chars(&chars, pos, list_tag_name);
+                    let list_inner: String = chars[list_content_start..list_end.min(len)]
+                        .iter()
+                        .collect();
+                    let close_marker = format!("</{list_tag_name}>");
+                    let list_inner = if let Some(idx) = list_inner.rfind(&close_marker) {
+                        &list_inner[..idx]
+                    } else {
+                        &list_inner
+                    };
+                    let sub_paras = self.parse_html_to_paragraphs(list_inner);
+                    paragraphs.extend(sub_paras);
+                    pos = list_end;
+                    continue;
+                } else if tag_lower.starts_with("<li") {
+                    // <li> 내부 전체(중첩 span/strong 등 포함)를 한 문단으로 묶어
+                    // parse_inline_content 로 서식까지 보존해 파싱하고, 글머리 기호를
+                    // 앞에 붙인다. 표 없는 최상위 <p> 처리와 동일한 패턴.
+                    if !pending_text.trim().is_empty() {
+                        self.flush_text_to_paragraphs(&mut paragraphs, &pending_text);
+                        pending_text.clear();
+                    }
+                    let li_content_start = tag_end + 1;
+                    let li_end = find_closing_tag_chars(&chars, pos, "li");
+                    let li_inner: String =
+                        chars[li_content_start..li_end.min(len)].iter().collect();
+                    let li_inner = if let Some(idx) = li_inner.rfind("</li>") {
+                        &li_inner[..idx]
+                    } else {
+                        &li_inner
+                    };
+                    let mut para = Paragraph::default();
+                    self.parse_inline_content(&mut para, li_inner);
+                    if !para.text.trim().is_empty() {
+                        para.text = format!("• {}", para.text);
+                        para.char_offsets = para
+                            .text
+                            .chars()
+                            .scan(0u32, |acc, c| {
+                                let off = *acc;
+                                *acc += c.len_utf16() as u32;
+                                Some(off)
+                            })
+                            .collect();
+                        para.char_count = para.text.encode_utf16().count() as u32 + 1;
+                        // 글머리 기호("• ")만큼 스타일 구간을 오른쪽으로 밀어 정렬을 맞춘다.
+                        // start_pos 는 UTF-16 코드유닛 단위(위 char_offsets 와 동일 축).
+                        let bullet_len = "• ".encode_utf16().count() as u32;
+                        for cs in &mut para.char_shapes {
+                            cs.start_pos += bullet_len;
+                        }
+                        paragraphs.push(para);
+                    }
+                    pos = li_end;
+                    continue;
                 } else if tag_lower.starts_with("<br") {
                     // <br> → 문단 구분
                     if !pending_text.is_empty() {
@@ -574,18 +643,26 @@ impl DocumentCore {
                 } else {
                     // 기타 태그 무시 (span 등 인라인은 <p> 밖에서 직접 올 수 있음)
                     if tag_lower.starts_with("<span") {
-                        // <span>...</span> 인라인 콘텐츠
+                        // [Gmail 등 웹메일 서명 붙여넣기가 raw 태그로 나오던 결함] 예전
+                        // 코드는 span 내부(중첩 <u>/<strong>/주석 포함)를 첫 ">" 뒤부터
+                        // 그대로 pending_text 에 밀어 넣어, 태그 자체가 문서에 문자로
+                        // 그대로 찍혔다. <p> 처리와 같은 방식으로 parse_inline_content 에
+                        // 넘겨 중첩 서식(굵게 등)까지 해석한 문단으로 만든다.
+                        if !pending_text.trim().is_empty() {
+                            self.flush_text_to_paragraphs(&mut paragraphs, &pending_text);
+                            pending_text.clear();
+                        }
                         let span_end = find_closing_tag_chars(&chars, pos, "span");
-                        let span_full: String =
-                            chars[tag_start..span_end.min(len)].iter().collect();
-                        let span_full = if let Some(idx) = span_full.rfind("</span>") {
-                            &span_full[..idx]
-                        } else {
-                            &span_full
-                        };
-                        // span 태그 내부 텍스트 추출
-                        if let Some(gt_pos) = span_full.find('>') {
-                            pending_text.push_str(&span_full[gt_pos + 1..]);
+                        let inner_start = tag_end + 1;
+                        let inner_end = span_end.saturating_sub(7); // "</span>".len()
+                        let span_inner: String = chars
+                            [inner_start..inner_end.max(inner_start).min(len)]
+                            .iter()
+                            .collect();
+                        let mut para = Paragraph::default();
+                        self.parse_inline_content(&mut para, &span_inner);
+                        if !para.text.trim().is_empty() {
+                            paragraphs.push(para);
                         }
                         pos = span_end;
                         continue;


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

Gmail 등 웹메일에서 서식 있는 서명/연락처 블록을 복사해 rhwp-studio에 붙여넣으면 서식 있는
문서로 렌더링되지 않고 raw HTML 태그·속성이 그대로 텍스트로 노출되는 결함을 수정한다
(사용자 실사용 재현).

`parse_html_to_paragraphs`(최상위 파서)는 `<table>`/`<img>`/`<p>`/`<div>`/`<br>`만 블록으로
인식했다. `<span>`이 `<p>` 밖에 바로 오면(실측 문서의 제목이 정확히 이 형태) 예전 코드는 span
내부(중첩 `<u>`/`<strong>`/주석 포함)를 그대로 텍스트로 밀어 넣었고, `<ul>`/`<li>`도 전혀
인식되지 않아 목록 항목이 통째로 raw 텍스트가 됐다.

최상위 `<span>` 처리를 `parse_inline_content`(중첩 서식 해석 가능)로 바꾸고, `<ul>`/`<ol>`을
컨테이너로, `<li>`를 글머리 기호 붙은 문단으로 파싱하도록 했다.

상세 원인·변경·검증 기록: [`mydocs/working/issue_6463_html_paste_raw_tags.md`](../mydocs/working/issue_6463_html_paste_raw_tags.md)

## 관련 이슈

closes #6463

관련(별개, 이번 PR로 해결 안 됨): `#6449` — 같은 문서에서 붙여넣기가 "응답 없음"으로 멈추는
증상. 빈 문서·큰 문서(382쪽) 양쪽 모두 재현되지 않아 사용자 특정 문서 상태 특이점으로 추정.

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] 새 integration test 추가 없음(실제 사용자 HTML로 로컬 실측만 수행, PR에 미포함) — 해당 없음
- [ ] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과
      — 해당 없음(`#[cfg(test)]` 변경 없음)
- [x] `cargo test` 통과 — `cargo test --lib -p rhwp` 3889 passed / 0 failed. 기존 HTML
      붙여넣기 단위 테스트 34개 전부 무회귀.
- [x] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음(붙여넣기 파서 로직, 렌더 출력 무관)
- [ ] 웹(WASM) 렌더링 확인 — 로컬 `wasm-pack build --target web`으로 재빌드해 rhwp-studio에서
      실제 사용자 HTML 붙여넣기 재현 확인 중, CI 확인 필요
- [ ] rhwp-studio 편집·UI 변경 — 해당 없음 (렌더러 코어 파서만 변경)
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — 코드 수정 작업이라 문서 편집용
      `rhwp replay --capsule` 캡슐 대신 처리 결과 문서로 검증 근거를 남김
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 — 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 (기존에 스킵하던 `<span>`/`<ul>`/`<li>` 태그를 처리 경로에 추가한
  것으로, 이런 태그가 없는 기존 콘텐츠 경로는 변경 없음)
- 재현·측정: 미측정

## 스크린샷

사용자가 제공한 실제 Gmail 클립보드 HTML(1207자)로 붙여넣기 전/후 문단 텍스트를 비교했다.
PR에는 미첨부, 처리 결과 문서에 실측 텍스트로 기록.
