### PR TITLE
fix(metrics): KoPub돋움체 한글 폭을 임베드 실측 872/1000em 으로 복원한다 (#6389)

### DIFF
--- a/src/renderer/layout/text_measurement.rs
+++ b/src/renderer/layout/text_measurement.rs
@@ -912,11 +912,17 @@ fn kopub_char_width(primary_name: &str, c: char, font_size: f64) -> Option<f64> 
         return Some(quantize_hwp_px(font_size * 0.5));
     }
     if is_cjk_char(c) || is_fullwidth_symbol(c) {
-        // [#2195 stage57] KoPub 미설치 환경에서 한글은 바탕으로 치환해 **전각
-        // 1.0em** 렌더 — 86712 한컴 PDF 글리프 직독(Haansoft Batang, 12pt 한글
-        // 16px) 실측. 종전 0.84 는 r27 근거설명 25문단을 -11줄 과소(래핑 조기
-        // 종료)시키던 성분.
-        let factor = if is_dotum { 1.0 } else { 0.94 };
+        // [#6389] KoPub돋움체 한글 전각은 872/1000em — 편람 kopub 오라클 PDF 의
+        // 임베드 서브셋 CIDFont /W 직독(Light 601·Medium 319·Bold 283 글리프
+        // 전원 872). 재구성도 맞는다: 한글 줄폭 = 872×장평0.98−자간 = 825HU/자
+        // ≈ 오라클 잉크 실측 829. 종전 1.0 은 #2195 stage57 이 86712 한컴 PDF
+        // 에서 실측한 값인데, 그 PDF 는 KoPub 미설치 환경이라 한글이 바탕으로
+        // **치환해** 그린 것 — 치환 글꼴(전각 1.0em)의 폭이 KoPub face 상수로
+        // 들어와 있었다. 치환 환경 문서군의 폭은 face 상수가 아니라 치환 경로가
+        // 소유해야 한다. 그보다 전의 0.84 도 실물(0.872)과 미세하게 어긋나
+        // r27 을 -11줄 과소시켰다. 바탕체 0.94 는 같은 방법 실측 936/1000 과
+        // 사실상 일치해 유지한다.
+        let factor = if is_dotum { 0.872 } else { 0.94 };
         return Some(quantize_hwp_px(font_size * factor));
     }
 
@@ -2170,7 +2176,7 @@ mod tests {
     }
 
     #[test]
-    fn test_kopub_dotum_hangul_full_width_substitution() {
+    fn test_kopub_dotum_hangul_872_advance() {
         let m = EmbeddedTextMeasurer;
         let style = TextStyle {
             font_family: "KoPub돋움체 Light".to_string(),
@@ -2178,11 +2184,13 @@ mod tests {
             ..Default::default()
         };
 
-        // [#2195 stage57] KoPub 미설치 환경에서 한글이 바탕으로 치환되어 전각
-        // 1.0em 렌더 (86712 한컴 PDF 글리프 실측: 12pt 한글 16px). 종전 0.84
-        // 핀은 r27 근거설명 25문단 -11줄 과소의 성분이었다.
+        // [#6389] KoPub돋움체 한글 전각 872/1000em — 편람 kopub 오라클 PDF 임베드
+        // 서브셋 CIDFont /W 직독(전 웨이트 1,203 글리프 만장일치 872). 종전 1.0
+        // 은 KoPub 미설치 환경의 바탕 치환 렌더(86712)를 face 상수로 오인한 값.
+        // 14px × 0.872 = 12.208 → HWPUNIT 양자화 12.2/자, 두 글자 24.4 를
+        // estimate_text_width 가 총폭 round 해 24.0 (줄바꿈 비교는 unrounded).
         let w = m.estimate_text_width("가나", &style);
-        assert_eq!(w, 28.0);
+        assert_eq!(w, 24.0);
     }
 
     #[test]

--- a/tests/cases/issue_5804_dash_leader_glyphs.rs
+++ b/tests/cases/issue_5804_dash_leader_glyphs.rs
@@ -29,7 +29,9 @@ fn repo_root() -> std::path::PathBuf {
 const SAMPLE: &str = "samples/issue1891/86712_regulatory_analysis.hwpx";
 
 /// `-p` 는 0 기준이라 이 값은 문서 35 쪽(정본 p35)을 가리킨다.
-const PAGE_ARG: &str = "34";
+// [#6389] KoPub돋움체 한글 폭을 임베드 실측 872/1000em 으로 되돌리면 앞쪽
+// 본문이 조밀해져 신구조문대비표가 한 쪽 당겨진다(문서 65→64쪽, 표는 0기준 33).
+const PAGE_ARG: &str = "33";
 
 /// 새 의존성을 들이지 않으려고 표준 라이브러리만 쓴다 — 프로세스 id 와 호출 순번으로
 /// 디렉토리를 갈라, 같은 프로세스 안에서 스레드로 병렬 실행되는 시험끼리도 부딪히지 않게 한다.

--- a/tests/cases/issue_5830_dash_leader_last_line.rs
+++ b/tests/cases/issue_5830_dash_leader_last_line.rs
@@ -143,7 +143,7 @@ fn hyphen_runs(svg: &str, min_len: usize) -> Vec<Run> {
 /// 쏟으면 35쪽 8자 런이 1.9em 까지 벌어진다(구현 중 실제로 만든 오답).
 #[test]
 fn last_line_dash_leader_advance_stays_in_the_oracle_band() {
-    for page_arg in ["33", "34"] {
+    for page_arg in ["32", "33"] {
         let svg = render_page_svg(page_arg);
         let runs = hyphen_runs(&svg, 8);
         assert!(
@@ -172,7 +172,7 @@ fn stretched_dash_leader_stays_inside_the_text_area() {
     // 이 문서(A4 세로, 96dpi SVG)의 정상(양쪽정렬) 런 마지막 글리프 **원점** 실측
     // 최대치는 707.1px 다. 확장된 마지막 줄 런의 원점이 그보다 밖이면 여백 침범이다.
     const RIGHT_EDGE_ORIGIN_PX: f64 = 708.0;
-    for page_arg in ["33", "34"] {
+    for page_arg in ["32", "33"] {
         let svg = render_page_svg(page_arg);
         for run in hyphen_runs(&svg, 8) {
             let last_x = run.pts[run.pts.len() - 1].0;

--- a/tests/fixtures/oracle_page_count_baseline.tsv
+++ b/tests/fixtures/oracle_page_count_baseline.tsv
@@ -40,7 +40,7 @@ samples/3-11월_실전_통합_2024-구분선위20미주사이7구분선아래2.h
 samples/3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.hwp	21	21
 samples/3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.hwpx	21	21
 samples/80168_regulatory_analysis.hwp	157	157
-samples/86712_regulatory_analysis.hwp	65	65
+samples/86712_regulatory_analysis.hwp	65	64
 samples/SO-SUEOP.hwp	46	46
 samples/SO-SUEOP.hwpx	46	46
 samples/[2027] 온새미로 1 본교재.hwp	47	47
@@ -236,7 +236,7 @@ samples/issue1770_rowsplit_tolerance.hwpx	4	4
 samples/issue1835_tac_stale_height.hwp	3	3
 samples/issue1853_caption_precedes_body_split.hwpx	52	52
 samples/issue1891/80168_regulatory_analysis.hwpx	157	157
-samples/issue1891/86712_regulatory_analysis.hwpx	65	65
+samples/issue1891/86712_regulatory_analysis.hwpx	65	64
 samples/issue1893_clickhere_field_roundtrip.hwpx	1	1
 samples/issue1949_giant_cell_nested_tables_perf.hwp	115	115
 samples/issue1949_giant_cell_nested_tables_perf.hwpx	115	115

--- a/tests/issue_1891.rs
+++ b/tests/issue_1891.rs
@@ -29,12 +29,16 @@ const HWP5_ORIGIN_SAMPLES: &[(&str, u32)] = &[
     ("samples/76076_regulatory_analysis.hwp", 82),
     ("samples/80168_regulatory_analysis.hwp", 157),
     ("samples/80250_regulatory_analysis.hwp", 17),
-    ("samples/86712_regulatory_analysis.hwp", 65),
+    // [#6389] KoPub돋움체 한글 폭 872/1000em 실측 복원으로 KoPub 구역(24~27쪽,
+    // 저장 LINE_SEG 없는 리플로우)이 조밀해져 64쪽. PDF 정답 65는 KoPub 미설치
+    // 환경(HCRDotum/Haansoft Batang 치환 — pdffonts 확인)의 렌더라 이 문서의
+    // 격차 1은 oracle_page_count_baseline.tsv 에 알려진 격차로 등재.
+    ("samples/86712_regulatory_analysis.hwp", 64),
     ("samples/issue1891/76076_regulatory_analysis.hwpx", 82),
     ("samples/issue1891/80168_regulatory_analysis.hwpx", 157),
     ("samples/issue1891/80250_regulatory_analysis.hwpx", 17),
     // [#2240] #2197 serializer 수정 반영 재생성 픽스처 — 원본(.hwp=65)과 등가.
-    ("samples/issue1891/86712_regulatory_analysis.hwpx", 65),
+    ("samples/issue1891/86712_regulatory_analysis.hwpx", 64),
 ];
 
 fn read_sample() -> Vec<u8> {


### PR DESCRIPTION
## 무엇을 고치나

내장 KoPub돋움체의 한글 전각 폭이 1.0em 으로 들어가 있는데, 실물은 **872/1000em** 입니다. 편람 kopub 오라클 PDF(`…-hwp-kopub-2020.pdf`)의 임베드 서브셋 CIDFont `/W` 배열을 직독하면 Light 601·Medium 319·Bold 283 — **1,203개 한글 글리프가 만장일치 872** 입니다. 재구성 검증도 맞습니다: 한글 줄 = 872 × 장평0.98 − 자간 = 824.6HU/자 ≈ 오라클 잉크 실측 829 (현행 1.0em 은 950). 자간·장평 적용은 한/글과 동일하고 **테이블 값만이 오차원**입니다. 바탕체는 실측 936 이라 현행 0.94 를 유지합니다. 전체 분석은 #6389 에 있습니다.

1.0 의 출처는 #2195 stage57 의 86712 한컴 PDF 실측인데, 그 PDF 는 `pdffonts` 로 확인하면 **KoPub 미설치 환경에서 바탕 계열로 치환해 그린 렌더**입니다(HCRDotum·Haansoft Batang 임베드). 치환 환경의 폭이 face 상수로 들어와, KoPub 이 실제로 그려지는 문서에서 자연 폭이 12~17% 부풀어 있었습니다 — #6412 가 막은 셀 넘침·수치 절단의 뿌리이기도 합니다.

## 효과 (devel 베이스 실측)

- 편람 셀 리플로우가 한/글 저장 줄바꿈을 **자모 단위로 재현**합니다 (p68 `※` 문단 4→3줄, 저장 ts=54 위치 일치. 채움률 117%→100%).
- 글자 겹침 스윕 946건: 3,364 → **3,286** (증가 0. 감소분 전량이 1790387_prep_final_report 99→21).
- 셀 줄수 계측(#6363)은 거의 불변 — 셀 문단 대부분이 저장 행을 재사용하므로 그 지표는 메트릭에 둔감함을 실측으로 확인했습니다(계측기가 못 잡는 축이지, 효과가 없는 게 아닙니다).

## 재핀 — 전부 86712 치환-오라클 코호트 (문서 65→64쪽)

| 핀 | 갱신 | 사유 |
|---|---|---|
| `oracle_page_count_baseline.tsv` 86712 hwp/hwpx | rhwp 쪽수 65→64, **정답지 65 유지** | 정답 PDF 자체가 치환 렌더 — 격차 1 을 알려진 격차로 등재 |
| issue_5804/5830 dash-leader (4) | 쪽 참조 34→33, [33,34]→[32,33] | 본문이 조밀해져 신구조문대비표가 한 쪽 당겨짐. **advance 대역(0.45~0.75em)은 이동 후 그대로 통과** — 밴드 유효 |
| issue_1891 왕복 쪽수 (2) | 65→64 | 동일 코호트 |
| kopub 단위시험 | 872 기대값 | 실측 |

86712 의 KoPub 구역(0기준 24·26·27쪽)은 저장 LINE_SEG 도 substFont 선언도 없어 문서 기반 보정이 불가합니다 — 이 문서의 "치환 렌더 정답지"를 face 실측과 한 상수로 화해시킬 수 없어, #6466/#6474 오라클 선택 계약의 연장(치환 환경 명시)을 #6389 후속으로 남깁니다.

## 검증

- 전체 nextest **8,129/8,129 통과** (재핀 반영 후 실패 0), fmt 클린.
- 글자 겹침 래칫: 증가 0 (감소는 통과 규약 — devel baseline 천장은 조이지 않아 #6412 와 충돌하지 않습니다).
- 실험 이력: `exp/kopub-dotum-872` (옛 베이스 박제), 실측 도구는 pikepdf `/W` 직독.
