### PR TITLE
fix(layout): 쪽높이급 TAC 표를 leftover 에 끼우지 않는다 (#6409)

### DIFF
--- a/mydocs/working/issue_6409_table_page_top_vpos.md
+++ b/mydocs/working/issue_6409_table_page_top_vpos.md
@@ -1,0 +1,35 @@
+---
+kind: working
+status: active
+issue: 6409
+---
+
+# 저장 vpos=0 TAC 표를 leftover 에 끼우지 않는다 (#6409)
+
+브랜치: `fix/6409-table-page-top-vpos` (`upstream/devel` 격리 worktree)
+
+## 한 줄
+
+HWPX 가 글자처럼 취급 표를 쪽높이급 한 줄로 저장했고 그 높이가 leftover 에
+안 들어가면, CellBreak 로 끼우지 않고 다음 쪽 상단에서 시작한다.
+원본 XML vertpos=0 은 typeset 전 누적 vpos(524475)로 덮이므로 줄 높이를 본다.
+
+## 실측
+
+`samples/issue6031/3249937_asset_management_rules.hwpx`
+
+- 41쪽(0-based 40): `<붙임 4>`(pageBreak=1) + 25×34 표(vertpos=2800)
+- leftover ~210px 에 39×22 부동산거래계약 신고서(vertpos=0, vertsize=69344)가
+  끼어 11행이 앞쪽으로 온다. 한글은 그 표를 42쪽 상단에 둔다.
+- layout-anomaly 의 38.69px 는 Table2 **우측** 초과(선언 폭 51092 vs 단 48188).
+  쪽 경계 문자 +199 는 별도 기전이다.
+
+## 범위
+
+- `src/renderer/typeset.rs` — 첫 행 이월 게이트에 저장 쪽-상단 TAC 표 조건
+- `tests/cases/issue_6409_table_page_top_vpos.rs`
+
+## 비범위
+
+- 표 폭 38.69px 우측 초과(`noAdjust=1`) — 쪽 경계와 다른 축
+- gym, 새 CLI, DocumentCore 편집 발명

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -3322,6 +3322,38 @@ fn is_synthetic_line_seg(ls: &LineSeg) -> bool {
     ls.tag & 0x80000000 != 0
 }
 
+/// [#6409] HWPX 가 글자처럼 취급 표를 쪽높이급 **한 줄**로 저장했으면, leftover
+/// 에 행 분할로 끼우지 않고 다음 쪽 상단에서 시작한다.
+///
+/// 원본 XML 의 vertpos=0 은 typeset 전에 누적 vpos 로 덮인다(3249937 신고서
+/// 표 0 → 524475). 남는 신호는 단일 LINE_SEG 높이(vertsize=69344 ≈ 본문 92%).
+/// 붙임4 표도 한 줄이지만 잔여에 통째로 들어가(762px < leftover) 그대로 둔다.
+fn hwpx_stored_tac_table_starts_at_page_top(
+    para: &Paragraph,
+    table: &crate::model::table::Table,
+    current_items_empty: bool,
+    current_height: f64,
+    body_available: f64,
+    dpi: f64,
+) -> bool {
+    if current_items_empty || current_height < 1.0 || !table.common.treat_as_char {
+        return false;
+    }
+    let segs: Vec<&LineSeg> = para
+        .line_segs
+        .iter()
+        .filter(|seg| !is_synthetic_line_seg(seg))
+        .collect();
+    let Some(seg) = segs.first() else {
+        return false;
+    };
+    if segs.len() != 1 {
+        return false;
+    }
+    let stored_h = hwpunit_to_px(seg.line_height, dpi);
+    stored_h >= body_available * 0.5 && current_height + stored_h > body_available
+}
+
 /// [#5921] stored near-top 리셋이 이번 쪽 잔여를 넘는가.
 ///
 /// `native_near_top_reset` 은 저장 vpos≈sb 만 보고 쪽을 가른다. 잔여에
@@ -23789,7 +23821,18 @@ impl TypesetEngine {
                         - st.current_zone_y_offset
                         - st.current_bottom_fixed_exclusion
                         + 0.5;
-        if remaining_on_page < split_unit_h && !st.current_items.is_empty() {
+        let stored_page_top_tac_table = st.profile.hwpx_stored_layout()
+            && hwpx_stored_tac_table_starts_at_page_top(
+                para,
+                table,
+                st.current_items.is_empty(),
+                st.current_height,
+                st.base_available_height(),
+                self.dpi,
+            );
+        if stored_page_top_tac_table
+            || (remaining_on_page < split_unit_h && !st.current_items.is_empty())
+        {
             let first_row_splittable = (first_block_is_single_row || !first_block_protected)
                 && can_intra_split
                 && mt.is_row_splittable(0);
@@ -23884,7 +23927,8 @@ impl TypesetEngine {
                     multirow_clean_defer
                 );
             }
-            if (!first_row_splittable && !first_row_force_splittable)
+            if stored_page_top_tac_table
+                || (!first_row_splittable && !first_row_force_splittable)
                 || remaining_on_page < min_content
                 || multirow_clean_defer
             {

--- a/tests/cases/issue_6409_table_page_top_vpos.rs
+++ b/tests/cases/issue_6409_table_page_top_vpos.rs
@@ -1,0 +1,60 @@
+//! [Issue #6409] 저장 vpos=0 쪽-상단 TAC 표가 앞쪽 leftover 에 끼어
+//! 한글 42쪽 몫 ~200자를 41쪽으로 끌어온다
+//! (`samples/issue6031/3249937_asset_management_rules.hwpx`).
+//!
+//! 붙임4 표(25×34, 한 줄 vertsize=57204)는 leftover 에 통째로 들어가 41쪽에
+//! 남고, 바로 다음 부동산거래계약 신고서(39×22, treatAsChar, 한 줄
+//! vertsize=69344)는 한글이 42쪽 상단에 둔다. leftover ~210px 에 신고서 앞
+//! 11행을 끼우면 41쪽 본문 하단이 809pt 까지 내려간다.
+//!
+//! 수정: HWPX TAC 표가 쪽높이급 단일 LINE_SEG 로 저장됐고 그 높이가 잔여에
+//! 안 들어가면, CellBreak 행 분할로 leftover 에 끼우지 않고 다음 쪽으로 이월한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+
+const SAMPLE: &str = "samples/issue6031/3249937_asset_management_rules.hwpx";
+
+#[test]
+fn issue_6409_form_table_starts_on_next_page_not_leftover() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let core = DocumentCore::from_bytes(&std::fs::read(path).expect("read sample")).expect("open");
+
+    assert_eq!(core.page_count(), 60, "한글 2020 정본은 60쪽이다");
+
+    let p41 = core.render_page_svg_native(40).expect("page 41 svg");
+    let p42 = core.render_page_svg_native(41).expect("page 42 svg");
+
+    let p41_text = svg_glyphs(&p41);
+    let p42_text = svg_glyphs(&p42);
+
+    assert!(
+        !p41_text.contains("신고서"),
+        "41쪽 leftover 에 부동산거래계약 신고서가 끼면 안 된다: {}",
+        clip(&p41_text, 120)
+    );
+    assert!(
+        p42_text.contains("신고서") || p42_text.contains("부동산"),
+        "42쪽 상단에 부동산거래계약 신고서가 있어야 한다: {}",
+        clip(&p42_text, 120)
+    );
+}
+
+fn svg_glyphs(svg: &str) -> String {
+    let mut out = String::new();
+    for chunk in svg.split("<text").skip(1) {
+        let Some(tag_end) = chunk.find('>') else {
+            continue;
+        };
+        if let Some(close) = chunk[tag_end + 1..].find("</text>") {
+            out.push_str(&chunk[tag_end + 1..tag_end + 1 + close]);
+        }
+    }
+    out
+}
+
+fn clip(s: &str, n: usize) -> String {
+    s.chars().take(n).collect()
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

HWPX 가 글자처럼 취급 표를 쪽높이급 **한 줄**로 저장했고 그 높이가 leftover 에 안 들어가면, CellBreak 행 분할로 끼우지 않고 다음 쪽 상단에서 시작합니다.

`samples/issue6031/3249937_asset_management_rules.hwpx` 41쪽 leftover(~210px)에 부동산거래계약 신고서(39×22, 저장 `vertsize=69344`)가 끼어 한글 42쪽 몫 ~200자가 앞쪽으로 오던 결함입니다. 원본 XML `vertpos=0` 은 typeset 전 누적 vpos(524475)로 덮이므로 줄 높이를 봅니다. 같은 문서의 붙임4 표도 한 줄이지만 leftover 에 통째로 들어가 41쪽에 그대로 둡니다.

실측: dump-pages 41쪽 usedHeight 999.5→805.7, 신고서 표는 42쪽 통째 배치(929.8px). 총 쪽수 60 유지.

layout-anomaly 가 보고한 38.69px 는 Table2 **우측** 초과(선언 폭 51092 vs 단 48188, `noAdjust=1`)로, 이번 PR의 쪽 경계 축과 별개입니다.

## 관련 이슈

closes #6409

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (변경 파일은 저장소 `rustfmt.toml`로 `--check`. contributor worktree에는 generated suite 가 없어 `cargo fmt --all` 이 그 경로를 읽지 못함. CI Lint 가 동일 게이트를 돌림. `cargo fmt --check` 만으로는 안 됨)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음
- [ ] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (해당 없음)
- [x] `cargo check -p rhwp --lib` 통과
- [ ] `cargo clippy -- -D warnings` 통과 (디스크 부족으로 로컬 생략, CI Lint 가 수행)
- [x] 관련 샘플 파일로 SVG 내보내기 확인 (테스트가 page 41/42 SVG 글리프를 단언)
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오 또는 편집 커맨드 리뷰 체크리스트 통과 · 링크:
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: capability 카탈로그 등록·검증 규칙 반영 (해당 없음)

로컬 검증:

```
rustfmt --config-path rustfmt.toml --check src/renderer/typeset.rs tests/cases/issue_6409_table_page_top_vpos.rs
cargo check -p rhwp --lib
```

테스트: `tests/cases/issue_6409_table_page_top_vpos.rs` — 41쪽에 `신고서` 없음, 42쪽에 `신고서`/`부동산`, 총 쪽수 60.

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (첫 행 이월 게이트에 저장 vpos 조건 하나)
- 재현·측정: `samples/issue6031/3249937_asset_management_rules.hwpx` dump-pages 40/41

## 스크린샷

이슈 #6409 의 41·42쪽 대조. 수정 후 신고서 표는 42쪽 상단에서 시작합니다.
