### PR TITLE
수정: 여백 있는 빈 본문 문단이 margin_left 를 두 번 먹지 않게 한다 (#5677)

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -1875,6 +1875,11 @@ fn collect_shape_marker_labels(show_ctrl: bool, para: Option<&Paragraph>) -> Vec
     }
 }
 
+/// [#5677] 빈 문단의 저장 `column_start` 가 그 문단 자신의 `margin_left` 와 같다고 볼
+/// 허용치 (HWPUNIT, 2pt). 발행 시 기하 pitch(`snap_base_left`)가 몇 HWPUNIT 을 올릴 수
+/// 있어 정확 일치를 요구하지 않는다. 진짜 어울림 배제는 이보다 훨씬 크게 벌어진다.
+const EMPTY_LINE_OWN_MARGIN_TOLERANCE_HU: i32 = 200;
+
 impl LayoutEngine {
     /// [#5729] 저장 줄 밴드가 정확히 `om_top + 선언높이 + om_bottom` 인 TAC 표는
     /// 한글이 표 상단을 **줄 상단 + om_top** 에 앉힌다 (156505870 4표 실측:
@@ -4070,11 +4075,26 @@ impl LayoutEngine {
                     .and_then(|p| p.line_segs.get(line_idx))
                     .map(|seg| seg.is_in_wrap_zone(col_area_w_hu))
                     .unwrap_or(false);
+            // [#5677] `column_start` 가 **문단 자신의 `margin_left`** 로 설명되면 그
+            // 좁음의 출처는 외부 기하가 아니라 문단 여백이다. 그런 줄에 저장 기하를
+            // 쓰면 `effective_col_x = col_area.x + cs` 로 여백을 한 번 먹고, 아래
+            // `hwp5_stored_line_start_eligible` 이 `!uses_stored_segment_geometry` 를
+            // 요구해 거짓이 되므로 `margin_left` 를 **또** 더한다.
+            //
+            // hwp3-sample 문단 53(빈 본문, `margin_left=18.56px`, 저장 `cs=1392HU`)이
+            // 그 형상으로, 줄 좌단이 단 좌단 + **37.12px**(=2×18.56)에 놓였다.
+            // `ParagraphBox::body_for_style` 의 원점 차단이 `head_type` 을 키로 잡아
+            // `HeadType::None` 인 본문 문단은 빠져 있었는데, 그 주석이 스스로 적어
+            // 두었듯 위험은 목록이 아니라 **비어 있음**에 있다.
+            let own_margin_hu = crate::renderer::px_to_hwpunit(margin_left, self.dpi);
+            let cs_is_own_margin = (comp_line.column_start - own_margin_hu).abs()
+                <= EMPTY_LINE_OWN_MARGIN_TOLERANCE_HU;
             let empty_stored_wrap_line = cell_ctx.is_none()
                 && para
                     .map(|p| p.text.is_empty() && p.controls.is_empty())
                     .unwrap_or(false)
                 && comp_line.column_start > 0
+                && !cs_is_own_margin
                 && comp_line.segment_width > 0
                 && comp_line.segment_width < col_area_w_hu;
             // [#5818] 어울림(Square 계열) float 그림이 있는 **셀** 의 줄도 저장

--- a/tests/cases/issue_5677_empty_body_para_margin_applied_twice.rs
+++ b/tests/cases/issue_5677_empty_body_para_margin_applied_twice.rs
@@ -1,0 +1,128 @@
+//! [#5677] 여백 있는 **빈** 본문 문단이 편집 후 `margin_left` 를 두 번 먹지 않는다.
+//!
+//! `samples/hwp3-sample.hwp` 의 구역 0 문단 53 이 그 형상이다 — 텍스트도 컨트롤도 없고
+//! `ParaShape.margin_left > 0` 이며 `head_type = None`(목록 아님).
+//!
+//! **경로.** 편집이 걸리면 `reflow_line_segs_impl` 이
+//! `column_start = snap_base_left(margin_left)` 을 발행한다(종전에는 0). 그 값이
+//! `ComposedLine` 으로 복사되고 `paragraph_layout` 의 `empty_stored_wrap_line` 이
+//! 발동해 `effective_col_x = col_area.x + column_start` 가 된다. 그런데 같은 자리의
+//! `hwp5_stored_line_start_eligible` 은 `!uses_stored_segment_geometry` 를 요구하므로
+//! 거짓이 되어 `margin_left` 가 **또** 더해진다.
+//!
+//! **차단이 `head_type` 을 키로 잡고 있었다.** `ParagraphBox::body_for_style` 은
+//! 목록(`HeadType != None|Outline`)일 때만 원점 발행을 막는데, 그 주석이 스스로 적어
+//! 두었듯 **위험은 목록이 아니라 "비어 있음"** 에 있다(`issue_1329_bullet_caret`:
+//! 같은 저장 기록인데 빈 줄만 캐럿이 26.6px 어긋난다). `HeadType::None` 인 빈 본문
+//! 문단은 차단에서 빠져 있어 이 경로가 열려 있었다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+use rhwp::renderer::style_resolver::resolve_styles_with_variant;
+use rhwp::renderer::DEFAULT_DPI;
+
+/// 이 형상을 가진 문단 (구역 0).
+const EMPTY_MARGIN_PARA: usize = 53;
+
+fn core() -> DocumentCore {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/hwp3-sample.hwp");
+    let bytes = std::fs::read(path).expect("read hwp3-sample.hwp");
+    DocumentCore::from_bytes(&bytes).expect("parse hwp3-sample.hwp")
+}
+
+/// 문단이 실제로 "여백 있는 빈 본문 문단"인지 — 전제가 상하면 이 시험은 무의미하다.
+fn assert_shape(core: &DocumentCore) -> f64 {
+    let doc = core.document();
+    let para = &doc.sections[0].paragraphs[EMPTY_MARGIN_PARA];
+    assert!(
+        para.text.is_empty() && para.controls.is_empty(),
+        "문단 {EMPTY_MARGIN_PARA} 이 비어 있어야 한다"
+    );
+    let styles = resolve_styles_with_variant(&doc.doc_info, DEFAULT_DPI, true);
+    let style = styles
+        .para_styles
+        .get(para.para_shape_id as usize)
+        .expect("문단 모양");
+    assert!(
+        style.margin_left > 0.0,
+        "문단 {EMPTY_MARGIN_PARA} 은 왼쪽 여백이 있어야 한다: {}",
+        style.margin_left
+    );
+    assert!(
+        matches!(style.head_type, rhwp::model::style::HeadType::None),
+        "이 시험은 목록이 아닌 본문 문단을 다룬다"
+    );
+    style.margin_left
+}
+
+/// `pi` 문단이 그린 첫 줄의 좌단과, 그 줄이 속한 단(Column)의 좌단.
+fn line_and_column_left(root: &RenderNode, pi: usize) -> Option<(f64, f64)> {
+    fn walk(node: &RenderNode, pi: usize, col_x: Option<f64>, out: &mut Option<(f64, f64)>) {
+        let col_x = match &node.node_type {
+            RenderNodeType::Column(_) => Some(node.bbox.x),
+            _ => col_x,
+        };
+        if out.is_none() {
+            if let RenderNodeType::TextLine(line) = &node.node_type {
+                if line.para_index == Some(pi) {
+                    if let Some(cx) = col_x {
+                        *out = Some((node.bbox.x, cx));
+                    }
+                }
+            }
+        }
+        for child in &node.children {
+            walk(child, pi, col_x, out);
+        }
+    }
+    let mut out = None;
+    walk(root, pi, None, &mut out);
+    out
+}
+
+fn find_line_left(core: &DocumentCore, pi: usize) -> (f64, f64) {
+    for page in 1..=12u32 {
+        let Ok(tree) = core.build_page_render_tree(page) else {
+            continue;
+        };
+        if let Some(found) = line_and_column_left(&tree.root, pi) {
+            return found;
+        }
+    }
+    panic!("문단 {pi} 의 줄을 어느 쪽에서도 찾지 못했다");
+}
+
+/// 편집으로 재조판이 걸려도 줄 좌단이 `단 좌단 + margin_left` 를 넘지 않는다.
+///
+/// 종전에는 `col_area.x + margin_left + margin_left` 로 한 번 더 밀렸다.
+#[test]
+fn empty_body_paragraph_keeps_single_margin_after_edit() {
+    let mut core = core();
+    let margin_left = assert_shape(&core);
+    let (before_x, before_col) = find_line_left(&core, EMPTY_MARGIN_PARA);
+
+    // 편집 → 되돌리기. 문단은 다시 비지만 LINE_SEG 는 재발행된 상태다.
+    core.insert_text_native(0, EMPTY_MARGIN_PARA, 0, "X")
+        .expect("insert");
+    core.delete_text_native(0, EMPTY_MARGIN_PARA, 0, 1)
+        .expect("delete");
+    assert!(
+        core.document().sections[0].paragraphs[EMPTY_MARGIN_PARA]
+            .text
+            .is_empty(),
+        "되돌린 뒤에도 빈 문단이어야 한다"
+    );
+
+    let (after_x, after_col) = find_line_left(&core, EMPTY_MARGIN_PARA);
+    let before_inset = before_x - before_col;
+    let after_inset = after_x - after_col;
+    assert!(
+        after_inset <= margin_left + 1.0,
+        "편집 뒤 줄 좌단이 여백을 한 번만 먹어야 한다: \
+         margin_left={margin_left:.2}px, 편집 전 들여쓴 폭={before_inset:.2}px, \
+         편집 후={after_inset:.2}px"
+    );
+}


### PR DESCRIPTION
여백 있는 **빈** 본문 문단의 줄 좌단이 `margin_left` 를 두 번 먹던 것을 고친다. Fixes #5677.

## 재현 — 이슈보다 조건이 넓다

`samples/hwp3-sample.hwp` 구역 0 문단 53 이 그 형상이다 — 텍스트도 컨트롤도 없고
`margin_left = 18.56px`, `head_type = None`(목록 아님).

```
단 좌단 대비 줄 좌단 들여쓴 폭
  편집 전  37.12px   ← 2 × 18.56
  편집 후  37.12px
```

이슈는 "편집 후 재조판"으로 좁혀 잡았지만, 이 문서는 **저장 `cs=1392HU` 가 곧
`margin_left`** 라 편집을 기다릴 것 없이 저장 기록만으로 이미 두 배다. 편집 경로는
`reflow_line_segs_impl` 이 같은 값을 다시 발행해 조건을 넓힐 뿐이다.

## 근인

이슈 본문의 경로 추적이 그대로 맞다.

1. `empty_stored_wrap_line` 이 발동한다 (`text.is_empty() && controls.is_empty() &&
   column_start > 0 && segment_width > 0 && segment_width < col_area_w_hu`)
2. `uses_stored_segment_geometry` 가 참 → `effective_col_x = col_area.x + column_start`
   — 여기서 여백을 **한 번** 먹는다
3. `hwp5_stored_line_start_eligible` 이 `!uses_stored_segment_geometry` 를 요구하므로
   거짓 → `effective_margin_left = margin_left` 가 **또** 더해진다

차단이 있어야 할 자리는 `ParagraphBox::body_for_style` 인데, 거기서는
`head_type` 을 키로 잡는다.

> `with_derivable_origin` … 이유는 계산할 수 없어서가 아니라 렌더 쪽이 **빈** 목록
> 문단에 대해 아직 그것을 소비하지 못하기 때문이다

주석이 스스로 적어 두었듯 **위험은 목록이 아니라 "비어 있음"** 에 있다
(`issue_1329_bullet_caret`: 같은 저장 기록인데 빈 줄만 캐럿이 26.6px 어긋난다).
`HeadType::None` 인 본문 문단은 그 차단에서 빠져 있어 경로가 열려 있었다.

## 수정

발행 계약(`body_for_style`)을 건드리면 저장 파일의 `column_start` 까지 바뀌므로,
**소비 지점**에서 갈랐다 — `column_start` 가 문단 자신의 `margin_left` 로 설명되면
그 좁음의 출처는 외부 기하가 아니므로 저장 기하를 쓰지 않는다.

허용치는 `200 HWPUNIT`(2pt)이다. 발행 시 기하 pitch(`snap_base_left`)가 몇 HWPUNIT 을
올릴 수 있어 정확 일치를 요구하지 않고, 진짜 어울림 배제는 이보다 훨씬 크게 벌어진다
(`#547`·`#1440` 핀의 wrap zone 은 `col_w - 200` 미만을 요구한다).

## 확인 사항 대조

- [x] 차단 조건을 `head_type` 이 아니라 **문단 비어 있음 + cs 출처**로 다시 잡았다
- [x] 여백 있는 빈 본문 문단의 줄 x 가 두 번 밀리지 않는다 (37.12 → 18.56px)
- [ ] `empty_stored_wrap_line` 과 `hwp5_stored_line_start_eligible` 의 전제 통합 —
      이번에는 전자만 좁혔다. 두 술어를 한 출처로 합치는 것은 별건으로 남긴다.

## 검증

- 재현물은 저장소에 이미 있다 — `samples/hwp3-sample.hwp`
- 잠금 시험 1건 — 음성 대조에서 `37.12px` 로 실패한다. 전제(빈 문단·`margin_left>0`·
  `HeadType::None`)를 시험 안에서 먼저 단언해, 문서가 바뀌면 공허하게 통과하지 않는다.
- `cargo clippy --all-targets` 무경고, 변경 파일 `rustfmt`
- 전체 `cargo nextest run --cargo-profile release-test` — 8856건 중 실패 1건은 기존
  `wmf_emf_goldens` CRLF 잡음이다

🤖 Generated with [Claude Code](https://claude.com/claude-code)
