### PR TITLE
test: 셀 줄나눔 계측기의 남은 왜곡 두 겹을 걷어낸다 — 개행 셀 누락·빈 키 유령 (#6363)

### DIFF
--- a/scripts/cell-lineseg-agreement-baseline.json
+++ b/scripts/cell-lineseg-agreement-baseline.json
@@ -1,18 +1,19 @@
 {
   "_comment": [
     "셀 안 문단의 줄 나눔이 한/글 저장 기록과 일치하는 비율 (내용 키 짝짓기, v3).",
-    "비교 모수는 저장 줄수가 있는 셀만. 기록 없음(noStoredRecord)은 불일치가 아니다.",
+    "비교 모수는 저장 줄수가 있는 셀만. 기록 없음은 noStoredRecord.",
     "갱신: node scripts/cell-lineseg-agreement.mjs --update",
     "이 비율은 내려갈 수 없다. 올리는 것이 목표다."
   ],
   "documents": 369,
-  "unpairedStored": 886,
-  "unpairedRendered": 11701,
-  "noStoredRecord": 44723,
-  "cells": 124721,
-  "agree": 124053,
-  "disagree": 668,
-  "renderedMore": 122,
-  "renderedFewer": 546,
-  "agreementPercent": 99.46
+  "unpairedStored": 872,
+  "unpairedRendered": 2126,
+  "noStoredRecord": 20127,
+  "emptyCells": 136528,
+  "cells": 86620,
+  "agree": 86066,
+  "disagree": 554,
+  "renderedMore": 300,
+  "renderedFewer": 254,
+  "agreementPercent": 99.36
 }

--- a/scripts/cell-lineseg-agreement.mjs
+++ b/scripts/cell-lineseg-agreement.mjs
@@ -52,7 +52,29 @@ export function textKey(text) {
 export function storedCells(dumpText) {
   const stack = []; // { indent, cell }
   const cells = [];
-  for (const line of dumpText.split('\n')) {
+  // 셀 텍스트의 개행은 dump 에 물리 줄바꿈으로 그대로 찍힌다 — `text="` 가 열린 채
+  // 끝나는 줄은 닫는 따옴표가 나올 때까지 이어붙여 한 줄로 되돌린다. 안 하면 그 셀이
+  // 통째로 누락되고, 셀의 ls 줄이 직전 셀에 가산돼 거짓 불일치가 생긴다(k-water 의
+  // '운영중\n(사업대상)' 열이 이웃 열 전체를 +2 로 부풀렸다).
+  const reassembled = [];
+  let open = null;
+  for (const raw of dumpText.split('\n')) {
+    if (open !== null) {
+      open += `\n${raw}`;
+      if (raw.includes('"')) {
+        reassembled.push(open);
+        open = null;
+      }
+      continue;
+    }
+    if (/text="[^"]*$/.test(raw)) {
+      open = raw;
+      continue;
+    }
+    reassembled.push(raw);
+  }
+  if (open !== null) reassembled.push(open);
+  for (const line of reassembled) {
     const m = PREFIX.exec(line);
     if (!m) continue;
     const indent = m[1].length;
@@ -175,6 +197,15 @@ export function mergePageSplitFragments(stored, rendered) {
  * 렌더 여러 개이면 `hdr=true` 는 조각마다 비교하고 `hdr=false` 는 줄 수를 합산한다.
  */
 export function tallyDocument(stored, rendered, totals) {
+  // 내용 키가 빈 셀은 짝짓기에서 뺀다 — 빈 셀은 문서에 수백 개씩 있어 (행, 열, 빈 키)가
+  // 식별력을 잃고, 무관한 셀끼리 붙어 거짓 불일치를 만든다(편람: 저장 3줄 빈 셀의 진짜
+  // 렌더는 3줄로 일치하는데, 계측은 다른 쪽의 1줄짜리 무관 빈 셀과 붙여 "더 적게"를
+  // 보고했다). 짝지을 수 없는 것은 못 짝지은 것과 달라 emptyCells 로 따로 센다.
+  const measurable = (cell) => textKey(cell.text) !== '';
+  totals.emptyCells += stored.filter((c) => !measurable(c)).length;
+  totals.emptyCells += rendered.filter((c) => !measurable(c)).length;
+  stored = stored.filter(measurable);
+  rendered = rendered.filter(measurable);
   const renderedForPairing = mergePageSplitFragments(stored, rendered);
   const buckets = new Map();
   for (const cell of stored) {
@@ -252,6 +283,7 @@ function emptyTotals() {
     unpairedStored: 0,
     unpairedRendered: 0,
     noStoredRecord: 0,
+    emptyCells: 0,
     cells: 0,
     agree: 0,
     disagree: 0,
@@ -295,6 +327,7 @@ function sweep() {
 function report(t) {
   console.log(`  문서 ${t.documents}개 (못 짝지은 셀: 저장 ${t.unpairedStored} / 렌더 ${t.unpairedRendered})`);
   console.log(`  기록 없음 ${t.noStoredRecord}개 (비교 모수에서 제외)`);
+  console.log(`  빈 셀 ${t.emptyCells}개 (내용 키 없음 — 짝짓기 불가, 비교 제외)`);
   console.log(`  측정 셀 ${t.cells}개   일치 ${t.agree} = ${agreementPercent(t).toFixed(2)}%`);
   console.log(`  불일치 ${t.disagree}  (rhwp 가 더 많이 ${t.renderedMore} / 더 적게 ${t.renderedFewer})`);
 }

--- a/scripts/tests/cell-lineseg-agreement.test.mjs
+++ b/scripts/tests/cell-lineseg-agreement.test.mjs
@@ -23,6 +23,7 @@ function totals() {
     documents: 0,
     unpairedStored: 0,
     unpairedRendered: 0,
+    emptyCells: 0,
     noStoredRecord: 0,
     cells: 0,
     agree: 0,
@@ -113,8 +114,8 @@ test('개수가 달라도 문서를 버리지 않는다 — 남는 셀만 unpair
 test('렌더 0줄 셀은 판정하지 않되 짝은 소비한다', () => {
   const t = totals();
   tallyDocument(
-    [cell(0, 0, '', 1), cell(0, 0, '', 1)],
-    [cell(0, 0, '', 0), cell(0, 0, '', 1)],
+    [cell(0, 0, '가', 1), cell(0, 0, '가', 1)],
+    [cell(0, 0, '가', 0), cell(0, 0, '가', 1)],
     t,
   );
   assert.equal(t.cells, 1);
@@ -125,11 +126,44 @@ test('렌더 0줄 셀은 판정하지 않되 짝은 소비한다', () => {
 test('같은 키가 여럿이면 순서대로 맞춘다', () => {
   const t = totals();
   tallyDocument(
-    [cell(0, 0, '', 1), cell(0, 0, '', 2)],
-    [cell(0, 0, '', 1), cell(0, 0, '', 2)],
+    [cell(0, 0, '가', 1), cell(0, 0, '가', 2)],
+    [cell(0, 0, '가', 1), cell(0, 0, '가', 2)],
     t,
   );
   assert.equal(t.agree, 2);
+});
+
+test('개행 든 셀 텍스트를 닫는 따옴표까지 재조립해 등록한다', () => {
+  // dump 는 셀 텍스트의 개행을 물리 줄바꿈으로 찍는다 — 재조립하지 않으면 그 셀이
+  // 통째로 빠지고 ls 가 직전 셀에 가산된다(k-water '운영중\n(사업대상)' 열).
+  const dump = [
+    '  [0]   셀[0] r=0,c=0 rs=1,cs=1 h=1 w=100 pad=(0,0,0,0) valign=Center aim=false hdr=false bf=1 paras=1 text="운영중',
+    '(사업대상)"',
+    '  [0]     p[0] ps_id=1 ctrls=0 text_len=10 ls[0] ts=0 vpos=0 lh=1000 ls=600 cs=0 sw=90',
+    '  [0]   셀[1] r=0,c=1 rs=1,cs=1 h=1 w=100 pad=(0,0,0,0) valign=Center aim=false hdr=false bf=1 paras=1 text="이웃"',
+    '  [0]     p[0] ps_id=1 ctrls=0 text_len=2 ls[0] ts=0 vpos=0 lh=1000 ls=600 cs=0 sw=90',
+  ].join('\n');
+  const cells = storedCells(dump);
+  assert.equal(cells.length, 2);
+  assert.equal(cells[0].lines, 1);
+  assert.equal(cells[1].lines, 1);
+  assert.ok(cells[0].text.includes('운영중'));
+});
+
+test('내용 키가 빈 셀은 짝짓기에서 빼고 emptyCells 로 센다 — 식별력이 없다', () => {
+  // 빈 키는 (행, 열)만으로 수백 셀이 겹쳐 무관한 셀끼리 붙는다(편람: 저장 3줄 빈 셀이
+  // 다른 쪽 1줄 빈 셀과 붙어 거짓 "더 적게"). 짝짓기 불가는 못 짝지음과 다른 사실이다.
+  const t = totals();
+  tallyDocument(
+    [cell(0, 0, '||', 3), cell(0, 0, '가', 1)],
+    [cell(0, 0, '|', 1), cell(0, 0, '가', 1)],
+    t,
+  );
+  assert.equal(t.emptyCells, 2);
+  assert.equal(t.cells, 1);
+  assert.equal(t.agree, 1);
+  assert.equal(t.disagree, 0);
+  assert.equal(t.unpairedStored + t.unpairedRendered, 0);
 });
 
 test('일치율이 내려가면 회귀다', () => {


### PR DESCRIPTION
## 무엇을 바꾸나

#6473 으로 들어온 계측기 v3(kevin9327)가 #6363 의 왜곡 1·2호(기록 없는 문단 분리, 쪽 나눔 조각 합산)를 걷어냈습니다. 이 PR 은 같은 이슈의 **남은 두 겹**을 그 위에 최소 증분으로 얹습니다.

3. **개행 든 셀 텍스트의 파서 누락** — dump 는 셀 텍스트의 개행을 물리 줄바꿈으로 찍는데, 닫는 따옴표가 다음 줄로 넘어가면 셀 정규식이 미매치돼 그 셀이 통째로 빠지고 셀의 ls 줄 수가 직전 셀에 가산됩니다. k-water 의 `운영중\n(사업대상)` 열이 이웃 열 전체를 +2 로 부풀려 가짜 "더 적게"를 만들었습니다. 열린 `text="` 를 닫는 따옴표까지 재조립합니다.
4. **내용 키가 빈 셀의 유령 짝짓기** — 빈 셀은 문서에 수백 개씩 있어 (행, 열, 빈 키)가 식별력을 잃고 무관한 셀끼리 붙습니다(편람: 저장 3줄 빈 셀의 진짜 렌더는 3줄 일치인데, 다른 쪽 1줄 빈 셀과 붙어 거짓 "더 적게"). 짝짓기 전에 `emptyCells` 로 분리 집계합니다 — 짝지을 수 없는 것은 못 짝지은 것(unpaired)과 다른 사실입니다.

## 수치 (devel 8a150f9a8, 같은 release 바이너리로 전/후)

| | v3 (devel 현행) | +이 PR |
|---|---|---|
| 측정 셀 | 127,422 | 86,620 (빈 키 136,528 분리) |
| 불일치 | **1,288** | **554 (−57%)** |
| 일치율 | 98.99% | 99.36% |
| 기록 없음 | 44,724 | 20,127 (빈 키 셀 몫이 emptyCells 로) |

남은 554 중 일부는 (행,열)이 여러 표에 반복될 때의 짝짓기 한계입니다 — 부모 표 좌표 기반 그루핑은 범위를 키우므로 후속으로 남깁니다.

## 검증

- 단위 계약 21개(+2: 개행 재조립 등록, 빈 키 분리 집계) — `node --test scripts/tests/cell-lineseg-agreement.test.mjs`
- 빈 텍스트를 쓰던 기존 픽스처 2개는 내용 키를 갖게 갱신(4호 필터가 빈 키를 비교 이전에 빼므로)
- scripts 전용 변경 — src 0 파일
