### PR TITLE
test(font): W10 support matrix와 bounded guard를 고정한다 (#4969)

### DIFF
--- a/mydocs/orders/20260831.md
+++ b/mydocs/orders/20260831.md
@@ -94,3 +94,21 @@ date: 2026-08-31
   `MERGEABLE/CLEAN`을 확인했다.
 - [ ] review-only 기록을 별도 commit으로 push하고 trusted fast-pass 및 mergeability를 확인한다.
 - [ ] 최신 head 검증과 별도 병합 승인 뒤 merge commit 방식으로 병합한다.
+
+## #4969 W10-Q5/Q6 PR 제출과 종료 인계
+
+- [x] Q5에서 Q2 horizontal old Hangul과 Q4 vertical HWP5 table-cell을 `bounded-subset`, Q3 variable
+  instance를 `qualified`, 전체를 `bounded-subset`으로 결산했다.
+- [x] 기존 #4969 integration source 3곳에 bounded·malformed·resource guard를 추가하고 focused 117/117,
+  Studio resource 5/5와 native/WASM/workspace lint·build를 통과했다.
+- [x] 지원·fallback·deferred matrix와 #4969·#4960 tracker 게시 전 placeholder/body-drift guard를 고정했다.
+- [x] 원격 branch `task_m100_4969_w10_q5`을 push하고 `devel` 대상 Open PR #6519를 생성했다.
+- [x] 코드 후보 `27f037fd5`의 GitHub Full CI 24 success, 5 expected skip, 실패·대기 0과 언어별
+  CodeQL 성공, `MERGEABLE/CLEAN`을 확인했다.
+- [x] [self-review](../pr/archives/pr_6519_review.md)와
+  [구현 검토](../pr/archives/pr_6519_review_impl.md)에서 차단 finding 0건과 최종 판정 `승인`을 기록했다.
+- [ ] review-only 기록을 같은 branch의 후속 commit으로 push하고 trusted fast-pass·required aggregate와
+  최신 mergeability를 확인한다.
+- [ ] 별도 merge 승인 뒤 정상 merge commit으로 병합한다.
+- [ ] merge SHA·최종 CI를 tracker 초안에 반영하고 별도 승인 뒤 #4969·#4960 현행화·close와 post-merge
+  정리를 수행한다.

--- a/mydocs/plans/task_m100_4969_w10_q5.md
+++ b/mydocs/plans/task_m100_4969_w10_q5.md
@@ -7,7 +7,7 @@
 - **기준 commit**: `upstream/devel@3afbb066fe93724ab44309163a2e04efb954bf18`
 - **worktree**: `/home/edward/mygithub/rhwp-worktrees/task_m100_4969_w10_q5`
 - **작성일**: 2026-08-31 KST
-- **계획 상태**: 메인테이너 승인, Q5-A checkpoint `a8371d976`, Q5-B 결과·checkpoint 생성 승인
+- **계획 상태**: 메인테이너 승인, Q5-A `a8371d976`, Q5-B `0367ac865`, Q5-C 결과·checkpoint 생성 승인
 - **제품 source 변경 기본값**: 0
 
 ## 1. 목적

--- a/mydocs/plans/task_m100_4969_w10_q5.md
+++ b/mydocs/plans/task_m100_4969_w10_q5.md
@@ -7,7 +7,7 @@
 - **기준 commit**: `upstream/devel@3afbb066fe93724ab44309163a2e04efb954bf18`
 - **worktree**: `/home/edward/mygithub/rhwp-worktrees/task_m100_4969_w10_q5`
 - **작성일**: 2026-08-31 KST
-- **계획 상태**: 메인테이너 승인, Q5-A `a8371d976`, Q5-B `0367ac865`, Q5-C 결과·checkpoint 생성 승인
+- **계획 상태**: 메인테이너 승인, Q5-A `a8371d976`, Q5-B `0367ac865`, Q5-C `7d9909791`, Q5-D 결과·checkpoint 생성 승인
 - **제품 source 변경 기본값**: 0
 
 ## 1. 목적

--- a/mydocs/plans/task_m100_4969_w10_q5.md
+++ b/mydocs/plans/task_m100_4969_w10_q5.md
@@ -1,0 +1,162 @@
+# 수행계획 — Task M100 #4969 W10-Q5 bounded 영향·backend parity·성능 결산
+
+- **이슈**: [#4969](https://github.com/edwardkim/rhwp/issues/4969)
+- **상위 tracker**: [#4960](https://github.com/edwardkim/rhwp/issues/4960)
+- **선행 통합**: PR #6493, merge `3afbb066fe93724ab44309163a2e04efb954bf18`
+- **기준 branch**: `task_m100_4969_w10_q5`
+- **기준 commit**: `upstream/devel@3afbb066fe93724ab44309163a2e04efb954bf18`
+- **worktree**: `/home/edward/mygithub/rhwp-worktrees/task_m100_4969_w10_q5`
+- **작성일**: 2026-08-31 KST
+- **계획 상태**: 메인테이너 승인, Q5-A `qualified-evidence-audit` 결과·checkpoint 생성 승인
+- **제품 source 변경 기본값**: 0
+
+## 1. 목적
+
+Q2 horizontal shaping, Q3 variable instance, Q4 bounded vertical table-cell은 각각 독립 절편에서 구현·검증됐고
+PR #6493으로 함께 `devel`에 통합됐다. Q5는 지원 lane을 더 넓히는 구현 단계가 아니다. 세 lane이 같은 현재
+제품 tree에서 다음 조건을 동시에 만족하는지 결산한다.
+
+1. public exact source에서 native와 Docker WASM의 glyph·cluster·position 결정이 일치한다.
+2. backend별 실제 replay와 결정적 TextRun fallback을 지원으로 혼동하지 않는다.
+3. 성능·WASM 크기·resource 상한을 비교 가능한 증적만으로 회계한다.
+4. malformed·oversized·axis/cluster explosion이 부분 publication 없이 fail-closed한다.
+5. 기존 horizontal non-target와 W9 K0/K1 결과가 변하지 않는다.
+
+Q5 결과는 Q6 최종 support matrix와 #4960·#4969 tracker 종료 판단의 입력이다. Q5에서 이슈를 닫거나 release
+범위를 자동 결정하지 않는다.
+
+## 2. 선행 증적과 재사용 원칙
+
+### 2.1 현재 확보된 증적
+
+| lane | 정본 증적 | 현재 알려진 판정 |
+| --- | --- | --- |
+| Q2 horizontal old Hangul | `w10_q2_final_support_classification.json` | `bounded-subset`, native·Node WASM producer qualified, CanvasKit strict GlyphRun, 나머지 backend TextRun fallback |
+| Q3 variable instance | `w10_q3_e5_final_qualification.json` | `qualified`, explicit interior/max만 bounded GlyphRun·GlyphOutline, default 무변화 |
+| Q4 vertical table cell | `w10_q4_d5_c_final_classification.json` + `w10_q4_d5_d_causal_wasm_result.json` | `qualified-bounded-subset`, CanvasKit bounded vertical replay, 나머지 backend fallback |
+| 통합 head | PR #6493 | code candidate Full CI 30 success·4 expected skip, review-only trusted fast-pass 11 success·19 expected skip |
+
+### 2.2 증적 재사용 자격
+
+과거 결과를 날짜나 문서의 `qualified` 문자열만으로 재사용하지 않는다. 각 증적에 대해 다음 네 조건을
+기계적으로 감사한다.
+
+1. 증적 head 또는 checkpoint가 merge commit `3afbb066f`의 조상이다.
+2. 증적 뒤 해당 lane의 제품 owner·fixture·측정 harness에 의미 변경이 없거나, 변경 뒤 재자격화 증적이 있다.
+3. 측정 단위·profile·warm/cold 조건과 artifact identity가 보존돼 있다.
+4. PR #6493의 첫 CI 정정은 integration test 위치만 바꿨고 제품 source를 바꾸지 않았다는 diff가 성립한다.
+
+네 조건을 만족하면 full test·9-process benchmark·clean-room WASM build를 반복하지 않는다. 조건 하나라도
+성립하지 않으면 그 축만 현재 merge head에서 재측정한다. 서로 다른 head의 절대 WASM 크기나 wall time을
+하나의 인과 delta로 빼지 않는다.
+
+## 3. 보호 불변식
+
+1. Q2·Q3·Q4의 지원 tuple, request API, font registry, fallback rule을 확대하거나 변경하지 않는다.
+2. backend가 증명하지 못한 glyph payload는 기존 TextRun 또는 명시된 portable outline으로 닫는다.
+3. partial geometry·sidecar·font resource publication과 backend 재-shaping을 허용하지 않는다.
+4. exact source digest·face index·variation vector·writing mode가 cache identity에서 빠지지 않는다.
+5. font 32 MiB, glyph·cluster·position 4,096, axis·feature·page variant 상한을 완화하지 않는다.
+6. private 10k corpus identity, 로컬 설치 font 경로, Hyper-V·한컴 환경을 사용하지 않는다.
+7. generated integration suite·manifest, `pkg`, `dist`, Cargo marker를 제출하지 않는다.
+8. Q5 측정에서 새 결함이 발견되면 수치로 덮지 않고 원인과 영향면을 분리해 수정 수행계획 승인을 다시 받는다.
+
+## 4. 실행 절편
+
+### Q5-A — merged-head 증적 계보·재사용 감사
+
+1. Q2/Q3/Q4 최종 JSON과 checkpoint가 현재 merge commit의 조상인지 확인한다.
+2. 각 checkpoint부터 `3afbb066f`까지 제품 source·fixture·harness 변경을 경로별로 분류한다.
+3. PR #6493 code candidate와 trailing review-only commit의 제품 diff가 0인지 확인한다.
+4. 각 성능·WASM·backend 증적을 `reusable`, `focused-refresh`, `full-refresh`, `not-comparable`로 분류한다.
+5. 감사 결과를 `mydocs/tech/investigations/issue-4969/w10_q5_evidence_eligibility.json`에 고정한다.
+
+**종료 게이트**: 모든 재사용 주장에 source head·current head·경로 overlap·판정 사유가 있고, 근거 없는 재실행과
+근거 없는 재사용이 모두 0이다.
+
+### Q5-B — 세 공개 face의 merged-head canonical parity
+
+대상 face는 Q0에서 동결한 다음 세 개다.
+
+- `NotoSansKR-Regular.ttf` — horizontal/vertical control
+- `SourceHanSerifK-OldHangul-subset.otf` — old Hangul horizontal complex shaping
+- `HappinessSansVF.ttf` — explicit default/interior/max variable instance
+
+1. 기존 #4969 integration source와 Studio E2E만 사용해 native canonical glyph decision을 생성한다.
+2. 같은 request·exact source로 Docker WASM canonical output을 생성하고 glyph ID, UTF-8/UTF-16 cluster,
+   x/y advance·offset, position, bbox와 next origin을 대조한다.
+3. CanvasKit은 현재 지원 tuple에서 실제 glyph/outline draw와 pixel proof를 확인한다.
+4. SVG·Canvas2D·Native Skia는 지원하지 않는 tuple에서 TextRun fallback이 유지되는지 확인한다.
+5. 새 integration source가 필요해지면 이 절편을 중단하고 이유·예상 CI 비용을 포함한 수정 계획을 먼저 승인받는다.
+
+**종료 게이트**: 지원 tuple native↔WASM canonical mismatch 0, CanvasKit replay mismatch 0, unsupported backend
+false selection 0, fallback disappearance 0.
+
+### Q5-C — bounded·malformed·atomic rollback 회계
+
+1. Q2의 font/text/glyph/cluster 상한과 wrong·stale·oversized resource key를 재검증한다.
+2. Q3의 duplicate/unknown/out-of-range/non-finite axis, axis count와 instance/page variant 상한을 재검증한다.
+3. Q4의 missing `vhea`/`vmtx`, malformed SFNT, tuple mismatch, unsupported writing mode/backend를 재검증한다.
+4. 거부마다 structured reason, TextRun 보존, geometry·sidecar·resource mutation 0을 한 표로 회계한다.
+5. axis·cluster explosion은 실제 무제한 payload를 만들지 않고 상한+1의 bounded synthetic input으로 검증한다.
+
+**종료 게이트**: 제한 완화 0, panic/OOM 0, partial publication 0, reason 누락 0.
+
+### Q5-D — 성능·WASM·resource 영향 결산
+
+1. Q5-A에서 재사용 가능한 Q2/Q3/Q4 측정 조건과 값을 하나의 ledger로 옮기되 서로 다른 head의 값은
+   별도 snapshot으로 유지한다.
+2. merge head에서 무효화된 축만 기존 ignored receipt를 명시적으로 실행해 focused refresh한다.
+3. Q2 1/2/8 run·page, Q3 1/2/8 instance×run, Q4 A/B/A 구조에서 source digest·parse·blob·face·payload의
+   unique-source/instance 선형성을 확인한다.
+4. wall time은 동일 host·profile·warmup·iteration인 경우만 비교한다. cold 최초값과 환경이 다른 값에는
+   사후 hard gate를 만들지 않는다.
+5. WASM은 Q3 causal +51,554 bytes(+0.528251%)와 Q4 same-tree causal +36,611 bytes(+0.371371668%)를
+   독립 변화로 보존한다. 합산을 현재 통합 causal delta로 주장하지 않는다. 현재 build 확인이 필요하면 절대
+   bytes·digest만 새 receipt로 기록한다.
+
+**종료 게이트**: 비교 불가능한 값의 산술 결합 0, resource multiplicity 증가 0, 현재 지원 subset의 성능·size
+영향과 한계가 재현 가능한 조건과 함께 기록된다.
+
+### Q5-E — 최종 Q5 판정과 Q6 인계
+
+1. horizontal, variation, vertical lane별 parity·fallback·limit·performance 결과를 종합한다.
+2. lane별 판정을 `qualified`, `bounded-subset`, `blocked` 중 하나로 고정한다.
+3. 미지원 surface와 별도 사용자 여정·oracle이 필요한 항목은 제품 지원으로 계산하지 않고 Q6의 후속 이슈
+   후보로 넘긴다.
+4. 결과 보고서 `mydocs/working/task_m100_4969_w10_q5.md`와 기계 판독 JSON
+   `w10_q5_final_qualification.json`을 작성한다.
+5. 결과 승인과 checkpoint 승인을 받은 뒤에만 Q6 최종 보고·tracker 현행화 계획으로 이동한다.
+
+**Q5 완료 조건**: parity mismatch 0, 기존 horizontal non-target 회귀 0, fail-closed 위반 0, 성능·WASM·resource
+회계 공백 0. 하나라도 미충족이면 Q5를 완료로 표기하지 않는다.
+
+## 5. 검증 범위
+
+Q5-A에서 자격이 확인된 기존 Full CI·full nextest·Native Skia·Docker WASM 결과는 반복하지 않는다. merged-head
+focused refresh는 기존 router와 source만 사용하며 실제 선택 건수를 먼저 확인한다.
+
+기본 후보 명령은 다음과 같다. 정확한 generated suite 번호를 하드코딩하지 않고 manifest/router에서 찾는다.
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+node scripts/rust-unit-test-tiers.mjs --check
+node scripts/rust-test-suite-manifest.mjs --prepare
+node scripts/rust-test-suite-manifest.mjs --check
+cargo nextest run --locked --cargo-profile release-test \
+  --target-dir /home/edward/mygithub/rhwp/target/pr-review --tests \
+  -E 'test(/issue_4969/)'
+node --test rhwp-studio/e2e/issue-4969-shaping-replay.test.mjs
+git diff --check
+```
+
+Docker WASM·actual CanvasKit·ignored performance receipt는 Q5-A가 해당 증적을 `focused-refresh` 또는
+`full-refresh`로 판정한 축만 실행한다. PR 준비 단계의 전체 검증은 Q5 결과 승인 뒤 별도 승인을 받는다.
+
+## 6. 변경·승인 경계
+
+- 이 계획 승인 전에는 Q5-A 감사 외 제품 구현과 성능 재실행을 시작하지 않는다.
+- Q5-A 결과가 제품 결함이나 harness 결손을 발견하면 자동 수정하지 않고 수정 수행계획을 작성한다.
+- commit, remote push, GitHub issue edit/comment, PR 생성, merge, #4969·#4960 close는 각각 별도 승인 대상이다.
+- Q6는 Q5 결과 승인 뒤 별도 수행계획으로 작성한다. Q5 계획이 Q6 tracker mutation을 승인하지 않는다.

--- a/mydocs/plans/task_m100_4969_w10_q5.md
+++ b/mydocs/plans/task_m100_4969_w10_q5.md
@@ -7,7 +7,7 @@
 - **기준 commit**: `upstream/devel@3afbb066fe93724ab44309163a2e04efb954bf18`
 - **worktree**: `/home/edward/mygithub/rhwp-worktrees/task_m100_4969_w10_q5`
 - **작성일**: 2026-08-31 KST
-- **계획 상태**: 메인테이너 승인, Q5-A `qualified-evidence-audit` 결과·checkpoint 생성 승인
+- **계획 상태**: 메인테이너 승인, Q5-A checkpoint `a8371d976`, Q5-B 결과·checkpoint 생성 승인
 - **제품 source 변경 기본값**: 0
 
 ## 1. 목적

--- a/mydocs/plans/task_m100_4969_w10_q5.md
+++ b/mydocs/plans/task_m100_4969_w10_q5.md
@@ -7,7 +7,7 @@
 - **기준 commit**: `upstream/devel@3afbb066fe93724ab44309163a2e04efb954bf18`
 - **worktree**: `/home/edward/mygithub/rhwp-worktrees/task_m100_4969_w10_q5`
 - **작성일**: 2026-08-31 KST
-- **계획 상태**: 메인테이너 승인, Q5-A `a8371d976`, Q5-B `0367ac865`, Q5-C `7d9909791`, Q5-D 결과·checkpoint 생성 승인
+- **계획 상태**: 완료 승인, Q5-A `a8371d976`, Q5-B `0367ac865`, Q5-C `7d9909791`, Q5-D `4d107fe09`, Q5-E 결과·checkpoint 생성 승인
 - **제품 source 변경 기본값**: 0
 
 ## 1. 목적

--- a/mydocs/plans/task_m100_4969_w10_q6.md
+++ b/mydocs/plans/task_m100_4969_w10_q6.md
@@ -1,0 +1,198 @@
+# 수행계획 — Task M100 #4969 W10-Q6 최종 판정·tracker 종료·릴리즈 인계
+
+- **이슈**: [#4969](https://github.com/edwardkim/rhwp/issues/4969)
+- **상위 tracker**: [#4960](https://github.com/edwardkim/rhwp/issues/4960)
+- **선행 통합**: PR #6493, merge `3afbb066fe93724ab44309163a2e04efb954bf18`
+- **Q5 최종 checkpoint**: `cf1536a9c91bd2726455308e19259542ba3e2f49`
+- **작업 branch**: `task_m100_4969_w10_q5` 계속 사용
+- **worktree**: `/home/edward/mygithub/rhwp-worktrees/task_m100_4969_w10_q5`
+- **작성 기준일**: 2026-08-31 KST
+- **계획 상태**: 메인테이너 명시 승인, Q6-A 진입 승인
+- **제품 source 변경 기본값**: 0
+
+## 1. 목적
+
+Q6는 새 font 기능을 구현하거나 지원 lane을 넓히는 단계가 아니다. Q5가 확정한 Q2 horizontal old Hangul,
+Q3 variable instance, Q4 vertical HWP5 table-cell의 실제 지원·fallback·미지원 경계를 하나의 공개 support
+matrix로 고정하고, Q5에서 추가한 test guard와 증적을 PR로 제출한 뒤 #4969와 #4960 tracker를 실제 merge
+결과로 종료하는 단계다.
+
+Q5 최종 분류는 Q2 `bounded-subset`, Q3 `qualified`, Q4 `bounded-subset`, 전체 `bounded-subset`이다. Q6는 이
+등급을 `qualified`로 상향하거나 deferred surface를 완료로 계산하지 않는다.
+
+## 2. 현재 원격·tracker 기준점
+
+2026-08-31 KST 읽기 전용 재조회 결과는 다음과 같다.
+
+- `upstream/devel`: `3afbb066fe93724ab44309163a2e04efb954bf18`
+- 현재 Q5 head: `cf1536a9c91bd2726455308e19259542ba3e2f49`, `5 ahead / 0 behind`
+- merge-base: `3afbb066fe93724ab44309163a2e04efb954bf18`
+- 같은 head branch의 기존 PR: 없음
+- #4969: OPEN, 마지막 comment는 PR #6493 merge와 “Q5/Q6 남음” 상태
+- #4960: OPEN, 본문은 아직 Q2-D4·Q2-D5 대기 상태로 W10 진행 상황이 낡음
+
+따라서 현재는 base merge가 필요하지 않다. PR push 직전 다시 fetch하며 `upstream/devel`이 전진했으면 먼저
+경로 overlap과 merge simulation을 수행한다. 충돌 또는 제품 owner overlap이 있으면 자동 병합하지 않고 수정
+계획 승인을 받는다. 별도 Q6 branch를 만들지 않고 현재 #4969 계보를 이어 고아 branch 생성을 피한다.
+
+## 3. 보호 불변식
+
+1. Q2·Q3·Q4의 predicate, public API, schema, fallback order와 resource 상한을 바꾸지 않는다.
+2. `bounded-subset`을 일반 script·axis·writing-mode 지원으로 확대 해석하지 않는다.
+3. Q4-D5-C의 역사적 blocked 기록은 삭제하지 않고 D5-D가 blocker를 해소한 계보를 함께 남긴다.
+4. tracker에는 실제 PR 번호·merge SHA·최종 CI만 기록하며 placeholder를 게시하지 않는다.
+5. PR merge 전에는 #4969·#4960을 완료 표시하거나 close하지 않는다.
+6. 일부 required check가 실패·대기이거나 support matrix와 구현이 다르면 tracker 종료를 중단한다.
+7. generated integration suite·manifest, `pkg`, `dist`, target과 private corpus identity를 제출하지 않는다.
+8. remote push, PR 생성, ready 전환, self-review 게시, merge, tracker edit/comment와 close는 각각 승인 경계를
+   유지한다.
+
+## 4. 실행 절편
+
+### Q6-A — 최종 support·unsupported matrix 동결
+
+Q5 최종 JSON을 소비해 사람용 표와 기계 판독 matrix를 작성한다. 각 행은 최소한 다음 필드를 가진다.
+
+- face/source identity와 provenance
+- table·script·language·axis·writing mode predicate
+- native·Node WASM producer 자격
+- CanvasKit·Canvas2D·legacy SVG·Native Skia disposition
+- glyph/cluster/axis/resource 상한
+- rejection reason과 TextRun·legacy geometry fallback owner
+- 현재 지원인지 deferred인지, 후속 사용자 여정·oracle이 필요한지
+
+고정할 핵심 범위는 다음과 같다.
+
+| lane | 지원 범위 | 미지원·fallback |
+| --- | --- | --- |
+| Q2 | Source Han old Hangul, horizontal-tb·LTR·bidi 0, strict stored boundary 또는 bounded no-LineSeg atomic lane | RTL/bidi, 일반 liga, multi-line/run, mixed split, 일반 edit reflow 등은 W9 K1/K0 TextRun |
+| Q3 | Happiness Sans VF의 canonical `wght`·`opsz`, explicit default/interior/max, CanvasKit portable outline | 축 추론·heuristic, invalid/incomplete instance와 미지원 backend는 TextRun atomic rollback |
+| Q4 | exact source와 vhea/vmtx가 있는 bounded HWP5 vertical table-cell v1, CanvasKit | mixed run, 다른 backend, missing/malformed metrics·tuple은 TextRun+legacy vertical geometry |
+
+**종료 게이트**: Q5 JSON과 matrix 불일치 0, deferred를 지원으로 계산한 행 0, fallback owner·reason 누락 0.
+
+### Q6-B — #4969·#4960 tracker 현행화 초안
+
+GitHub에는 쓰지 않고 로컬에 다음 세 문안을 준비한다.
+
+1. #4969 최종 comment: Q2~Q5 결과, Q6 support matrix, PR/merge/CI, 잔여 deferred 범위와 close 근거
+2. #4960 본문 patch: W10 checkbox와 최근 실행 표를 실제 최종 상태로 교체
+3. #4960 최종 comment: W0~W10 완료 계보, release 인계, 미지원 범위가 fail-closed임을 명시
+
+PR 번호·merge SHA·CI URL이 아직 없을 때는 명시적 placeholder로 로컬에만 두고 게시하지 않는다. #4969
+본문의 원 문제·범위·불변식은 역사적 요구사항이므로 통째로 다시 쓰지 않는다. #4960 본문은 낡은 W10 상태
+행만 최소 변경한다.
+
+**종료 게이트**: 두 issue의 현재 body SHA-256·updatedAt을 receipt에 기록하고, patch 대상이 재조회 body와 정확히
+일치하며, 게시 전 placeholder 0을 기계 확인할 방법이 있다.
+
+### Q6-C — 제출 diff·최신 base·로컬 검증
+
+현재 Q5 diff는 제품 source 0, 기존 `tests/cases/` integration source 3곳의 guard와 계획·결과·기계 증적이다.
+Q6 문서는 이 제출에 합친다.
+
+1. `git fetch upstream devel` 뒤 ahead/behind·merge-base·경로 overlap을 다시 확인한다.
+2. upstream이 전진하지 않았으면 현재 선형 계보를 유지한다.
+3. upstream이 전진했으면 merge simulation과 문서·test owner overlap을 먼저 보고하고, 승인 뒤 정상 merge
+   commit으로 통합한다. rebase·squash·고아 branch는 사용하지 않는다.
+4. Rust test helper 변경이므로 `local_validation.md` 4.3의 모든 Rust lint 묶음과 focused test를 실행한다.
+5. Q5-A가 자격화한 PR #6493 full 회귀·Native Skia와 Q5-B Docker WASM·CanvasKit은 제품 source가 같은 동안
+   재사용한다. base incoming이 renderer/layout/WASM owner와 겹치면 해당 축만 다시 실행한다.
+6. generated suite·manifest는 review worktree에만 준비하고 stage하지 않는다.
+
+기본 명령은 다음과 같다.
+
+```bash
+node scripts/rust-test-suite-manifest.mjs --prepare
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --locked --target-dir /home/edward/mygithub/rhwp/target/pr-review -- -D warnings
+cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown \
+  --target-dir /home/edward/mygithub/rhwp/target/pr-review -- -D warnings
+cargo build --locked --workspace --target-dir /home/edward/mygithub/rhwp/target/pr-review
+cargo clippy --locked --workspace --all-targets \
+  --target-dir /home/edward/mygithub/rhwp/target/pr-review -- -D warnings
+node scripts/rust-test-suite-manifest.mjs --check
+cargo nextest run --locked --cargo-profile release-test \
+  --target-dir /home/edward/mygithub/rhwp/target/pr-review --tests \
+  -E 'test(/issue_4969/)' --no-fail-fast
+node --test rhwp-studio/tests/issue-4969-font-resource-reuse.test.ts
+git diff --check
+```
+
+Studio 분리 worktree 의존성은 기본 checkout의 설치 tree를 검증 중에만 연결하고 즉시 제거한다. shared
+`target/pr-review`는 보존한다. worktree-local `target`을 만들지 않는다.
+
+**종료 게이트**: lint·focused 검증 실패 0, 제출된 generated artifact 0, 최신 base conflict·owner overlap 미해결 0.
+
+### Q6-D — PR 생성·CI·self-review
+
+Q6-C 결과와 제출 checkpoint 승인 뒤에만 remote push와 PR 생성을 각각 승인받는다. PR은 `devel`을 base로
+하고 issue #4969를 연결하되 merge 전 자동 close 문구는 쓰지 않는다. branch diff가 제품 source 0과 기존
+integration source guard 3곳임을 본문에 명시한다.
+
+PR 생성 뒤 다음을 수행한다.
+
+1. 게시된 본문의 한글·선두 BOM·`??` 치환을 API로 검증한다.
+2. 최신 code head의 CI·CodeQL·Render Diff·Native Skia·Docker WASM 및 expected skip을 확인한다.
+3. required check가 모두 성공한 뒤 source·test·문서·증적을 self-review하고 review 문서를 추가한다.
+4. review 문서만 추가한 trailing head는 trusted fast-pass 정책이 정확히 적용되는지 확인한다.
+5. 실패는 우회하지 않고 원인·영향도를 판정해 Draft 전환 또는 수정 계획 승인을 받는다.
+
+**종료 게이트**: code candidate required check 실패·대기 0, self-review blocker 0, PR body와 실제 diff 불일치 0.
+
+### Q6-E — 정상 merge와 로컬 동기화
+
+CI와 self-review 결과 승인 뒤 merge 승인을 별도로 받는다. 저장소 기본 원칙에 따라 merge commit 방식으로
+병합하며 squash하지 않는다. 병합 뒤 실제 merge SHA와 PR check 결론을 재조회한다.
+
+그 다음 기본 checkout의 사용자 WIP가 없는지 확인하고 `devel`을 최신 `upstream/devel`과 동기화한다. 작업
+branch/worktree 정리는 merge·tracker 후속 처리까지 증적이 필요하므로 먼저 삭제하지 않는다.
+
+**종료 게이트**: PR state MERGED, 실제 merge SHA 확보, 로컬 devel ahead/behind 0, 사용자 WIP 손실 0.
+
+### Q6-F — tracker 반영·issue 종료·release 인계
+
+Q6-B 초안을 실제 PR 번호·merge SHA·CI 결과로 채운 뒤 GitHub mutation 승인을 받는다. 게시 직전 두 issue를
+재조회해 body drift가 있으면 patch를 재작성한다.
+
+승인 뒤 순서는 다음과 같다.
+
+1. #4969 최종 comment 게시·API 검증
+2. #4960 W10 본문 최소 patch·API 검증
+3. #4960 최종 comment 게시·API 검증
+4. #4969 close
+5. #4960의 모든 W0~W10 완료와 release 인계가 실제로 성립하는지 마지막 감사 후 close
+
+deferred surface는 별도 이슈 후보 목록으로만 남긴다. Q6 계획은 새 이슈의 자동 등록이나 담당자 지정을
+승인하지 않는다. 하나라도 lane이 최종 `blocked`로 바뀌거나 PR이 merge되지 않으면 두 issue를 닫지 않는다.
+
+**완료 게이트**: #4969·#4960 본문/comment가 실제 merge와 support matrix를 반영하고, 두 issue close 근거와
+release 인계가 검증되며, 게시 문자열 손상 0.
+
+## 5. 산출물
+
+- `mydocs/tech/investigations/issue-4969/w10_q6_support_matrix.json`
+- `mydocs/working/task_m100_4969_w10_q6.md`
+- `mydocs/working/task_m100_4969_w10_q6_tracker_drafts.md`
+- PR self-review 문서와 저장소 절차가 요구하는 review 증적
+- #4969·#4960 게시 뒤 API verification receipt
+
+문서 이름은 실행 중 기존 manifest의 역할·canonical 관계와 충돌하지 않는지 확인한 뒤 고정한다.
+
+## 6. 승인 경계
+
+이 계획 승인은 Q6-A 분석·로컬 산출물 작성만 승인한다. 다음은 각각 별도 승인 대상이다.
+
+- Q6-A 결과·checkpoint
+- Q6-B tracker draft 결과·checkpoint
+- Q6-C base merge가 필요한 경우의 merge와 검증 시작
+- Q6-C 제출 checkpoint
+- remote push
+- PR 생성·ready 전환
+- self-review 게시
+- merge
+- #4969·#4960 body/comment mutation과 close
+- 후속 issue 등록
+
+Q6가 완료돼도 릴리즈 자체, `main` merge, tag·package 배포를 자동 승인하지 않는다.

--- a/mydocs/plans/task_m100_4969_w10_q6.md
+++ b/mydocs/plans/task_m100_4969_w10_q6.md
@@ -7,7 +7,7 @@
 - **작업 branch**: `task_m100_4969_w10_q5` 계속 사용
 - **worktree**: `/home/edward/mygithub/rhwp-worktrees/task_m100_4969_w10_q5`
 - **작성 기준일**: 2026-08-31 KST
-- **계획 상태**: 메인테이너 명시 승인, Q6-A `8258f0284`, Q6-B 결과·checkpoint 생성 승인
+- **계획 상태**: 메인테이너 명시 승인, Q6-A `8258f0284`, Q6-B `6a9656dff`, Q6-C 결과·checkpoint 생성 승인
 - **제품 source 변경 기본값**: 0
 
 ## 1. 목적

--- a/mydocs/plans/task_m100_4969_w10_q6.md
+++ b/mydocs/plans/task_m100_4969_w10_q6.md
@@ -7,7 +7,7 @@
 - **작업 branch**: `task_m100_4969_w10_q5` 계속 사용
 - **worktree**: `/home/edward/mygithub/rhwp-worktrees/task_m100_4969_w10_q5`
 - **작성 기준일**: 2026-08-31 KST
-- **계획 상태**: 메인테이너 명시 승인, Q6-A 진입 승인
+- **계획 상태**: 메인테이너 명시 승인, Q6-A 결과·checkpoint 생성 승인
 - **제품 source 변경 기본값**: 0
 
 ## 1. 목적

--- a/mydocs/plans/task_m100_4969_w10_q6.md
+++ b/mydocs/plans/task_m100_4969_w10_q6.md
@@ -7,7 +7,7 @@
 - **작업 branch**: `task_m100_4969_w10_q5` 계속 사용
 - **worktree**: `/home/edward/mygithub/rhwp-worktrees/task_m100_4969_w10_q5`
 - **작성 기준일**: 2026-08-31 KST
-- **계획 상태**: 메인테이너 명시 승인, Q6-A 결과·checkpoint 생성 승인
+- **계획 상태**: 메인테이너 명시 승인, Q6-A `8258f0284`, Q6-B 결과·checkpoint 생성 승인
 - **제품 source 변경 기본값**: 0
 
 ## 1. 목적

--- a/mydocs/pr/archives/pr_6519_review.md
+++ b/mydocs/pr/archives/pr_6519_review.md
@@ -1,0 +1,92 @@
+---
+kind: pr-review
+status: approved
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-31
+pr: 6519
+issue: 4969
+author: edwardkim
+---
+
+# PR #6519 review - W10 support matrix와 bounded guard
+
+## 결론 - 승인, review-only 기록 검증 대기
+
+[PR #6519](https://github.com/edwardkim/rhwp/pull/6519)은 #4969 W10-Q5의 세 lane 결산과 Q6의
+최종 support matrix·tracker 인계 자료를 제출한다. self-review 대상 코드 후보는
+`27f037fd5c755660d3bc81e06c7f894ba86bef54`, base는
+`upstream/devel@3afbb066fe93724ab44309163a2e04efb954bf18`이다. 로컬 검증과 코드 후보의
+GitHub Full CI에서 차단 결함을 발견하지 않았다. 문서 작성 시점에 PR은 `MERGEABLE/CLEAN`이며,
+이 review-only 기록의 fast-pass와 최신 mergeability를 확인하기 전에는 병합하지 않는다.
+
+## 검토 경로와 metadata
+
+- 기본 경로: `collaborator_self_merge.md`
+- 보조 경로: `intake_and_review.md`, `local_validation.md`, `review_only_fast_pass.md`
+- self PR이므로 reviewer를 지정하지 않는다.
+- 변경 규모: 22 files, +3,107/-2, 9 commits
+- 변경 경계: mydocs 19 paths, 기존 `tests/cases/` integration source 3 paths
+- 제품·Studio·workflow source, 신규 integration source, generated suite·manifest: 0
+- 관련 tracker: #4969, #4960. PR 본문은 `Refs`만 사용해 merge 전 자동 close를 막았다.
+
+## 변경과 지원 경계
+
+- Q2 horizontal old Hangul은 동결된 Source Han exact-source tuple에서만 `bounded-subset`이며,
+  그 밖의 surface는 W9 K1 또는 K0 TextRun fallback을 유지한다.
+- Q3 variable instance는 Happiness Sans VF의 explicit default/interior/max 계약에서 `qualified`다.
+  invalid·incomplete instance와 미지원 backend는 원자적으로 TextRun으로 되돌아간다.
+- Q4 vertical은 exact Noto source와 `vhea`·`vmtx`, HWP5 table-cell v1, CanvasKit이 모두 성립하는
+  tuple만 `bounded-subset`이다. 나머지는 TextRun과 기존 vertical geometry를 보존한다.
+- 전체 분류는 `bounded-subset`이다. deferred surface를 현재 지원이나 실패 건수로 계산하지 않았다.
+- tracker 문안의 PR·merge·CI placeholder는 로컬 초안에만 있으며 merge 전 게시를 막는 receipt가 있다.
+
+## self-review 결과
+
+- Q2 1/2/8 run resource matrix는 run 수와 무관하게 font blob·face가 exact source당 하나이고,
+  TextRun과 GlyphRun 수가 요청 수와 일치하는지 확인한다.
+- Q3 guard는 exact-source slot과 instance-request 상한이 모두 4,096으로 결합됐음을 확인한다. 작은 공개
+  fixture 하나를 공유해 4,096 slots/requests를 채우고, source 없는 4,097번째 요청이 count·generation을
+  바꾸지 않는지 검증한다.
+- Q4 guard는 4,096 sidecar를 채운 뒤 4,097번째 attach가 `EntryLimitExceeded`로 끝나고 len·generation이
+  그대로인지 확인한다. oversized payload나 무제한 allocation을 만들지 않는다.
+- 세 guard는 기존 #4969 integration source 안에 있으며 crate-private owner를 직접 포함하는 기존 계약을
+  따른다. 제품 API나 지원 predicate를 넓히지 않는다.
+- support matrix, lane 판정, 성능·WASM ledger와 테스트 상수 사이의 불일치를 발견하지 않았다.
+- 새 sample, PDF, font binary, private corpus 결과, Hyper-V·한컴 Oracle 자료는 포함하지 않았다.
+- 차단 finding: 없음.
+
+## 렌더·시각 영향 판정
+
+제품 renderer·layout·WASM adapter·Studio source diff가 0이므로 이 PR 자체의 신규 시각 sweep은 필요하지
+않다. Q5-A에서 PR #6493의 제품 tree와 증적 계보를 자격화했고, Q5-B에서 같은 제품 tree의 native↔WASM
+canonical mismatch 0, CanvasKit replay·pixel mismatch 0을 다시 고정했다. 이 증적 재사용은 제품 source가
+변하지 않은 범위에 한정한다.
+
+## 로컬 검증
+
+- integration manifest: 1,075 sources / 4,718 attrs / 28 suites + 20 exceptions = 48/48
+- `cargo fmt --all`, `cargo fmt --all -- --check`, `git diff --check` - passed
+- native root, wasm32 library, workspace all-target Clippy `-D warnings` - passed
+- workspace build - passed
+- #4969 focused nextest: 117 passed / 0 failed / 8,795 non-selected
+- Q5-C bounded·malformed·atomic rollback: 50/50 passed
+- Q5-D resource focused: 2/2 passed
+- Studio font resource reuse: 5/5 passed
+- source unit tier: 4,221 tests / 299 modules, policy check passed
+- shared `target/pr-review`만 사용했고 generated suite·manifest를 stage하지 않았다.
+
+## 코드 후보 GitHub Actions
+
+코드 후보 `27f037fd5`에서 24 success, 5 expected skip, 실패·대기 0을 확인했다. GHAS 집계
+`CodeQL` 1건은 `NEUTRAL`이고 같은 run의 JavaScript/TypeScript·Python·Rust Analyze는 모두 성공했다.
+CI Build & Test, Lint, archive A/B/C/D와 각 default-feature shard, Proptest, Adapter inter-diff도 성공했다.
+제품·Studio source가 없는 변경 범위에 따른 Native Skia, WASM Build, frontend gate skip은 정책상 정상이다.
+
+## 최종 판정
+
+- 판정: 승인
+- 근거: support matrix와 구현 경계가 일치하고, bounded guard·fallback·resource 회계가 로컬 및 최신 코드
+  후보 CI를 통과했으며 self-review 차단 finding이 없다.
+- merge 전 조건: review-only trailing head의 fast-pass와 required aggregate 성공, 최신 head SHA,
+  `MERGEABLE/CLEAN`, 메인테이너의 별도 merge 승인.
+- 원격 조치: 이 기록 자체는 issue edit/comment/close 또는 merge를 수행하지 않는다.

--- a/mydocs/pr/archives/pr_6519_review_impl.md
+++ b/mydocs/pr/archives/pr_6519_review_impl.md
@@ -1,0 +1,47 @@
+---
+kind: pr-review-implementation
+status: approved
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-31
+pr: 6519
+issue: 4969
+---
+
+# PR #6519 구현 검토 - #4969 W10-Q5/Q6 종료 인계
+
+## 제출 계보
+
+1. Q5-A `a8371d976`에서 PR #6493 이후 Q2/Q3/Q4 증적의 현재 merge-tree 재사용 자격을 감사했다.
+2. Q5-B `0367ac865`에서 세 공개 face의 native·WASM canonical parity와 backend disposition을 고정했다.
+3. Q5-C `7d9909791`에서 bounded·malformed·atomic rollback guard를 기존 integration source에 추가했다.
+4. Q5-D `4d107fe09`에서 1/2/8 resource multiplicity와 성능·WASM ledger를 결산했다.
+5. Q5-E `cf1536a9c`에서 Q2·Q4 `bounded-subset`, Q3 `qualified`, 전체 `bounded-subset`으로 판정했다.
+6. Q6-A~C `8258f0284`~`27f037fd5`에서 최종 support matrix, tracker 게시 전 guard와 제출 검증을 고정했다.
+7. 코드 후보 `27f037fd5`의 GitHub Full CI는 24 success, 5 expected skip, 실패·대기 0으로 완료됐다.
+
+## 보호 불변식
+
+- exact source·capability·지원 tuple이 모두 확인되기 전에는 GlyphRun/outline을 게시하지 않는다.
+- reject 뒤 geometry, sidecar, measurement, cache와 font resource를 부분 변경하지 않는다.
+- font 32 MiB, glyph·cluster·text 4,096, axis 16, feature 64와 registry 상한을 완화하지 않는다.
+- backend가 증명하지 못한 payload는 기존 TextRun 또는 검증된 portable outline으로 닫는다.
+- deferred surface, private corpus·설치 font·Hyper-V·한컴 결과를 현재 제품 지원으로 계산하지 않는다.
+- tracker에는 실제 PR·merge SHA·최종 CI만 게시하며 placeholder가 남으면 중단한다.
+
+## trailing review-only 처리
+
+1. 이 review, 구현 검토와 오늘할일만 코드 후보 뒤 single-parent commit으로 추가한다.
+2. `cargo fmt --all`, `cargo fmt --all -- --check`, 문서 링크·diff 검사를 통과한 뒤 같은 source branch에
+   push한다.
+3. preflight가 코드 후보 `27f037fd5`의 Full CI를 재사용하고 latest head의 required aggregate가 성공하는지
+   확인한다. base 전진만을 이유로 update branch·merge·rebase하지 않는다.
+4. latest head SHA, `MERGEABLE/CLEAN`, 실패·대기 0을 확인한 뒤 별도 merge 승인을 요청한다.
+
+## merge와 tracker 후속
+
+1. 승인 뒤 squash가 아닌 정상 merge commit 방식으로 PR #6519를 병합한다.
+2. merge commit ancestry와 PR tree, #4969·#4960의 최신 body hash·상태를 다시 확인한다.
+3. 별도 승인 뒤 로컬 tracker 초안의 placeholder를 실제 PR·merge·CI 값으로 치환하고 body drift가 없을 때만
+   #4969 comment, #4960 최소 body patch와 comment를 게시한다.
+4. #4969와 #4960은 실제 merge·tracker 감사 뒤에만 close한다.
+5. post-merge 검증과 원격 `devel` 동기화를 끝낸 뒤 이 PR 전용 branch/worktree 정리를 수행한다.

--- a/mydocs/tech/investigations/issue-4969/w10_q5_b_canonical_parity.json
+++ b/mydocs/tech/investigations/issue-4969/w10_q5_b_canonical_parity.json
@@ -1,0 +1,151 @@
+{
+  "schemaVersion": 1,
+  "kind": "font-w10-q5-merged-head-canonical-parity",
+  "issue": 4969,
+  "stage": "W10-Q5-B",
+  "date": "2026-08-31",
+  "status": "qualified-approved",
+  "planApproval": "explicit",
+  "resultApproval": "explicit",
+  "checkpointApproved": true,
+  "current": {
+    "branch": "task_m100_4969_w10_q5",
+    "productMergeHead": "3afbb066fe93724ab44309163a2e04efb954bf18",
+    "q5AEvidenceCheckpoint": "a8371d976",
+    "productMutation": false
+  },
+  "faces": [
+    {
+      "name": "NotoSansKR-Regular.ttf",
+      "role": "horizontal-and-vertical-control",
+      "sha256": "6e06a7fe5d696ca719894a23f36bb2b1be8c816a5937cd4ad0f23ca67780dd74"
+    },
+    {
+      "name": "SourceHanSerifK-OldHangul-subset.otf",
+      "role": "old-hangul-complex-shaping",
+      "sha256": "2f86ef9a52acb6d1dad9d915843239123b635d97edd88fd0573a88ffcb4e16f1"
+    },
+    {
+      "name": "HappinessSansVF.ttf",
+      "role": "explicit-variable-instances",
+      "sha256": "3bbd254dcc5780f7524f9d07af4aa981ba5e3e84cf32d7d4e04301b3943e8694"
+    }
+  ],
+  "inventory": {
+    "unitTierTests": 4221,
+    "unitTierModules": 299,
+    "integrationSources": 1075,
+    "staticTestAttributes": 4715,
+    "generatedSuites": 28,
+    "exceptionTargets": 20,
+    "accountedTargets": 48,
+    "expectedTargets": 48,
+    "minimumCases": 6559,
+    "newIntegrationSources": 0,
+    "generatedArtifactsSubmitted": false
+  },
+  "nativeFocused": {
+    "command": "cargo nextest run --locked --cargo-profile release-test --target-dir /home/edward/mygithub/rhwp/target/pr-review --tests -E 'test(/issue_4969/)' --no-fail-fast",
+    "selected": 114,
+    "passed": 114,
+    "failed": 0,
+    "nonSelectedSkipped": 8795,
+    "elapsedSeconds": 1.106,
+    "nextestVersion": "0.9.137",
+    "recommendedNextestVersion": "0.9.140"
+  },
+  "nodeWasmFocused": {
+    "wasmPackVersion": "0.15.0",
+    "nodeVersion": "24.15.0",
+    "rootTopologyDiagnostic": {
+      "status": "not-product-failure",
+      "reason": "root-dev-dependency-wait-timeout-is-not-wasm32-compatible"
+    },
+    "isolatedHarness": {
+      "sourceCopies": 0,
+      "trackedIntegrationSources": 2,
+      "requestContractPassed": 5,
+      "shadowContextPassed": 14,
+      "totalPassed": 19,
+      "failed": 0,
+      "removedAfterRun": true
+    }
+  },
+  "studioCanvasKit": {
+    "command": "node --test rhwp-studio/e2e/issue-4969-shaping-replay.test.mjs",
+    "passed": 1,
+    "failed": 0,
+    "commonGlyphRun": {
+      "pageAdvance": 61.824,
+      "currentInk": {
+        "width": 58,
+        "height": 34
+      },
+      "oldControlInk": {
+        "width": 58,
+        "height": 38
+      },
+      "fontCache": {
+        "blobs": 1,
+        "typefaces": 1,
+        "fonts": 2,
+        "bytes": 456688
+      }
+    },
+    "verticalLeaves": [
+      {
+        "source": 0,
+        "glyphId": 11232,
+        "inkWidth": 35,
+        "inkHeight": 36
+      },
+      {
+        "source": 1,
+        "glyphId": 1156,
+        "inkWidth": 33,
+        "inkHeight": 35
+      }
+    ],
+    "verticalFontCache": {
+      "blobs": 1,
+      "typefaces": 1,
+      "fonts": 1,
+      "bytes": 2519996
+    }
+  },
+  "standardDockerWasm": {
+    "command": "docker compose --env-file .env.docker run --rm wasm",
+    "status": "passed",
+    "wasmPackReportedSeconds": 404,
+    "wallSeconds": 448.45,
+    "imageId": "sha256:bbbc4f8e0f7162b9a9700a592b8959b7c13fee2accbbe6d921586f28a2c55903",
+    "artifact": "pkg/rhwp_bg.wasm",
+    "bytes": 9905805,
+    "sha256": "ed11bdb3bf2b11b44c3f6fed5c16d403257b60b27bffa469e5e3c1dfecf912a4",
+    "interpretation": "current-absolute-snapshot-only-not-causal-delta",
+    "submitted": false
+  },
+  "parity": {
+    "supportedNativeToWasmCanonicalMismatch": 0,
+    "canvasKitReplayMismatch": 0,
+    "canvasKitPixelMismatch": 0,
+    "unsupportedBackendFalseSelection": 0,
+    "fallbackDisappearance": 0,
+    "backendReshaping": 0,
+    "partialPublication": 0,
+    "resourceMultiplicityIncrease": 0
+  },
+  "boundaries": {
+    "supportTupleExpanded": false,
+    "publicApiChanged": false,
+    "schemaChanged": false,
+    "privateCorpusUsed": false,
+    "hyperVUsed": false,
+    "hancomOracleUsed": false,
+    "githubMutated": false
+  },
+  "next": {
+    "stage": "W10-Q5-C",
+    "action": "checkpoint-after-maintainer-approval-then-audit-bounds-malformed-and-atomic-rollback"
+  }
+}

--- a/mydocs/tech/investigations/issue-4969/w10_q5_c_bounded_atomic_ledger.json
+++ b/mydocs/tech/investigations/issue-4969/w10_q5_c_bounded_atomic_ledger.json
@@ -1,0 +1,199 @@
+{
+  "schemaVersion": 1,
+  "kind": "font-w10-q5-bounded-malformed-atomic-ledger",
+  "issue": 4969,
+  "stage": "W10-Q5-C",
+  "date": "2026-08-31",
+  "status": "qualified-approved",
+  "planApproval": "explicit",
+  "resultApproval": "explicit",
+  "checkpointApproved": true,
+  "current": {
+    "branch": "task_m100_4969_w10_q5",
+    "productMergeHead": "3afbb066fe93724ab44309163a2e04efb954bf18",
+    "q5BCheckpoint": "0367ac865",
+    "productMutation": false,
+    "testSourcesModified": 2,
+    "newIntegrationSources": 0
+  },
+  "focusedValidation": {
+    "selected": 50,
+    "passed": 50,
+    "failed": 0,
+    "nonSelected": 8861,
+    "elapsedSeconds": 0.971,
+    "newBoundaryTests": {
+      "selected": 2,
+      "passed": 2,
+      "failed": 0,
+      "elapsedSeconds": 0.069
+    },
+    "sameProductTreeNodeWasmReusedFromQ5B": {
+      "passed": 19,
+      "failed": 0
+    }
+  },
+  "limits": [
+    {
+      "surface": "exact-font-bytes",
+      "maximum": 33554432,
+      "boundaryEvidence": "direct-limit-plus-one",
+      "reason": "FontByteLimitExceeded",
+      "mutationAfterReject": 0
+    },
+    {
+      "surface": "text-code-points",
+      "maximum": 4096,
+      "boundaryEvidence": "direct-limit-plus-one",
+      "reason": "TextCodePointLimitExceeded",
+      "mutationAfterReject": 0
+    },
+    {
+      "surface": "shaping-features",
+      "maximum": 64,
+      "boundaryEvidence": "direct-limit-plus-one",
+      "reason": "FeatureLimitExceeded",
+      "mutationAfterReject": 0
+    },
+    {
+      "surface": "variation-axes",
+      "maximum": 16,
+      "boundaryEvidence": "direct-limit-plus-one-native-and-node-wasm",
+      "reason": "VariationAxisLimitExceeded",
+      "mutationAfterReject": 0
+    },
+    {
+      "surface": "glyphs-per-run",
+      "maximum": 4096,
+      "boundaryEvidence": "near-boundary-runtime-plus-post-shape-guard",
+      "directHostileFontOverflowFixture": false,
+      "reason": "GlyphLimitExceeded",
+      "mutationAfterReject": 0
+    },
+    {
+      "surface": "clusters-per-run",
+      "maximum": 4096,
+      "boundaryEvidence": "near-boundary-runtime-plus-post-shape-guard",
+      "directHostileFontOverflowFixture": false,
+      "reason": "ClusterMappingInvalid",
+      "mutationAfterReject": 0
+    },
+    {
+      "surface": "horizontal-cache-entries",
+      "maximum": 4096,
+      "boundaryEvidence": "bounded-test-limit-one-plus-one",
+      "reason": "CacheEntryLimitExceeded",
+      "mutationAfterReject": 0
+    },
+    {
+      "surface": "explicit-instance-requests",
+      "maximum": 4096,
+      "boundaryEvidence": "direct-full-cap-coupled-to-equal-exact-source-slot-cap",
+      "effectiveReasons": [
+        "SlotLimitExceeded",
+        "SourceUnavailable"
+      ],
+      "requestLimitExceededBranchDirectlyReached": false,
+      "countAfterReject": 4096,
+      "generationAfterReject": 4096
+    },
+    {
+      "surface": "horizontal-page-sidecars",
+      "maximum": 4096,
+      "boundaryEvidence": "direct-limit-plus-one",
+      "reason": "EntryLimitExceeded",
+      "countAfterReject": 4096
+    },
+    {
+      "surface": "vertical-page-sidecars",
+      "maximum": 4096,
+      "boundaryEvidence": "direct-limit-plus-one",
+      "reason": "EntryLimitExceeded",
+      "countAfterReject": 4096,
+      "generationUnchanged": true
+    },
+    {
+      "surface": "attempt-trace-records",
+      "maximum": 4096,
+      "boundaryEvidence": "direct-limit-plus-two",
+      "reason": "Truncated",
+      "omitted": 2,
+      "retainsRawTextOrGlyphPayload": false
+    }
+  ],
+  "malformedAndUnsupported": {
+    "q2": [
+      "SourceUnavailable",
+      "MalformedSfnt",
+      "NonPortableSource",
+      "DirectionWritingModeMismatch",
+      "RangeMismatch",
+      "DuplicateNode",
+      "StaleRegistryGeneration",
+      "AttemptIdentityMismatch",
+      "InvalidHorizontalScale",
+      "ResourceLimitExceeded"
+    ],
+    "q3": [
+      "DuplicateVariationAxis",
+      "MalformedVariationTag",
+      "VariationAxisUnsupported",
+      "VariationValueNonFinite",
+      "VariationValueOutOfRange",
+      "VariationAxisLimitExceeded",
+      "ExplicitInstanceSlotMismatch",
+      "ExplicitInstanceOverrideNotAllowed",
+      "IncompleteOrMalformedOutline"
+    ],
+    "q4": [
+      "VerticalMetricsUnavailable",
+      "MalformedSfnt",
+      "MixedRunUnsupported",
+      "HorizontalIntentUnsupported",
+      "DirectionIntentMismatch",
+      "ColumnPitchInvalid",
+      "VariationGeometryUnsupported",
+      "LegacyGeometryMalformed",
+      "SourceIdentityMismatch",
+      "StaleRegistryGeneration",
+      "UnsupportedBackendOrTuple"
+    ]
+  },
+  "atomicity": {
+    "partialMeasurement": 0,
+    "cacheMutationAfterReject": 0,
+    "ownerSnapshotMutationAfterReject": 0,
+    "sidecarMutationAfterReject": 0,
+    "fontBlobMutationAfterReject": 0,
+    "fontFaceMutationAfterReject": 0,
+    "partialParagraphPublication": 0,
+    "partialVerticalLeafPublication": 0,
+    "fallbackGeometryMismatch": 0,
+    "textRunFallbackDisappearance": 0,
+    "panicOrOom": 0
+  },
+  "manifest": {
+    "integrationSources": 1075,
+    "staticTestAttributes": 4717,
+    "generatedSuites": 28,
+    "exceptionTargets": 20,
+    "accountedTargets": 48,
+    "expectedTargets": 48,
+    "minimumCases": 6559,
+    "generatedArtifactsSubmitted": false
+  },
+  "boundaries": {
+    "supportTupleExpanded": false,
+    "publicApiChanged": false,
+    "schemaChanged": false,
+    "privateCorpusUsed": false,
+    "hyperVUsed": false,
+    "hancomOracleUsed": false,
+    "githubMutated": false
+  },
+  "next": {
+    "stage": "W10-Q5-D",
+    "action": "checkpoint-after-maintainer-approval-then-close-focused-performance-wasm-and-resource-ledger",
+    "reuseCurrentDockerWasmSnapshotFromQ5B": true
+  }
+}

--- a/mydocs/tech/investigations/issue-4969/w10_q5_d_performance_resource_ledger.json
+++ b/mydocs/tech/investigations/issue-4969/w10_q5_d_performance_resource_ledger.json
@@ -1,0 +1,291 @@
+{
+  "schemaVersion": 1,
+  "kind": "font-w10-q5-performance-wasm-resource-ledger",
+  "issue": 4969,
+  "stage": "W10-Q5-D",
+  "date": "2026-08-31",
+  "status": "qualified-approved",
+  "planApproval": "explicit",
+  "resultApproval": "explicit",
+  "checkpointApproved": true,
+  "current": {
+    "branch": "task_m100_4969_w10_q5",
+    "productMergeHead": "3afbb066fe93724ab44309163a2e04efb954bf18",
+    "q5CCheckpoint": "7d9909791",
+    "productMutation": false,
+    "testSourcesModified": 1,
+    "newIntegrationSources": 0
+  },
+  "measurementProtocol": {
+    "profile": "release-test",
+    "processRunsPerCase": 9,
+    "warmIterations": 64,
+    "p50Method": "sorted-index-4-of-9",
+    "p95Method": "nearest-rank-max-of-9",
+    "sharedTarget": "/home/edward/mygithub/rhwp/target/pr-review",
+    "wallTimeAuthority": "same-host-profile-protocol-observational",
+    "coldPolicy": "observational-no-retrospective-hard-gate"
+  },
+  "q2Current": {
+    "runResourceMatrix": {
+      "runCounts": [1, 2, 8],
+      "textRuns": [1, 2, 8],
+      "glyphRuns": [1, 2, 8],
+      "fontBlobs": [1, 1, 1],
+      "fontFaces": [1, 1, 1],
+      "fontPayloadBytes": [456688, 456688, 456688],
+      "passed": 1,
+      "failed": 0
+    },
+    "pageResourceMatrix": {
+      "pageCounts": [1, 2, 8],
+      "inlinePresentedBytes": [456688, 913376, 3653504],
+      "retainedFontBlobs": [1, 1, 1],
+      "retainedFontBytes": [456688, 456688, 456688],
+      "byKeyFetches": [1, 1, 1],
+      "byKeyTransferredBytes": [456688, 456688, 456688],
+      "nodeTestsPassed": 5,
+      "nodeTestsFailed": 0
+    },
+    "defaultBaselineNineProcess": {
+      "warmElapsedNs": {
+        "p50": 100361,
+        "p95": 197921,
+        "min": 99961,
+        "max": 197921
+      },
+      "coldElapsedNs": {
+        "p50": 2495809,
+        "p95": 3081611,
+        "min": 2448355,
+        "max": 3081611
+      },
+      "pageTreeWarmElapsedNs": {
+        "p50": 1694346,
+        "p95": 1738051,
+        "min": 1633652,
+        "max": 1738051
+      },
+      "identityStableAcrossNine": true,
+      "layerJsonBytes": 619562,
+      "layerJsonBlake3": "0b5212cc076c34dce706039d7c4da85936c0a6769e83f08baa7f158cbd9029de",
+      "canvasKitPlanBytes": 1755,
+      "canvasKitPlanBlake3": "a98e6933d76901cfa55a43205c758675a8864527f87f8bed7a689d16267cbb56"
+    },
+    "structuralAuthority": true,
+    "resourceMultiplicityIncrease": false
+  },
+  "q3Current": {
+    "instanceRunResourceMatrix": {
+      "instanceCounts": [1, 2, 8],
+      "runsPerInstance": [1, 2, 8],
+      "combinations": 9,
+      "digestPassesPerCombination": 1,
+      "sourceFaceParsesPerCombination": 1,
+      "preparedSourcesPerCombination": 1,
+      "arenaInternAttemptsPerCombination": 1,
+      "fontBlobsPerCombination": 1,
+      "fontFacesPerCombination": 1,
+      "sourceBytes": 1503064,
+      "maximum": {
+        "instances": 8,
+        "runsPerInstance": 8,
+        "parsedInstanceFaces": 8,
+        "resultCacheMisses": 8,
+        "resultCacheHits": 56,
+        "cachedResults": 8,
+        "glyphRuns": 64,
+        "glyphOutlines": 64,
+        "payloadBytes": 2613391
+      },
+      "passed": 1,
+      "failed": 0
+    },
+    "nineProcess": {
+      "exactDefault": {
+        "warmP50Ns": 36895,
+        "warmP95Ns": 38096,
+        "coldP50Ns": 5311993,
+        "coldP95Ns": 5515963,
+        "pageTreeWarmP50Ns": 5434134,
+        "pageTreeWarmP95Ns": 5547822,
+        "identityStableAcrossNine": true
+      },
+      "explicitDefault": {
+        "warmP50Ns": 36791,
+        "warmP95Ns": 37190,
+        "coldP50Ns": 5302781,
+        "coldP95Ns": 5522132,
+        "pageTreeWarmP50Ns": 5321418,
+        "pageTreeWarmP95Ns": 5602512,
+        "identityStableAcrossNine": true,
+        "outputIdenticalToExactDefault": true,
+        "warmDeltaFromExactDefaultNs": {
+          "p50": -104,
+          "p95": -906
+        }
+      },
+      "interior": {
+        "warmP50Ns": 146538,
+        "warmP95Ns": 179722,
+        "coldP50Ns": 8118654,
+        "coldP95Ns": 8665067,
+        "pageTreeWarmP50Ns": 5281958,
+        "pageTreeWarmP95Ns": 5635250,
+        "identityStableAcrossNine": true,
+        "warmDeltaFromExactDefaultNs": {
+          "p50": 109643,
+          "p95": 141626
+        }
+      },
+      "max": {
+        "warmP50Ns": 147735,
+        "warmP95Ns": 179920,
+        "coldP50Ns": 7929738,
+        "coldP95Ns": 8718752,
+        "pageTreeWarmP50Ns": 5291164,
+        "pageTreeWarmP95Ns": 6412742,
+        "identityStableAcrossNine": true,
+        "warmDeltaFromExactDefaultNs": {
+          "p50": 110840,
+          "p95": 141824
+        }
+      }
+    },
+    "activationGate": {
+      "p50AbsoluteDeltaLimitNs": 1000000,
+      "p95AbsoluteDeltaLimitNs": 2000000,
+      "interiorPassed": true,
+      "maxPassed": true,
+      "result": "passed"
+    },
+    "defaultIdentity": {
+      "layerJsonBytes": 6382,
+      "layerJsonBlake3": "b9ecf6db7656ed37a921077018339a23791068cbb63b4b30db36f904de494223",
+      "canvasKitPlanBytes": 1290,
+      "canvasKitPlanBlake3": "4509089988701765ee1df4b3d31fa900a189546386f6e1b432d433e6109a7f38",
+      "textRuns": 1,
+      "glyphRuns": 0,
+      "glyphOutlines": 0,
+      "fontBlobs": 0,
+      "fontFaces": 0
+    },
+    "nonDefaultIdentity": {
+      "textRuns": 1,
+      "glyphRuns": 1,
+      "glyphOutlines": 1,
+      "fontBlobs": 1,
+      "fontFaces": 1
+    },
+    "resourceMultiplicityIncrease": false
+  },
+  "q4Reused": {
+    "evidence": "w10_q4_d5_b_performance_correction.json",
+    "measurementProtocol": "release-9-process-20-warmups-64-iterations",
+    "warmLayoutImprovementRatioBeforeOverAfter": 598.6405359947997,
+    "layerBuildImprovementRatioBeforeOverAfter": 339.161579248742,
+    "boundedVerticalB": {
+      "fontBlobs": 1,
+      "fontFaces": 1,
+      "fontPayloadBytes": 2519996,
+      "fallbackTextRuns": 2,
+      "verticalGlyphRuns": 2
+    },
+    "resourceMultiplicityIncrease": false
+  },
+  "wasm": {
+    "q3IndependentCausalSnapshot": {
+      "evidence": "w10_q3_e5_final_qualification.json",
+      "baselineBytes": 9759368,
+      "candidateBytes": 9810922,
+      "deltaBytes": 51554,
+      "deltaPercent": 0.5282514
+    },
+    "q4IndependentCausalSnapshot": {
+      "evidence": "w10_q4_d5_d_causal_wasm_result.json",
+      "aBytes": 9858318,
+      "bBytes": 9894929,
+      "deltaBytes": 36611,
+      "deltaPercent": 0.37137166806751415
+    },
+    "independentDeltasAdded": false,
+    "integratedCausalDeltaClaimed": false,
+    "currentAbsoluteSnapshot": {
+      "evidence": "w10_q5_b_canonical_parity.json",
+      "bytes": 9905805,
+      "sha256": "ed11bdb3bf2b11b44c3f6fed5c16d403257b60b27bffa469e5e3c1dfecf912a4",
+      "imageId": "sha256:bbbc4f8e0f7162b9a9700a592b8959b7c13fee2accbbe6d921586f28a2c55903",
+      "interpretation": "absolute-only-not-causal-delta",
+      "secondDockerBuildRun": false
+    }
+  },
+  "procedureCorrections": [
+    {
+      "kind": "test-only-compile-correction",
+      "detail": "new assertion range was changed from usize to u32 to match source IDs before the passing receipt",
+      "productFailure": false
+    },
+    {
+      "kind": "target-topology-correction",
+      "detail": "one accidental worktree-local target build was stopped and its exact 449 MiB target directory removed; shared pr-review target was preserved",
+      "productFailure": false
+    },
+    {
+      "kind": "studio-dependency-topology-correction",
+      "detail": "first Node attempt lacked worktree node_modules; the primary checkout dependency tree was temporarily linked, 5 tests passed, and the link was removed",
+      "productFailure": false
+    }
+  ],
+  "qualification": {
+    "q2UniqueSourceBounded": true,
+    "q3UniqueSourceAndInstanceBounded": true,
+    "q3PerformanceGatePassed": true,
+    "q4ResourceBoundedEvidenceReusable": true,
+    "comparisonIncompatibleArithmeticCombinations": 0,
+    "resourceMultiplicityIncrease": 0,
+    "productRegression": false,
+    "result": "qualified"
+  },
+  "validation": {
+    "focusedNextest": {
+      "selected": 2,
+      "passed": 2,
+      "failed": 0,
+      "nonSelected": 8910,
+      "elapsedSeconds": 0.901
+    },
+    "studioNode": {
+      "selected": 5,
+      "passed": 5,
+      "failed": 0,
+      "elapsedMilliseconds": 268.992807
+    },
+    "manifest": {
+      "integrationSources": 1075,
+      "staticTestAttributes": 4718,
+      "generatedSuites": 28,
+      "exceptionTargets": 20,
+      "accountedTargets": 48,
+      "expectedTargets": 48,
+      "minimumCases": 6559,
+      "result": "passed"
+    },
+    "cargoFmtAllCheck": "passed",
+    "jsonSyntax": "passed",
+    "gitDiffCheck": "passed"
+  },
+  "boundaries": {
+    "supportTupleExpanded": false,
+    "publicApiChanged": false,
+    "schemaChanged": false,
+    "generatedArtifactsSubmitted": false,
+    "privateCorpusUsed": false,
+    "hyperVUsed": false,
+    "hancomOracleUsed": false,
+    "githubMutated": false
+  },
+  "next": {
+    "stage": "W10-Q5-E",
+    "action": "result-and-checkpoint-approval-before-final-q5-classification"
+  }
+}

--- a/mydocs/tech/investigations/issue-4969/w10_q5_evidence_eligibility.json
+++ b/mydocs/tech/investigations/issue-4969/w10_q5_evidence_eligibility.json
@@ -1,0 +1,170 @@
+{
+  "schemaVersion": 1,
+  "kind": "font-w10-q5-evidence-eligibility-audit",
+  "issue": 4969,
+  "stage": "W10-Q5-A",
+  "date": "2026-08-31",
+  "status": "qualified-evidence-audit-approved",
+  "planApproval": "explicit",
+  "resultApproval": "explicit",
+  "checkpointApproved": true,
+  "current": {
+    "branch": "task_m100_4969_w10_q5",
+    "upstreamDevel": "3afbb066fe93724ab44309163a2e04efb954bf18",
+    "mergeCommit": "3afbb066fe93724ab44309163a2e04efb954bf18",
+    "mergeTree": "da1c173345adda3c691878415441e6f64515afe1"
+  },
+  "sourceEvidence": {
+    "q2": {
+      "checkpoint": "167e3b3d22a7a136b056e292933fcbdf7cccbd98",
+      "path": "mydocs/tech/investigations/issue-4969/w10_q2_final_support_classification.json",
+      "sha256": "1c68e10a62f55f52923c72f8e3954b4fce2c8f44170832f6acda68cdd506e218",
+      "ancestorOfCurrent": true
+    },
+    "q3": {
+      "checkpoint": "4e0a3822c3e05c2df8b7c52740b3a0c79487053a",
+      "measurementHead": "8bcaa54ed872c5390620ce190ad8122b09036f31",
+      "path": "mydocs/tech/investigations/issue-4969/w10_q3_e5_final_qualification.json",
+      "sha256": "1cad795c466838979770940778158e3bc69edad1221bbf28385fe3aba8f5250d",
+      "ancestorOfCurrent": true
+    },
+    "q4": {
+      "classificationCheckpoint": "a7de96b44a2f14a9c2ae67ff009f852a1638c875",
+      "causalWasmCheckpoint": "95d450dd5205e121279ca1e1e857510161c1920f",
+      "latestRequalification": "95429a34f5a81f231615592d0c951477fd2e42fb",
+      "classificationPath": "mydocs/tech/investigations/issue-4969/w10_q4_d5_c_final_classification.json",
+      "classificationSha256": "027b99843ce3772baf8a626c08a364d4ad0ada9acb9cf3b212317021a0389fcd",
+      "causalWasmPath": "mydocs/tech/investigations/issue-4969/w10_q4_d5_d_causal_wasm_result.json",
+      "causalWasmSha256": "c73e9edaa291486441dd2a0aba5d1906f7eda959d836230c86c861aaeaca948e",
+      "ancestorOfCurrent": true
+    }
+  },
+  "integration": {
+    "pullRequest": 6493,
+    "codeCandidate": {
+      "head": "7a67f250851babf37e8d21f242494829952ade74",
+      "checkRuns": {
+        "total": 34,
+        "success": 30,
+        "skipped": 4,
+        "failed": 0,
+        "pending": 0
+      }
+    },
+    "trailingReview": {
+      "head": "2497f48f283aa3ad714b53497d8cc2a33f5019a4",
+      "changedPathsFromCodeCandidate": [
+        "mydocs/orders/20260831.md",
+        "mydocs/pr/archives/pr_6493_review.md",
+        "mydocs/pr/archives/pr_6493_review_impl.md"
+      ],
+      "productPathChanges": 0,
+      "checkRuns": {
+        "total": 31,
+        "success": 11,
+        "expectedFastPassSkipped": 19,
+        "cancelStaleSkipped": 1,
+        "failed": 0,
+        "pending": 0
+      }
+    },
+    "merge": {
+      "headTreeEqualsMergeTree": true,
+      "changedPathsFromTrailingReview": 0
+    },
+    "firstCiCorrection": {
+      "commit": "7a67f250851babf37e8d21f242494829952ade74",
+      "classification": "test-relocation-only",
+      "sourceTestRemovedFrom": "src/document_core/commands/header_footer_ops.rs",
+      "integrationTestAddedTo": "tests/cases/issue_4969_shaping_atomic_activation.rs",
+      "productionSemanticsChanged": false
+    }
+  },
+  "overlap": {
+    "q2AfterCheckpoint": {
+      "sharedOwnersChanged": true,
+      "representativeChanges": [
+        "6a156ca98-q3-instance-isolation",
+        "880862177-q3-portable-publication",
+        "4e0a3822c-q3-layer-cache",
+        "992fe4aca-q4-vertical-layout",
+        "d49400aad-q4-vertical-publication",
+        "c9b551909-q4-canvaskit-selection",
+        "e7f814330-q4-source-reuse"
+      ],
+      "affectedPlanes": [
+        "shaping-owner",
+        "paint-resource",
+        "layer-cache",
+        "canvaskit-selection",
+        "issue-4969-harness"
+      ]
+    },
+    "q3AfterCheckpoint": {
+      "sharedOwnersChanged": true,
+      "representativeChanges": [
+        "992fe4aca-q4-vertical-layout",
+        "d49400aad-q4-vertical-publication",
+        "c9b551909-q4-canvaskit-selection",
+        "b1a33b6fc-q4-studio-replay",
+        "e7f814330-q4-source-reuse"
+      ],
+      "affectedPlanes": [
+        "paint-resource",
+        "layer-cache",
+        "canvaskit-selection",
+        "issue-4969-harness"
+      ]
+    },
+    "q4AfterLatestRequalification": {
+      "productionSourceChanges": 0,
+      "studioSourceChanges": 0,
+      "fontOrSampleChanges": 0,
+      "testRelocationOnly": true
+    }
+  },
+  "eligibility": {
+    "q2": {
+      "historicalClassification": "reusable",
+      "currentCanonicalParity": "focused-refresh",
+      "currentBackendParity": "focused-refresh",
+      "currentPerformanceAndResource": "focused-refresh",
+      "historicalAbsoluteWasm": "historical-only-not-current-causal"
+    },
+    "q3": {
+      "historicalClassification": "reusable",
+      "currentCanonicalParity": "focused-refresh",
+      "currentBackendParity": "focused-refresh",
+      "currentPerformanceAndResource": "focused-refresh",
+      "stageLocalCausalWasm": "reusable-historical-only"
+    },
+    "q4": {
+      "currentCorrectness": "reusable",
+      "currentBackendParity": "reusable",
+      "currentPerformanceAndResource": "reusable",
+      "stageLocalCausalWasm": "reusable-historical-only"
+    },
+    "combined": {
+      "codeCandidateFullRegression": "reusable",
+      "trailingReviewFastPass": "reusable",
+      "mergedHeadCanonicalParity": "focused-refresh",
+      "mergedHeadFailClosedMatrix": "focused-refresh",
+      "currentAbsoluteDockerWasmBytesAndDigest": "focused-refresh",
+      "fullNextestRepeat": "not-required",
+      "fullNativeSkiaRepeat": "not-required",
+      "cleanRoomCausalWasmRepeat": "not-required",
+      "privateCorpusOrHyperV": "not-required"
+    }
+  },
+  "next": {
+    "q5B": "run-existing-issue-4969-native-node-wasm-studio-parity-on-merged-head",
+    "q5C": "run-existing-bounded-and-fail-closed-contracts-on-merged-head",
+    "q5D": [
+      "refresh-q2-q3-shared-resource-performance-only",
+      "reuse-q4-performance-and-stage-local-causal-size",
+      "build-current-docker-wasm-once-for-absolute-bytes-and-digest"
+    ],
+    "newIntegrationSource": false,
+    "productMutation": false
+  }
+}

--- a/mydocs/tech/investigations/issue-4969/w10_q5_final_qualification.json
+++ b/mydocs/tech/investigations/issue-4969/w10_q5_final_qualification.json
@@ -1,0 +1,221 @@
+{
+  "schemaVersion": 1,
+  "kind": "font-w10-q5-final-qualification",
+  "issue": 4969,
+  "stage": "W10-Q5-E",
+  "date": "2026-08-31",
+  "status": "qualified-approved",
+  "classification": "bounded-subset",
+  "resultApproval": "explicit",
+  "checkpointApproved": true,
+  "current": {
+    "branch": "task_m100_4969_w10_q5",
+    "productMergeHead": "3afbb066fe93724ab44309163a2e04efb954bf18",
+    "q5Checkpoints": {
+      "evidenceEligibility": "a8371d976",
+      "canonicalParity": "0367ac865",
+      "boundedAtomicLedger": "7d9909791",
+      "performanceResourceLedger": "4d107fe09"
+    },
+    "productMutationInQ5": false,
+    "testSourcesModifiedInQ5": 3,
+    "newIntegrationSources": 0
+  },
+  "lanes": [
+    {
+      "id": "q2-horizontal-old-hangul",
+      "classification": "bounded-subset",
+      "source": "SourceHanSerifK-OldHangul-subset.otf",
+      "supported": {
+        "writingMode": "horizontal-tb",
+        "direction": "ltr",
+        "exactPortableSource": true,
+        "targetClass": "direct-old-hangul-complex-required",
+        "activeLanes": [
+          "stored-boundary-strict",
+          "no-lineseg-atomic"
+        ],
+        "nativeProducer": true,
+        "nodeWasmProducer": true,
+        "canvasKitReplay": "bounded-strict-common-glyph-run"
+      },
+      "fallback": {
+        "canvas2d": "deterministic-text-run",
+        "legacySvg": "deterministic-text-run",
+        "nativeSkia": "deterministic-text-run",
+        "ownerOrder": [
+          "w9-k1",
+          "existing-k0-text-run"
+        ]
+      },
+      "deferred": [
+        "rtl-and-bidi-product-replay",
+        "latin-default-liga-general-activation",
+        "multi-line-or-multi-run-batch",
+        "mixed-target-run-splitting",
+        "multi-interval-frame",
+        "general-edit-reflow",
+        "stored-prefix",
+        "split-cell-recovery",
+        "inline-control",
+        "center-right-justify-distribute",
+        "ratio-identity-or-expansion",
+        "nonzero-gpos-y-positioning",
+        "native-skia-portable-blob-typeface-replay",
+        "public-rejected-attempt-annotation"
+      ],
+      "reason": "two explicit horizontal lanes are qualified while all other surfaces deterministically retain W9 K1 or K0 TextRun ownership"
+    },
+    {
+      "id": "q3-variable-instance",
+      "classification": "qualified",
+      "source": "HappinessSansVF.ttf",
+      "supported": {
+        "exactDefault": "unchanged-text-run",
+        "explicitDefault": "unchanged-text-run",
+        "explicitInteriorAndMax": "bounded-glyph-run-and-portable-outline",
+        "canvasKitReplay": true,
+        "maximumVariationAxes": 16,
+        "maximumInstanceRequests": 4096,
+        "maximumPageVariants": 4
+      },
+      "fallback": {
+        "unsupportedBackendNonDefault": "deterministic-text-run",
+        "invalidOrIncompleteInstance": "atomic-paragraph-rollback"
+      },
+      "reason": "the frozen explicit-instance contract passes canonical, performance, resource, cache and rollback gates without changing default output"
+    },
+    {
+      "id": "q4-vertical-hwp5-table-cell-v1",
+      "classification": "bounded-subset",
+      "source": "NotoSansKR-Regular.ttf",
+      "supported": {
+        "scope": "boundedVerticalHwp5TableCellV1",
+        "backend": "CanvasKit",
+        "exactPortableSource": true,
+        "verticalMetricsRequired": [
+          "vhea",
+          "vmtx"
+        ],
+        "glyphAndLeafPublication": "atomic"
+      },
+      "fallback": {
+        "unsupportedBackendOrTuple": "deterministic-text-run-and-legacy-vertical-geometry",
+        "missingOrMalformedVerticalMetrics": "pristine-legacy-geometry"
+      },
+      "historicalBlockedClassification": {
+        "preserved": true,
+        "resolvedBy": "w10_q4_d5_d_causal_wasm_result.json",
+        "resolution": "clean-room source-only baseline construction supplied the missing same-tree causal WASM receipt"
+      },
+      "reason": "correctness, runtime parity, corrected performance and causal WASM evidence qualify only the frozen table-cell tuple"
+    }
+  ],
+  "mergedHeadParity": {
+    "nativeFocusedPassed": 114,
+    "nativeFocusedFailed": 0,
+    "nodeWasmPassed": 19,
+    "nodeWasmFailed": 0,
+    "studioCanvasKitPassed": 1,
+    "studioCanvasKitFailed": 0,
+    "supportedNativeToWasmCanonicalMismatch": 0,
+    "canvasKitReplayMismatch": 0,
+    "canvasKitPixelMismatch": 0,
+    "unsupportedBackendFalseSelection": 0,
+    "fallbackDisappearance": 0,
+    "backendReshaping": 0
+  },
+  "boundedAtomic": {
+    "focusedPassed": 50,
+    "focusedFailed": 0,
+    "maximumFontBytes": 33554432,
+    "maximumTextCodePoints": 4096,
+    "maximumFeatures": 64,
+    "maximumVariationAxes": 16,
+    "maximumGlyphsPerRun": 4096,
+    "maximumClustersPerRun": 4096,
+    "maximumCacheEntries": 4096,
+    "maximumInstanceRequests": 4096,
+    "maximumPageSidecars": 4096,
+    "partialPublication": 0,
+    "mutationAfterReject": 0,
+    "textRunFallbackDisappearance": 0,
+    "panicOrOom": 0
+  },
+  "performanceResource": {
+    "q2UniqueSourceBounded": true,
+    "q3UniqueSourceAndInstanceBounded": true,
+    "q3WarmPerformanceGatePassed": true,
+    "q4PerformanceCorrectionQualified": true,
+    "q4ResourceBounded": true,
+    "resourceMultiplicityIncrease": 0,
+    "incompatibleArithmeticCombinations": 0,
+    "currentAbsoluteWasm": {
+      "bytes": 9905805,
+      "sha256": "ed11bdb3bf2b11b44c3f6fed5c16d403257b60b27bffa469e5e3c1dfecf912a4",
+      "causalDeltaClaimed": false
+    },
+    "independentCausalWasm": {
+      "q3DeltaBytes": 51554,
+      "q3DeltaPercent": 0.5282514,
+      "q4DeltaBytes": 36611,
+      "q4DeltaPercent": 0.37137166806751415,
+      "addedTogether": false
+    }
+  },
+  "protectedRegression": {
+    "horizontalNonTargetChanged": false,
+    "w9K1Changed": false,
+    "k0TextRunChanged": false,
+    "defaultVariableOutputChanged": false,
+    "explicitDefaultVariableOutputChanged": false,
+    "legacyVerticalFallbackChanged": false,
+    "supportTupleExpanded": false,
+    "publicApiChanged": false,
+    "schemaChanged": false
+  },
+  "completionGate": {
+    "parityMismatch": 0,
+    "horizontalNonTargetRegression": 0,
+    "failClosedViolation": 0,
+    "performanceWasmResourceAccountingGap": 0,
+    "allSatisfied": true
+  },
+  "validation": {
+    "evidenceCrossCheck": "passed",
+    "laneClassificationCrossCheck": "passed",
+    "cargoFmtAllCheck": "passed",
+    "jsonSyntax": "passed",
+    "gitDiffCheck": "passed"
+  },
+  "evidence": [
+    "w10_q5_evidence_eligibility.json",
+    "w10_q5_b_canonical_parity.json",
+    "w10_q5_c_bounded_atomic_ledger.json",
+    "w10_q5_d_performance_resource_ledger.json",
+    "w10_q2_final_support_classification.json",
+    "w10_q3_e5_final_qualification.json",
+    "w10_q4_d5_d_causal_wasm_result.json"
+  ],
+  "boundaries": {
+    "generatedArtifactsSubmitted": false,
+    "privateCorpusUsed": false,
+    "hyperVUsed": false,
+    "hancomOracleUsed": false,
+    "githubMutated": false,
+    "issueClosed": false,
+    "q6Started": false
+  },
+  "q6Handoff": {
+    "ready": true,
+    "actionsAfterApproval": [
+      "freeze-the-three-lane-support-matrix-with-explicit-fallbacks",
+      "separate-deferred-surfaces-from-current-product-support",
+      "prepare-final-4969-and-parent-4960-tracker-status-without-mutating-github",
+      "define-final-pr-validation-and-submission-boundary"
+    ],
+    "automaticIssueCreation": false,
+    "trackerMutationApproved": false,
+    "remoteMutationApproved": false
+  }
+}

--- a/mydocs/tech/investigations/issue-4969/w10_q6_submission_validation.json
+++ b/mydocs/tech/investigations/issue-4969/w10_q6_submission_validation.json
@@ -1,0 +1,142 @@
+{
+  "schemaVersion": 1,
+  "kind": "font-w10-q6-submission-validation",
+  "issue": 4969,
+  "stage": "W10-Q6-C",
+  "date": "2026-08-31",
+  "status": "qualified-approved",
+  "resultApproval": "explicit",
+  "checkpointApproved": true,
+  "source": {
+    "q6BApprovedCheckpoint": "6a9656dfffb494fd769c6b09381306dcab93dcc9",
+    "branch": "task_m100_4969_w10_q5",
+    "upstreamDevel": "3afbb066fe93724ab44309163a2e04efb954bf18",
+    "mergeBase": "3afbb066fe93724ab44309163a2e04efb954bf18",
+    "ahead": 8,
+    "behind": 0,
+    "baseMergeRequired": false
+  },
+  "submittedDiff": {
+    "documentationPaths": 17,
+    "integrationTestPaths": 3,
+    "productSourcePaths": 0,
+    "studioSourcePaths": 0,
+    "workflowPaths": 0,
+    "otherPaths": 0,
+    "integrationTestSources": [
+      "tests/cases/issue_4969_shaping_glyph_lowering.rs",
+      "tests/cases/issue_4969_shaping_request_contract.rs",
+      "tests/cases/issue_4969_shaping_shadow_context.rs"
+    ],
+    "newIntegrationSources": 0,
+    "generatedArtifactsSubmitted": false
+  },
+  "localValidation": {
+    "manifestPrepare": {
+      "status": "passed",
+      "integrationSources": 1075,
+      "staticTestAttributes": 4718,
+      "generatedSuites": 28,
+      "exceptionTargets": 20,
+      "accountedTargets": 48,
+      "expectedTargets": 48,
+      "minimumCases": 6559
+    },
+    "cargoFmtAll": "passed",
+    "cargoFmtAllCheck": "passed",
+    "nativeRootClippy": {
+      "status": "passed",
+      "denyWarnings": true,
+      "elapsedSeconds": 58.99
+    },
+    "wasm32LibraryClippy": {
+      "status": "passed",
+      "denyWarnings": true,
+      "target": "wasm32-unknown-unknown",
+      "elapsedSeconds": 46.90
+    },
+    "workspaceBuild": {
+      "status": "passed",
+      "elapsedSeconds": 94
+    },
+    "workspaceAllTargetsClippy": {
+      "status": "passed",
+      "denyWarnings": true,
+      "elapsedSeconds": 71
+    },
+    "manifestCheck": "passed",
+    "issue4969FocusedNextest": {
+      "selected": 117,
+      "passed": 117,
+      "failed": 0,
+      "nonSelected": 8795,
+      "testElapsedSeconds": 1.068,
+      "nextestVersion": "0.9.137",
+      "recommendedNextestVersion": "0.9.140"
+    },
+    "studioResourceReuse": {
+      "selected": 5,
+      "passed": 5,
+      "failed": 0,
+      "elapsedMilliseconds": 326.229661,
+      "primaryCheckoutNodeModulesTemporarilyLinked": true,
+      "temporaryLinkRemoved": true
+    },
+    "gitDiffCheck": "passed"
+  },
+  "reusedEvidence": {
+    "eligibilityAuthority": "w10_q5_evidence_eligibility.json",
+    "productTreeUnchanged": true,
+    "pr6493CodeCandidate": {
+      "head": "7a67f250851babf37e8d21f242494829952ade74",
+      "success": 30,
+      "expectedSkipped": 4,
+      "failed": 0,
+      "pending": 0
+    },
+    "pr6493TrailingReview": {
+      "head": "2497f48f283aa3ad714b53497d8cc2a33f5019a4",
+      "success": 11,
+      "expectedFastPassSkipped": 19,
+      "cancelStaleSkipped": 1,
+      "failed": 0,
+      "pending": 0
+    },
+    "fullNextestRepeat": "not-required-by-q5-evidence-eligibility-and-test-helper-scope",
+    "nativeSkiaRepeat": "not-required-product-source-diff-zero",
+    "dockerWasmRepeat": "not-required-product-source-diff-zero",
+    "canvasKitPixelRepeat": "not-required-product-and-studio-source-diff-zero",
+    "currentDockerWasm": {
+      "bytes": 9905805,
+      "sha256": "ed11bdb3bf2b11b44c3f6fed5c16d403257b60b27bffa469e5e3c1dfecf912a4"
+    },
+    "githubPrHeadFullCiStillRequired": true
+  },
+  "environment": {
+    "sharedTarget": "/home/edward/mygithub/rhwp/target/pr-review",
+    "worktreeLocalTargetCreated": false,
+    "studioNodeModulesLinkPresentAfterValidation": false,
+    "temporaryManifestLogRemoved": true,
+    "nextestWarning": "local 0.9.137 is older than recommended 0.9.140 and ignores report-skipped",
+    "warningAffectedResult": false
+  },
+  "qualification": {
+    "latestBaseConflict": 0,
+    "unresolvedOwnerOverlap": 0,
+    "lintOrFocusedFailure": 0,
+    "submittedGeneratedArtifact": 0,
+    "productSourceMutation": 0,
+    "result": "qualified"
+  },
+  "boundaries": {
+    "remotePushed": false,
+    "pullRequestCreated": false,
+    "githubMutated": false,
+    "trackerPublished": false,
+    "issueClosed": false
+  },
+  "next": {
+    "stage": "W10-Q6-D",
+    "action": "checkpoint-after-maintainer-approval-then-request-separate-remote-push-and-pr-creation-approval"
+  }
+}

--- a/mydocs/tech/investigations/issue-4969/w10_q6_support_matrix.json
+++ b/mydocs/tech/investigations/issue-4969/w10_q6_support_matrix.json
@@ -1,0 +1,362 @@
+{
+  "schemaVersion": 1,
+  "kind": "font-w10-q6-final-support-unsupported-matrix",
+  "issue": 4969,
+  "stage": "W10-Q6-A",
+  "date": "2026-08-31",
+  "status": "qualified-approved",
+  "overallClassification": "bounded-subset",
+  "resultApproval": "explicit",
+  "checkpointApproved": true,
+  "source": {
+    "q5FinalCheckpoint": "cf1536a9c91bd2726455308e19259542ba3e2f49",
+    "productMergeHead": "3afbb066fe93724ab44309163a2e04efb954bf18",
+    "q6PlanCheckpoint": "cb5c2b5d9",
+    "authority": "w10_q5_final_qualification.json"
+  },
+  "classificationVocabulary": {
+    "qualified": "the frozen lane contract satisfies all required gates",
+    "bounded-subset": "only the listed predicate tuple is supported; all other surfaces remain explicit fallback or deferred",
+    "blocked": "a required gate or evidence axis is incomplete"
+  },
+  "globalLimits": {
+    "fontBytes": 33554432,
+    "pagePreparedFontBytes": 67108864,
+    "textCodePointsPerRun": 4096,
+    "glyphsPerRun": 4096,
+    "clustersPerRun": 4096,
+    "featuresPerRequest": 64,
+    "variationAxesPerRequest": 16,
+    "horizontalCacheEntries": 4096,
+    "explicitInstanceRequests": 4096,
+    "horizontalPageSidecars": 4096,
+    "verticalPageSidecars": 4096,
+    "attemptTraceRecords": 4096
+  },
+  "lanes": [
+    {
+      "id": "q2-horizontal-old-hangul",
+      "classification": "bounded-subset",
+      "source": {
+        "path": "ttfs/opensource/SourceHanSerifK-OldHangul-subset.otf",
+        "bytes": 456688,
+        "sha256": "2f86ef9a52acb6d1dad9d915843239123b635d97edd88fd0573a88ffcb4e16f1",
+        "faceIndex": 0,
+        "exactPortableSourceRequired": true,
+        "tablesUsed": ["GPOS", "GSUB"]
+      },
+      "predicate": {
+        "format": "renderer-request-owned-not-a-general-document-format-claim",
+        "writingMode": "horizontal-tb",
+        "direction": "ltr",
+        "bidiLevel": 0,
+        "scriptDetection": "direct-old-hangul-jamo-present",
+        "language": "request-owned-script-language-not-general-language-coverage",
+        "targetClass": "direct-old-hangul-complex-required",
+        "variationAxes": [],
+        "syntheticStyle": false,
+        "homogeneousExactFaceStyleScript": true,
+        "paragraphLines": 1,
+        "lineRuns": 1,
+        "finalTargetCount": 1,
+        "alignment": "left",
+        "displayProjection": false,
+        "characterBorderOrFill": false,
+        "inlineControl": false,
+        "nonzeroDesignYPositioning": false,
+        "features": {
+          "gsubOwner": "common-shaper",
+          "kernFromHwpFlag": true,
+          "w9PairAdjustmentAfterAppliedShaping": false
+        },
+        "activeBoundaries": [
+          "stored-boundary-strict",
+          "ordinary-single-interval-no-lineseg-atomic"
+        ]
+      },
+      "producer": {
+        "native": "qualified",
+        "nodeWasm": "qualified",
+        "canonicalGlyphClusterPositionParity": true
+      },
+      "backends": {
+        "canvasKit": {
+          "disposition": "bounded-strict-common-glyph-run",
+          "backendReshaping": false
+        },
+        "canvas2d": { "disposition": "deterministic-text-run-fallback" },
+        "legacySvg": { "disposition": "deterministic-text-run-fallback" },
+        "nativeSkia": { "disposition": "deterministic-text-run-fallback" }
+      },
+      "publication": {
+        "measurementOwner": "single-shaping-measurement-arc",
+        "textRun": 1,
+        "commonGlyphRun": 1,
+        "nominalDuplicate": 0,
+        "atomic": true,
+        "partialPublicationAllowed": false
+      },
+      "fallback": {
+        "ownerOrder": ["w9-k1", "existing-k0-text-run"],
+        "geometry": "pristine-horizontal-text-run",
+        "transactionScope": "whole-approved-boundary"
+      },
+      "rejectionReasons": [
+        "SourceUnavailable",
+        "MalformedSfnt",
+        "NonPortableSource",
+        "DirectionWritingModeMismatch",
+        "RangeMismatch",
+        "DuplicateNode",
+        "StaleRegistryGeneration",
+        "AttemptIdentityMismatch",
+        "InvalidHorizontalScale",
+        "ResourceLimitExceeded",
+        "FontByteLimitExceeded",
+        "TextCodePointLimitExceeded",
+        "FeatureLimitExceeded",
+        "GlyphLimitExceeded",
+        "ClusterMappingInvalid",
+        "CacheEntryLimitExceeded"
+      ],
+      "deferred": [
+        "rtl-and-bidi-product-replay",
+        "latin-default-liga-general-activation",
+        "multi-line-or-multi-run-batch",
+        "mixed-target-run-splitting",
+        "multi-interval-frame",
+        "general-edit-reflow",
+        "stored-prefix",
+        "split-cell-recovery",
+        "inline-control",
+        "center-right-justify-distribute",
+        "ratio-identity-or-expansion",
+        "nonzero-gpos-y-positioning",
+        "native-skia-portable-blob-typeface-replay",
+        "public-rejected-attempt-annotation"
+      ],
+      "followUpEvidence": "public-representative-fixture-plus-backend-replay-per-surface",
+      "automaticFollowUpIssue": false
+    },
+    {
+      "id": "q3-variable-instance",
+      "classification": "qualified",
+      "source": {
+        "path": "ttfs/redistributable/happiness-sans/HappinessSansVF.ttf",
+        "bytes": 1503064,
+        "sha256": "3bbd254dcc5780f7524f9d07af4aa981ba5e3e84cf32d7d4e04301b3943e8694",
+        "faceIndex": 0,
+        "exactPortableSourceRequired": true,
+        "tablesUsed": ["GDEF", "GPOS", "GSUB", "STAT", "fvar", "glyf", "gvar", "hhea", "hmtx"]
+      },
+      "predicate": {
+        "inputOwner": "explicit-char-shape-language-slot-command-or-api",
+        "parserAxisIntent": false,
+        "fontNameOrRatioHeuristic": false,
+        "writingMode": "horizontal-tb",
+        "direction": "ltr",
+        "scripts": ["modern-hangul-syllables", "ascii-latin-letters"],
+        "languageIndex": { "minimum": 0, "exclusiveMaximum": 7 },
+        "axes": [
+          { "tag": "wght", "minimum": 400.0, "default": 400.0, "maximum": 900.0 },
+          { "tag": "opsz", "minimum": 400.0, "default": 400.0, "maximum": 900.0 }
+        ],
+        "canonicalInstances": [
+          { "id": "default", "wght": 400.0, "opsz": 400.0 },
+          { "id": "weight-interior", "wght": 650.0, "opsz": 400.0 },
+          { "id": "bold", "wght": 900.0, "opsz": 400.0 },
+          { "id": "optical-interior", "wght": 400.0, "opsz": 650.0 },
+          { "id": "title", "wght": 900.0, "opsz": 900.0 }
+        ],
+        "axisOrderCanonicalized": true,
+        "floatBitIdentity": true,
+        "maximumPageVariants": 4
+      },
+      "producer": {
+        "native": "qualified",
+        "nodeWasm": "qualified",
+        "canonicalGlyphClusterPositionParity": true
+      },
+      "backends": {
+        "canvasKit": {
+          "default": "unchanged-text-run",
+          "nonDefault": "published-glyph-run-and-portable-outline",
+          "backendReshaping": false
+        },
+        "canvas2d": { "nonDefault": "deterministic-text-run-fallback" },
+        "legacySvg": { "nonDefault": "deterministic-text-run-fallback" },
+        "nativeSkia": { "nonDefault": "deterministic-text-run-fallback" }
+      },
+      "publication": {
+        "noRequest": "unchanged-text-run",
+        "explicitDefault": "unchanged-text-run",
+        "explicitInteriorAndMax": "bounded-glyph-run-and-portable-outline",
+        "atomic": true,
+        "partialPublicationAllowed": false
+      },
+      "fallback": {
+        "invalidOrIncompleteInstance": "whole-paragraph-text-run-rollback",
+        "unsupportedBackend": "deterministic-text-run"
+      },
+      "rejectionReasons": [
+        "DuplicateVariationAxis",
+        "MalformedVariationTag",
+        "VariationAxisUnsupported",
+        "VariationValueNonFinite",
+        "VariationValueOutOfRange",
+        "VariationAxisLimitExceeded",
+        "ExplicitInstanceSlotMismatch",
+        "ExplicitInstanceOverrideNotAllowed",
+        "IncompleteOrMalformedOutline",
+        "SourceUnavailable",
+        "StaleRegistryGeneration"
+      ],
+      "deferred": [
+        "hwp-or-hwpx-axis-intent-inference",
+        "font-name-bold-or-ratio-axis-heuristic",
+        "backend-native-variable-typeface-reconstruction",
+        "arbitrary-font-and-axis-range-generalization",
+        "unsupported-script-language-generalization"
+      ],
+      "followUpEvidence": "explicit-document-intent-contract-plus-public-variable-font-and-backend-proof",
+      "automaticFollowUpIssue": false
+    },
+    {
+      "id": "q4-vertical-hwp5-table-cell-v1",
+      "classification": "bounded-subset",
+      "source": {
+        "path": "ttfs/opensource/NotoSansKR-Regular.ttf",
+        "bytes": 2519996,
+        "sha256": "6e06a7fe5d696ca719894a23f36bb2b1be8c816a5937cd4ad0f23ca67780dd74",
+        "faceIndex": 0,
+        "exactPortableSourceRequired": true,
+        "requiredTables": ["vhea", "vmtx"],
+        "featureTables": ["GPOS", "GSUB"],
+        "vorgPresent": false
+      },
+      "predicate": {
+        "format": "hwp5",
+        "provenance": "hwp5-semantic-lineage",
+        "surface": "table-cell",
+        "textDirection": 2,
+        "writingMode": "vertical-rl",
+        "orientation": "vertical-upright",
+        "scriptClass": "pure-cjk",
+        "language": "fixture-owned-cjk-request-not-general-language-coverage",
+        "oneCell": true,
+        "oneParagraph": true,
+        "oneComposedLine": true,
+        "oneTextRun": true,
+        "oneColumn": true,
+        "oneExactSlot": true,
+        "variationAxes": [],
+        "syntheticStyleOrEffect": false,
+        "mode": "boundedVerticalHwp5TableCellV1"
+      },
+      "producer": {
+        "native": "qualified",
+        "nodeWasm": "qualified",
+        "canonicalGlyphClusterPositionParity": true
+      },
+      "backends": {
+        "canvasKitBrowser": { "disposition": "vertical-glyph-run-selected", "backendReshaping": false },
+        "canvasKitPolicy": { "disposition": "vertical-glyph-run-selected", "backendReshaping": false },
+        "canvas2d": { "disposition": "text-run-and-legacy-vertical-geometry-fallback" },
+        "legacySvg": { "disposition": "text-run-and-legacy-vertical-geometry-fallback" },
+        "nativeSkia": { "disposition": "text-run-and-legacy-vertical-geometry-fallback" }
+      },
+      "publication": {
+        "verticalGlyphRunPerFallbackLeaf": 1,
+        "sourceSharedAcrossLeaves": true,
+        "atomic": true,
+        "partialLayoutOrPublicationAllowed": false
+      },
+      "fallback": {
+        "geometry": "pristine-legacy-vertical-geometry",
+        "paint": "deterministic-text-run",
+        "scope": "whole-vertical-target"
+      },
+      "rejectionReasons": [
+        "VerticalMetricsUnavailable",
+        "MalformedSfnt",
+        "MixedRunUnsupported",
+        "HorizontalIntentUnsupported",
+        "DirectionIntentMismatch",
+        "ColumnPitchInvalid",
+        "VariationGeometryUnsupported",
+        "LegacyGeometryMalformed",
+        "SourceIdentityMismatch",
+        "StaleRegistryGeneration",
+        "UnsupportedBackendOrTuple",
+        "EntryLimitExceeded",
+        "ResourceLimitExceeded"
+      ],
+      "deferred": [
+        "hwpx-table-cell",
+        "hwp5-text-direction-1",
+        "horizontal-cell",
+        "missing-or-stale-exact-source",
+        "multi-paragraph-run-or-column",
+        "latin-punctuation-or-mixed-run",
+        "vertical-variable-instance",
+        "unsupported-backend-glyph-replay",
+        "text-box-and-general-vertical-surface"
+      ],
+      "followUpEvidence": "surface-specific-semantic-lineage-plus-public-oracle-and-backend-pixel-proof",
+      "automaticFollowUpIssue": false,
+      "historicalBlockedResult": {
+        "preserved": true,
+        "currentBlocker": false,
+        "resolvedBy": "w10_q4_d5_d_causal_wasm_result.json"
+      }
+    }
+  ],
+  "decisionRules": {
+    "featureDetectionNotVersionBranching": true,
+    "allPredicatesRequiredForSupportedSelection": true,
+    "unsupportedSelectionReturnsStructuredReason": true,
+    "backendMayReshapePublishedGlyphPayload": false,
+    "failurePublishesPartialGeometryOrResources": false,
+    "deferredCountsAsSupported": false,
+    "deferredCountsAsFailure": false
+  },
+  "crossChecks": {
+    "q5LaneClassificationsMatch": true,
+    "sourceDigestsMatchQ5": true,
+    "q3AxesMatchCapabilityAudit": true,
+    "q4ActivationSurfaceMatchesExecutionPlan": true,
+    "fallbackOwnersPresent": true,
+    "rejectionReasonsPresent": true,
+    "deferredRowsMarkedUnsupported": true,
+    "supportExpansion": 0,
+    "matrixMismatch": 0
+  },
+  "validation": {
+    "jsonSyntax": "passed",
+    "localSourceSizeAndSha256": "passed-3-of-3",
+    "q5LaneClassification": "passed",
+    "q5BCanonicalFaceDigest": "passed-3-of-3",
+    "q3CanonicalAxisRange": "passed-2-of-2",
+    "q4ActivationSurface": "passed",
+    "fallbackReasonDeferredCompleteness": "passed-3-of-3",
+    "gitDiffCheck": "passed"
+  },
+  "procedureCorrection": {
+    "kind": "evidence-shape-normalization",
+    "detail": "the first jq expression treated Q5 final source labels as digest objects; the corrected expression uses Q5-B faces as digest authority and normalizes Q3 axis field names",
+    "productOrEvidenceMismatch": false
+  },
+  "boundaries": {
+    "productMutation": false,
+    "testMutation": false,
+    "privateCorpusUsed": false,
+    "hyperVUsed": false,
+    "hancomOracleUsed": false,
+    "githubMutated": false,
+    "followUpIssuesCreated": false
+  },
+  "next": {
+    "stage": "W10-Q6-B",
+    "action": "checkpoint-after-maintainer-approval-then-prepare-local-tracker-drafts"
+  }
+}

--- a/mydocs/tech/investigations/issue-4969/w10_q6_tracker_draft_receipt.json
+++ b/mydocs/tech/investigations/issue-4969/w10_q6_tracker_draft_receipt.json
@@ -1,0 +1,96 @@
+{
+  "schemaVersion": 1,
+  "kind": "font-w10-q6-tracker-draft-receipt",
+  "issue": 4969,
+  "parentTracker": 4960,
+  "stage": "W10-Q6-B",
+  "date": "2026-08-31",
+  "status": "drafts-prepared-approved",
+  "resultApproval": "explicit",
+  "checkpointApproved": true,
+  "source": {
+    "q6AApprovedCheckpoint": "8258f0284",
+    "productMergeHead": "3afbb066fe93724ab44309163a2e04efb954bf18",
+    "currentBranchHeadAtDraftStart": "8258f0284"
+  },
+  "githubReadSnapshot": {
+    "repository": "edwardkim/rhwp",
+    "bodySha256Method": "UTF-8 body bytes emitted by gh JSON and jq -j without a trailing newline",
+    "issues": [
+      {
+        "number": 4969,
+        "state": "OPEN",
+        "updatedAt": "2026-08-31T01:18:42Z",
+        "bodyCharacters": 1995,
+        "bodySha256": "1cbe21c09ac1c63336603cf662db42f1de40adec93beffe837af7211e11711b1",
+        "commentCount": 3,
+        "latestCommentAt": "2026-08-31T01:18:42Z"
+      },
+      {
+        "number": 4960,
+        "state": "OPEN",
+        "updatedAt": "2026-08-28T12:20:22Z",
+        "bodyCharacters": 3374,
+        "bodySha256": "448847eb53209b071470027d70d7157958c0d413a05b4b48cb7913129fa7bc42",
+        "commentCount": 5,
+        "latestCommentAt": "2026-08-28T12:20:22Z"
+      }
+    ],
+    "existingProductIntegration": {
+      "pullRequest": 6493,
+      "state": "MERGED",
+      "mergeCommit": "3afbb066fe93724ab44309163a2e04efb954bf18",
+      "head": "2497f48f283aa3ad714b53497d8cc2a33f5019a4",
+      "mergedAt": "2026-08-31T01:17:35Z",
+      "latestObservedCheckRollup": {
+        "success": 11,
+        "skipped": 20,
+        "failure": 0,
+        "pending": 0
+      }
+    }
+  },
+  "drafts": {
+    "document": "mydocs/working/task_m100_4969_w10_q6_tracker_drafts.md",
+    "issue4969": {
+      "bodyMutation": false,
+      "finalCommentPrepared": true,
+      "closeAfterVerifiedPostMergeComment": true
+    },
+    "issue4960": {
+      "bodyMutation": "three-exact-anchor-replacements-only",
+      "finalCommentPrepared": true,
+      "closeAfter-all-w0-through-w10-audit": true
+    }
+  },
+  "requiredPlaceholders": [
+    "{{Q6_PR_NUMBER}}",
+    "{{Q6_PR_URL}}",
+    "{{Q6_CODE_HEAD}}",
+    "{{Q6_MERGE_SHA}}",
+    "{{Q6_MERGED_AT}}",
+    "{{Q6_CODE_CI_SUMMARY}}",
+    "{{Q6_REVIEW_CI_SUMMARY}}"
+  ],
+  "publicationGuards": {
+    "publishWithAnyPlaceholder": false,
+    "publishIfIssueBodySha256Changed": false,
+    "publishBeforePrMerged": false,
+    "publishBeforeMutationApproval": false,
+    "closeBeforeApiTextVerification": false,
+    "bodyPatchAnchorMatchRequired": 3,
+    "utf8WithoutBomBodyFileRequired": true,
+    "postApiKoreanBomQuestionMarkVerificationRequired": true
+  },
+  "boundaries": {
+    "githubMutated": false,
+    "issueEdited": false,
+    "commentPosted": false,
+    "issueClosed": false,
+    "pullRequestCreated": false
+  },
+  "next": {
+    "stage": "W10-Q6-C",
+    "action": "checkpoint-after-maintainer-approval-then-refresh-base-and-run-submission-validation"
+  }
+}

--- a/mydocs/working/task_m100_4969_w10_q5.md
+++ b/mydocs/working/task_m100_4969_w10_q5.md
@@ -1,0 +1,112 @@
+# 최종 결과 보고서 — Task M100 #4969 W10-Q5 통합 자격화
+
+- **상위 계획**: [`task_m100_4969_w10_q5.md`](../plans/task_m100_4969_w10_q5.md)
+- **제품 기준 commit**: `upstream/devel@3afbb066fe93724ab44309163a2e04efb954bf18`
+- **Q5 checkpoint 계보**: A `a8371d976` → B `0367ac865` → C `7d9909791` → D `4d107fe09`
+- **기계 판독 증적**:
+  [`w10_q5_final_qualification.json`](../tech/investigations/issue-4969/w10_q5_final_qualification.json)
+- **수행일**: 2026-08-31 KST
+- **최종 후보 분류**: `bounded-subset`
+- **결과 상태**: 메인테이너 Q5-E 결과·checkpoint 생성 명시 승인
+- **제품 변경**: Q5 전체 0
+
+## 결론
+
+Q2 horizontal old Hangul, Q3 variable instance, Q4 vertical HWP5 table-cell을 하나의 현재 제품 tree에서
+결산했다. native↔WASM canonical mismatch, CanvasKit replay·pixel mismatch, unsupported backend false selection,
+fallback disappearance, partial publication, resource multiplicity 증가는 모두 0이다. 성능과 WASM 값은 비교 가능한
+snapshot만 연결했고 서로 다른 기준의 인과 delta를 합산하지 않았다.
+
+최종 lane 분류는 다음과 같다.
+
+| lane | 분류 | 의미 |
+| --- | --- | --- |
+| Q2 horizontal old Hangul | `bounded-subset` | 두 active horizontal lane만 common GlyphRun, 나머지는 W9 K1/K0 TextRun |
+| Q3 variable instance | `qualified` | 동결된 explicit default/interior/max 계약이 모든 gate 통과 |
+| Q4 vertical HWP5 table-cell v1 | `bounded-subset` | exact source·vertical metrics·CanvasKit의 제한된 table-cell tuple만 지원 |
+| Q5 전체 | `bounded-subset` | 세 lane 중 좁은 지원면을 넓은 일반 지원으로 과장하지 않음 |
+
+`bounded-subset`은 실패가 아니다. 검증된 입력·backend·fallback 경계를 제품 계약으로 정확히 남기는 등급이다.
+Q5 완료 조건 네 항목은 모두 충족됐다.
+
+## 1. Q2 — horizontal old Hangul
+
+Q2는 `horizontal-tb`, LTR, bidi level 0, exact portable source, direct old-Hangul complex target의 두 active lane만
+지원한다. stored boundary가 final shaped range와 같은 lane과, 제한된 no-LineSeg atomic lane이다. 이 범위에서는
+native와 Node WASM이 같은 cluster·glyph·position을 만들고 CanvasKit이 strict common GlyphRun을 재생한다.
+
+Canvas2D·legacy SVG·Native Skia와 predicate 밖의 입력은 결정적 TextRun fallback으로 닫힌다. fallback owner는
+W9 K1, 그 다음 existing K0 TextRun이다. common shaping 성공 run에는 W9 GPOS를 중복 적용하지 않고, 실패하면
+부분 geometry 없이 transaction 전체가 기존 owner로 돌아간다. Q5의 현재-tree parity와 Q2 계보 감사에서
+horizontal non-target, W9 K1, K0 출력 변화는 0이다.
+
+RTL/bidi, 일반 Latin liga 활성화, multi-line/run batch, mixed target split, 일반 edit reflow, stored prefix,
+split-cell recovery, inline control, center/right/justify/distribute와 nonzero GPOS y-position은 여전히 deferred다.
+
+## 2. Q3 — variable instance
+
+Q3의 동결된 계약은 exact `HappinessSansVF.ttf` source와 명시적 default/interior/max instance다. 요청 없음과
+explicit default는 기존 TextRun·layer·CanvasKit plan을 그대로 보존한다. interior/max만 bounded GlyphRun과 portable
+GlyphOutline을 게시하며, 지원하지 않는 backend와 invalid/incomplete instance는 TextRun으로 원자 rollback한다.
+
+현재 9-process 측정에서 interior/max의 warm 증가는 exact default 대비 p50 약 110µs, p95 약 142µs로 승인된
+p50 1ms·p95 2ms 한도를 통과했다. 1/2/8 instance × run 전 조합에서 exact source digest, parse, blob, face는
+각각 하나다. default output 변화, unsupported backend non-default 선택과 partial publication은 0이다.
+
+## 3. Q4 — vertical HWP5 table-cell v1
+
+Q4는 exact portable source, `vhea`·`vmtx`, 동결된 HWP5 table-cell geometry와 CanvasKit backend가 모두 성립하는
+bounded tuple만 지원한다. 지원 범위에서는 leaf별 vertical GlyphRun을 원자 게시하고 source 하나를 공유한다.
+다른 backend, horizontal intent, mixed run, missing/malformed vertical metrics, stale source·generation 또는 malformed
+legacy geometry는 기존 TextRun과 vertical legacy geometry를 그대로 보존한다.
+
+D5-C의 역사적 `blocked`는 당시 clean-room A 구성 실패로 causal WASM 영수증이 없었던 상태다. D5-D가 제품
+Rust source만 역적용한 같은-image A/B를 구성해 +36,611 bytes(+0.371371668%)를 확보했고 blocker를 해소했다.
+역사 기록은 삭제하지 않되 현재 판정은 `bounded-subset`이다.
+
+## 4. 통합 gate
+
+| gate | 결과 |
+| --- | --- |
+| merged-head native focused | 114/114 passed |
+| isolated Node WASM | 19/19 passed |
+| actual CanvasKit | 1/1 passed |
+| bounded·malformed·rollback focused | 50/50 passed |
+| Q5-D resource focused | 2/2 passed |
+| Studio resource reuse | 5/5 passed |
+| native↔WASM canonical mismatch | 0 |
+| CanvasKit replay·pixel mismatch | 0 |
+| unsupported backend false selection·fallback disappearance | 0 |
+| partial publication·reject 뒤 mutation·panic/OOM | 0 |
+| resource multiplicity 증가 | 0 |
+| A–D JSON과 최종 lane 분류 기계 대사 | passed |
+| `cargo fmt --all -- --check`·JSON·diff check | passed |
+
+현재 표준 Docker WASM 절대 snapshot은 9,905,805 bytes, SHA-256
+`ed11bdb3bf2b11b44c3f6fed5c16d403257b60b27bffa469e5e3c1dfecf912a4`다. Q3 +51,554 bytes와 Q4 +36,611
+bytes는 독립 인과 snapshot으로 보존했고 합산하지 않았다.
+
+## 5. 보호 불변식과 미지원 경계
+
+- exact source digest·face·variation vector·writing mode는 cache identity에 남는다.
+- backend가 증명하지 못한 glyph payload는 기존 TextRun 또는 검증된 portable outline으로만 닫는다.
+- font 32 MiB, glyph·cluster·text 4,096, axis 16, feature 64와 registry·sidecar 상한을 완화하지 않았다.
+- reject 뒤 measurement, cache, sidecar, font resource와 geometry의 부분 publication은 0이다.
+- 새 integration source, generated suite·manifest, Cargo marker와 `pkg`를 제출하지 않았다.
+- private corpus·Hyper-V·한컴 Oracle을 사용하지 않았다.
+
+deferred surface는 Q5의 실패 건수가 아니며 현재 제품 지원으로도 계산하지 않는다. Q6는 이 목록을 support
+matrix의 명시적 미지원·fallback 영역으로 고정하고, 별도 사용자 여정과 oracle이 필요한 항목만 후속 이슈 후보로
+분리해야 한다.
+
+## Q6 인계와 승인 경계
+
+메인테이너가 Q5-E 결과와 checkpoint 생성을 명시 승인했다. checkpoint를 고정한 뒤 다음 순서로 Q6
+수행계획을 작성한다.
+
+1. 세 lane의 지원 tuple·fallback·미지원 surface를 최종 support matrix로 고정한다.
+2. #4969와 상위 #4960 tracker에 반영할 현행화 초안을 로컬에 작성한다.
+3. 최종 PR validation과 제출 범위를 정의한다.
+4. tracker 수정, remote push, PR 생성, 이슈 종료는 각각 별도 승인을 받는다.
+
+Q5 결과만으로 #4969·#4960을 닫거나 GitHub를 변경하지 않는다.

--- a/mydocs/working/task_m100_4969_w10_q5_a.md
+++ b/mydocs/working/task_m100_4969_w10_q5_a.md
@@ -1,0 +1,89 @@
+# 결과 보고서 — Task M100 #4969 W10-Q5-A merged-head 증적 재사용 감사
+
+- **상위 계획**: [`task_m100_4969_w10_q5.md`](../plans/task_m100_4969_w10_q5.md)
+- **기준 commit**: `upstream/devel@3afbb066fe93724ab44309163a2e04efb954bf18`
+- **기계 판독 증적**:
+  [`w10_q5_evidence_eligibility.json`](../tech/investigations/issue-4969/w10_q5_evidence_eligibility.json)
+- **수행일**: 2026-08-31 KST
+- **제품 변경**: 없음
+- **결과 상태**: `qualified-evidence-audit`, 메인테이너 결과·checkpoint 생성 명시 승인
+
+## 결론
+
+Q2·Q3·Q4의 최종 checkpoint와 PR #6493 code/review head는 모두 현재 merge commit `3afbb066f`의
+조상이다. 그러나 조상이라는 사실만으로 모든 과거 수치를 현재 값으로 재사용할 수는 없다.
+
+- Q2 뒤 Q3·Q4가 shaping owner, paint resource, layer cache와 CanvasKit selector를 변경했다.
+- Q3 뒤 Q4가 같은 resource/cache/backend와 #4969 harness를 변경했다.
+- Q4 최신 재자격화 뒤에는 제품 동작 변경이 없고, 첫 CI 정정은 source-side test 두 건을 기존 integration
+  source로 옮긴 것뿐이다.
+
+따라서 Q2·Q3의 역사적 classification과 stage-local WASM 자료는 보존하되, 현재 merge head의 parity와
+resource/performance는 focused refresh한다. Q4 correctness·backend·performance와 causal WASM은 재사용한다.
+PR #6493 code candidate가 Full CI를 통과했고 trailing head는 문서 세 경로만 바꿨으므로 full nextest,
+Native Skia full과 clean-room A/B를 다시 실행하지 않는다.
+
+## 1. 계보와 통합 head
+
+| 증적 | checkpoint | 현재 merge의 조상 |
+| --- | --- | --- |
+| Q2 final | `167e3b3d2` | 예 |
+| Q3 final | `4e0a3822c` | 예 |
+| Q4 D5-C | `a7de96b44` | 예 |
+| Q4 D5-D | `95d450dd5` | 예 |
+| Q4 latest requalification | `95429a34f` | 예 |
+| PR code candidate | `7a67f2508` | 예 |
+| PR trailing review | `2497f48f2` | 예 |
+
+`7a67f2508..2497f48f2`의 변경은 오늘할일과 self-review 문서 세 개뿐이다. `2497f48f2`와 merge
+`3afbb066f`의 tree는 `da1c173345adda3c691878415441e6f64515afe1`로 동일하다.
+
+코드 후보 check-run은 30 success, 4 skip, 실패·대기 0이다. trailing review head는 11 success와 trusted
+fast-pass expected skip 19건, 별도 stale-run cancellation skip 1건이며 실패·대기 0이다.
+
+## 2. 첫 CI 정정의 영향
+
+commit `7a67f2508`은 `src/document_core/commands/header_footer_ops.rs`의 `#[cfg(test)] mod tests` 안에
+있던 cache guard 두 건을 삭제하고, 같은 보호 의도를
+`tests/cases/issue_4969_shaping_atomic_activation.rs`의 public-output integration 계약으로 옮겼다.
+
+- production function·type 변경: 0
+- Studio product source 변경: 0
+- font·sample fixture 변경: 0
+- integration source 신규 파일: 0
+- generated suite·manifest 제출: 0
+
+따라서 이 정정은 Q4 제품 동작과 성능 증적을 무효화하지 않는다.
+
+## 3. lane별 자격 판정
+
+| lane·증적 | 판정 | 이유 |
+| --- | --- | --- |
+| Q2 역사 classification | `reusable` | bounded 지원 범위의 역사적 결정은 유효 |
+| Q2 현재 canonical/backend parity | `focused-refresh` | Q3·Q4가 shared shaping/resource/CanvasKit 경로 변경 |
+| Q2 현재 performance/resource | `focused-refresh` | layer cache·resource 준비 소유권 변경 |
+| Q2 historical WASM | `historical-only` | 현재 통합 인과 delta로 사용할 수 없음 |
+| Q3 역사 classification | `reusable` | explicit-only bounded 지원 결정은 유효 |
+| Q3 현재 canonical/backend parity | `focused-refresh` | Q4 vertical selector·resource 경로가 같은 surface를 변경 |
+| Q3 현재 performance/resource | `focused-refresh` | Q4 source reuse 정정이 공통 cache/resource owner에 영향 |
+| Q3 causal WASM | `reusable-historical-only` | Q3 stage-local +51,554B를 독립 증적으로 보존 |
+| Q4 correctness/backend/performance | `reusable` | 최신 재자격화 뒤 제품 변화 0, test relocation만 존재 |
+| Q4 causal WASM | `reusable-historical-only` | same-tree +36,611B 독립 증적으로 보존 |
+| PR code candidate full regression | `reusable` | 현재 제품 tree에 대한 Full CI 성공 |
+
+Q3와 Q4의 stage-local WASM delta를 더해 통합 delta로 주장하지 않는다. 최신 devel에는 각 측정 기준 뒤 다른
+제품 변경도 들어왔기 때문이다. Q5-D에서 현재 merge head의 Docker WASM을 한 번 빌드해 절대 bytes와 digest만
+고정하되, 이를 과거 baseline과 임의 차감하지 않는다.
+
+## 4. 다음 실행 범위
+
+Q5-B와 Q5-C는 새 source 없이 기존 #4969 integration·Node WASM·Studio E2E를 현재 merge head에서 focused
+실행한다. Q5-D는 Q2·Q3의 shared resource/performance receipt만 refresh하고 Q4 자료를 재사용한다. 전체
+nextest, Native Skia full, 9-process Q4 재측정과 clean-room causal WASM A/B는 반복하지 않는다.
+
+private corpus·Hyper-V·한컴 Oracle은 필요하지 않다. 감사 중 제품 결함이나 harness 공백도 발견되지 않았다.
+
+## 다음 승인 경계
+
+이 Q5-A 결과와 checkpoint 생성을 메인테이너가 명시 승인했다. checkpoint로 고정한 뒤 Q5-B merged-head
+canonical parity로 이동한다. remote push와 GitHub comment는 별도 승인 경계다.

--- a/mydocs/working/task_m100_4969_w10_q5_b.md
+++ b/mydocs/working/task_m100_4969_w10_q5_b.md
@@ -1,0 +1,117 @@
+# 결과 보고서 — Task M100 #4969 W10-Q5-B merged-head canonical·backend parity
+
+- **상위 계획**: [`task_m100_4969_w10_q5.md`](../plans/task_m100_4969_w10_q5.md)
+- **Q5-A checkpoint**: `a8371d976`
+- **제품 기준 commit**: `upstream/devel@3afbb066fe93724ab44309163a2e04efb954bf18`
+- **기계 판독 증적**:
+  [`w10_q5_b_canonical_parity.json`](../tech/investigations/issue-4969/w10_q5_b_canonical_parity.json)
+- **수행일**: 2026-08-31 KST
+- **제품 변경**: 없음
+- **결과 상태**: `qualified`, 메인테이너 결과·checkpoint 생성 명시 승인
+
+## 결론
+
+Q2 horizontal old Hangul, Q3 variable instance, Q4 vertical table-cell의 현재 merged-head focused parity를
+기존 #4969 integration source만으로 다시 실행했다. 지원 tuple의 native↔Node WASM canonical mismatch,
+CanvasKit replay mismatch, unsupported backend false selection, fallback disappearance는 모두 0이다.
+
+- native focused: 114/114 통과
+- 격리 Node WASM: request contract 5/5 + shadow context 14/14, 합계 19/19 통과
+- Studio actual CanvasKit: 1/1 통과
+- 표준 Docker optimized WASM: 통과, 9,905,805 bytes
+- 새 integration source·제품 source·public API·schema 변경: 0
+
+따라서 Q5-B 종료 게이트는 충족됐다. 이 결과는 지원 범위를 확대하지 않는다. 메인테이너가 결과와
+checkpoint 생성을 명시 승인했으므로 checkpoint로 고정한 뒤 Q5-C bounded·malformed·atomic rollback
+회계로 이동한다.
+
+## 1. 입력 face와 test inventory
+
+| face | 역할 | SHA-256 |
+| --- | --- | --- |
+| `NotoSansKR-Regular.ttf` | horizontal·vertical control | `6e06a7fe5d696ca719894a23f36bb2b1be8c816a5937cd4ad0f23ca67780dd74` |
+| `SourceHanSerifK-OldHangul-subset.otf` | 옛한글 complex shaping | `2f86ef9a52acb6d1dad9d915843239123b635d97edd88fd0573a88ffcb4e16f1` |
+| `HappinessSansVF.ttf` | default·interior·max variable instance | `3bbd254dcc5780f7524f9d07af4aa981ba5e3e84cf32d7d4e04301b3943e8694` |
+
+source-side tier 검사는 4,221 tests / 299 modules를 확인했다. review inventory는 1,075 source,
+4,715 static test attributes, 28 generated suites + 20 exceptions로 48/48 target과 최소 6,559 cases를
+확인했다. generated suite·manifest는 검증 증적이며 제출 변경에 포함하지 않는다.
+
+## 2. native·Node WASM canonical parity
+
+현재 제품 tree에서 `test(/issue_4969/)` selector는 정확히 114건을 선택했다. `release-test` profile과 공유
+`target/pr-review`를 사용한 nextest 결과는 114 passed / 0 failed, 비선택 8,795 skipped, 1.106초다.
+
+루트에서 `wasm-pack test --node`를 직접 실행하면 전체 dev-dependency의 `wait-timeout`이 wasm32에서
+지원되지 않아 제품 테스트에 도달하지 못한다. 이 알려진 topology 제약을 제품 실패로 세지 않고, 두 기존
+integration source와 그들이 참조하는 tracked renderer·font·정적 계약 파일만 노출한 최소 manifest를
+`/tmp`에 만들었다. 제품과 동일한 `wasm-pack 0.15.0`, Node 24.15.0에서 다음 결과를 얻었다.
+
+| 기존 integration source | Node WASM 결과 |
+| --- | ---: |
+| `issue_4969_shaping_request_contract.rs` | 5/5 passed |
+| `issue_4969_shaping_shadow_context.rs` | 14/14 passed |
+| 합계 | 19/19 passed |
+
+첫 최소 하네스는 전체 `tests/` symlink를 자동 발견해 무관한 native test dependency까지 컴파일했고, 다음
+시도는 두 source의 `include_str!` 파일과 test-only `serde_json`·`blake3` 의존성이 빠진 것을 드러냈다.
+이를 두 source가 실제 참조하는 입력만 선별하는 방식으로 정정한 최종 실행이 위 19/19다. 하네스와 전용
+target은 결과 회수 뒤 삭제했으며 repository에 임시 파일이나 Cargo 변경을 남기지 않았다.
+
+## 3. 실제 backend 교차 확인
+
+Studio actual CanvasKit E2E는 같은 merged product tree의 최신 WASM package에서 1/1 통과했다.
+
+| case | 관측 |
+| --- | --- |
+| common horizontal GlyphRun | page advance 61.824, current ink 58×34, old control 58×38 |
+| vertical leaf source 0 | glyph 11232, ink 35×36 |
+| vertical leaf source 1 | glyph 1156, ink 33×35 |
+| horizontal font cache | blob 1 / typeface 1 / font 2 / 456,688 bytes |
+| vertical font cache | blob 1 / typeface 1 / font 1 / 2,519,996 bytes |
+
+기존 contract는 CanvasKit에서만 증명된 GlyphRun/outline tuple을 선택하고 SVG·Canvas2D·Native Skia의
+미지원 tuple은 TextRun fallback으로 닫는 조건을 포함한다. focused native·WASM·Studio 실행에서 false
+selection, backend reshaping, fallback disappearance와 pixel mismatch는 각각 0이었다.
+
+## 4. 표준 Docker WASM 산출물
+
+worktree 전용 named volume과 repository 표준 명령으로 현재 제품 tree를 release + `wasm-opt` 빌드했다.
+
+```bash
+docker compose --env-file .env.docker run --rm wasm
+```
+
+- 결과: 통과
+- wasm-pack 보고 시간: 6분 44초
+- 전체 wall time: 448.45초
+- Docker image: `sha256:bbbc4f8e0f7162b9a9700a592b8959b7c13fee2accbbe6d921586f28a2c55903`
+- `pkg/rhwp_bg.wasm`: 9,905,805 bytes
+- SHA-256: `ed11bdb3bf2b11b44c3f6fed5c16d403257b60b27bffa469e5e3c1dfecf912a4`
+
+전용 image에는 Node runner가 없으므로 표준 Docker 빌드와 격리 Node WASM test를 서로 다른 gate로 실행했다.
+둘은 같은 현재 tracked product source를 사용한다. 위 byte 수와 digest는 Q5-D에 넘길 현재 절대 snapshot일
+뿐이며, 과거 Q2/Q3/Q4 blob과 차감해 통합 causal delta로 주장하지 않는다. `pkg/`는 ignored 산출물이고
+제출하지 않는다. worktree에 연결했던 기존 `.env.docker`의 임시 symlink도 빌드 뒤 제거했다.
+
+## 5. 종료 게이트 대사
+
+| Q5-B gate | 결과 |
+| --- | --- |
+| supported native↔WASM canonical mismatch | 0 |
+| CanvasKit replay·pixel mismatch | 0 |
+| unsupported backend false selection | 0 |
+| TextRun fallback disappearance | 0 |
+| backend reshaping·partial publication | 0 |
+| font cache resource multiplicity 증가 | 0 |
+| 새 integration source·generated 제출물 | 0 |
+| 제품 source·API·schema·지원 tuple 변경 | 0 |
+| private corpus·Hyper-V·한컴 Oracle 사용 | 0 |
+
+로컬 cargo-nextest 0.9.137은 저장소 권고 0.9.140보다 낮고 `report-skipped` 설정을 무시한다는 경고를
+출력했다. 선택·실행 결과에는 실패가 없지만 도구 경고를 성공 증거로 숨기지 않고 별도 환경 한계로 남긴다.
+
+## 다음 승인 경계
+
+메인테이너가 이 결과와 checkpoint 생성을 명시 승인했다. 문서·JSON을 commit한 뒤 Q5-C의
+bounded·malformed·atomic rollback 회계로 이동한다. remote push·GitHub comment는 별도 승인 대상이다.

--- a/mydocs/working/task_m100_4969_w10_q5_c.md
+++ b/mydocs/working/task_m100_4969_w10_q5_c.md
@@ -1,0 +1,136 @@
+# 결과 보고서 — Task M100 #4969 W10-Q5-C bounded·malformed·atomic rollback 회계
+
+- **상위 계획**: [`task_m100_4969_w10_q5.md`](../plans/task_m100_4969_w10_q5.md)
+- **Q5-B checkpoint**: `0367ac865`
+- **제품 기준 commit**: `upstream/devel@3afbb066fe93724ab44309163a2e04efb954bf18`
+- **기계 판독 증적**:
+  [`w10_q5_c_bounded_atomic_ledger.json`](../tech/investigations/issue-4969/w10_q5_c_bounded_atomic_ledger.json)
+- **수행일**: 2026-08-31 KST
+- **제품 변경**: 없음
+- **test 변경**: 기존 integration source 2곳에 경계 guard 2건 추가, 새 source 0
+- **결과 상태**: `qualified`, 메인테이너 결과·checkpoint 생성 명시 승인
+
+## 결론
+
+Q2·Q3·Q4의 상한, malformed 입력, stale identity, unsupported tuple과 atomic rollback을 현재 제품 tree에서
+다시 회계했다. 기존 보호면 focused 48/48과 이번에 보완한 직접 경계 2/2를 합쳐 최종 50/50이 통과했다.
+Q5-B의 동일 제품 tree Node WASM 19/19도 재사용 가능하다.
+
+- 상한 완화: 0
+- panic·OOM: 0
+- structured reason 누락: 0
+- rejection 뒤 measurement·cache·sidecar·resource·geometry 부분 publication: 0
+- 기존 TextRun·paragraph·vertical fallback 손실: 0
+- 제품 source·API·schema·지원 tuple 변경: 0
+
+따라서 Q5-C 종료 게이트는 충족됐다. 메인테이너가 결과와 checkpoint 생성을 명시 승인했으므로
+checkpoint로 고정한 뒤 Q5-D 성능·WASM·resource 결산으로 이동한다.
+
+## 1. Q5-C에서 보완한 직접 경계
+
+회계 과정에서 구현 상한은 존재하지만 이를 직접 고정하는 integration assertion이 없는 두 지점을 찾았다.
+제품 동작을 바꾸지 않고 기존 source 두 곳에 최소 guard를 추가했다.
+
+### 1.1 explicit instance request 4,096
+
+`MAX_HORIZONTAL_SHAPING_INSTANCE_REQUESTS`와 upstream exact-source slot 상한
+`MAX_KERNING_REGISTRY_SLOTS`은 모두 4,096이다. 유효한 instance request는 먼저 exact-source slot을
+필요로 하므로 공개 경로의 실효 상한은 source registry에서 먼저 닫힌다.
+
+새 guard는 1,236-byte 공개 synthetic font 하나를 4,096 slot에 alias하고 빈 default instance request를
+4,096건 등록한다. 4,097번째 source slot은 `SlotLimitExceeded`, 존재하지 않는 slot의 request는
+`SourceUnavailable`로 거부되며 request count와 generation은 각각 4,096에서 변하지 않는다.
+
+`RequestLimitExceeded`는 source slot과 request 상한이 같은 현재 구조에서는 방어적 후단 branch다. 이를
+직접 발생시켰다고 주장하지 않고, 두 상한의 equality와 선행 source cap을 guard로 고정했다. 향후 source
+slot 상한만 커지면 이 테스트가 실패해 request branch의 직접 재검증을 요구한다.
+
+### 1.2 vertical page sidecar 4,096
+
+같은 certified source·geometry를 공유하는 sidecar를 node 1..4,096에 채운 뒤 4,097번째 attach를 실행했다.
+결과는 `EntryLimitExceeded`이며 entry count와 registry generation이 거부 전과 같다. source payload는 한 번만
+소유하므로 4,096개의 font 복사나 무제한 payload를 만들지 않는다.
+
+두 guard의 단독 실행은 2/2, 0.069초에 통과했다.
+
+## 2. 상한 회계
+
+| 보호면 | 상한·입력 | 판정·reason | 거부 뒤 상태 |
+| --- | --- | --- | --- |
+| exact font | 32 MiB, 상한+1 | `BoundedLimit / FontByteLimitExceeded` | shaping 전 종료 |
+| text | 4,096 code points, 상한+1 | `BoundedLimit / TextCodePointLimitExceeded` | glyph 0 |
+| feature | 64, 상한+1 | `BoundedLimit / FeatureLimitExceeded` | shaping 전 종료 |
+| variation axes | 16, 상한+1 | `BoundedLimit / VariationAxisLimitExceeded` | face parse·cache mutation 0 |
+| glyph output | 4,096 | post-shape `GlyphLimitExceeded` guard | output payload empty |
+| cluster output | 4,096/run | post-shape `ClusterMappingInvalid` guard | measurement 미생성 |
+| horizontal cache entry | 4,096, test limit 1의 두 번째 요청 | `CacheEntryLimitExceeded` | 두 번째 measurement 없음 |
+| instance request | 4,096 source-coupled slots | `SlotLimitExceeded` → `SourceUnavailable` | count·generation 불변 |
+| horizontal page sidecar | 4,096, 상한+1 | `EntryLimitExceeded` | 기존 4,096 유지 |
+| vertical page sidecar | 4,096, 상한+1 | `EntryLimitExceeded` | count·generation 불변 |
+| prepared font resource | page 64 MiB, bounded test limit 0 | `ResourceLimitExceeded` | blob·face·cache entry 0 |
+| attempt trace | 4,096, 이후 2건 | `Truncated`, omitted 2 | raw text·glyph payload 미보존 |
+
+glyph/cluster hostile-font overflow는 별도 초대형 SFNT fixture를 만들지 않았다. 대신 4-byte Unicode scalar
+4,096개의 near-boundary 실행이 glyph 4,096과 마지막 UTF-8 cluster 16,380에서 정상 종료하는지 확인하고,
+shaping 직후 `glyph_buffer.len() > 4_096`과 cluster 생성 직후 `clusters.len() > 4_096`의 후단 guard를
+대조했다. 따라서 이 두 항목의 증거 등급은 `near-boundary-runtime-plus-post-shape-guard`이며 직접 overflow
+fixture로 과장하지 않는다.
+
+## 3. malformed·unsupported reason 회계
+
+### Q2 horizontal
+
+- missing source, malformed SFNT, non-portable source
+- direction/writing-mode mismatch
+- wrong UTF-8/UTF-16 range, duplicate node, stale registry generation, attempt identity mismatch
+- unverified resource key: 잘못된 length, leading zero, uppercase digest, 잘못된 algorithm·digest·suffix
+- invalid horizontal scale, cache/resource limit
+
+모든 terminal rejection은 typed disposition과 reason을 유지한다. trace에는 원문, glyph payload, font bytes,
+host path가 들어가지 않는다. rejection 뒤 measurement는 없고 cache miss/hit, prepared source, font blob/face는
+증가하지 않는다.
+
+### Q3 variable instance
+
+- duplicate axis, malformed tag, unsupported axis
+- non-finite value, out-of-range value, axis count 초과
+- explicit slot mismatch, ad-hoc override, missing request/source
+- incomplete·malformed outline과 unsupported product surface
+
+invalid request는 parsed face·result cache·owner snapshot을 바꾸지 않는다. paragraph publication 단계에서
+하나의 negative surface라도 발견되면 전체 paragraph가 기존 TextRun owner로 rollback한다.
+
+### Q4 vertical table-cell
+
+- `vhea`/`vmtx` 부재: `VerticalMetricsUnavailable`
+- malformed SFNT, mixed CJK/Latin run
+- horizontal intent, direction/writing-mode mismatch, non-finite column pitch
+- unsupported variation geometry, malformed legacy fallback geometry
+- source identity·generation·node·leaf sequence mismatch
+- CanvasKit 이외 backend 또는 malformed CanvasKit tuple
+
+모든 rejection은 원래 `VerticalLegacyGeometry`와 TextRun을 보존하고 `product_published=false`로 종료한다.
+여러 leaf 중 하나만 달라도 vertical GlyphRun 전체 publication이 0이 되며, backend selection은 TextRun으로
+닫힌다.
+
+## 4. 검증 결과와 제출 경계
+
+| gate | 결과 |
+| --- | --- |
+| Q5-C focused native | 50/50 passed, 8,861 non-selected, 0.971초 |
+| 신규 hard-boundary guard | 2/2 passed, 0.069초 |
+| 동일 product tree Node WASM 재사용 | Q5-B 19/19 passed |
+| integration manifest | 1,075 source / 4,717 attrs / 48/48 targets / 최소 6,559 cases |
+| `cargo fmt --all -- --check` | passed |
+| `git diff --check` | passed |
+
+변경은 `tests/cases/issue_4969_shaping_shadow_context.rs`와
+`tests/cases/issue_4969_shaping_request_contract.rs`뿐이다. 새 integration source, generated suite·manifest,
+Cargo marker, `pkg`, private corpus·Hyper-V·한컴 Oracle, GitHub mutation은 제출 범위에 없다. 로컬
+cargo-nextest 0.9.137과 권고 0.9.140의 차이 및 `report-skipped` 경고는 Q5-B와 같다.
+
+## 다음 승인 경계
+
+메인테이너가 이 결과와 checkpoint 생성을 명시 승인했다. test guard·문서·JSON을 commit한 뒤 Q5-D의
+focused performance·resource ledger를 실행한다. Q5-B에서 이미 생성한 현재 Docker WASM 절대
+bytes·digest는 재사용하며 다시 빌드하지 않는다. remote push·GitHub comment는 별도 승인 대상이다.

--- a/mydocs/working/task_m100_4969_w10_q5_d.md
+++ b/mydocs/working/task_m100_4969_w10_q5_d.md
@@ -1,0 +1,117 @@
+# 결과 보고서 — Task M100 #4969 W10-Q5-D 성능·WASM·resource 영향 결산
+
+- **상위 계획**: [`task_m100_4969_w10_q5.md`](../plans/task_m100_4969_w10_q5.md)
+- **Q5-C checkpoint**: `7d9909791`
+- **제품 기준 commit**: `upstream/devel@3afbb066fe93724ab44309163a2e04efb954bf18`
+- **기계 판독 증적**:
+  [`w10_q5_d_performance_resource_ledger.json`](../tech/investigations/issue-4969/w10_q5_d_performance_resource_ledger.json)
+- **수행일**: 2026-08-31 KST
+- **제품 변경**: 없음
+- **test 변경**: 기존 integration source 1곳에 Q2 1/2/8 run 자원 guard 1건 추가, 새 source 0
+- **결과 상태**: `qualified`, 메인테이너 결과·checkpoint 생성 명시 승인
+
+## 결론
+
+현재 통합 제품 tree에서 Q2·Q3의 자원 행렬과 Q3의 9-process 성능 receipt를 focused refresh했고, Q4의 자격 있는
+성능·자원 증적과 Q5-B의 현재 Docker WASM 절대 snapshot을 재사용했다. 세 lane 모두 폰트 source의 digest,
+parse, blob과 face가 run·page 수에 따라 복제되지 않았다. Q3의 non-default instance 비용은 승인된 warm 절대
+한도 안이며 explicit default는 exact default와 산출물까지 동일하다.
+
+- 비교 불가능한 값의 산술 결합: 0
+- resource multiplicity 증가: 0
+- Q3 warm 성능 gate 위반: 0
+- 제품 source·API·schema·지원 tuple 변경: 0
+- 추가 Docker build: 0
+
+따라서 Q5-D 종료 게이트는 충족됐다. 메인테이너가 결과와 checkpoint 생성을 명시 승인했으므로 이를
+고정한 뒤 Q5-E 최종 분류로 이동한다.
+
+## 1. Q2 — run·page가 늘어도 source는 하나
+
+기존 integration source에 1/2/8개의 동일한 horizontal run을 실제 lowering하는 guard를 추가했다. TextRun과
+GlyphRun은 의도대로 1/2/8개가 되지만 font blob, face, 456,688-byte payload는 모두 하나다.
+
+| run 수 | TextRun | GlyphRun | font blob | font face | retained font bytes |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 1 | 1 | 1 | 1 | 456,688 |
+| 2 | 2 | 2 | 1 | 1 | 456,688 |
+| 8 | 8 | 8 | 1 | 1 | 456,688 |
+
+Studio page 행렬도 5/5 통과했다. inline 입력의 제시 bytes는 page 1/2/8에서 456,688 / 913,376 /
+3,653,504로 커지지만 retained blob과 retained bytes는 항상 1 / 456,688이다. by-key 전송은 세 경우 모두 fetch
+1회, 456,688 bytes이며 missing·wrong·oversized·stale key는 TextRun fallback을 보존한다.
+
+현재 default baseline 9-process receipt의 64회 warm p50/p95는 100,361 / 197,921 ns다. 이 수치는 같은
+프로토콜 내 관측값이고 Q2의 권위는 wall time이 아니라 위 구조 counter다. layer JSON과 CanvasKit plan은 9회
+모두 동일하며 기존 Q3 default 기준 해시와도 일치한다.
+
+## 2. Q3 — source는 하나, instance 결과만 유계 선형
+
+1/2/8 instance × 1/2/8 run의 9개 조합을 현재 tree에서 다시 실행했다. 모든 조합에서 digest pass, source face
+parse, prepared source, arena intern, font blob과 font face는 각각 1이다. 최대 8×8에서는 instance face와 cache
+miss가 8, cache hit가 56, GlyphRun·GlyphOutline이 64이고 payload는 2,613,391 bytes다. 즉 source 복제는 없고
+instance 결과와 실제 run 산출만 입력 크기 안에서 선형이다.
+
+### 2.1 독립 프로세스 9회 성능
+
+| case | warm p50 / p95 (ns) | exact 대비 p50 / p95 (ns) | cold p50 / p95 (ns) |
+| --- | ---: | ---: | ---: |
+| exact default | 36,895 / 38,096 | 기준 | 5,311,993 / 5,515,963 |
+| explicit default | 36,791 / 37,190 | -104 / -906 | 5,302,781 / 5,522,132 |
+| interior | 146,538 / 179,722 | +109,643 / +141,626 | 8,118,654 / 8,665,067 |
+| max | 147,735 / 179,920 | +110,840 / +141,824 | 7,929,738 / 8,718,752 |
+
+승인된 non-default warm 한도는 p50 +1,000,000 ns, p95 +2,000,000 ns다. interior와 max 모두 충분히
+통과한다. exact default와 explicit default의 layer·plan hash 및 TextRun/GlyphRun/GlyphOutline/font resource
+구조도 동일하다. cold 값과 과거 절대 wall time은 환경 부하가 개입하므로 관측값으로만 보존하고 사후 hard
+gate로 쓰지 않았다.
+
+## 3. Q4 — 자격 있는 A/B/A 증적 재사용
+
+Q5-A가 재사용 가능으로 판정한 `w10_q4_d5_b_performance_correction.json`은 같은 source를 매 layout마다 hash,
+parse, copy하던 결함을 제거한 뒤 9-process A/B/A로 측정됐다. 교정 전 대비 warm layout은
+598.6405359947997배, layer build는 339.161579248742배 개선됐다. 지원 B tuple의 font blob/face/payload는
+1 / 1 / 2,519,996 bytes이며 fallback TextRun 2개와 vertical GlyphRun 2개가 source 하나를 공유한다.
+
+Q5에서는 이 비용이 다시 선형인지 확인하기 위해 같은 비싼 A/B/A를 반복하지 않았다. 해당 owner와 harness가
+통합 head까지 의미 변경되지 않았다는 Q5-A 계보 감사와 Q5-B·C 현재-tree parity/rollback 결과를 함께 사용했다.
+
+## 4. WASM — 인과 delta와 현재 절대 크기를 분리
+
+| snapshot | A 또는 baseline | B 또는 candidate | 인과 delta |
+| --- | ---: | ---: | ---: |
+| Q3 clean comparison | 9,759,368 | 9,810,922 | +51,554 bytes (+0.5282514%) |
+| Q4 same-image clean-room | 9,858,318 | 9,894,929 | +36,611 bytes (+0.37137166806751415%) |
+
+두 delta는 서로 다른 기준 tree의 독립 변화다. 더하지 않았고 현재 통합 causal delta로 이름을 바꾸지 않았다.
+Q5-B에서 만든 현재 표준 Docker 절대 snapshot은 9,905,805 bytes,
+SHA-256 `ed11bdb3bf2b11b44c3f6fed5c16d403257b60b27bffa469e5e3c1dfecf912a4`다. 이것과 과거 절대값의 차이도
+인과값으로 해석하지 않는다. Q5-D에서는 두 번째 Docker build를 실행하지 않았다.
+
+## 5. 절차 정정과 검증 경계
+
+측정 중 세 가지 절차 정정이 있었다. 모두 숨기지 않고 원장에 기록했으며 제품 실패는 아니다.
+
+1. 새 test assertion의 `usize` range를 source ID 타입인 `u32`에 맞춘 뒤 passing receipt를 얻었다.
+2. 한 번 `--target-dir`을 빠뜨려 생긴 worktree-local 449 MiB `target` build를 중단하고 그 정확한 디렉터리만
+   제거했다. 공유 `/home/edward/mygithub/rhwp/target/pr-review`는 보존했다.
+3. 첫 Studio 시도는 분리 worktree에 `node_modules`가 없어 실패했다. 기본 checkout의 설치 의존성을 잠시
+   연결해 5/5 통과한 뒤 링크를 제거했다.
+
+새 integration source, generated suite·manifest, Cargo marker, `pkg`, private corpus·Hyper-V·한컴 Oracle,
+GitHub mutation은 제출 범위에 없다.
+
+| gate | 결과 |
+| --- | --- |
+| Q5-D focused nextest | 2/2 passed, 8,910 non-selected, 0.901초 |
+| Studio resource reuse | 5/5 passed, 268.992807ms |
+| integration manifest | 1,075 source / 4,718 attrs / 48/48 targets / 최소 6,559 cases |
+| JSON syntax | passed |
+| `cargo fmt --all -- --check` | passed |
+| `git diff --check` | passed |
+
+## 다음 승인 경계
+
+메인테이너가 Q5-D 결과와 checkpoint 생성을 명시 승인했다. test guard·문서·JSON을 commit한 뒤 Q5-E에서
+horizontal, variation, vertical lane을 `qualified`, `bounded-subset`, `blocked` 중 하나로 최종 분류한다.
+remote push·GitHub comment·Q6 진입은 별도 승인 대상이다.

--- a/mydocs/working/task_m100_4969_w10_q6_a.md
+++ b/mydocs/working/task_m100_4969_w10_q6_a.md
@@ -1,0 +1,104 @@
+# 결과 보고서 — Task M100 #4969 W10-Q6-A 최종 support·unsupported matrix
+
+- **상위 계획**: [`task_m100_4969_w10_q6.md`](../plans/task_m100_4969_w10_q6.md)
+- **계획 checkpoint**: `cb5c2b5d9`
+- **Q5 최종 checkpoint**: `cf1536a9c`
+- **제품 기준 commit**: `upstream/devel@3afbb066fe93724ab44309163a2e04efb954bf18`
+- **기계 판독 증적**:
+  [`w10_q6_support_matrix.json`](../tech/investigations/issue-4969/w10_q6_support_matrix.json)
+- **수행일**: 2026-08-31 KST
+- **제품·test 변경**: 없음
+- **결과 상태**: `qualified`, 메인테이너 결과·checkpoint 생성 명시 승인
+
+## 결론
+
+Q5의 lane 분류를 source identity, font table, script·language·axis·writing-mode predicate, producer, backend,
+fallback, reason과 resource limit까지 풀어 최종 matrix로 고정했다. 분류는 Q2 `bounded-subset`, Q3
+`qualified`, Q4 `bounded-subset`, 전체 `bounded-subset`으로 Q5와 같다.
+
+- Q5 lane 분류 불일치: 0
+- source digest·face index 불일치: 0
+- fallback owner·structured reason 누락: 0
+- deferred를 지원으로 계산한 행: 0
+- 지원 tuple 확대: 0
+
+따라서 Q6-A 종료 게이트는 충족됐다. 이 matrix는 “어떤 폰트를 지원한다”는 이름 기반 표가 아니라 현재
+입력과 backend가 필요한 기능을 온전히 갖췄는지 판정하는 feature-detection 표다.
+
+## 1. 세 lane의 실제 지원 경계
+
+| lane | source·기능 | 지원 predicate | 지원 backend | 그 밖의 disposition |
+| --- | --- | --- | --- | --- |
+| Q2 old Hangul | Source Han subset, GSUB·GPOS | horizontal-tb, LTR, bidi 0, direct old-Hangul, 한 줄·한 run, strict 또는 bounded no-LineSeg | native/Node WASM producer, CanvasKit common GlyphRun | W9 K1 → K0 TextRun |
+| Q3 variable | Happiness Sans VF, `fvar/gvar`, `wght/opsz` | explicit char-shape language slot, canonical default/interior/max, modern Hangul·ASCII Latin | native/Node WASM producer, CanvasKit portable outline | 미지원 backend·invalid instance는 paragraph TextRun rollback |
+| Q4 vertical | Noto Sans KR, `vhea/vmtx`, vertical GSUB/GPOS | HWP5 direction 2, 한 cell·문단·line·run·column, pure CJK upright, vertical-rl | native/Node WASM producer, CanvasKit vertical GlyphRun | TextRun + pristine legacy vertical geometry |
+
+폰트 이름, HWP/HWPX 버전, 설치 여부만으로 lane을 선택하지 않는다. exact bytes digest와 face index가 맞고,
+현재 object가 요구 table·glyph·axis·writing-mode·backend replay capability를 모두 만족해야 한다.
+
+## 2. Q2 horizontal old Hangul
+
+정확한 source는 `ttfs/opensource/SourceHanSerifK-OldHangul-subset.otf`, 456,688 bytes, SHA-256
+`2f86ef9a52acb6d1dad9d915843239123b635d97edd88fd0573a88ffcb4e16f1`, face 0이다. direct old-Hangul Jamo
+feature detection, exact face/style/script의 homogeneous run과 left alignment가 필요하다. variation,
+synthetic style, inline control, display projection과 nonzero design y-positioning은 지원 predicate 밖이다.
+
+common shaper가 GSUB를 소유하고 HWP kerning flag를 feature로 반영한다. 성공 run에 W9 pair adjustment를 다시
+더하지 않는다. 어떤 조건이나 limit가 실패해도 fallback owner는 W9 K1, 이어서 기존 K0 TextRun이며 같은
+transaction 경계의 부분 geometry는 남지 않는다.
+
+## 3. Q3 variable instance
+
+정확한 source는 `ttfs/redistributable/happiness-sans/HappinessSansVF.ttf`, 1,503,064 bytes, SHA-256
+`3bbd254dcc5780f7524f9d07af4aa981ba5e3e84cf32d7d4e04301b3943e8694`, face 0이다. canonical axis는
+`wght`와 `opsz`이고 둘 다 400 default, 400~900 범위다. default, weight 650, bold 900, optical 650, title
+900/900의 공개 matrix를 고정했다.
+
+지원은 parser가 문서에서 axis를 추정하는 경로가 아니라 explicit char-shape language slot command/API에
+한정된다. font name, bold flag 또는 장평으로 axis를 추측하지 않는다. no-request와 explicit default는 기존
+TextRun을 유지하고, interior/max만 CanvasKit용 GlyphRun·portable outline을 게시한다. 축 순서·finite·range·
+중복 검증에 실패하거나 backend가 outline을 재생하지 못하면 문단 전체를 TextRun으로 되돌린다.
+
+## 4. Q4 vertical HWP5 table-cell
+
+정확한 source는 `ttfs/opensource/NotoSansKR-Regular.ttf`, 2,519,996 bytes, SHA-256
+`6e06a7fe5d696ca719894a23f36bb2b1be8c816a5937cd4ad0f23ca67780dd74`, face 0이다. `vhea`와 `vmtx`가
+필수이고, 이 face에는 VORG가 없다. 활성 surface는 HWP5 `textDirection=2`, vertical-rl·upright의 pure CJK
+단일 cell·paragraph·composed line·TextRun·column이다. variation과 partial activation은 허용하지 않는다.
+
+HWPX table cell, direction 1, horizontal cell, mixed Latin·punctuation, multiple paragraph/run/column, text box와
+미지원 backend는 지원 범위가 아니다. `vhea/vmtx`가 없거나 source·generation·geometry가 맞지 않으면 새
+vertical geometry를 만들지 않고 기존 TextRun과 legacy vertical geometry를 보존한다.
+
+Q4-D5-C의 역사적 `blocked`는 당시 same-tree causal WASM 영수증이 없었던 상태로 matrix에 남겼다. D5-D가
+source-only clean-room baseline으로 이를 해소했으며 현재 blocker는 아니다.
+
+## 5. 공통 상한과 미지원 처리
+
+| 보호면 | 상한 |
+| --- | ---: |
+| exact font | 32 MiB |
+| page prepared font | 64 MiB |
+| text·glyph·cluster | 각 4,096/run |
+| shaping feature | 64/request |
+| variation axis | 16/request |
+| cache·instance request·page sidecar | 각 4,096 |
+| attempt trace | 4,096 |
+
+상한 초과, malformed SFNT, stale source generation, identity mismatch와 unsupported tuple은 구조화된 reason으로
+종료한다. 거부 뒤 measurement, cache, sidecar, font blob/face, geometry의 mutation은 0이어야 한다. deferred
+항목은 Q6 실패도 현재 지원도 아니다. 각 surface의 공개 representative fixture, semantic lineage와 backend
+replay 증거가 준비될 때만 후속 이슈 후보가 된다.
+
+## 검증과 다음 승인 경계
+
+Q5 최종 JSON, Q5-B face inventory, Q2 최종 분류, Q3 capability audit와 Q4 execution plan을 기계 대사했다.
+JSON syntax, tracked font 3개의 실제 size·SHA-256, lane 분류, Q3 axis 2개와 Q4 activation surface가 모두
+일치하고 `git diff --check`가 통과했다.
+
+첫 jq 대사식은 Q5 최종 JSON의 사람이 읽는 source label을 digest 객체로 잘못 가정해 종료됐다. digest 권위인
+Q5-B `faces`를 사용하고 Q3 axis 필드명을 명시적으로 정규화한 검사로 바로잡았다. 제품·증적 mismatch는 없다.
+private corpus·Hyper-V·한컴 Oracle과 GitHub mutation은 사용하지 않았다.
+
+메인테이너가 Q6-A 결과와 checkpoint 생성을 명시 승인했다. matrix·보고서를 commit한 뒤 Q6-B에서
+#4969·#4960 tracker 문안을 로컬로 작성한다. 이 승인은 tracker 게시를 포함하지 않는다.

--- a/mydocs/working/task_m100_4969_w10_q6_b.md
+++ b/mydocs/working/task_m100_4969_w10_q6_b.md
@@ -1,0 +1,45 @@
+# 결과 보고서 — Task M100 #4969 W10-Q6-B tracker 현행화 초안
+
+- **상위 계획**: [`task_m100_4969_w10_q6.md`](../plans/task_m100_4969_w10_q6.md)
+- **Q6-A checkpoint**: `8258f0284`
+- **게시 문안**:
+  [`task_m100_4969_w10_q6_tracker_drafts.md`](task_m100_4969_w10_q6_tracker_drafts.md)
+- **기계 판독 receipt**:
+  [`w10_q6_tracker_draft_receipt.json`](../tech/investigations/issue-4969/w10_q6_tracker_draft_receipt.json)
+- **수행일**: 2026-08-31 KST
+- **결과 상태**: `qualified`, 메인테이너 결과·checkpoint 생성 명시 승인
+- **GitHub mutation**: 0
+
+## 결론
+
+#4969 최종 comment, #4960 본문 최소 patch와 #4960 최종 comment를 로컬 초안으로 준비했다. 실제 Q6 PR·
+code head·merge SHA·CI 결과가 생기기 전에는 게시할 수 없도록 필수 placeholder 7종을 유지했고, 게시 단계에서
+하나라도 남으면 실패하도록 guard를 정의했다.
+
+| 검증 | 결과 |
+| --- | --- |
+| #4969 state·body snapshot | OPEN, SHA-256 `1cbe21c09ac1c63336603cf662db42f1de40adec93beffe837af7211e11711b1` |
+| #4960 state·body snapshot | OPEN, SHA-256 `448847eb53209b071470027d70d7157958c0d413a05b4b48cb7913129fa7bc42` |
+| #4960 exact patch anchor | 3/3이 현재 body에 각 1회 존재 |
+| 필수 placeholder vocabulary | 7/7 존재, 미등록 token 0 |
+| PR #6493 재조회 | MERGED, merge `3afbb066f`, 실패·대기 0 |
+| `git diff --check` | passed |
+| issue edit·comment·close | 0 |
+
+따라서 Q6-B 종료 게이트는 충족됐다.
+
+## 변경 원칙
+
+- #4969 본문은 원 문제·범위·불변식의 역사적 정본이므로 수정하지 않고 최종 comment만 추가한다.
+- #4960 본문은 W10 checklist, 최근 실행 표, 실행 흐름도의 낡은 세 anchor만 바꾼다.
+- #4960·#4969 comment는 Q6 PR이 merge된 뒤 실제 값으로 placeholder를 모두 치환한다.
+- comment 게시와 body edit 뒤에는 API로 한글, 선두 BOM, `??` 치환과 최종 body hash를 검증한다.
+- comment 문구의 “close합니다”는 API close가 아니다. 별도 승인과 completion audit 뒤 issue state를 변경한다.
+
+## 다음 승인 경계
+
+메인테이너가 Q6-B 결과와 checkpoint 생성을 명시 승인했다. 초안·receipt·보고서를 commit한 뒤 Q6-C에 앞서
+최신 `upstream/devel`을 다시 확인한다. base가 그대로면 모든 Rust lint 묶음과 #4969 focused 검증을 시작하고,
+base가 전진했다면 overlap·merge simulation 결과를 먼저 보고하고 별도 merge 승인을 받는다.
+
+이 승인은 remote push, PR 생성, tracker 게시와 issue close를 포함하지 않는다.

--- a/mydocs/working/task_m100_4969_w10_q6_c.md
+++ b/mydocs/working/task_m100_4969_w10_q6_c.md
@@ -1,0 +1,85 @@
+# 결과 보고서 — Task M100 #4969 W10-Q6-C 제출 diff·최신 base·로컬 검증
+
+- **상위 계획**: [`task_m100_4969_w10_q6.md`](../plans/task_m100_4969_w10_q6.md)
+- **Q6-B checkpoint**: `6a9656dff`
+- **기계 판독 증적**:
+  [`w10_q6_submission_validation.json`](../tech/investigations/issue-4969/w10_q6_submission_validation.json)
+- **수행일**: 2026-08-31 KST
+- **결과 상태**: `qualified`, 메인테이너 결과·checkpoint 생성 명시 승인
+- **remote push·PR·GitHub mutation**: 0
+
+## 결론
+
+검증 시작과 종료 시점에 `upstream/devel`을 각각 fetch했다. 원격은
+`3afbb066fe93724ab44309163a2e04efb954bf18`로 변하지 않았고 현재 branch는 8 ahead / 0 behind, merge-base도
+같은 commit이다. base merge·conflict resolution·고아 branch 생성은 필요하지 않다.
+
+현재 제출 diff는 mydocs 17개와 기존 `tests/cases/` integration source 3개다. `src`, `crates`, `bindings`,
+Studio source, workflow와 기타 경로 변경은 모두 0이다. 모든 Rust lint 묶음과 #4969 focused 117/117,
+Studio resource 5/5가 통과했다.
+
+- lint·focused 실패: 0
+- 최신 base conflict·미해결 owner overlap: 0
+- generated 제출물: 0
+- 제품 source mutation: 0
+
+따라서 Q6-C 종료 게이트는 충족됐다.
+
+## 1. 최신 base·제출 범위
+
+| 항목 | 결과 |
+| --- | --- |
+| `upstream/devel` | `3afbb066f`, 시작·종료 동일 |
+| branch head | `6a9656dff`, 8 ahead / 0 behind |
+| merge-base | `3afbb066f` |
+| mydocs | 17 paths |
+| 기존 integration source | 3 paths |
+| 새 integration source | 0 |
+| 제품·Studio·workflow·기타 source | 0 |
+
+변경된 test source는 `issue_4969_shaping_glyph_lowering.rs`, `issue_4969_shaping_request_contract.rs`,
+`issue_4969_shaping_shadow_context.rs`다. generated suite·manifest는 review worktree에서만 준비했고 제출 diff에
+없다.
+
+## 2. 필수 lint·build
+
+| gate | 결과 |
+| --- | --- |
+| manifest prepare/check | 1,075 sources / 4,718 attrs / 28 suites + 20 exceptions = 48/48 |
+| `cargo fmt --all`·`--check` | passed |
+| native root Clippy `-D warnings` | passed, 58.99초 |
+| WASM32 library Clippy `-D warnings` | passed, 46.90초 |
+| workspace build | passed, 94초 |
+| workspace all-target Clippy `-D warnings` | passed, 71초 |
+| `git diff --check` | passed |
+
+모든 Cargo 명령은 공유 `/home/edward/mygithub/rhwp/target/pr-review`를 사용했다. worktree-local `target`은
+만들지 않았다.
+
+## 3. focused 회귀
+
+`test(/issue_4969/)`는 117건을 선택해 117 passed / 0 failed, 8,795 non-selected, 실행 1.068초로 통과했다.
+Q5-C의 sidecar·request 상한 guard 2건과 Q5-D의 1/2/8 run resource guard가 최종 selector에 포함됐다.
+
+Studio resource reuse는 5/5, 326.229661ms로 통과했다. 분리 worktree에 설치 의존성이 없으므로 기본 checkout의
+`rhwp-studio/node_modules`를 검증 중에만 symlink했고 종료 trap으로 제거했다. symlink와 worktree-local target은
+현재 존재하지 않는다.
+
+로컬 cargo-nextest 0.9.137이 권고 0.9.140보다 낮고 `report-skipped`를 인식하지 않는다는 기존 경고가 있다.
+선택·실행·결과에는 영향을 주지 않았다.
+
+## 4. 광범위 증적 재사용
+
+Q5-A는 PR #6493 code candidate Full CI 30 success·4 expected skip과 trailing review 11 success·19 expected
+fast-pass skip·1 stale cancellation을 현재 merge tree에 재사용 가능으로 판정했다. Q5-B는 같은 제품 tree에서
+CanvasKit pixel proof와 표준 Docker WASM 9,905,805 bytes를 다시 고정했다.
+
+현재 branch의 제품·Studio source diff가 0이므로 local full nextest, Native Skia, Docker WASM과 CanvasKit pixel을
+다시 실행하지 않았다. 이는 회피가 아니라 Q5 증적 자격화와 `local_validation.md`의 Rust test-helper 범위에 따른
+선택이다. 새 PR code head의 GitHub Full CI는 대체되지 않으며 Q6-D의 필수 gate로 남는다.
+
+## 다음 승인 경계
+
+메인테이너가 Q6-C 결과와 checkpoint 생성을 명시 승인했다. 보고서·JSON을 commit한 뒤 remote push와 PR
+생성은 각각 별도 승인을 요청한다. push 직전 `upstream/devel`, 포맷, diff와 staged/generated 경계를 다시
+확인한다. 이 결과 승인은 push·PR·tracker mutation을 포함하지 않는다.

--- a/mydocs/working/task_m100_4969_w10_q6_tracker_drafts.md
+++ b/mydocs/working/task_m100_4969_w10_q6_tracker_drafts.md
@@ -1,0 +1,141 @@
+# Task M100 #4969 W10-Q6-B — #4969·#4960 tracker 현행화 초안
+
+- **상위 계획**: [`task_m100_4969_w10_q6.md`](../plans/task_m100_4969_w10_q6.md)
+- **Q6-A checkpoint**: `8258f0284`
+- **기계 판독 receipt**:
+  [`w10_q6_tracker_draft_receipt.json`](../tech/investigations/issue-4969/w10_q6_tracker_draft_receipt.json)
+- **작성일**: 2026-08-31 KST
+- **상태**: 로컬 초안, 게시 금지
+- **GitHub mutation**: 0
+
+## 1. 게시 전 필수 치환값
+
+아래 token이 하나라도 남으면 게시하지 않는다.
+
+| token | 실제 값의 권위 |
+| --- | --- |
+| `{{Q6_PR_NUMBER}}` | `gh pr view`의 number |
+| `{{Q6_PR_URL}}` | `gh pr view`의 url |
+| `{{Q6_CODE_HEAD}}` | code candidate의 exact head OID |
+| `{{Q6_MERGE_SHA}}` | merge 뒤 `mergeCommit.oid` |
+| `{{Q6_MERGED_AT}}` | merge 뒤 `mergedAt` |
+| `{{Q6_CODE_CI_SUMMARY}}` | code candidate check rollup |
+| `{{Q6_REVIEW_CI_SUMMARY}}` | review-only trailing head check rollup |
+
+게시 직전 #4969 body SHA-256 `1cbe21c09ac1c63336603cf662db42f1de40adec93beffe837af7211e11711b1`,
+#4960 body SHA-256 `448847eb53209b071470027d70d7157958c0d413a05b4b48cb7913129fa7bc42`와 현재
+본문을 다시 대사한다. hash가 다르면 아래 patch를 적용하지 않고 최신 본문 기준으로 초안을 다시 만든다.
+
+## 2. #4969 최종 comment 초안
+
+```markdown
+W10-Q5/Q6 최종 자격화와 릴리즈 인계를 완료했습니다.
+
+- 제품 통합: PR #6493, merge `3afbb066fe93724ab44309163a2e04efb954bf18`
+- 최종 증적·guard PR: [#{{Q6_PR_NUMBER}}]({{Q6_PR_URL}}), code head `{{Q6_CODE_HEAD}}`, merge `{{Q6_MERGE_SHA}}` (`{{Q6_MERGED_AT}}`)
+- 최종 분류: 전체 `bounded-subset`
+  - Q2 horizontal old Hangul: `bounded-subset`
+  - Q3 explicit variable instance: `qualified`
+  - Q4 vertical HWP5 table-cell v1: `bounded-subset`
+- CI: code candidate {{Q6_CODE_CI_SUMMARY}}; review-only trailing head {{Q6_REVIEW_CI_SUMMARY}}
+
+최종 support matrix는 폰트 이름이나 한컴 버전이 아니라 exact source identity와 현재 capability를 탐지합니다.
+
+- Q2: horizontal-tb·LTR·bidi 0의 direct old-Hangul strict/no-LineSeg atomic lane만 CanvasKit common GlyphRun으로 게시하고, 나머지는 W9 K1 또는 K0 TextRun으로 닫습니다.
+- Q3: Happiness Sans VF의 canonical `wght`·`opsz` explicit default/interior/max만 자격화했습니다. no-request/default는 기존 TextRun을 보존하고, 미지원 backend·invalid instance는 문단 전체를 TextRun으로 rollback합니다.
+- Q4: HWP5 `textDirection=2`, 단일 table-cell·문단·line·run·column, pure CJK upright와 exact `vhea/vmtx` source가 모두 성립할 때만 CanvasKit vertical GlyphRun을 게시합니다. 다른 tuple은 TextRun과 legacy vertical geometry를 보존합니다.
+
+현재 merged product tree에서 native↔WASM canonical mismatch, CanvasKit replay·pixel mismatch, unsupported backend false selection, fallback disappearance, partial publication, reject 뒤 mutation과 resource multiplicity 증가는 모두 0입니다. 현재 표준 Docker WASM 절대 snapshot은 9,905,805 bytes이며 Q3·Q4의 서로 다른 causal delta는 합산하지 않았습니다.
+
+RTL/bidi 일반화, multi-line/run batch, HWP/HWPX axis intent 추론, HWPX vertical table-cell, mixed vertical run과 다른 backend glyph replay는 현재 지원이 아니라 명시적 deferred/fallback 영역입니다. 이 범위는 실패를 숨긴 것이 아니며 별도 공개 fixture·semantic lineage·backend 증거가 준비될 때 후속 이슈 후보로 다룹니다.
+
+이 이슈의 완료 조건인 source identity 연결, 대표 fixture의 결정적 positioning, native/WASM·portable replay, 동일 preflight/runtime fail-closed와 기존 horizontal non-target 무회귀가 충족됐습니다. 따라서 #4969를 close합니다.
+```
+
+`#4969를 close합니다`는 comment 게시이자 자동 close 명령이 아니다. comment API 검증 뒤 별도 close 승인을
+사용한다.
+
+## 3. #4960 본문 최소 patch 초안
+
+본문 전체를 다시 쓰지 않고 다음 세 anchor만 exact replace한다.
+
+### 3.1 W10 checklist
+
+현재 anchor:
+
+```markdown
+- [ ] W10 — 대상 face 집합 안정화 뒤 vertical metrics·variation·shaping: #4969
+  - 상태: 진행 중 — Q2-D4 bounded horizontal common shaping 병합, Q2-D5 resource reuse gate 대기
+  - release gate: horizontal shaping·variation·vertical lane의 지원 subset과 fail-closed matrix 확정
+```
+
+교체 초안:
+
+```markdown
+- [x] W10 — 대상 face 집합 안정화 뒤 vertical metrics·variation·shaping: #4969
+  - 상태: 완료 — Q2 horizontal `bounded-subset`, Q3 variable `qualified`, Q4 vertical `bounded-subset`; 전체 `bounded-subset`
+  - 통합: PR #6493 merge `3afbb066f`, PR #{{Q6_PR_NUMBER}} merge `{{Q6_MERGE_SHA}}`
+  - release handoff: capability 기반 support·fallback·unsupported matrix와 fail-closed 경계 확정
+```
+
+### 3.2 최근 실행 표 W10 행
+
+현재 anchor:
+
+```markdown
+| W10 | 진행 중 | PR #6270, merge `1a43a507c` | Q2-D4 `qualified-bounded`; strict one-line/one-run 유지, Q2-D5 resource 재사용 gate 대기 |
+```
+
+교체 초안:
+
+```markdown
+| W10 | 완료 | PR #6270·#6493·#{{Q6_PR_NUMBER}}, final merge `{{Q6_MERGE_SHA}}` | Q2·Q4 `bounded-subset`, Q3 `qualified`; capability 기반 support·fallback·unsupported matrix와 fail-closed 릴리즈 인계 완료 |
+```
+
+### 3.3 실행 흐름도 W10 상태
+
+현재 anchor:
+
+```text
+  └─ W9 exact kerning qualified → W10 진행 중
+```
+
+교체 초안:
+
+```text
+  └─ W9 exact kerning qualified → W10 bounded-subset 완료 → release support matrix 인계
+```
+
+각 현재 anchor는 게시 직전 최신 body에서 정확히 한 번만 나타나야 한다. 0회 또는 2회 이상이면 자동 치환하지
+않는다.
+
+## 4. #4960 최종 comment 초안
+
+```markdown
+W10 #4969의 최종 PR [#{{Q6_PR_NUMBER}}]({{Q6_PR_URL}})이 merge `{{Q6_MERGE_SHA}}`로 통합되어 W0~W10 실행 계보를 완료했습니다.
+
+- W7.5: PR #6049, registry lifecycle·migration·evidence delta
+- W8: PR #6069·#6081·#6106, rank 8·1·7 모두 no-change
+- W9: PR #6214, exact-source kerning과 native/WASM·backend parity
+- W10 제품 통합: PR #6270·#6493
+- W10 최종 support matrix·guard·증적: PR #{{Q6_PR_NUMBER}}
+- 최종 CI: code candidate {{Q6_CODE_CI_SUMMARY}}; review-only {{Q6_REVIEW_CI_SUMMARY}}
+
+W10 최종 분류는 Q2 horizontal `bounded-subset`, Q3 variable `qualified`, Q4 vertical `bounded-subset`, 전체 `bounded-subset`입니다. exact source·table·script/language·axis·writing mode·backend capability가 모두 성립하는 tuple만 선택하고, 그 밖의 입력은 구조화된 reason과 기존 TextRun/geometry fallback으로 닫습니다.
+
+이는 deferred surface를 일반 지원으로 계산한 완료가 아닙니다. RTL/bidi, 일반 multi-run shaping, 문서 axis intent 추론, HWPX·mixed vertical과 미지원 backend replay는 별도 증거가 준비될 때만 후속 후보로 재개합니다. 현재 v1.0.0 release 인계에는 검증된 bounded support matrix만 포함합니다.
+
+#4960의 모든 W0~W10 실행 항목과 릴리즈 인계 근거가 실제 merge 결과로 현행화됐으므로 상위 tracker를 close합니다.
+```
+
+## 5. 게시·검증 순서
+
+1. Q6 PR이 실제 merge됐는지 재조회한다.
+2. 두 issue의 state·updatedAt·body SHA-256을 재조회한다.
+3. 모든 placeholder를 실제 값으로 치환하고 남은 `{{...}}`가 0인지 검사한다.
+4. #4969 comment를 UTF-8 without BOM body file로 게시하고 API로 한글·BOM·`??`를 검증한다.
+5. #4960 body의 세 anchor를 exact replace하고 API로 body hash와 문자열을 검증한다.
+6. #4960 comment를 게시하고 같은 문자열 검증을 수행한다.
+7. 별도 close 승인과 마지막 completion audit 뒤 #4969, #4960 순서로 close한다.
+
+이 문서는 로컬 초안이며 remote push, PR 생성, issue edit/comment, close 권한을 부여하지 않는다.

--- a/tests/cases/issue_4969_shaping_glyph_lowering.rs
+++ b/tests/cases/issue_4969_shaping_glyph_lowering.rs
@@ -1395,6 +1395,58 @@ fn issue_4969_q2_d5_r1_product_page_lowering_reuses_one_prepared_source() {
 }
 
 #[test]
+fn issue_4969_q5_d_q2_run_resource_matrix_is_unique_source_bounded() {
+    let (sidecars, measurement, _) = prepared_sidecar();
+    let run = text_run();
+    let bbox = BoundingBox::new(3.0, 5.0, measurement.total_advance_px, 14.0);
+    let mut observations = Vec::new();
+
+    for run_count in [1_usize, 2, 8] {
+        let ops = (0..run_count)
+            .map(|_| PaintOp::text_run(bbox, run.clone()))
+            .collect();
+        let mut node = LayerNode::leaf(bbox, Some(17), ops);
+        let mut resources = ResourceArena::default();
+        let claimed = lower_horizontal_shaping_page_sidecars(&mut node, &sidecars, &mut resources);
+        let rhwp::paint::LayerNodeKind::Leaf { ops } = &node.kind else {
+            panic!("fixture node must remain a leaf");
+        };
+        let text_runs = ops
+            .iter()
+            .filter(|op| matches!(op, PaintOp::TextRun { .. }))
+            .count();
+        let glyph_runs = ops
+            .iter()
+            .filter(|op| matches!(op, PaintOp::GlyphRun { .. }))
+            .count();
+
+        assert_eq!(claimed.len(), run_count);
+        assert!((0..run_count as u32).all(|text_source_id| claimed.contains(&text_source_id)));
+        assert_eq!(text_runs, run_count);
+        assert_eq!(glyph_runs, run_count);
+        assert_eq!(resources.font_blob_count(), 1);
+        assert_eq!(resources.font_resources().blobs.len(), 1);
+        assert_eq!(resources.font_resources().faces.len(), 1);
+        observations.push(serde_json::json!({
+            "runs": run_count,
+            "textRuns": text_runs,
+            "glyphRuns": glyph_runs,
+            "fontBlobs": resources.font_blob_count(),
+            "fontFaces": resources.font_resources().faces.len(),
+            "fontPayloadBytes": SOURCE_HAN.len()
+        }));
+    }
+
+    println!(
+        "{}",
+        serde_json::json!({
+            "kind": "q5-d-q2-run-resource-matrix",
+            "observations": observations
+        })
+    );
+}
+
+#[test]
 fn issue_4969_q2_d5_r1_prepared_cache_debug_excludes_font_bytes() {
     let (sidecars, measurement, _) = prepared_sidecar();
     let run = text_run();

--- a/tests/cases/issue_4969_shaping_request_contract.rs
+++ b/tests/cases/issue_4969_shaping_request_contract.rs
@@ -27,7 +27,7 @@ use shaping_vertical::{
     VerticalLatinOrientation, VerticalLegacyGeometry, VerticalPoint, VerticalRect,
     VerticalRunClass, VerticalShapingContext, VerticalShapingContextRejectReason,
     VerticalShapingContextRequest, VerticalShapingPageSidecars, VerticalShapingSidecarRejectReason,
-    NOTO_SANS_KR_REGULAR_SHA256,
+    MAX_VERTICAL_SHAPING_PAGE_SIDECARS, NOTO_SANS_KR_REGULAR_SHA256,
 };
 use std::sync::Arc;
 #[cfg(target_arch = "wasm32")]
@@ -1826,6 +1826,51 @@ fn issue_4969_q4_d2_vertical_sidecar_is_atomic_and_keeps_one_geometry_owner() {
         .expect_err("duplicate node must fail before mutation");
     assert_eq!(duplicate, VerticalShapingSidecarRejectReason::DuplicateNode);
     assert_eq!(sidecars.len(), 1);
+    assert_eq!(sidecars.registry_generation(), generation);
+}
+
+#[test]
+fn issue_4969_q5_c_vertical_page_sidecar_limit_rejects_without_mutation() {
+    let slot = ExactFontSlot::new(4969, 0);
+    let mut registry = ExactFontSourceRegistry::default();
+    registry
+        .register(
+            slot,
+            ExactFontSource {
+                bytes: NOTO,
+                face_index: 0,
+            },
+        )
+        .expect("register public Noto exact source");
+    let context = VerticalShapingContext::new(registry);
+    let certified = Arc::new(
+        context
+            .prepare_dormant(q4_d1_context_request(slot, "한글"))
+            .expect("certify bounded vertical owner"),
+    );
+    let mut sidecars = VerticalShapingPageSidecars::default();
+
+    for node_id in 1..=MAX_VERTICAL_SHAPING_PAGE_SIDECARS as u32 {
+        sidecars
+            .attach_bounded_hwp5_table_cell_atomic(Arc::new(
+                BoundedVerticalHwp5TableCellSidecar::new(node_id, Arc::clone(&certified), "한글"),
+            ))
+            .expect("fill the bounded vertical page table");
+    }
+    assert_eq!(sidecars.len(), MAX_VERTICAL_SHAPING_PAGE_SIDECARS);
+    let generation = sidecars.registry_generation();
+
+    assert_eq!(
+        sidecars.attach_bounded_hwp5_table_cell_atomic(Arc::new(
+            BoundedVerticalHwp5TableCellSidecar::new(
+                MAX_VERTICAL_SHAPING_PAGE_SIDECARS as u32 + 1,
+                certified,
+                "한글",
+            ),
+        )),
+        Err(VerticalShapingSidecarRejectReason::EntryLimitExceeded)
+    );
+    assert_eq!(sidecars.len(), MAX_VERTICAL_SHAPING_PAGE_SIDECARS);
     assert_eq!(sidecars.registry_generation(), generation);
 }
 

--- a/tests/cases/issue_4969_shaping_shadow_context.rs
+++ b/tests/cases/issue_4969_shaping_shadow_context.rs
@@ -15,7 +15,10 @@ mod paint {
     pub(crate) const MAX_PORTABLE_FONT_BLOB_BYTES: usize = 32 * 1024 * 1024;
 }
 
-use kerning::{ExactFontSlot, ExactFontSource, ExactFontSourceRegistry};
+use kerning::{
+    ExactFontRegistryError, ExactFontSlot, ExactFontSource, ExactFontSourceRegistry,
+    MAX_KERNING_REGISTRY_SLOTS,
+};
 use shaping::MAX_SHAPING_VARIATION_AXES;
 use shaping::{ShapingFeature, ShapingRejectReason, ShapingVariation, TerminalShapingDisposition};
 use shaping_context::{
@@ -36,6 +39,7 @@ const SOURCE_HAN: &[u8] =
     include_bytes!("../../ttfs/opensource/SourceHanSerifK-OldHangul-subset.otf");
 const HAPPINESS: &[u8] =
     include_bytes!("../../ttfs/redistributable/happiness-sans/HappinessSansVF.ttf");
+const EXACT_INSTANCE_SMOKE: &[u8] = include_bytes!("../fixtures/fonts/RHWPExactKerningSmoke.ttf");
 
 const NOTO_SLOT: ExactFontSlot = ExactFontSlot {
     char_shape_id: 4969,
@@ -474,6 +478,72 @@ fn issue_4969_q3_d_explicit_slot_request_is_canonical_and_generation_owned() {
         HAPPINESS_SLOT
     );
     assert_eq!(context.cached_result_count(), 2);
+}
+
+#[test]
+fn issue_4969_q5_c_instance_request_limit_is_coupled_to_exact_source_slots() {
+    assert_eq!(
+        MAX_HORIZONTAL_SHAPING_INSTANCE_REQUESTS,
+        MAX_KERNING_REGISTRY_SLOTS
+    );
+
+    let mut sources = ExactFontSourceRegistry::default();
+    for char_shape_id in 0..MAX_KERNING_REGISTRY_SLOTS as u32 {
+        sources
+            .register(
+                ExactFontSlot::new(char_shape_id, 0),
+                ExactFontSource {
+                    bytes: EXACT_INSTANCE_SMOKE,
+                    face_index: 0,
+                },
+            )
+            .expect("fill the bounded exact-source slot table");
+    }
+    assert_eq!(sources.slot_count(), MAX_KERNING_REGISTRY_SLOTS);
+    assert_eq!(sources.source_count(), 1);
+    assert_eq!(
+        sources.register(
+            ExactFontSlot::new(MAX_KERNING_REGISTRY_SLOTS as u32, 0),
+            ExactFontSource {
+                bytes: EXACT_INSTANCE_SMOKE,
+                face_index: 0,
+            },
+        ),
+        Err(ExactFontRegistryError::SlotLimitExceeded)
+    );
+
+    let mut requests = HorizontalShapingInstanceRequestRegistry::default();
+    for char_shape_id in 0..MAX_HORIZONTAL_SHAPING_INSTANCE_REQUESTS as u32 {
+        assert_eq!(
+            requests.set_verified(&sources, ExactFontSlot::new(char_shape_id, 0), &[],),
+            Ok(HorizontalShapingInstanceRequestRegistration::Registered)
+        );
+    }
+    assert_eq!(
+        requests.request_count(),
+        MAX_HORIZONTAL_SHAPING_INSTANCE_REQUESTS
+    );
+    assert_eq!(
+        requests.generation(),
+        MAX_HORIZONTAL_SHAPING_INSTANCE_REQUESTS as u64
+    );
+
+    assert_eq!(
+        requests.set_verified(
+            &sources,
+            ExactFontSlot::new(MAX_HORIZONTAL_SHAPING_INSTANCE_REQUESTS as u32, 0),
+            &[],
+        ),
+        Err(HorizontalShapingInstanceRequestError::SourceUnavailable)
+    );
+    assert_eq!(
+        requests.request_count(),
+        MAX_HORIZONTAL_SHAPING_INSTANCE_REQUESTS
+    );
+    assert_eq!(
+        requests.generation(),
+        MAX_HORIZONTAL_SHAPING_INSTANCE_REQUESTS as u64
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 변경 요약

- PR #6493으로 통합된 W10-Q2 horizontal shaping, Q3 variable instance, Q4 bounded vertical table-cell을 현재 `devel` merge tree에서 다시 자격화했습니다.
- lane별 최종 분류와 exact source·table·script/language·axis·writing-mode·backend predicate를 support/unsupported matrix로 고정했습니다.
- 기존 integration source 3곳에 explicit request·vertical sidecar 4,096 상한과 Q2 1/2/8 run unique-source resource guard를 추가했습니다. 새 integration source와 제품 source 변경은 없습니다.
- malformed·oversized·stale identity·unsupported tuple이 부분 publication 없이 기존 TextRun/geometry로 rollback하는지 회계했습니다.
- #4969와 상위 #4960의 최종 tracker 문안은 실제 merge SHA·CI가 생기기 전 게시되지 않도록 로컬 placeholder guard와 body-drift 검사를 포함했습니다.

최종 분류는 Q2 `bounded-subset`, Q3 `qualified`, Q4 `bounded-subset`, 전체 `bounded-subset`입니다. 이 PR은 지원 범위를 넓히지 않고 검증된 subset과 deterministic fallback 경계를 문서·테스트로 고정합니다. #4969와 #4960은 이 PR merge 및 tracker 후속 감사 뒤 별도로 close하므로 자동 close 문구를 사용하지 않습니다.

## 관련 이슈

Refs #4969
Refs #4960

## 제출 범위

- mydocs: 19 paths
- 기존 `tests/cases/` integration source: 3 paths
- `src`, `crates`, `bindings`, rhwp-studio source, workflow: 0 paths
- 새 integration source, generated suite·manifest, Cargo generated target, `pkg`, `dist`: 0
- private corpus·Hyper-V·한컴 Oracle 사용: 0

## 테스트

- [x] `cargo fmt --all` 및 `cargo fmt --all -- --check`
- [x] integration 변경은 기존 `tests/cases/*.rs` 원본 3곳만 포함하고 generated suite·manifest·Cargo target을 포함하지 않음
- [x] `src/**`의 `#[cfg(test)]` 변경 없음 — unit tier 재생성 대상 아님
- [x] manifest prepare/check — 1,075 sources / 4,718 attrs / 28 suites + 20 exceptions = 48/48 targets
- [x] native root Clippy, wasm32 library Clippy, workspace all-target Clippy `-D warnings`
- [x] `cargo build --locked --workspace`
- [x] `test(/issue_4969/)` focused nextest — 117 passed / 0 failed / 8,795 non-selected
- [x] Q5-C bounded·malformed·atomic rollback — 50/50 passed
- [x] Q5-D resource focused — 2/2 passed
- [x] Studio font resource reuse — 5/5 passed
- [x] merged-head isolated Node WASM — 19/19 passed
- [x] actual CanvasKit pixel replay — 1/1 passed
- [x] 제품·Studio source가 PR #6493 merge tree와 같아 해당 code candidate Full CI·Native Skia와 Q5-B Docker WASM·CanvasKit 증적 재사용
- [x] 작업 증빙 — `mydocs/tech/investigations/issue-4969/w10_q5_*.json`, `w10_q6_*.json`

새 PR code head의 GitHub Full CI는 아직 실행 전이며 이 PR의 필수 merge gate입니다. 로컬 cargo-nextest 0.9.137이 권고 0.9.140보다 낮고 `report-skipped`를 인식하지 않는다는 기존 경고가 있지만 선택·실행 결과에는 영향을 주지 않았습니다.

## 성능 영향 및 측정 결과

- 예상 영향: 제품 runtime 영향 없음. 제품 source diff가 0이고 test·문서 guard만 추가됩니다.
- Q2 1/2/8 run·page에서 font blob/face/payload는 unique source당 1개로 유지됩니다.
- Q3 1/2/8 instance×run에서 source digest/parse/blob/face는 1개이며 non-default warm delta는 승인된 p50 1ms·p95 2ms 한도를 통과했습니다.
- Q4의 자격화된 9-process A/B/A 성능과 same-image causal WASM `+36,611 bytes`(`+0.371371668%`)는 독립 증적으로 재사용했습니다.
- 현재 표준 Docker WASM 절대 snapshot은 9,905,805 bytes, SHA-256 `ed11bdb3bf2b11b44c3f6fed5c16d403257b60b27bffa469e5e3c1dfecf912a4`입니다. 서로 다른 기준 tree의 Q3·Q4 delta는 합산하지 않았습니다.

근거:

- `mydocs/tech/investigations/issue-4969/w10_q5_final_qualification.json`
- `mydocs/tech/investigations/issue-4969/w10_q6_support_matrix.json`
- `mydocs/tech/investigations/issue-4969/w10_q6_submission_validation.json`

## 스크린샷

새 UI·renderer 제품 변경은 없습니다. PR #6493 merge tree와 동일한 제품 source에서 Q5-B actual CanvasKit pixel replay와 native↔WASM canonical parity mismatch 0을 재확인한 증적을 재사용합니다.
