### PR TITLE
CI: 동일 merge tree의 post-merge 검증 재사용

### DIFF
--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -57,6 +57,74 @@ jobs:
         run: |
           printf 'reuse=false\nreason=not-a-devel-push\n' >> "$GITHUB_OUTPUT"
 
+      # pull_request runs execute refs/pull/N/merge, while the Actions API exposes
+      # only the source head as workflow_run.head_sha. Preserve the actual tested
+      # merge commit and tree in an immutable run artifact so a later devel push
+      # can prove that its merge tree is byte-for-byte identical.
+      - name: Capture PR merge-tree evidence
+        id: pr-merge-tree
+        if: ${{ inputs.caller_event_name == 'pull_request' && startsWith(inputs.caller_ref, 'refs/pull/') }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CALLER_SHA: ${{ inputs.caller_sha }}
+          WORKFLOW_FILE: ${{ inputs.workflow_file }}
+        with:
+          script: |
+            const fs = require('node:fs');
+            const mergeSha = process.env.CALLER_SHA;
+            const pullRequest = context.payload.pull_request;
+            if (
+              !/^[0-9a-f]{40}$/.test(mergeSha || '')
+              || !pullRequest
+              || pullRequest.head?.repo?.full_name !== process.env.GITHUB_REPOSITORY
+              || !/^[0-9a-f]{40}$/.test(pullRequest.base?.sha || '')
+              || !/^[0-9a-f]{40}$/.test(pullRequest.head?.sha || '')
+            ) {
+              core.warning('PR merge-tree identity is unavailable; no reuse evidence will be published.');
+              return;
+            }
+            try {
+              const { data: commit } = await github.rest.repos.getCommit({
+                ...context.repo,
+                ref: mergeSha,
+              });
+              const parents = (commit.parents || []).map((parent) => parent.sha);
+              const treeSha = commit.commit?.tree?.sha || '';
+              if (
+                commit.sha !== mergeSha
+                || parents.length !== 2
+                || parents[0] !== pullRequest.base.sha
+                || parents[1] !== pullRequest.head.sha
+                || !/^[0-9a-f]{40}$/.test(treeSha)
+              ) {
+                core.warning('PR merge ref does not match the event base/head pair; no evidence will be published.');
+                return;
+              }
+              const artifactName = `trusted-postmerge-merge-tree-v1-${mergeSha}-${treeSha}`;
+              fs.writeFileSync('trusted-postmerge-merge-tree.json', `${JSON.stringify({
+                schema: 1,
+                repository: process.env.GITHUB_REPOSITORY,
+                workflow_file: process.env.WORKFLOW_FILE,
+                run_id: String(context.runId),
+                merge_sha: mergeSha,
+                parents,
+                tree_sha: treeSha,
+              }, null, 2)}\n`);
+              core.setOutput('artifact_name', artifactName);
+              core.info(`Captured exact PR merge-tree evidence: ${artifactName}`);
+            } catch (error) {
+              core.warning(`Could not capture PR merge-tree evidence. ${error.message}`);
+            }
+
+      - name: Upload PR merge-tree evidence
+        if: ${{ steps.pr-merge-tree.outputs.artifact_name != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0 # v7.0.1
+        with:
+          name: ${{ steps.pr-merge-tree.outputs.artifact_name }}
+          path: trusted-postmerge-merge-tree.json
+          retention-days: 7
+          if-no-files-found: error
+
       # Resolve the merge's pre-PR source parent before any local verifier code
       # is checked out. An initial rollout has no base verifier and therefore
       # falls back to full CI; later PRs use this immutable pre-merge revision.
@@ -218,6 +286,60 @@ jobs:
                   break;
                 }
               }
+              const mergeTreeEvidenceByRunId = {};
+              const createdAt = Date.parse(pr.created_at || '');
+              const mergedAt = Date.parse(pr.merged_at || '');
+              const finalHeadRuns = workflowRuns.filter((run) => (
+                run.event === 'pull_request'
+                && run.head_sha === pr.head.sha
+                && run.head_branch === pr.head.ref
+                && run.head_repository?.full_name === process.env.GITHUB_REPOSITORY
+                && Number.isFinite(createdAt)
+                && Number.isFinite(mergedAt)
+                && Date.parse(run.created_at || '') >= createdAt
+                && Date.parse(run.updated_at || '') <= mergedAt
+              )).sort((left, right) => (
+                Date.parse(right.updated_at || '') - Date.parse(left.updated_at || '')
+                || Number(right.run_attempt || 0) - Number(left.run_attempt || 0)
+                || Number(right.id || 0) - Number(left.id || 0)
+              ));
+              const finalHeadRun = finalHeadRuns[0];
+              if (finalHeadRun?.status === 'completed' && finalHeadRun?.conclusion === 'success') {
+                const artifacts = await github.paginate(
+                  github.rest.actions.listWorkflowRunArtifacts,
+                  { owner, repo, run_id: finalHeadRun.id, per_page: 100 },
+                );
+                const evidenceArtifacts = artifacts
+                  .filter((artifact) => artifact.expired !== true)
+                  .map((artifact) => ({
+                    artifact,
+                    match: /^trusted-postmerge-merge-tree-v1-([0-9a-f]{40})-([0-9a-f]{40})$/
+                      .exec(artifact.name || ''),
+                  }))
+                  .filter(({ match }) => match !== null);
+                if (evidenceArtifacts.length === 1) {
+                  const [, testedMergeSha, encodedTreeSha] = evidenceArtifacts[0].match;
+                  const testedMerge = (await github.rest.repos.getCommit({
+                    owner,
+                    repo,
+                    ref: testedMergeSha,
+                  })).data;
+                  const testedParents = (testedMerge.parents || []).map((parent) => parent.sha);
+                  const testedTreeSha = testedMerge.commit?.tree?.sha || '';
+                  if (
+                    testedMerge.sha === testedMergeSha
+                    && testedParents.length === 2
+                    && testedParents[1] === pr.head.sha
+                    && testedTreeSha === encodedTreeSha
+                  ) {
+                    mergeTreeEvidenceByRunId[String(finalHeadRun.id)] = {
+                      sha: testedMergeSha,
+                      parents: testedParents,
+                      treeSha: testedTreeSha,
+                    };
+                  }
+                }
+              }
               const requireFullLaneEvidence = ["ci.yml", "codeql.yml"]
                 .includes(process.env.WORKFLOW_FILE);
               const reviewOnlyWorker = {
@@ -296,6 +418,7 @@ jobs:
                 pullFiles,
                 prCommits,
                 workflowRuns,
+                mergeTreeEvidenceByRunId,
               };
               if (requireFullLaneEvidence) {
                 evidence.fullLaneRunIds = fullLaneRunIds;

--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload PR merge-tree evidence
         if: ${{ steps.pr-merge-tree.outputs.artifact_name != '' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0 # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.pr-merge-tree.outputs.artifact_name }}
           path: trusted-postmerge-merge-tree.json

--- a/mydocs/orders/20260830.md
+++ b/mydocs/orders/20260830.md
@@ -6,6 +6,20 @@ date: 2026-08-30
 
 # 오늘 할 일 - 2026년 8월 30일
 
+## #6476 동일 merge tree post-merge CI 재사용
+
+- [x] [PR #6477](https://github.com/edwardkim/rhwp/pull/6477)를 생성했다. PR merge ref의 parent와 tree를
+  trusted artifact로 보존하고 final merge tree와 정확히 같을 때만 stale-base PR의 성공한 CI를 재사용한다.
+- [x] 증적 누락, parent/tree 불일치, CI enforcement 변경, stale squash merge는 기존처럼 Full lane으로
+  fail-closed 처리한다. 재사용이 허용된 경우에는 기존 duration artifact를 이용해
+  `Refresh nextest target duration data`만 수행한다.
+- [x] Node evaluator 15/15, 관련 Python workflow contract 6/6, 전체 workflow contract 171/171,
+  `actionlint`, `git diff --check`를 통과했다. 최초 CI의 39자리 `upload-artifact` SHA를 runner가 요구한
+  40자리로 보정하고 모든 `uses:` pin 길이 계약을 추가했다. Rust 제품 소스·test/baseline·renderer/fixture
+  변경은 없다.
+- [ ] 최신 PR head CI가 성공한 뒤 merge한다. merge 후에는 final merge tree가 동일한 stale-base PR의
+  devel push에서 heavy worker 대신 duration refresh만 수행되는지 실제 run으로 확인한다.
+
 ## #6415 Oracle page-count 선택 계약 보정
 
 - [x] 최신 `upstream/devel@bd78a53122e4b532eeee330b2788cbc858dad2b0` 위에서 원 PR #6415의

--- a/mydocs/pr/archives/pr_6477_review.md
+++ b/mydocs/pr/archives/pr_6477_review.md
@@ -1,0 +1,74 @@
+---
+kind: pr-review
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-30
+pr: 6477
+issue: 6476
+author: jangster77
+---
+
+# PR #6477 review - 동일 merge tree post-merge 검증 재사용
+
+## 라우팅과 metadata
+
+- PR: [#6477](https://github.com/edwardkim/rhwp/pull/6477), base: `devel`.
+- 작성자 self-review: `jangster77` collaborator PR이므로 reviewer request는 등록하지 않았다.
+- code candidate: `5b8ee8b510e00e16528a367dae828bd1a4525f35`
+  (`ci: 동일 merge tree의 post-merge 검증을 재사용한다`), 5 files, `+265/-21`.
+- 문서 작성 시점 참고 상태: `mergeable=MERGEABLE`, `mergeStateStatus=BLOCKED`.
+  최신 head의 GitHub Actions 완료 및 merge 직전 재확인이 필요하다.
+- 관련 이슈: [#6476](https://github.com/edwardkim/rhwp/issues/6476). PR 본문의 `Closes #6476`는
+  merge 뒤 자동 종료 여부를 확인한다.
+- base route: `collaborator_self_merge.md`.
+  modifiers: `intake_and_review.md`, `local_validation.md`.
+  loaded documents: `pr_review_workflow.md`, `pr_review/README.md`,
+  `pr_review/collaborator_self_merge.md`, `pr_review/intake_and_review.md`,
+  `pr_review/local_validation.md`, `github_operations.md`.
+
+## 변경 범위와 판단
+
+이전 trusted post-merge verifier는 PR head가 최종 merge base를 조상으로 포함하지 않으면, 최종 merge tree가
+이미 PR merge ref와 완전히 같아도 재사용을 거부했다. 이 PR은 PR event에서 실제 merge ref의 두 parent와
+tree SHA를 artifact로 보존하고, devel push에서 최종 merge commit과 그 증적을 다시 대조한다.
+
+다음 조건을 모두 만족할 때만 성공한 PR CI를 재사용한다.
+
+1. artifact가 가리키는 merge ref parent가 final merge의 base parent와 PR head다.
+2. artifact tree와 final merge tree가 정확히 일치한다.
+3. 최종 성공 PR workflow run 및 필요한 Full-lane 증거가 존재한다.
+
+그 경우 기존 duration artifact를 내려받아 `Refresh nextest target duration data`만 실행한다. 증적 누락,
+parent 또는 tree 불일치, CI enforcement 변경, stale squash merge와 같은 경계는 새 예외로 열지 않고 기존
+Full lane으로 fail-closed 처리한다. Rust 제품 소스, renderer, HWP/HWPX/PDF fixture는 변경하지 않아
+visual sweep은 대상이 아니다.
+
+## 로컬 검증
+
+- `node --test scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs`:
+  15 passed, 0 failed.
+- `python3 -m unittest scripts.tests.test_trusted_postmerge_ci_reuse_workflow`:
+  6 passed, 0 failed.
+- `python3 -m unittest discover -s scripts/tests -p 'test_*workflow.py'`:
+  171 passed, 0 failed.
+- `actionlint .github/workflows/trusted-postmerge-ci-reuse.yml`: 통과.
+- `git diff --check`: 통과.
+- CI workflow와 JavaScript/Python 계약만 변경했으며 Rust source/test/baseline helper는 변경하지 않아
+  Cargo lint/test와 visual sweep은 실행하지 않았다.
+- 최초 PR CI에서 `actions/upload-artifact` ref가 39자리여서 action download 전에 reusable workflow가
+  실패했다. runner가 제시한 40자리 SHA로 보정하고, workflow의 모든 `uses:` ref 길이를 확인하는 계약을
+  추가했다. 보정 head의 관련 workflow contract와 전체 workflow contract를 다시 실행해 통과했다.
+
+## 위험과 CI 관찰
+
+- artifact name 또는 manifest가 예상과 다르거나 API 조회가 불완전하면 verifier는
+  `pr-merge-tree-evidence-unavailable`로 재사용을 거부하고 Full lane을 실행한다.
+- artifact를 정상적으로 찾더라도 final merge tree의 parent와 tree가 모두 같아야 하므로, 최신 base에서
+  code tree가 달라진 경우에는 PR 결과를 재사용하지 않는다.
+- merge 후에는 동일 merge tree의 stale-base PR에서 CI/CodeQL/Adapter/Proptest의 heavy worker가 재사용되고,
+  duration refresh만 수행되는지를 실제 devel push run으로 확인해야 한다.
+
+## 최종 판단
+
+**수용 후보, CI 대기.** 로컬 policy contract는 모두 통과했고 재사용 경로는 exact merge-tree 증적으로
+좁게 제한된다. 최종 수용과 merge는 최신 PR head의 required checks 및 mergeability를 확인한 뒤에만 진행한다.

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import unittest
 from pathlib import Path
 
@@ -18,6 +19,14 @@ WORKFLOWS = {
 
 
 class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
+    def test_reusable_workflow_actions_are_pinned_to_full_commit_shas(self) -> None:
+        workflow = REUSABLE.read_text(encoding="utf-8")
+        pins = re.findall(
+            r"^\s*uses:\s+[^@\s]+@([0-9a-f]+)\b", workflow, flags=re.MULTILINE
+        )
+        self.assertGreater(len(pins), 0)
+        self.assertTrue(all(len(pin) == 40 for pin in pins))
+
     def test_reusable_verifier_is_read_only_and_fail_closed(self) -> None:
         workflow = REUSABLE.read_text(encoding="utf-8")
         self.assertIn("actions: read", workflow)

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -48,6 +48,13 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
         self.assertIn('`nextest-target-durations-${workflowRun.id}-${label}`', workflow)
         self.assertIn("never checks out or executes", workflow)
         self.assertIn("the merged PR head", workflow)
+        self.assertIn("Capture PR merge-tree evidence", workflow)
+        self.assertIn("Upload PR merge-tree evidence", workflow)
+        self.assertIn("trusted-postmerge-merge-tree-v1-", workflow)
+        self.assertIn("mergeTreeEvidenceByRunId", workflow)
+        self.assertIn("parents[0] !== pullRequest.base.sha", workflow)
+        self.assertIn("parents[1] !== pullRequest.head.sha", workflow)
+        self.assertIn("testedTreeSha === encodedTreeSha", workflow)
 
     def test_all_duplicate_postmerge_workflows_call_the_shared_verifier(self) -> None:
         expected_workflow_files = {

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs
@@ -85,3 +85,18 @@ test("fails closed when a squash merge has no unique associated PR", () => {
   assert.equal(result.reuse, false);
   assert.equal(result.reason, "merge-commit-must-map-to-one-merged-same-repository-pr");
 });
+
+test("does not apply two-parent merge-ref evidence to a stale squash merge", () => {
+  const result = evaluateTrustedPostMergeReuse(input({
+    mergeBaseSha: "6".repeat(40),
+    mergeTreeEvidenceByRunId: {
+      123: {
+        sha: "7".repeat(40),
+        parents: [base, head],
+        treeSha: tree,
+      },
+    },
+  }));
+  assert.equal(result.reuse, false);
+  assert.equal(result.reason, "pr-merge-tree-evidence-unavailable");
+});

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
@@ -8,6 +8,8 @@ const head = "2".repeat(40);
 const merge = "3".repeat(40);
 const tree = "4".repeat(40);
 const code = "5".repeat(40);
+const oldBase = "6".repeat(40);
+const testedMerge = "7".repeat(40);
 
 function candidate(overrides = {}) {
   return {
@@ -71,6 +73,64 @@ test("fails closed for direct pushes, stale bases, enforcement changes, and inco
   assert.equal(evaluateTrustedPostMergeReuse(input({ mergeBaseSha: "5".repeat(40) })).reuse, false);
   assert.equal(evaluateTrustedPostMergeReuse(input({ pullFiles: [{ filename: ".github/workflows/ci.yml" }] })).reuse, false);
   assert.equal(evaluateTrustedPostMergeReuse(input({ workflowRuns: [candidate({ status: "in_progress", conclusion: null })] })).reuse, false);
+});
+
+test("reuses a stale-head PR when its tested merge ref exactly matches the final merge tree", () => {
+  const result = evaluateTrustedPostMergeReuse(input({
+    sourceCommit: { sha: head, commit: { tree: { sha: "8".repeat(40) } } },
+    mergeBaseSha: oldBase,
+    mergeTreeEvidenceByRunId: {
+      123: {
+        sha: testedMerge,
+        parents: [base, head],
+        treeSha: tree,
+      },
+    },
+    fullLaneRunIds: ["123"],
+  }));
+  assert.deepEqual(result, {
+    reuse: true,
+    reason: "exact-merge-tree-green-pr-workflow-reused",
+    sourceRunId: "123",
+    pullNumber: "42",
+  });
+});
+
+test("fails closed when stale-head merge-tree evidence is absent or mismatched", () => {
+  const stale = {
+    sourceCommit: { sha: head, commit: { tree: { sha: "8".repeat(40) } } },
+    mergeBaseSha: oldBase,
+    fullLaneRunIds: ["123"],
+  };
+  assert.equal(
+    evaluateTrustedPostMergeReuse(input(stale)).reason,
+    "pr-merge-tree-evidence-unavailable",
+  );
+  assert.equal(evaluateTrustedPostMergeReuse(input({
+    ...stale,
+    mergeTreeEvidenceByRunId: {
+      123: { sha: testedMerge, parents: [base, head], treeSha: "9".repeat(40) },
+    },
+  })).reason, "pr-merge-tree-evidence-unavailable");
+  assert.equal(evaluateTrustedPostMergeReuse(input({
+    ...stale,
+    mergeTreeEvidenceByRunId: {
+      123: { sha: testedMerge, parents: [oldBase, head], treeSha: tree },
+    },
+  })).reason, "pr-merge-tree-evidence-unavailable");
+});
+
+test("stale-head exact-tree reuse still requires full-lane evidence", () => {
+  const result = evaluateTrustedPostMergeReuse(input({
+    sourceCommit: { sha: head, commit: { tree: { sha: "8".repeat(40) } } },
+    mergeBaseSha: oldBase,
+    mergeTreeEvidenceByRunId: {
+      123: { sha: testedMerge, parents: [base, head], treeSha: tree },
+    },
+    fullLaneRunIds: [],
+  }));
+  assert.equal(result.reuse, false);
+  assert.equal(result.reason, "candidate-full-lane-evidence-unavailable");
 });
 
 test("reuses the preceding full CI through a linear review-only tail", () => {

--- a/scripts/verify-trusted-postmerge-ci-reuse.mjs
+++ b/scripts/verify-trusted-postmerge-ci-reuse.mjs
@@ -173,6 +173,24 @@ function hasReviewOnlyFastPassEvidence(input, run) {
     && input.reviewOnlyFastPassRunIds.some((id) => String(id) === runId);
 }
 
+function hasExactMergeTreeEvidence(input, run, pullRequest, parents, treeSha) {
+  const runId = String(run?.id || "");
+  const evidence = input?.mergeTreeEvidenceByRunId?.[runId];
+  const evidenceParents = Array.isArray(evidence?.parents)
+    ? evidence.parents.filter(validSha)
+    : [];
+  return (
+    runId !== ""
+    && validSha(evidence?.sha)
+    && validSha(evidence?.treeSha)
+    && parents.length === 2
+    && evidenceParents.length === 2
+    && evidenceParents.every((sha, index) => sha === parents[index])
+    && evidenceParents.includes(pullRequest.head.sha)
+    && evidence.treeSha === treeSha
+  );
+}
+
 export function evaluateTrustedPostMergeReuse(input) {
   if (input?.eventName !== "push" || input?.ref !== "refs/heads/devel") {
     return denied("not-a-devel-push");
@@ -208,31 +226,47 @@ export function evaluateTrustedPostMergeReuse(input) {
   const baseParent = parents.length === 1
     ? parents[0]
     : parents.find((parent) => parent !== pullRequest.head.sha);
-  if (!baseParent || input.mergeBaseSha !== baseParent) {
-    return denied("pr-head-does-not-contain-merge-base");
+  if (!baseParent) {
+    return denied("merge-base-parent-unavailable");
   }
   if (input.sourceCommit?.sha !== pullRequest.head.sha) {
     return denied("source-commit-does-not-match-pr-head");
   }
+  if (enforcementPathChanged(input.pullFiles)) {
+    return denied("pr-changes-ci-enforcement-surface");
+  }
+  const mergeTreeSha = input.mergeCommit?.commit?.tree?.sha;
+  if (!validSha(mergeTreeSha)) {
+    return denied("merge-tree-unavailable");
+  }
+  const headContainsBase = input.mergeBaseSha === baseParent;
+  const finalHeadCandidate = latestCandidateRun(
+    input.workflowRuns,
+    pullRequest,
+    input.repository,
+    pullRequest.head.sha,
+  );
+  const exactMergeTreeEvidence = hasExactMergeTreeEvidence(
+    input,
+    finalHeadCandidate,
+    pullRequest,
+    parents,
+    mergeTreeSha,
+  );
   if (
-    input.mergeCommit?.commit?.tree?.sha !== input.sourceCommit?.commit?.tree?.sha
-    || !input.mergeCommit?.commit?.tree?.sha
+    headContainsBase
+    && mergeTreeSha !== input.sourceCommit?.commit?.tree?.sha
+    && !exactMergeTreeEvidence
   ) {
     return denied("merge-tree-does-not-match-pr-head");
   }
-  if (enforcementPathChanged(input.pullFiles)) {
-    return denied("pr-changes-ci-enforcement-surface");
+  if (!headContainsBase && !exactMergeTreeEvidence) {
+    return denied("pr-merge-tree-evidence-unavailable");
   }
 
   // A direct review-only PR has no code candidate. It is safe to reuse only
   // when this worker's exact PR run proves that preflight skipped the worker.
   if (isDirectReviewOnlyPullRequest(pullRequest, input.pullFiles, input.prCommits)) {
-    const finalHeadCandidate = latestCandidateRun(
-      input.workflowRuns,
-      pullRequest,
-      input.repository,
-      pullRequest.head.sha,
-    );
     if (!finalHeadCandidate) {
       return denied("direct-review-only-pr-workflow-unavailable");
     }
@@ -258,12 +292,6 @@ export function evaluateTrustedPostMergeReuse(input) {
     return denied("review-tail-evidence-unavailable");
   }
 
-  const finalHeadCandidate = latestCandidateRun(
-    input.workflowRuns,
-    pullRequest,
-    input.repository,
-    pullRequest.head.sha,
-  );
   if (
     finalHeadCandidate
     && finalHeadCandidate.status === "completed"
@@ -272,12 +300,23 @@ export function evaluateTrustedPostMergeReuse(input) {
   ) {
     return {
       reuse: true,
-      reason: candidateSource.hasReviewOnlyTail
-        ? "review-tail-final-head-green-pr-workflow-reused"
-        : "exact-green-pr-workflow-reused",
+      reason: !headContainsBase
+        ? (candidateSource.hasReviewOnlyTail
+          ? "review-tail-exact-merge-tree-green-pr-workflow-reused"
+          : "exact-merge-tree-green-pr-workflow-reused")
+        : (candidateSource.hasReviewOnlyTail
+          ? "review-tail-final-head-green-pr-workflow-reused"
+          : "exact-green-pr-workflow-reused"),
       sourceRunId: String(finalHeadCandidate.id),
       pullNumber: String(pullRequest.number),
     };
+  }
+
+  if (!headContainsBase) {
+    if (!hasFullLaneEvidence(input, finalHeadCandidate)) {
+      return denied("candidate-full-lane-evidence-unavailable");
+    }
+    return denied("latest-pr-workflow-candidate-not-successful");
   }
 
   const candidate = latestCandidateRun(


### PR DESCRIPTION
## 변경 요약

- PR workflow가 생성한 실제 merge ref의 parents와 tree SHA를 trusted artifact로 보존합니다.
- `devel` push에서는 최종 merge commit과 해당 증적이 정확히 일치할 때만 stale-base PR의 성공한 CI를 재사용합니다.
- 재사용 시 기존 duration artifact를 받아 `Refresh nextest target duration data`만 수행합니다.
- 증적 누락, parent/tree 불일치, enforcement 경로, stale squash merge는 모두 기존 Full lane으로 fail-closed 처리합니다.

## 검증

- `node --test scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs` - 15/15 통과
- `python3 -m unittest scripts.tests.test_trusted_postmerge_ci_reuse_workflow` - 6/6 통과
- `python3 -m unittest discover -s scripts/tests -p 'test_*workflow.py'` - 171/171 통과
- `actionlint .github/workflows/trusted-postmerge-ci-reuse.yml` - 통과
- `git diff --check` 통과

## 범위와 안전성

- Rust 제품 소스, renderer, fixture는 변경하지 않았으므로 시각 검증 대상이 아닙니다.
- 새 artifact 증적을 검증할 수 없는 모든 경로는 검증 재사용을 허용하지 않습니다.
- 최초 CI에서 발견된 39자리 `actions/upload-artifact` pin을 40자리 SHA로 보정하고, 모든 action pin 길이를
  계약 테스트로 확인합니다.

Closes #6476
