### PR TITLE
fix(ci): review/PDF tail의 Full 후보를 merge 후 재사용한다

### DIFF
--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -304,11 +304,15 @@ jobs:
                 || Number(right.id || 0) - Number(left.id || 0)
               ));
               const finalHeadRun = finalHeadRuns[0];
-              if (finalHeadRun?.status === 'completed' && finalHeadRun?.conclusion === 'success') {
-                const artifacts = await github.paginate(
-                  github.rest.actions.listWorkflowRunArtifacts,
-                  { owner, repo, run_id: finalHeadRun.id, per_page: 100 },
-                );
+              async function recordMergeTreeEvidence(workflowRun, artifacts) {
+                if (
+                  workflowRun?.event !== 'pull_request'
+                  || workflowRun?.head_branch !== pr.head.ref
+                  || workflowRun?.head_repository?.full_name !== process.env.GITHUB_REPOSITORY
+                  || !/^[0-9a-f]{40}$/.test(workflowRun?.head_sha || '')
+                ) {
+                  return;
+                }
                 const evidenceArtifacts = artifacts
                   .filter((artifact) => artifact.expired !== true)
                   .map((artifact) => ({
@@ -329,16 +333,23 @@ jobs:
                   if (
                     testedMerge.sha === testedMergeSha
                     && testedParents.length === 2
-                    && testedParents[1] === pr.head.sha
+                    && testedParents[1] === workflowRun.head_sha
                     && testedTreeSha === encodedTreeSha
                   ) {
-                    mergeTreeEvidenceByRunId[String(finalHeadRun.id)] = {
+                    mergeTreeEvidenceByRunId[String(workflowRun.id)] = {
                       sha: testedMergeSha,
                       parents: testedParents,
                       treeSha: testedTreeSha,
                     };
                   }
                 }
+              }
+              if (finalHeadRun?.status === 'completed' && finalHeadRun?.conclusion === 'success') {
+                const artifacts = await github.paginate(
+                  github.rest.actions.listWorkflowRunArtifacts,
+                  { owner, repo, run_id: finalHeadRun.id, per_page: 100 },
+                );
+                await recordMergeTreeEvidence(finalHeadRun, artifacts);
               }
               const requireFullLaneEvidence = ["ci.yml", "codeql.yml"]
                 .includes(process.env.WORKFLOW_FILE);
@@ -369,6 +380,7 @@ jobs:
                     const available = new Set(artifacts.map((artifact) => artifact.name));
                     if ([...expected].every((name) => available.has(name))) {
                       fullLaneRunIds.push(String(workflowRun.id));
+                      await recordMergeTreeEvidence(workflowRun, artifacts);
                     }
                     continue;
                   }
@@ -382,6 +394,11 @@ jobs:
                     && job.conclusion === "success"
                   ))) {
                     fullLaneRunIds.push(String(workflowRun.id));
+                    const artifacts = await github.paginate(
+                      github.rest.actions.listWorkflowRunArtifacts,
+                      { owner, repo, run_id: workflowRun.id, per_page: 100 },
+                    );
+                    await recordMergeTreeEvidence(workflowRun, artifacts);
                   }
                 }
               }

--- a/mydocs/pr/archives/pr_6488_review.md
+++ b/mydocs/pr/archives/pr_6488_review.md
@@ -1,0 +1,69 @@
+---
+kind: pr-review
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-31
+pr: 6488
+issue: 6279
+author: jangster77
+---
+
+# PR #6488 review - review/PDF tail의 Full 후보 재사용
+
+## 라우팅과 metadata
+
+- PR: [#6488](https://github.com/edwardkim/rhwp/pull/6488), base: `devel`.
+- 작성자 self-review: `jangster77` collaborator PR이므로 reviewer request는 등록하지 않았다.
+- code candidate: `53d9fea2ed4203a4b87c6cf59fab8f010fc144de`
+  (`fix(ci): review/PDF tail의 Full 후보를 재사용한다 (#6279)`), 4 files, `+203/-34`.
+- 이 review record는 code candidate 뒤에 붙는 trailing documentation commit이다. 문서 작성 시점의
+  code candidate는 `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`이고, merge 직전에는 이 review
+  record를 포함한 최신 head의 required check와 mergeability를 다시 확인한다.
+- 관련 이슈: [#6279](https://github.com/edwardkim/rhwp/issues/6279). PR 본문의 `Closes #6279`는
+  merge 뒤 자동 종료 여부를 확인한다.
+- base route: `collaborator_self_merge.md`.
+  modifiers: `intake_and_review.md`, `local_validation.md`, `post_merge.md`.
+  loaded documents: `pr_review_workflow.md`, `pr_review/README.md`,
+  `pr_review/collaborator_self_merge.md`, `pr_review/intake_and_review.md`,
+  `pr_review/local_validation.md`, `post_merge.md`.
+
+## 변경 범위와 판단
+
+`#6485`의 최종 head에는 code candidate 뒤에 허용된 review/PDF 증적 tail이 추가됐다. 기존 verifier는
+최종 code candidate 하나만 조회해, 그 후보가 fast-pass였을 때 이전의 성공 Full run `40fbca176eee3874f5acf5687c91d4c9ec5a6d07`을
+발견하지 못하고 `no-current-pr-workflow-candidate`로 Full lane을 다시 실행했다.
+
+이 PR은 선형 review/PDF tail의 각 commit을 최신 순으로 Full 후보로 탐색한다. 후보는 해당 workflow run의
+immutable merge-tree artifact가 후보 head를 정확히 가리킬 때만 채택한다. 최종 head의 stale-base
+merge-tree 증적, 후보 run의 Full-lane 성공, duration artifact, CodeQL Analyze worker를 모두 다시
+확인한다. 비선형 tail, artifact/API 누락, enforcement 변경, 증적 불일치는 계속 Full lane으로
+fail-closed 한다.
+
+CI controller와 JavaScript/Python 계약만 변경했다. Rust 제품 소스·test·baseline helper, renderer,
+HWP/HWPX/PDF fixture와 visual output은 변경하지 않았으므로 visual sweep은 대상이 아니다.
+
+## 로컬 검증
+
+- `node --test scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs`:
+  18 passed, 0 failed.
+- `python3 -m unittest discover -s scripts/tests -p 'test_*workflow.py'`:
+  171 passed, 0 failed.
+- `actionlint .github/workflows/trusted-postmerge-ci-reuse.yml`: 통과.
+- `git diff --check`: 통과.
+- Rust source/test/baseline helper와 renderer가 범위 밖이므로 Cargo lint/test와 visual sweep은 실행하지 않았다.
+
+## CI와 잔여 위험
+
+- code candidate `53d9fea2...`의 CI, CodeQL, Adapter inter-diff, Proptest와 workflow contract는 모두
+  성공했다. 최초 `Frontend package gates`는 Chrome websocket startup timeout으로 실패했으나, 소스 변경
+  없이 failed job 재실행 후 성공했다. 이는 이 PR의 controller 변경과 무관한 CI browser startup 변동으로
+  기록하며, 최신 trailing head의 결과를 다시 확인한다.
+- review/PDF tail의 허용 범위나 merge-tree 증적이 불완전하면 이 PR도 재사용하지 않고 Full lane으로
+  되돌아간다. merge 뒤 실제 devel push가 `Refresh nextest target duration data`만 실행하는지는 post-merge
+  확인 항목이다.
+
+## 최종 판정
+
+**승인.** code candidate의 로컬 계약 검증과 최신 GitHub Actions가 통과했다. merge 전 조건은 이 review
+record를 포함한 최신 PR head의 required checks 성공, `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`,
+그리고 작업지시자의 merge 승인이다.

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -62,7 +62,8 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
         self.assertIn("trusted-postmerge-merge-tree-v1-", workflow)
         self.assertIn("mergeTreeEvidenceByRunId", workflow)
         self.assertIn("parents[0] !== pullRequest.base.sha", workflow)
-        self.assertIn("parents[1] !== pullRequest.head.sha", workflow)
+        self.assertIn("recordMergeTreeEvidence", workflow)
+        self.assertIn("testedParents[1] === workflowRun.head_sha", workflow)
         self.assertIn("testedTreeSha === encodedTreeSha", workflow)
 
     def test_all_duplicate_postmerge_workflows_call_the_shared_verifier(self) -> None:

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
@@ -10,6 +10,7 @@ const tree = "4".repeat(40);
 const code = "5".repeat(40);
 const oldBase = "6".repeat(40);
 const testedMerge = "7".repeat(40);
+const reviewed = "8".repeat(40);
 
 function candidate(overrides = {}) {
   return {
@@ -159,6 +160,109 @@ test("reuses the preceding full CI through a linear review-only tail", () => {
     sourceRunId: "456",
     pullNumber: "42",
   });
+});
+
+test("reuses a full review-evidence candidate before a later fast-pass tail", () => {
+  const result = evaluateTrustedPostMergeReuse(input({
+    prCommits: [
+      {
+        sha: code,
+        parents: [{ sha: base }],
+        files: [{ filename: "src/renderer/layout.rs", status: "modified" }],
+      },
+      {
+        sha: reviewed,
+        parents: [{ sha: code }],
+        files: [{ filename: "pdf/pr_6279/reference.pdf", status: "added" }],
+      },
+      {
+        sha: head,
+        parents: [{ sha: reviewed }],
+        files: [{ filename: "mydocs/pr/archives/pr_6279_review.md", status: "added" }],
+      },
+    ],
+    workflowRuns: [
+      candidate({ id: 123, head_sha: head }),
+      candidate({ id: 456, head_sha: reviewed }),
+    ],
+    fullLaneRunIds: ["456"],
+    mergeTreeEvidenceByRunId: {
+      456: { sha: testedMerge, parents: [base, reviewed], treeSha: tree },
+    },
+  }));
+  assert.deepEqual(result, {
+    reuse: true,
+    reason: "review-tail-green-pr-workflow-reused",
+    sourceRunId: "456",
+    pullNumber: "42",
+  });
+});
+
+test("reuses a full review-evidence candidate through a stale-base tail", () => {
+  const result = evaluateTrustedPostMergeReuse(input({
+    sourceCommit: { sha: head, commit: { tree: { sha: "9".repeat(40) } } },
+    mergeBaseSha: oldBase,
+    prCommits: [
+      {
+        sha: code,
+        parents: [{ sha: base }],
+        files: [{ filename: "src/renderer/layout.rs", status: "modified" }],
+      },
+      {
+        sha: reviewed,
+        parents: [{ sha: code }],
+        files: [{ filename: "pdf/pr_6279/reference.pdf", status: "added" }],
+      },
+      {
+        sha: head,
+        parents: [{ sha: reviewed }],
+        files: [{ filename: "mydocs/pr/archives/pr_6279_review.md", status: "added" }],
+      },
+    ],
+    workflowRuns: [
+      candidate({ id: 123, head_sha: head }),
+      candidate({ id: 456, head_sha: reviewed }),
+    ],
+    fullLaneRunIds: ["456"],
+    mergeTreeEvidenceByRunId: {
+      123: { sha: testedMerge, parents: [base, head], treeSha: tree },
+      456: { sha: "a".repeat(40), parents: [base, reviewed], treeSha: tree },
+    },
+  }));
+  assert.deepEqual(result, {
+    reuse: true,
+    reason: "review-tail-green-pr-workflow-reused",
+    sourceRunId: "456",
+    pullNumber: "42",
+  });
+});
+
+test("fails closed when an intermediate full review candidate lacks merge-tree evidence", () => {
+  const result = evaluateTrustedPostMergeReuse(input({
+    prCommits: [
+      {
+        sha: code,
+        parents: [{ sha: base }],
+        files: [{ filename: "src/renderer/layout.rs", status: "modified" }],
+      },
+      {
+        sha: reviewed,
+        parents: [{ sha: code }],
+        files: [{ filename: "pdf/pr_6279/reference.pdf", status: "added" }],
+      },
+      {
+        sha: head,
+        parents: [{ sha: reviewed }],
+        files: [{ filename: "mydocs/pr/archives/pr_6279_review.md", status: "added" }],
+      },
+    ],
+    workflowRuns: [candidate({ id: 456, head_sha: reviewed })],
+    fullLaneRunIds: ["456"],
+  }));
+  assert.equal(
+    result.reason,
+    "review-tail-candidate-merge-tree-evidence-unavailable",
+  );
 });
 
 test("reuses an exact direct review-only PR fast pass after merge", () => {

--- a/scripts/verify-trusted-postmerge-ci-reuse.mjs
+++ b/scripts/verify-trusted-postmerge-ci-reuse.mjs
@@ -81,6 +81,7 @@ export function selectTrustedPostMergeCandidate(pullRequest, prCommits) {
 
   let expectedSha = pullRequest.head.sha;
   let hasReviewOnlyTail = false;
+  const fullLaneCandidates = [];
   for (let index = prCommits.length - 1; index >= 0; index -= 1) {
     const commit = prCommits[index];
     if (commit?.sha !== expectedSha) {
@@ -91,8 +92,16 @@ export function selectTrustedPostMergeCandidate(pullRequest, prCommits) {
       return null;
     }
     if (classification.kind === "code") {
-      return { sha: commit.sha, hasReviewOnlyTail };
+      return {
+        sha: commit.sha,
+        hasReviewOnlyTail,
+        fullLaneCandidates: [
+          ...fullLaneCandidates,
+          { sha: commit.sha, hasReviewOnlyTail },
+        ],
+      };
     }
+    fullLaneCandidates.push({ sha: commit.sha, hasReviewOnlyTail });
     hasReviewOnlyTail = true;
     expectedSha = classification.parentSha;
   }
@@ -188,6 +197,21 @@ function hasExactMergeTreeEvidence(input, run, pullRequest, parents, treeSha) {
     && evidenceParents.every((sha, index) => sha === parents[index])
     && evidenceParents.includes(pullRequest.head.sha)
     && evidence.treeSha === treeSha
+  );
+}
+
+function hasIntermediateCandidateMergeTreeEvidence(input, run) {
+  const runId = String(run?.id || "");
+  const evidence = input?.mergeTreeEvidenceByRunId?.[runId];
+  const evidenceParents = Array.isArray(evidence?.parents)
+    ? evidence.parents.filter(validSha)
+    : [];
+  return (
+    runId !== ""
+    && validSha(evidence?.sha)
+    && validSha(evidence?.treeSha)
+    && evidenceParents.length === 2
+    && evidenceParents[1] === run?.head_sha
   );
 }
 
@@ -312,37 +336,60 @@ export function evaluateTrustedPostMergeReuse(input) {
     };
   }
 
-  if (!headContainsBase) {
-    if (!hasFullLaneEvidence(input, finalHeadCandidate)) {
-      return denied("candidate-full-lane-evidence-unavailable");
+  let foundCandidateRun = false;
+  let foundFullLaneCandidate = false;
+  let missingIntermediateCandidateEvidence = false;
+  let unsuccessfulCandidate = false;
+  for (const candidateSourceEntry of candidateSource.fullLaneCandidates) {
+    const candidate = latestCandidateRun(
+      input.workflowRuns,
+      pullRequest,
+      input.repository,
+      candidateSourceEntry.sha,
+    );
+    if (!candidate) {
+      continue;
     }
-    return denied("latest-pr-workflow-candidate-not-successful");
+    foundCandidateRun = true;
+    if (!hasFullLaneEvidence(input, candidate)) {
+      continue;
+    }
+    foundFullLaneCandidate = true;
+    if (candidate.status !== "completed" || candidate.conclusion !== "success") {
+      unsuccessfulCandidate = true;
+      continue;
+    }
+    if (
+      candidateSourceEntry.sha !== candidateSource.sha
+      && !hasIntermediateCandidateMergeTreeEvidence(input, candidate)
+    ) {
+      missingIntermediateCandidateEvidence = true;
+      continue;
+    }
+    if (!Number.isInteger(candidate.id) && !/^[1-9][0-9]*$/.test(String(candidate.id || ""))) {
+      unsuccessfulCandidate = true;
+      continue;
+    }
+    return {
+      reuse: true,
+      reason: candidateSourceEntry.hasReviewOnlyTail
+        ? "review-tail-green-pr-workflow-reused"
+        : "exact-green-pr-workflow-reused",
+      sourceRunId: String(candidate.id),
+      pullNumber: String(pullRequest.number),
+    };
   }
-
-  const candidate = latestCandidateRun(
-    input.workflowRuns,
-    pullRequest,
-    input.repository,
-    candidateSource.sha,
-  );
-  if (!candidate) {
+  if (!foundCandidateRun) {
     return denied("no-current-pr-workflow-candidate");
   }
-  if (!hasFullLaneEvidence(input, candidate)) {
+  if (!foundFullLaneCandidate) {
     return denied("candidate-full-lane-evidence-unavailable");
   }
-  if (candidate.status !== "completed" || candidate.conclusion !== "success") {
+  if (missingIntermediateCandidateEvidence) {
+    return denied("review-tail-candidate-merge-tree-evidence-unavailable");
+  }
+  if (unsuccessfulCandidate) {
     return denied("latest-pr-workflow-candidate-not-successful");
   }
-  if (!Number.isInteger(candidate.id) && !/^[1-9][0-9]*$/.test(String(candidate.id || ""))) {
-    return denied("candidate-run-id-unavailable");
-  }
-  return {
-    reuse: true,
-    reason: candidateSource.hasReviewOnlyTail
-      ? "review-tail-green-pr-workflow-reused"
-      : "exact-green-pr-workflow-reused",
-    sourceRunId: String(candidate.id),
-    pullNumber: String(pullRequest.number),
-  };
+  return denied("candidate-run-id-unavailable");
 }


### PR DESCRIPTION
## 목적

`#6279`의 후행 review/PDF tail 재사용 경로를 보완합니다. 성공한 Full CI·CodeQL 후보 뒤에 허용된 PDF 증적과 review 기록이 추가된 경우, 최종 fast-pass run이 아니라 그 Full 후보를 trusted post-merge 재사용 대상으로 선택합니다.

Closes #6279

## 변경

- linear review/PDF tail의 각 commit을 Full 후보로 탐색합니다.
- 중간 review/PDF 후보는 해당 workflow run의 immutable merge-tree artifact가 후보 head를 정확히 가리킬 때만 허용합니다.
- final head의 stale-base merge-tree 증적과 중간 후보 증적을 함께 요구합니다.
- duration artifact, CodeQL Analyze worker, artifact 누락, 비선형 tail, enforcement 변경은 계속 Full lane으로 fail-closed 합니다.

## 검증

- `node --test scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs` - 18/18 통과
- `python3 -m unittest discover -s scripts/tests -p 'test_*workflow.py'` - 171/171 통과
- `actionlint .github/workflows/trusted-postmerge-ci-reuse.yml` 통과
- `git diff --check` 통과

## 범위

CI controller와 계약 테스트만 변경합니다. Rust renderer, fixture, PDF asset은 변경하지 않았습니다.
