### PR TITLE
chore(deps): Dependabot 12건 통합 및 quick-xml 0.42 보정

### DIFF
--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -96,7 +96,7 @@ jobs:
           toolchain: 1.93.1
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518 # v2.86.5
+        uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
         with:
           tool: nextest
 

--- a/.github/workflows/run-nextest-archives.yml
+++ b/.github/workflows/run-nextest-archives.yml
@@ -49,7 +49,7 @@ jobs:
           toolchain: 1.93.1
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518 # v2.86.5
+        uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
         with:
           tool: nextest
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3715,9 +3715,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.5"
+version = "8.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "inout",
 ]
 
@@ -26,7 +26,7 @@ checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -111,13 +111,13 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "argon2"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+checksum = "134c52ddac6d63c576bef8168db10c83c49c26444ecbc68060fef078925a901c"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "password-hash",
 ]
 
@@ -257,11 +257,11 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -274,16 +274,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -416,7 +407,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -437,8 +428,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer 0.12.1",
- "crypto-common 0.2.2",
+ "block-buffer",
+ "crypto-common",
  "inout",
 ]
 
@@ -576,15 +567,6 @@ checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -634,16 +616,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -668,9 +640,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.11.3",
+ "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -746,24 +718,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
- "subtle",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
 ]
 
@@ -1041,16 +1002,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,7 +1184,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -1410,7 +1361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffd9697dc4a9a62e2da93389f34400b77a28f0287711263cabb203b3ccb9c0e4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -1419,7 +1370,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "rand_core 0.10.1",
 ]
 
@@ -1598,7 +1549,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "add6b9d92e496f16f4526d68ff29da1483aba4b119baeab8bed3b9e3544a6f3d"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
  "hybrid-array",
  "module-lattice",
@@ -1820,13 +1771,11 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
+ "phc",
 ]
 
 [[package]]
@@ -1841,7 +1790,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
- "digest 0.11.3",
+ "digest",
  "hmac",
 ]
 
@@ -1876,6 +1825,16 @@ dependencies = [
  "kurbo 0.13.1",
  "linebender_resource_handle",
  "smallvec",
+]
+
+[[package]]
+name = "phc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
 ]
 
 [[package]]
@@ -1944,7 +1903,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "universal-hash",
 ]
 
@@ -2098,12 +2057,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -2584,8 +2537,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2595,8 +2548,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2605,7 +2558,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
- "digest 0.11.3",
+ "digest",
  "keccak",
 ]
 
@@ -2615,7 +2568,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
 dependencies = [
- "digest 0.11.3",
+ "digest",
  "keccak",
  "sponge-cursor",
 ]
@@ -2638,7 +2591,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -3191,7 +3144,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "memchr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,9 +2051,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,7 +264,7 @@ blake3 = "1"
 # 저장소는 getrandom 0.4 + wasm_js 를 쓴다). 여기 코드는 소금·논스를
 # `getrandom::fill` 로 직접 만들고 저수준 Argon2 API 만 쓰므로 그 피처가
 # 필요 없다 — 끊어 두면 wasm 빌드가 구버전 getrandom 을 아예 만나지 않는다.
-argon2 = { version = "0.5", default-features = false, features = ["alloc"] }
+argon2 = { version = "0.6", default-features = false, features = ["alloc"] }
 chacha20poly1305 = { version = "0.11", default-features = false, features = ["alloc"] }
 zeroize = "1"
 # [보안 트레일러 · 포스트양자] ML-KEM-768(NIST FIPS 203) 격자 KEM — 공개키 봉인의

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,7 +273,7 @@ zeroize = "1"
 ml-kem = "0.3"
 rand_core = "0.10"
 zip = { version = "8.5", default-features = false, features = ["deflate"] }
-quick-xml = "0.41"
+quick-xml = "0.42"
 roxmltree = "0.21"
 svgtypes = "0.16"
 codepage = "0.1.2"

--- a/crates/rhwp-ooxml-chart/Cargo.toml
+++ b/crates/rhwp-ooxml-chart/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 too_many_arguments = "allow"
 
 [dependencies]
-quick-xml = "0.41"
+quick-xml = "0.42"

--- a/crates/rhwp-ooxml-chart/src/data.rs
+++ b/crates/rhwp-ooxml-chart/src/data.rs
@@ -364,11 +364,8 @@ impl ScanState {
 /// `c:pt` 의 `idx` 속성.
 fn pt_index(e: &BytesStart) -> u32 {
     for attr in e.attributes().flatten() {
-        if attr.key.local_name().as_ref() == b"idx" {
-            return std::str::from_utf8(&attr.value)
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(0);
+        if attr.key.local_name().as_ref().as_bytes() == b"idx" {
+            return attr.value.as_ref().parse().unwrap_or(0);
         }
     }
     0
@@ -399,15 +396,15 @@ fn prefix_of(e: &BytesStart) -> String {
     let qname = e.name();
     let qname = qname.as_ref();
     let local_len = e.local_name().as_ref().len();
-    String::from_utf8_lossy(&qname[..qname.len().saturating_sub(local_len)]).into_owned()
+    qname[..qname.len().saturating_sub(local_len)].to_owned()
 }
 
 /// [#5652] 속성 `name` 의 값 — quick_xml 이 파싱한 그대로(이스케이프 해제 없음).
 fn attr_value(e: &BytesStart, name: &[u8]) -> Option<String> {
     e.attributes()
         .flatten()
-        .find(|attr| attr.key.local_name().as_ref() == name)
-        .map(|attr| String::from_utf8_lossy(&attr.value).into_owned())
+        .find(|attr| attr.key.local_name().as_ref().as_bytes() == name)
+        .map(|attr| attr.value.as_ref().to_owned())
 }
 
 /// [#5652] 태그 하나의 raw 구간(`tag`, `<` 부터 `>` 까지) 안에서 속성 `name` 의 값 텍스트
@@ -558,7 +555,7 @@ fn note_series_index(state: &mut ScanState, text: &str, tag_range: Range<usize>,
     let Some(cur) = state.cur.as_mut() else {
         return;
     };
-    let slot = match e.local_name().as_ref() {
+    let slot = match e.local_name().as_ref().as_bytes() {
         b"idx" => &mut cur.idx_span,
         b"order" => &mut cur.order_span,
         _ => return,
@@ -596,11 +593,13 @@ pub fn scan_chart_values(xml: &[u8]) -> Result<ChartData, ChartScanError> {
                 skip_depth -= 1;
             }
             Ok(Event::Empty(_)) if skip_depth > 0 => {}
-            Ok(Event::Start(ref e)) if is_skipped(e.local_name().as_ref()) => skip_depth = 1,
+            Ok(Event::Start(ref e)) if is_skipped(e.local_name().as_ref().as_bytes()) => {
+                skip_depth = 1
+            }
             Ok(Event::Start(ref e)) => {
                 // 이번 이벤트의 raw 태그 구간 — `<` 부터 `>` 까지. 속성값 구간은 이 안에서만 찾는다.
                 let tag_range = pos_before..reader.buffer_position() as usize;
-                match e.local_name().as_ref() {
+                match e.local_name().as_ref().as_bytes() {
                     b"ser" => {
                         state.cur = Some(ChartSeries {
                             name: None,
@@ -668,7 +667,7 @@ pub fn scan_chart_values(xml: &[u8]) -> Result<ChartData, ChartScanError> {
             }
             Ok(Event::Empty(ref e)) => {
                 let tag_range = pos_before..reader.buffer_position() as usize;
-                match e.local_name().as_ref() {
+                match e.local_name().as_ref().as_bytes() {
                     // 빈 요소 `<c:v/>` — 결측치다. 텍스트 구간이 없으니 구간 없이 싣는다.
                     // 읽기는 되고 그 점의 편집만 거부된다.
                     b"v" if state.capturing() => {
@@ -720,7 +719,7 @@ pub fn scan_chart_values(xml: &[u8]) -> Result<ChartData, ChartScanError> {
             }
             Ok(Event::End(ref e)) => {
                 let end = reader.buffer_position() as usize;
-                match e.local_name().as_ref() {
+                match e.local_name().as_ref().as_bytes() {
                     b"v" => {
                         if let Some(start) = state.v_start.take() {
                             // 닫는 태그 직전 = 텍스트 끝. 닫는 태그 길이를 계산하지 않는다.

--- a/crates/rhwp-ooxml-chart/src/parser.rs
+++ b/crates/rhwp-ooxml-chart/src/parser.rs
@@ -72,13 +72,14 @@ pub fn parse_chart_xml(xml: &[u8]) -> Option<OoxmlChart> {
             Ok(Event::Start(ref e)) => handle_start(e, &mut chart, &mut state),
             Ok(Event::Empty(ref e)) => {
                 handle_start(e, &mut chart, &mut state);
-                handle_end(e.local_name().as_ref(), &mut chart, &mut state);
+                handle_end(e.local_name().as_ref().as_bytes(), &mut chart, &mut state);
             }
-            Ok(Event::End(ref e)) => handle_end(e.local_name().as_ref(), &mut chart, &mut state),
+            Ok(Event::End(ref e)) => {
+                handle_end(e.local_name().as_ref().as_bytes(), &mut chart, &mut state)
+            }
             Ok(Event::Text(t)) => {
                 if state.in_v || state.in_a_t {
-                    let s = t.decode().unwrap_or_default();
-                    state.cur_text_buf.push_str(&s);
+                    state.cur_text_buf.push_str(t.as_ref());
                 }
             }
             Ok(Event::Eof) => break,
@@ -175,7 +176,7 @@ pub fn parse_chart_xml(xml: &[u8]) -> Option<OoxmlChart> {
 
 fn handle_start(e: &quick_xml::events::BytesStart, chart: &mut OoxmlChart, st: &mut ParseState) {
     let name = e.local_name();
-    let name_bytes = name.as_ref();
+    let name_bytes = name.as_ref().as_bytes();
     match name_bytes {
         b"barChart" => {
             chart.chart_type = OoxmlChartType::Column; // barDir로 세분
@@ -650,8 +651,8 @@ fn handle_end(name: &[u8], chart: &mut OoxmlChart, st: &mut ParseState) {
 
 fn attr_val(e: &quick_xml::events::BytesStart, key: &str) -> Option<String> {
     for attr in e.attributes().flatten() {
-        if attr.key.as_ref() == key.as_bytes() {
-            return Some(String::from_utf8_lossy(attr.value.as_ref()).to_string());
+        if attr.key.as_ref().as_bytes() == key.as_bytes() {
+            return Some(attr.value.as_ref().to_string());
         }
     }
     None

--- a/crates/rhwp-password-crypto/Cargo.toml
+++ b/crates/rhwp-password-crypto/Cargo.toml
@@ -16,7 +16,7 @@ flate2 = "1.0"
 getrandom = { version = "0.4", features = ["wasm_js"] }
 hmac = "0.13"
 pbkdf2 = "0.13"
-quick-xml = "0.41"
+quick-xml = "0.42"
 roxmltree = "0.21"
 sha1 = "0.11"
 sha2 = "0.11"

--- a/crates/rhwp-password-crypto/src/lib.rs
+++ b/crates/rhwp-password-crypto/src/lib.rs
@@ -647,7 +647,7 @@ fn strip_hwpx_encryption_data(manifest: &[u8]) -> Result<Vec<u8>, PasswordCrypto
         match reader.read_event_into(&mut buffer) {
             Ok(Event::Eof) => break,
             Ok(Event::Start(event))
-                if hwpx_local_name(event.name().as_ref()) == b"encryption-data" =>
+                if hwpx_local_name(event.name().as_ref().as_bytes()) == b"encryption-data" =>
             {
                 skipped_depth = 1;
             }

--- a/rhwp-chrome/package-lock.json
+++ b/rhwp-chrome/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
-        "puppeteer": "^25.7.0",
+        "puppeteer": "^25.9.0",
         "typescript": "^7.0.2",
         "vite": "^8.2.2"
       }
@@ -1211,9 +1211,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.8.0.tgz",
-      "integrity": "sha512-3gcUJ+Jfodb5zNa/lWLZukBUwYiRIwAc8WRICoqfi+ZYmNWqpsPFyanTU3Gw/lhgII9aotVbAmhT6/NKHWgyUA==",
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.9.0.tgz",
+      "integrity": "sha512-2JqQszD2pyDTpIvBH1ZCXdrHgENVNdJIeOM6asbwHRgWknFiaLd1gNB91w/B/0hQHNpafkpxa90lPpBaJM87Hw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1222,7 +1222,7 @@
         "chromium-bidi": "17.0.2",
         "devtools-protocol": "0.0.1666840",
         "lilconfig": "^3.1.3",
-        "puppeteer-core": "25.8.0",
+        "puppeteer-core": "25.9.0",
         "typed-query-selector": "^2.12.2"
       },
       "bin": {
@@ -1233,9 +1233,9 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.8.0.tgz",
-      "integrity": "sha512-LDOrawV8vfCVk+yLj2ozvajNP4Sv3OV9y3Tpiyy2g2Z+aQlbcozP6KJfI4iSBq7YQER+86ihEtPa5ioiZyWxMQ==",
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.9.0.tgz",
+      "integrity": "sha512-U61rCwSMha62CA/Opy6tCx2Fx+ck7ouiKnbpEApzSoLYMoEu9F71nuFpHL55vmIt33/GYm6eKZVhH2ev0nAIeg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1244,7 +1244,7 @@
         "devtools-protocol": "0.0.1666840",
         "typed-query-selector": "^2.12.2",
         "webdriver-bidi-protocol": "0.4.2",
-        "ws": "^8.21.1"
+        "ws": "^8.21.3"
       },
       "engines": {
         "node": ">=22.12.0"

--- a/rhwp-chrome/package.json
+++ b/rhwp-chrome/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf dist"
   },
   "devDependencies": {
-    "puppeteer": "^25.7.0",
+    "puppeteer": "^25.9.0",
     "typescript": "^7.0.2",
     "vite": "^8.2.2"
   }

--- a/rhwp-studio/package-lock.json
+++ b/rhwp-studio/package-lock.json
@@ -15,7 +15,7 @@
         "pngjs": "^7.0.0"
       },
       "devDependencies": {
-        "@types/chrome": "^0.2.6",
+        "@types/chrome": "^0.2.7",
         "puppeteer-core": "^25.9.0",
         "typescript": "^7.0.2",
         "vite": "^8.2.2",
@@ -2531,9 +2531,9 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.6.tgz",
-      "integrity": "sha512-8OgXtL+OcR2IpY2ul5itg0R3xmdceAM4ldcHxh4BFL20p5z7fjhpyP5KuXAp1LIxA7oQgyViKTS9d+W8Sn8jdQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.7.tgz",
+      "integrity": "sha512-9kjBozQ+jyDVt1eai3VZqjHDTN95JCuRmbRHOryOltBJmzrTmUw/9r/DznmjRaQ8WlyIfeCA4WNzoj0IvormJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/rhwp-studio/package-lock.json
+++ b/rhwp-studio/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "^2.3.0",
+        "@noble/hashes": "^2.4.0",
         "canvaskit-wasm": "^0.42.0",
         "pixelmatch": "^7.1.0",
         "pngjs": "^7.0.0"
@@ -1714,9 +1714,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
-      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"

--- a/rhwp-studio/package-lock.json
+++ b/rhwp-studio/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@types/chrome": "^0.2.6",
-        "puppeteer-core": "^25.8.0",
+        "puppeteer-core": "^25.9.0",
         "typescript": "^7.0.2",
         "vite": "^8.2.2",
         "vite-plugin-pwa": "^1.3.0",
@@ -5327,9 +5327,9 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.8.0.tgz",
-      "integrity": "sha512-LDOrawV8vfCVk+yLj2ozvajNP4Sv3OV9y3Tpiyy2g2Z+aQlbcozP6KJfI4iSBq7YQER+86ihEtPa5ioiZyWxMQ==",
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.9.0.tgz",
+      "integrity": "sha512-U61rCwSMha62CA/Opy6tCx2Fx+ck7ouiKnbpEApzSoLYMoEu9F71nuFpHL55vmIt33/GYm6eKZVhH2ev0nAIeg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5338,7 +5338,7 @@
         "devtools-protocol": "0.0.1666840",
         "typed-query-selector": "^2.12.2",
         "webdriver-bidi-protocol": "0.4.2",
-        "ws": "^8.21.1"
+        "ws": "^8.21.3"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -6849,9 +6849,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -84,7 +84,7 @@
     "serialize-javascript": "7.0.5"
   },
   "dependencies": {
-    "@noble/hashes": "^2.3.0",
+    "@noble/hashes": "^2.4.0",
     "canvaskit-wasm": "^0.42.0",
     "pixelmatch": "^7.1.0",
     "pngjs": "^7.0.0"

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -73,7 +73,7 @@
     "e2e:issue-6053": "node e2e/run-with-vite.mjs -- node e2e/chart-data-structure-issue6053.test.mjs --mode=headless"
   },
   "devDependencies": {
-    "@types/chrome": "^0.2.6",
+    "@types/chrome": "^0.2.7",
     "puppeteer-core": "^25.9.0",
     "typescript": "^7.0.2",
     "vite": "^8.2.2",

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -74,7 +74,7 @@
   },
   "devDependencies": {
     "@types/chrome": "^0.2.6",
-    "puppeteer-core": "^25.8.0",
+    "puppeteer-core": "^25.9.0",
     "typescript": "^7.0.2",
     "vite": "^8.2.2",
     "vite-plugin-pwa": "^1.3.0",

--- a/rhwp-vscode/package-lock.json
+++ b/rhwp-vscode/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "^2.3.0",
+        "@noble/hashes": "^2.4.0",
         "canvaskit-wasm": "^0.42.0"
       },
       "devDependencies": {
@@ -88,9 +88,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
-      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"

--- a/rhwp-vscode/package-lock.json
+++ b/rhwp-vscode/package-lock.json
@@ -20,7 +20,7 @@
         "null-loader": "^4.0.1",
         "ts-loader": "^9.6.2",
         "typescript": "npm:@typescript/typescript6@^6.0.2",
-        "webpack": "^5.109.2",
+        "webpack": "^5.110.1",
         "webpack-cli": "^7.2.2"
       },
       "engines": {
@@ -70,9 +70,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -700,9 +700,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1039,53 +1039,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/esrecurse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/esrecurse/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -1410,16 +1363,16 @@
       }
     },
     "node_modules/minimizer-webpack-plugin": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
-      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.8.0.tgz",
+      "integrity": "sha512-2cT9+goJfBhtMz+gJqejSf09ClgmYhPhccRb/fb0ztVbixt0BkO8mRuI26FoPPuUNkRk6iEDryWAIouc5W8eJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@jridgewell/trace-mapping": "^0.3.31",
         "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "terser": "^5.31.1"
+        "schema-utils": "^4.3.3",
+        "terser": "^5.51.0"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -1882,9 +1835,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
-      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+      "version": "5.51.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.51.2.tgz",
+      "integrity": "sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2029,9 +1982,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.109.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
-      "integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
+      "version": "5.110.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.1.tgz",
+      "integrity": "sha512-gInQB+jxXxgnZyvPwuzT5NGQmECDqeu85oxcrjinrYHqPoBex0hCAN2SFTJVyPVrK0Pq9E44VFP+e89fAc10/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2045,11 +1998,10 @@
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.24.4",
         "es-module-lexer": "^2.1.0",
-        "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "graceful-fs": "^4.2.11",
         "mime-db": "^1.54.0",
-        "minimizer-webpack-plugin": "^5.6.1",
+        "minimizer-webpack-plugin": "^5.7.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",

--- a/rhwp-vscode/package.json
+++ b/rhwp-vscode/package.json
@@ -109,7 +109,7 @@
     "package": "vsce package"
   },
   "dependencies": {
-    "@noble/hashes": "^2.3.0",
+    "@noble/hashes": "^2.4.0",
     "canvaskit-wasm": "^0.42.0"
   },
   "devDependencies": {

--- a/rhwp-vscode/package.json
+++ b/rhwp-vscode/package.json
@@ -120,7 +120,7 @@
     "null-loader": "^4.0.1",
     "ts-loader": "^9.6.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "webpack": "^5.109.2",
+    "webpack": "^5.110.1",
     "webpack-cli": "^7.2.2"
   }
 }

--- a/src/diagnostics/hwp5_char_shape_audit.rs
+++ b/src/diagnostics/hwp5_char_shape_audit.rs
@@ -314,8 +314,8 @@ fn parse_hwpx_signatures(xml: &str) -> Result<BTreeMap<usize, HwpxDecorationSign
 
 fn xml_required_id(event: &quick_xml::events::BytesStart<'_>) -> Result<usize, String> {
     for attribute in event.attributes().flatten() {
-        if attribute.key.as_ref() == b"id" {
-            let value = String::from_utf8_lossy(attribute.value.as_ref());
+        if attribute.key.as_ref().as_bytes() == b"id" {
+            let value = attribute.value.as_ref();
             return value
                 .parse::<usize>()
                 .map_err(|_| format!("HWPX charPr id가 올바르지 않습니다: {value}"));
@@ -342,20 +342,14 @@ fn xml_attribute_signature(event: &quick_xml::events::BytesStart<'_>) -> String 
     let mut attributes = event
         .attributes()
         .flatten()
-        .map(|attribute| {
-            format!(
-                "{}={}",
-                String::from_utf8_lossy(attribute.key.as_ref()),
-                String::from_utf8_lossy(attribute.value.as_ref())
-            )
-        })
+        .map(|attribute| format!("{}={}", attribute.key.as_ref(), attribute.value.as_ref()))
         .collect::<Vec<_>>();
     attributes.sort();
     attributes.join(",")
 }
 
-fn xml_local_name(name: &[u8]) -> &[u8] {
-    name.rsplit(|byte| *byte == b':').next().unwrap_or(name)
+fn xml_local_name(name: &str) -> &[u8] {
+    name.rsplit(':').next().unwrap_or(name).as_bytes()
 }
 
 fn read_char_shapes(path: &PathBuf) -> Result<Vec<CharShapeRecord>, String> {

--- a/src/paint/font_glyph.rs
+++ b/src/paint/font_glyph.rs
@@ -311,15 +311,14 @@ pub fn decode_font_svg_glyph_payload(
     loop {
         match reader.read_event() {
             Ok(Event::Start(element)) | Ok(Event::Empty(element)) => {
-                if view_box.is_none() && element.name().as_ref().eq_ignore_ascii_case(b"svg") {
+                if view_box.is_none() && element.name().as_ref().eq_ignore_ascii_case("svg") {
                     for attribute in element.attributes().with_checks(true) {
                         let attribute =
                             attribute.map_err(|_| FontSvgGlyphDecodeError::InvalidSvgXml)?;
-                        if !attribute.key.as_ref().eq_ignore_ascii_case(b"viewBox") {
+                        if !attribute.key.as_ref().eq_ignore_ascii_case("viewBox") {
                             continue;
                         }
-                        let value = std::str::from_utf8(attribute.value.as_ref())
-                            .map_err(|_| FontSvgGlyphDecodeError::InvalidViewBox)?;
+                        let value = attribute.value.as_ref();
                         let values = value
                             .split(|character: char| {
                                 character.is_ascii_whitespace() || character == ','

--- a/src/parser/hml/reader.rs
+++ b/src/parser/hml/reader.rs
@@ -811,13 +811,13 @@ impl<'a> ReadState<'a> {
         let path = format!("/{}", self.stack.join("/"));
         for item in element.attributes() {
             let attr = item.map_err(|error| HmlError::InvalidXml(error.to_string()))?;
-            let name = std::str::from_utf8(attr.key.as_ref())
+            let name = std::str::from_utf8(attr.key.as_ref().as_bytes())
                 .map_err(|_| HmlError::InvalidXml("non-UTF-8 attribute name".to_string()))?;
             if !matches!(
                 name,
                 "BaseLine" | "BaseUnit" | "TextColor" | "Version" | "Font"
             ) {
-                let raw = std::str::from_utf8(attr.value.as_ref())
+                let raw = std::str::from_utf8(attr.value.as_ref().as_bytes())
                     .map_err(|_| HmlError::InvalidXml("non-UTF-8 attribute".to_string()))?;
                 let value = quick_xml::escape::unescape(raw)
                     .map_err(|error| HmlError::InvalidXml(error.to_string()))?;
@@ -866,9 +866,9 @@ impl<'a> ReadState<'a> {
         };
         for item in element.attributes() {
             let attr = item.map_err(|error| HmlError::InvalidXml(error.to_string()))?;
-            let name = std::str::from_utf8(attr.key.as_ref())
+            let name = std::str::from_utf8(attr.key.as_ref().as_bytes())
                 .map_err(|_| HmlError::InvalidXml("non-UTF-8 attribute name".to_string()))?;
-            let raw = std::str::from_utf8(attr.value.as_ref())
+            let raw = std::str::from_utf8(attr.value.as_ref().as_bytes())
                 .map_err(|_| HmlError::InvalidXml("non-UTF-8 attribute".to_string()))?;
             let value = quick_xml::escape::unescape(raw)
                 .map_err(|error| HmlError::InvalidXml(error.to_string()))?;
@@ -1341,10 +1341,11 @@ impl<'a> ReadState<'a> {
             if unsupported_equation_child {
                 for item in element.attributes() {
                     let attr = item.map_err(|error| HmlError::InvalidXml(error.to_string()))?;
-                    let attr_name = std::str::from_utf8(attr.key.as_ref()).map_err(|_| {
-                        HmlError::InvalidXml("non-UTF-8 attribute name".to_string())
-                    })?;
-                    let raw = std::str::from_utf8(attr.value.as_ref())
+                    let attr_name =
+                        std::str::from_utf8(attr.key.as_ref().as_bytes()).map_err(|_| {
+                            HmlError::InvalidXml("non-UTF-8 attribute name".to_string())
+                        })?;
+                    let raw = std::str::from_utf8(attr.value.as_ref().as_bytes())
                         .map_err(|_| HmlError::InvalidXml("non-UTF-8 attribute".to_string()))?;
                     let value = quick_xml::escape::unescape(raw)
                         .map_err(|error| HmlError::InvalidXml(error.to_string()))?;
@@ -1429,7 +1430,7 @@ pub(crate) fn has_hwpml_root(xml: &str) -> bool {
     loop {
         match reader.read_event() {
             Ok(Event::Start(element)) | Ok(Event::Empty(element)) => {
-                return element.name().as_ref() == b"HWPML"
+                return element.name().as_ref().as_bytes() == b"HWPML"
                     && attribute(&element, b"Version")
                         .ok()
                         .flatten()
@@ -1441,7 +1442,7 @@ pub(crate) fn has_hwpml_root(xml: &str) -> bool {
             // 실패했다 — 실제로는 HWPML 인데 "알 수 없는 파일 형식"으로 거부됐다.
             Ok(Event::DocType(_)) => {}
             Ok(Event::Decl(_) | Event::Comment(_) | Event::PI(_)) => {}
-            Ok(Event::Text(text)) if text.iter().all(|byte| byte.is_ascii_whitespace()) => {}
+            Ok(Event::Text(text)) if text.as_ref().chars().all(char::is_whitespace) => {}
             Ok(Event::Eof) | Err(_) => return false,
             _ => return false,
         }
@@ -1469,7 +1470,7 @@ pub(crate) fn read_hml(xml: &str, limits: &HmlLimits) -> Result<HmlSource, HmlEr
                 enforce_depth(state.stack.len(), limits.max_depth)?;
                 state.empty(&element, limits, start_pos, end_pos)?;
             }
-            Event::End(element) => state.end(element.name().as_ref(), end_pos)?,
+            Event::End(element) => state.end(element.name().as_ref().as_bytes(), end_pos)?,
             Event::Text(text) => append_decoded_text(&mut state, &text, limits)?,
             Event::CData(text) => append_cdata(&mut state, &text, limits)?,
             Event::GeneralRef(reference) => append_reference(&mut state, &reference)?,
@@ -1497,10 +1498,7 @@ fn append_cdata(
     if text.len() > limits.max_text_node_bytes {
         return Err(HmlError::LimitExceeded("text node size".to_string()));
     }
-    let decoded = text
-        .decode()
-        .map_err(|error| HmlError::InvalidXml(error.to_string()))?;
-    state.append_text(&decoded)
+    state.append_text(text.as_ref())
 }
 
 fn enforce_depth(current_depth: usize, max_depth: usize) -> Result<(), HmlError> {
@@ -1518,10 +1516,7 @@ fn append_decoded_text(
     if text.len() > limits.max_text_node_bytes {
         return Err(HmlError::LimitExceeded("text node size".to_string()));
     }
-    let decoded = text
-        .decode()
-        .map_err(|error| HmlError::InvalidXml(error.to_string()))?;
-    state.append_text(&decoded)
+    state.append_text(text.as_ref())
 }
 
 /// [#5848] 숫자 문자참조(`&#160;` · `&#xA0;`)만 실제 문자로 푼다.
@@ -1572,10 +1567,7 @@ fn collect_doctype_entities(
     const MAX_ENTITIES: usize = 64;
     const MAX_VALUE_BYTES: usize = 256;
 
-    let text = doctype
-        .decode()
-        .map_err(|error| HmlError::InvalidXml(error.to_string()))?;
-    let mut rest = text.as_ref();
+    let mut rest = doctype.as_ref();
     while let Some(at) = rest.find("<!ENTITY") {
         rest = &rest[at + "<!ENTITY".len()..];
         let Some(decl_end) = rest.find('>') else {
@@ -1640,10 +1632,8 @@ fn append_reference(
     {
         return state.append_text(&character.to_string());
     }
-    let name = reference
-        .decode()
-        .map_err(|error| HmlError::InvalidXml(error.to_string()))?;
-    let value = match name.as_ref() {
+    let name = reference.as_ref();
+    let value = match name {
         "lt" => "<",
         "gt" => ">",
         "amp" => "&",
@@ -1665,9 +1655,7 @@ fn append_reference(
 }
 
 fn element_name(element: &BytesStart<'_>) -> Result<String, HmlError> {
-    std::str::from_utf8(element.name().as_ref())
-        .map(str::to_owned)
-        .map_err(|_| HmlError::InvalidXml("non-UTF-8 element name".to_string()))
+    Ok(element.name().as_ref().to_owned())
 }
 
 fn validate_attributes(element: &BytesStart<'_>, max: usize) -> Result<(), HmlError> {
@@ -1685,8 +1673,8 @@ fn validate_attributes(element: &BytesStart<'_>, max: usize) -> Result<(), HmlEr
 fn attribute(element: &BytesStart<'_>, key: &[u8]) -> Result<Option<String>, HmlError> {
     for item in element.attributes() {
         let attr = item.map_err(|error| HmlError::InvalidXml(error.to_string()))?;
-        if attr.key.as_ref() == key {
-            let raw = std::str::from_utf8(attr.value.as_ref())
+        if attr.key.as_ref().as_bytes() == key {
+            let raw = std::str::from_utf8(attr.value.as_ref().as_bytes())
                 .map_err(|_| HmlError::InvalidXml("non-UTF-8 attribute".to_string()))?;
             let value = quick_xml::escape::unescape(raw)
                 .map_err(|error| HmlError::InvalidXml(error.to_string()))?;

--- a/src/parser/hwp_summary.rs
+++ b/src/parser/hwp_summary.rs
@@ -69,11 +69,11 @@ fn hwpx_app_version(data: &[u8]) -> Option<String> {
                 for attr in element.attributes() {
                     let attr = attr.ok()?;
                     if local_name(attr.key.as_ref()) == b"appVersion" {
-                        let raw = String::from_utf8_lossy(&attr.value);
+                        let raw = attr.value.as_ref();
                         return Some(
                             quick_xml::escape::unescape(&raw)
                                 .map(|value| value.into_owned())
-                                .unwrap_or_else(|_| raw.into_owned()),
+                                .unwrap_or_else(|_| raw.to_owned()),
                         );
                     }
                 }
@@ -86,8 +86,8 @@ fn hwpx_app_version(data: &[u8]) -> Option<String> {
     }
 }
 
-fn local_name(name: &[u8]) -> &[u8] {
-    name.rsplit(|byte| *byte == b':').next().unwrap_or(name)
+fn local_name(name: &str) -> &[u8] {
+    name.rsplit(':').next().unwrap_or(name).as_bytes()
 }
 
 fn save_version(value: &str) -> Option<HancomOfficeSaveVersion> {

--- a/src/parser/hwpx/content.rs
+++ b/src/parser/hwpx/content.rs
@@ -66,7 +66,7 @@ pub fn parse_content_hpf(xml: &str) -> Result<PackageInfo, HwpxError> {
                         // isEmbeded="0" 인 경우만 false 로 설정.
                         let mut is_embedded = true;
                         for attr in e.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"id" => id = attr_value(&attr),
                                 b"href" => href = attr_value(&attr),
                                 b"media-type" => media_type = attr_value(&attr),
@@ -82,7 +82,7 @@ pub fn parse_content_hpf(xml: &str) -> Result<PackageInfo, HwpxError> {
                     }
                     b"itemref" => {
                         for attr in e.attributes().flatten() {
-                            if attr.key.as_ref() == b"idref" {
+                            if attr.key.as_ref().as_bytes() == b"idref" {
                                 spine_order.push(attr_value(&attr));
                             }
                         }
@@ -215,16 +215,12 @@ fn collect_section_master_pages(
 
 /// XML 어트리뷰트 값을 String으로 변환
 fn attr_value(attr: &quick_xml::events::attributes::Attribute) -> String {
-    String::from_utf8_lossy(&attr.value).to_string()
+    attr.value.as_ref().to_owned()
 }
 
 /// 네임스페이스 접두사를 제거하고 로컬 태그 이름을 반환
-fn local_tag_name(name: &[u8]) -> &[u8] {
-    if let Some(pos) = name.iter().position(|&b| b == b':') {
-        &name[pos + 1..]
-    } else {
-        name
-    }
+fn local_tag_name(name: &str) -> &[u8] {
+    name.rsplit(':').next().unwrap_or(name).as_bytes()
 }
 
 #[cfg(test)]

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -100,7 +100,7 @@ pub fn parse_hwpx_hwpml_version(xml: &str) -> Option<String> {
                 let name = e.name();
                 if local_name(name.as_ref()) == b"head" {
                     for attr in e.attributes().flatten() {
-                        if attr.key.as_ref() == b"version" {
+                        if attr.key.as_ref().as_bytes() == b"version" {
                             return Some(attr_str(&attr));
                         }
                     }
@@ -138,7 +138,7 @@ pub fn parse_hwpx_header(xml: &str) -> Result<(DocInfo, DocProperties), HwpxErro
                     b"fontface" => {
                         // <hh:fontface lang="HANGUL"> → 언어 그룹 설정
                         for attr in e.attributes().flatten() {
-                            if attr.key.as_ref() == b"lang" {
+                            if attr.key.as_ref().as_bytes() == b"lang" {
                                 current_font_group = match attr_str(&attr).as_str() {
                                     "HANGUL" => 0,
                                     "LATIN" => 1,
@@ -201,7 +201,7 @@ pub fn parse_hwpx_header(xml: &str) -> Result<(DocInfo, DocProperties), HwpxErro
                         // 자기 닫힘 태그: 빈 TabDef만 push
                         let mut td = TabDef::default();
                         for attr in e.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"autoTabLeft" => td.auto_tab_left = attr_str(&attr) == "1",
                                 b"autoTabRight" => td.auto_tab_right = attr_str(&attr) == "1",
                                 _ => {}
@@ -272,7 +272,7 @@ fn parse_doc_option_linkinfo(e: &quick_xml::events::BytesStart, doc_info: &mut D
     let mut footnote_inherit = false;
 
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"pageInherit" => page_inherit = parse_bool(&attr),
             b"footnoteInherit" => footnote_inherit = parse_bool(&attr),
             _ => {}
@@ -347,7 +347,7 @@ fn parse_memo_shape(e: &quick_xml::events::BytesStart, doc_info: &mut DocInfo) {
     let mut memo_type = 0u32;
 
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"width" => width = parse_u32(&attr),
             b"lineWidth" => line_width = parse_u8(&attr),
             b"lineType" => line_type = parse_memo_line_type(&attr_str(&attr)),
@@ -412,7 +412,7 @@ fn parse_memo_type(value: &str) -> u32 {
 
 fn parse_begin_num(e: &quick_xml::events::BytesStart, props: &mut DocProperties) {
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"page" => props.page_start_num = parse_u16(&attr),
             b"footnote" => props.footnote_start_num = parse_u16(&attr),
             b"endnote" => props.endnote_start_num = parse_u16(&attr),
@@ -441,7 +441,7 @@ fn parse_font(
     let mut subst_font = None;
 
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"face" => name = attr_str(&attr),
             b"type" => {
                 font_type = match attr_str(&attr).as_str() {
@@ -514,7 +514,7 @@ fn parse_font_type_info(
 
     for attr in e.attributes().flatten() {
         let value = attr_str(&attr);
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"familyType" => info[0] = font_family_type_to_u8(&value),
             b"weight" => info[2] = value.parse::<u8>().unwrap_or(0),
             b"proportion" => info[3] = value.parse::<u8>().unwrap_or(0),
@@ -537,7 +537,7 @@ fn parse_subst_font(e: &quick_xml::events::BytesStart) -> SubstFont {
     let mut sf = SubstFont::default();
     for attr in e.attributes().flatten() {
         let value = attr_str(&attr);
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"face" => sf.face = value,
             b"type" => {
                 sf.font_type = match value.as_str() {
@@ -612,7 +612,7 @@ fn parse_char_shape(
     let mut id: Option<usize> = None;
 
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"id" => id = Some(parse_u32(&attr) as usize),
             b"height" => cs.base_size = parse_i32(&attr),
             b"textColor" => cs.text_color = parse_color(&attr),
@@ -649,7 +649,7 @@ fn parse_char_shape(
                         b"fontRef" => {
                             for attr in ce.attributes().flatten() {
                                 let val = parse_u16(&attr);
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"hangul" => cs.font_ids[0] = val,
                                     b"latin" => cs.font_ids[1] = val,
                                     b"hanja" => cs.font_ids[2] = val,
@@ -664,7 +664,7 @@ fn parse_char_shape(
                         b"ratio" => {
                             for attr in ce.attributes().flatten() {
                                 let val = parse_u8(&attr);
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"hangul" => cs.ratios[0] = val,
                                     b"latin" => cs.ratios[1] = val,
                                     b"hanja" => cs.ratios[2] = val,
@@ -679,7 +679,7 @@ fn parse_char_shape(
                         b"spacing" => {
                             for attr in ce.attributes().flatten() {
                                 let val = parse_i8(&attr);
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"hangul" => cs.spacings[0] = val,
                                     b"latin" => cs.spacings[1] = val,
                                     b"hanja" => cs.spacings[2] = val,
@@ -694,7 +694,7 @@ fn parse_char_shape(
                         b"relSz" => {
                             for attr in ce.attributes().flatten() {
                                 let val = parse_u8(&attr);
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"hangul" => cs.relative_sizes[0] = val,
                                     b"latin" => cs.relative_sizes[1] = val,
                                     b"hanja" => cs.relative_sizes[2] = val,
@@ -709,7 +709,7 @@ fn parse_char_shape(
                         b"offset" => {
                             for attr in ce.attributes().flatten() {
                                 let val = parse_i8(&attr);
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"hangul" => cs.char_offsets[0] = val,
                                     b"latin" => cs.char_offsets[1] = val,
                                     b"hanja" => cs.char_offsets[2] = val,
@@ -725,7 +725,7 @@ fn parse_char_shape(
                         b"italic" => cs.italic = true,
                         b"underline" => {
                             for attr in ce.attributes().flatten() {
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"type" => {
                                         cs.underline_type = match attr_str(&attr).as_str() {
                                             "BOTTOM" => UnderlineType::Bottom,
@@ -761,7 +761,7 @@ fn parse_char_shape(
                         }
                         b"strikeout" => {
                             for attr in ce.attributes().flatten() {
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"shape" => {
                                         let val = attr_str(&attr);
                                         // 화이트리스트 방식: 한컴이 실제 렌더링하는
@@ -796,7 +796,7 @@ fn parse_char_shape(
                         }
                         b"outline" => {
                             for attr in ce.attributes().flatten() {
-                                if attr.key.as_ref() == b"type" {
+                                if attr.key.as_ref().as_bytes() == b"type" {
                                     let val = attr_str(&attr);
                                     // [#2695] 외곽선 8종 (표 27 선 종류 앞 7개 + NONE).
                                     // HWP5 attr bits 8-10 (3비트) 과 1:1 대응하므로
@@ -817,7 +817,7 @@ fn parse_char_shape(
                         }
                         b"shadow" => {
                             for attr in ce.attributes().flatten() {
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"type" => {
                                         let val = attr_str(&attr);
                                         // [#2695] HWP5 attr bits 11-12: 1=비연속(DROP,
@@ -890,7 +890,7 @@ fn parse_para_shape(
     let mut id: Option<usize> = None;
 
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"id" => id = Some(parse_u32(&attr) as usize),
             b"tabPrIDRef" => ps.tab_def_id = parse_u16(&attr),
             b"condense" => {
@@ -990,7 +990,7 @@ fn parse_para_shape_child(
     match local {
         b"align" => {
             for attr in ce.attributes().flatten() {
-                match attr.key.as_ref() {
+                match attr.key.as_ref().as_bytes() {
                     b"horizontal" => ps.alignment = parse_alignment(&attr),
                     b"vertical" => {
                         ps.attr1 = (ps.attr1 & !(0x03 << 20))
@@ -1003,7 +1003,7 @@ fn parse_para_shape_child(
         }
         b"heading" => {
             for attr in ce.attributes().flatten() {
-                match attr.key.as_ref() {
+                match attr.key.as_ref().as_bytes() {
                     b"type" => {
                         let val = attr_str(&attr);
                         ps.head_type = match val.as_str() {
@@ -1026,7 +1026,7 @@ fn parse_para_shape_child(
         }
         b"lineSpacing" => {
             for attr in ce.attributes().flatten() {
-                match attr.key.as_ref() {
+                match attr.key.as_ref().as_bytes() {
                     b"type" => {
                         let val = attr_str(&attr);
                         ps.line_spacing_type = match val.as_str() {
@@ -1050,7 +1050,7 @@ fn parse_para_shape_child(
         }
         b"border" => {
             for attr in ce.attributes().flatten() {
-                match attr.key.as_ref() {
+                match attr.key.as_ref().as_bytes() {
                     b"borderFillIDRef" => ps.border_fill_id = parse_u16(&attr),
                     b"offsetLeft" => ps.border_spacing[0] = parse_i16(&attr),
                     b"offsetRight" => ps.border_spacing[1] = parse_i16(&attr),
@@ -1077,7 +1077,7 @@ fn parse_para_shape_child(
         }
         b"breakSetting" => {
             for attr in ce.attributes().flatten() {
-                match attr.key.as_ref() {
+                match attr.key.as_ref().as_bytes() {
                     b"breakLatinWord" => {
                         // [#1986] 값 3종(BREAK_WORD/KEEP_WORD/HYPHENATION) — 원문 보존.
                         // 미보존 시 직렬화가 KEEP_WORD 로 고정해 꼬리말·표셀 재계산
@@ -1137,7 +1137,7 @@ fn parse_para_shape_child(
             // 해당 비트는 문단 세로 정렬이며, <align vertical="...">에서 채운다.
             // 한컴 HWP5의 자동 간격 정본은 attr2 bits 4/5다.
             for attr in ce.attributes().flatten() {
-                match attr.key.as_ref() {
+                match attr.key.as_ref().as_bytes() {
                     b"eAsianEng" => {
                         if parse_bool(&attr) {
                             ps.attr2 |= 1 << 4;
@@ -1164,7 +1164,7 @@ fn parse_para_shape_child(
 
 fn parse_para_shape_margin_attrs(ce: &quick_xml::events::BytesStart, ps: &mut ParaShape) {
     for attr in ce.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"left" => ps.margin_left = parse_i32(&attr),
             b"right" => ps.margin_right = parse_i32(&attr),
             b"indent" => ps.indent = parse_i32(&attr),
@@ -1183,7 +1183,7 @@ fn parse_para_shape_margin_value_child(ce: &quick_xml::events::BytesStart, ps: &
     }
 
     for attr in ce.attributes().flatten() {
-        if attr.key.as_ref() != b"value" {
+        if attr.key.as_ref().as_bytes() != b"value" {
             continue;
         }
         let value = parse_i32(&attr);
@@ -1280,7 +1280,7 @@ fn parse_para_shape_switch(
                             // margin 하위 요소들: <left value="..." />, <prev value="..." /> 등
                             let tag_name = local;
                             for attr in ce.attributes().flatten() {
-                                if attr.key.as_ref() == b"value" {
+                                if attr.key.as_ref().as_bytes() == b"value" {
                                     let val = parse_i32(&attr);
                                     if in_hwpunitchar_case {
                                         // HwpUnitChar 값은 실제 HWPUNIT(1× 스케일)이므로
@@ -1332,7 +1332,7 @@ fn parse_para_shape_switch(
                             let mut ls_type = None;
                             let mut ls_val = None;
                             for attr in ce.attributes().flatten() {
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"type" => {
                                         ls_type = Some(match attr_str(&attr).as_str() {
                                             "PERCENT" => LineSpacingType::Percent,
@@ -1484,7 +1484,7 @@ fn parse_style(e: &quick_xml::events::BytesStart, doc_info: &mut DocInfo) {
     let mut style = Style::default();
     style.lang_id = 1042; // default 한국어 (HWPX 미지정 시)
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"name" => style.local_name = attr_str(&attr),
             b"engName" => style.english_name = attr_str(&attr),
             b"type" => {
@@ -1501,7 +1501,7 @@ fn parse_style(e: &quick_xml::events::BytesStart, doc_info: &mut DocInfo) {
             // [Task #1058 후속] HWPX `langID` → Style.lang_id (spec 표 47).
             // HWPX 의 `langID="1042"` 가 한컴 정답지의 Style record 의 INT16 lang_id.
             b"langID" => {
-                if let Ok(s) = std::str::from_utf8(&attr.value) {
+                if let Ok(s) = std::str::from_utf8(attr.value.as_ref().as_bytes()) {
                     if let Ok(v) = s.parse::<i16>() {
                         style.lang_id = v;
                     }
@@ -1526,7 +1526,7 @@ fn parse_border_fill(
 ) -> Result<(), HwpxError> {
     let mut bf = BorderFill::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"centerLine" => {
                 bf.center_line = parse_center_line(&attr);
                 if bf.center_line == CenterLine::None {
@@ -1571,7 +1571,7 @@ fn parse_border_fill(
                             };
                             if idx < 4 {
                                 for attr in ce.attributes().flatten() {
-                                    match attr.key.as_ref() {
+                                    match attr.key.as_ref().as_bytes() {
                                         b"type" => {
                                             bf.borders[idx].line_type =
                                                 parse_border_line_type(&attr)
@@ -1587,7 +1587,7 @@ fn parse_border_fill(
                         }
                         b"diagonal" => {
                             for attr in ce.attributes().flatten() {
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"type" => {
                                         bf.diagonal.diagonal_type =
                                             parse_border_line_type_code(&attr)
@@ -1615,7 +1615,7 @@ fn parse_border_fill(
                             // 해석되어, 문단모양/렌더에 의도치 않은 배경이 생겼다.
                             let mut face_is_none = false;
                             for attr in ce.attributes().flatten() {
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"faceColor" => {
                                         if attr_str(&attr).eq_ignore_ascii_case("none") {
                                             face_is_none = true;
@@ -1656,7 +1656,7 @@ fn parse_border_fill(
                             bf.fill.fill_type = FillType::Gradient;
                             let mut grad = GradientFill::default();
                             for attr in ce.attributes().flatten() {
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"type" => {
                                         grad.gradient_type = parse_gradient_type(&attr_str(&attr))
                                     }
@@ -1680,7 +1680,7 @@ fn parse_border_fill(
                             // <hh:color value="#RRGGBB"/> — gradation 자식
                             if let Some(ref mut grad) = bf.fill.gradient {
                                 for attr in ce.attributes().flatten() {
-                                    if attr.key.as_ref() == b"value" {
+                                    if attr.key.as_ref().as_bytes() == b"value" {
                                         grad.colors.push(parse_color(&attr));
                                     }
                                 }
@@ -1690,7 +1690,7 @@ fn parse_border_fill(
                             bf.fill.fill_type = FillType::Image;
                             let mut img_fill = ImageFill::default();
                             for attr in ce.attributes().flatten() {
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"mode" => {
                                         img_fill.fill_mode = match attr_str(&attr).as_str() {
                                             "TILE" | "TILE_ALL" => ImageFillMode::TileAll,
@@ -1731,7 +1731,7 @@ fn parse_border_fill(
                             // 배경 워터마크 반투명 합성이 빠졌다 (SVG/PNG 회귀).
                             if let Some(ref mut img_fill) = bf.fill.image {
                                 for attr in ce.attributes().flatten() {
-                                    match attr.key.as_ref() {
+                                    match attr.key.as_ref().as_bytes() {
                                         b"binaryItemIDRef" => {
                                             let val = attr_str(&attr);
                                             let num: String = val
@@ -1761,7 +1761,7 @@ fn parse_border_fill(
                             // 선 종류가 아니다. 방향 비트(attr bits 2~4)만 설정하고,
                             // 선 종류/굵기/색은 <hh:diagonal> 요소가 전담한다.
                             for attr in ce.attributes().flatten() {
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"type" => {
                                         let code = parse_slash_shape_code(&attr);
                                         set_diagonal_attr_bits(&mut bf, 2, code);
@@ -1780,7 +1780,7 @@ fn parse_border_fill(
                         b"backSlash" => {
                             // backSlash 방향 비트(attr bits 5~7)만 설정.
                             for attr in ce.attributes().flatten() {
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"type" => {
                                         let code = parse_slash_shape_code(&attr);
                                         set_diagonal_attr_bits(&mut bf, 5, code);
@@ -1817,7 +1817,7 @@ fn parse_border_fill(
 fn parse_tab_item(ce: &quick_xml::events::BytesStart) -> TabItem {
     let mut item = TabItem::default();
     for attr in ce.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"pos" => item.position = parse_u32(&attr),
             b"type" => {
                 item.tab_type = match attr_str(&attr).as_str() {
@@ -1869,7 +1869,7 @@ fn parse_tab_def(
     let mut td = TabDef::default();
 
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"autoTabLeft" => td.auto_tab_left = attr_str(&attr) == "1",
             b"autoTabRight" => td.auto_tab_right = attr_str(&attr) == "1",
             _ => {}
@@ -1978,23 +1978,23 @@ fn parse_bullet_hwpx(
     let mut bullet = Bullet::default();
 
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"char" => {
-                if let Ok(s) = std::str::from_utf8(&attr.value) {
+                if let Ok(s) = std::str::from_utf8(attr.value.as_ref().as_bytes()) {
                     if let Some(c) = s.chars().next() {
                         bullet.bullet_char = c;
                     }
                 }
             }
             b"useImage" => {
-                if let Ok(s) = std::str::from_utf8(&attr.value) {
+                if let Ok(s) = std::str::from_utf8(attr.value.as_ref().as_bytes()) {
                     if s == "1" {
                         bullet.image_bullet = 1;
                     }
                 }
             }
             b"checkedChar" => {
-                if let Ok(s) = std::str::from_utf8(&attr.value) {
+                if let Ok(s) = std::str::from_utf8(attr.value.as_ref().as_bytes()) {
                     if let Some(c) = s.chars().next() {
                         bullet.check_bullet_char = c;
                     }
@@ -2024,9 +2024,9 @@ fn parse_bullet_hwpx(
                     if let Some(attr) = ce
                         .attributes()
                         .flatten()
-                        .find(|a| a.key.as_ref() == b"binaryItemIDRef")
+                        .find(|a| a.key.as_ref().as_bytes() == b"binaryItemIDRef")
                     {
-                        let s = String::from_utf8_lossy(&attr.value);
+                        let s = attr.value.as_ref().to_owned();
                         let num: String = s.chars().filter(|c| c.is_ascii_digit()).collect();
                         if let Ok(id) = num.parse::<i32>() {
                             bullet.image_bullet = id;
@@ -2071,7 +2071,7 @@ fn parse_bullet_hwpx(
 /// Bullet 필드(HWP5 BULLET record 의 문단 머리 정보 12바이트와 동일 의미)로 흡수한다.
 fn apply_bullet_para_head_attrs(bullet: &mut Bullet, e: &quick_xml::events::BytesStart) {
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"charPrIDRef" => bullet.char_shape_id = parse_u32(&attr),
             b"widthAdjust" => bullet.width_adjust = parse_i16(&attr),
             b"textOffset" => bullet.text_distance = parse_i16(&attr),
@@ -2089,7 +2089,7 @@ fn parse_numbering(
     let mut num = Numbering::default();
 
     for attr in e.attributes().flatten() {
-        if attr.key.as_ref() == b"start" {
+        if attr.key.as_ref().as_bytes() == b"start" {
             num.start_number = parse_u16(&attr);
         }
     }
@@ -2160,7 +2160,7 @@ fn parse_numbering_para_head_attrs(
     let mut format_str = String::new();
 
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"level" => level = parse_u32(&attr) as usize,
             b"start" => start = Some(parse_u32(&attr)),
             b"text" => format_str = attr_str(&attr),
@@ -2185,10 +2185,10 @@ fn read_numbering_para_head_text(reader: &mut Reader<&[u8]>) -> Result<String, H
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Text(ref t)) => {
-                text.push_str(&t.decode().unwrap_or_default());
+                text.push_str(t.as_ref());
             }
             Ok(Event::CData(ref t)) => {
-                text.push_str(&String::from_utf8_lossy(t.as_ref()));
+                text.push_str(t.as_ref());
             }
             Ok(Event::End(ref ee)) => {
                 if local_name(ee.name().as_ref()) == b"paraHead" {
@@ -2952,7 +2952,7 @@ mod tests {
         let mut buf = Vec::new();
         if let Ok(Event::Empty(ref e)) = reader.read_event_into(&mut buf) {
             for attr in e.attributes().flatten() {
-                if attr.key.as_ref() == b"color" {
+                if attr.key.as_ref().as_bytes() == b"color" {
                     assert_eq!(parse_color(&attr), 0x000000FF);
                 }
             }
@@ -2966,7 +2966,7 @@ mod tests {
         let mut buf = Vec::new();
         if let Ok(Event::Empty(ref e)) = reader.read_event_into(&mut buf) {
             for attr in e.attributes().flatten() {
-                if attr.key.as_ref() == b"color" {
+                if attr.key.as_ref().as_bytes() == b"color" {
                     assert_eq!(parse_color(&attr), 0xFFFFFFFF);
                 }
             }
@@ -2989,7 +2989,7 @@ mod tests {
             let mut buf = Vec::new();
             if let Ok(Event::Empty(ref e)) = reader.read_event_into(&mut buf) {
                 for attr in e.attributes().flatten() {
-                    if attr.key.as_ref() == b"type" {
+                    if attr.key.as_ref().as_bytes() == b"type" {
                         assert_eq!(parse_border_line_type(&attr), expected, "{value}");
                     }
                 }
@@ -3095,7 +3095,7 @@ mod tests {
             let mut buf = Vec::new();
             if let Ok(Event::Empty(ref e)) = reader.read_event_into(&mut buf) {
                 for attr in e.attributes().flatten() {
-                    if attr.key.as_ref() == b"horizontal" {
+                    if attr.key.as_ref().as_bytes() == b"horizontal" {
                         assert_eq!(parse_alignment(&attr), expected);
                     }
                 }
@@ -3110,7 +3110,7 @@ mod tests {
         let mut buf = Vec::new();
         if let Ok(Event::Empty(ref e)) = reader.read_event_into(&mut buf) {
             for attr in e.attributes().flatten() {
-                if attr.key.as_ref() == b"vertical" {
+                if attr.key.as_ref().as_bytes() == b"vertical" {
                     assert_eq!(parse_vertical_alignment_bits(&attr), 2);
                 }
             }
@@ -3518,7 +3518,7 @@ mod tests {
         let mut buf = Vec::new();
         if let Ok(Event::Empty(ref e)) = reader.read_event_into(&mut buf) {
             for attr in e.attributes().flatten() {
-                if attr.key.as_ref() == b"type" {
+                if attr.key.as_ref().as_bytes() == b"type" {
                     return parse_slash_shape_code(&attr);
                 }
             }

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -156,7 +156,7 @@ pub fn collect_hwpx_section_master_page_refs(xml: &str) -> Result<Vec<String>, H
 
 fn push_master_page_id_ref(e: &quick_xml::events::BytesStart, refs: &mut Vec<String>) {
     for attr in e.attributes().flatten() {
-        if attr.key.as_ref() == b"idRef" {
+        if attr.key.as_ref().as_bytes() == b"idRef" {
             let id_ref = attr_str(&attr);
             if !id_ref.is_empty() {
                 refs.push(id_ref);
@@ -246,7 +246,7 @@ fn parse_master_page_start(e: &quick_xml::events::BytesStart, master_page: &mut 
     let mut is_optional_page = false;
     let mut page_duplicate: Option<bool> = None;
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"type" => {
                 let value = attr_str(&attr);
                 match parse_hwpx_master_page_type(&value) {
@@ -297,7 +297,7 @@ fn parse_master_page_start(e: &quick_xml::events::BytesStart, master_page: &mut 
 
 fn parse_master_page_sub_list(e: &quick_xml::events::BytesStart, master_page: &mut MasterPage) {
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"textWidth" => master_page.text_width = parse_u32(&attr),
             b"textHeight" => master_page.text_height = parse_u32(&attr),
             b"hasTextRef" => master_page.text_ref = parse_u8(&attr),
@@ -331,7 +331,7 @@ fn build_hwpx_master_page_list_header(master_page: &MasterPage) -> Vec<u8> {
 
 fn parse_section_def_start(e: &quick_xml::events::BytesStart, sec_def: &mut SectionDef) {
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"textDirection" => {
                 let val = attr_str(&attr);
                 sec_def.text_direction = if val == "VERTICAL" { 1 } else { 0 };
@@ -365,7 +365,7 @@ fn parse_section_def_start(e: &quick_xml::events::BytesStart, sec_def: &mut Sect
 
 fn parse_page_pr(e: &quick_xml::events::BytesStart, page: &mut PageDef) {
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"width" => page.width = parse_u32(&attr),
             b"height" => page.height = parse_u32(&attr),
             // [#1166] HWPX 용지 방향. OWPML landscape 값:
@@ -399,7 +399,7 @@ fn parse_page_pr(e: &quick_xml::events::BytesStart, page: &mut PageDef) {
 
 fn parse_grid(e: &quick_xml::events::BytesStart, sec_def: &mut SectionDef) {
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"lineGrid" => sec_def.line_grid = parse_i32(&attr) as i16,
             b"charGrid" => sec_def.char_grid = parse_i32(&attr) as i16,
             _ => {}
@@ -409,7 +409,7 @@ fn parse_grid(e: &quick_xml::events::BytesStart, sec_def: &mut SectionDef) {
 
 fn parse_page_margin(e: &quick_xml::events::BytesStart, page: &mut PageDef) {
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"left" => page.margin_left = parse_u32(&attr),
             b"right" => page.margin_right = parse_u32(&attr),
             b"top" => page.margin_top = parse_u32(&attr),
@@ -545,9 +545,9 @@ fn parse_paragraph_body(
     let mut has_column_break_attr = false;
     let mut has_page_break_attr = false;
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"id" => {
-                if let Ok(s) = std::str::from_utf8(&attr.value) {
+                if let Ok(s) = std::str::from_utf8(attr.value.as_ref().as_bytes()) {
                     hp_p_id = s.parse::<u32>().unwrap_or(0);
                 }
             }
@@ -602,7 +602,7 @@ fn parse_paragraph_body(
                     b"run" => {
                         // 런 시작: charPrIDRef 읽기
                         for attr in ce.attributes().flatten() {
-                            if attr.key.as_ref() == b"charPrIDRef" {
+                            if attr.key.as_ref().as_bytes() == b"charPrIDRef" {
                                 current_char_shape_id = parse_u32(&attr);
                             }
                         }
@@ -769,7 +769,7 @@ fn parse_paragraph_body(
                         // 빈 paragraph 의 char_shape 가 누락되어 default(id=0) 로
                         // 처리되면 line height 계산이 어긋나 pagination 차이 발생.
                         for attr in ce.attributes().flatten() {
-                            if attr.key.as_ref() == b"charPrIDRef" {
+                            if attr.key.as_ref().as_bytes() == b"charPrIDRef" {
                                 current_char_shape_id = parse_u32(&attr);
                             }
                         }
@@ -1140,9 +1140,11 @@ fn parse_note_pr_children(
                 match local {
                     b"autoNumFormat" => {
                         for attr in e.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"type" => {
-                                    if let Ok(s) = std::str::from_utf8(&attr.value) {
+                                    if let Ok(s) =
+                                        std::str::from_utf8(attr.value.as_ref().as_bytes())
+                                    {
                                         shape.number_format =
                                             crate::model::footnote::FootnoteShape::number_format_from_name(
                                                 s,
@@ -1151,21 +1153,27 @@ fn parse_note_pr_children(
                                     }
                                 }
                                 b"suffixChar" => {
-                                    if let Ok(s) = std::str::from_utf8(&attr.value) {
+                                    if let Ok(s) =
+                                        std::str::from_utf8(attr.value.as_ref().as_bytes())
+                                    {
                                         if let Some(c) = s.chars().next() {
                                             shape.suffix_char = c;
                                         }
                                     }
                                 }
                                 b"prefixChar" => {
-                                    if let Ok(s) = std::str::from_utf8(&attr.value) {
+                                    if let Ok(s) =
+                                        std::str::from_utf8(attr.value.as_ref().as_bytes())
+                                    {
                                         if let Some(c) = s.chars().next() {
                                             shape.prefix_char = c;
                                         }
                                     }
                                 }
                                 b"userChar" => {
-                                    if let Ok(s) = std::str::from_utf8(&attr.value) {
+                                    if let Ok(s) =
+                                        std::str::from_utf8(attr.value.as_ref().as_bytes())
+                                    {
                                         if let Some(c) = s.chars().next() {
                                             shape.user_char = c;
                                         }
@@ -1180,9 +1188,11 @@ fn parse_note_pr_children(
                     }
                     b"noteLine" => {
                         for attr in e.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"length" => {
-                                    if let Ok(s) = std::str::from_utf8(&attr.value) {
+                                    if let Ok(s) =
+                                        std::str::from_utf8(attr.value.as_ref().as_bytes())
+                                    {
                                         if let Ok(v) = s.parse::<i32>() {
                                             // 한컴 미주 기본값 "14692344"(전폭 sentinel)는 i16을
                                             // 넘으므로 절단하지 않고 그대로 보존한다. 렌더러가 col
@@ -1192,7 +1202,9 @@ fn parse_note_pr_children(
                                     }
                                 }
                                 b"type" => {
-                                    if let Ok(s) = std::str::from_utf8(&attr.value) {
+                                    if let Ok(s) =
+                                        std::str::from_utf8(attr.value.as_ref().as_bytes())
+                                    {
                                         shape.separator_line_type = match s {
                                             "SOLID" => 1,
                                             "DASH" => 2,
@@ -1213,12 +1225,16 @@ fn parse_note_pr_children(
                                 b"width" => {
                                     // 미주/각주 구분선 굵기도 테두리 굵기 raw 코드와 같은 표를 쓴다.
                                     // 예: 0.12mm → 1, 0.7mm → 9.
-                                    if let Ok(s) = std::str::from_utf8(&attr.value) {
+                                    if let Ok(s) =
+                                        std::str::from_utf8(attr.value.as_ref().as_bytes())
+                                    {
                                         shape.separator_line_width = parse_hwpx_line_width(s);
                                     }
                                 }
                                 b"color" => {
-                                    if let Ok(s) = std::str::from_utf8(&attr.value) {
+                                    if let Ok(s) =
+                                        std::str::from_utf8(attr.value.as_ref().as_bytes())
+                                    {
                                         // "#RRGGBB" → ColorRef (0xBBGGRR LE = HWP 표준)
                                         if let Some(hex) = s.strip_prefix('#') {
                                             if let Ok(rgb) = u32::from_str_radix(hex, 16) {
@@ -1236,27 +1252,33 @@ fn parse_note_pr_children(
                     }
                     b"noteSpacing" => {
                         for attr in e.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 // 공식 미주/각주 모양 의미:
                                 // betweenNotes → 앞 번호 주석 내용과 다음 번호 주석 내용 사이
                                 // belowLine → 구분선과 주석 내용 사이
                                 // aboveLine → 본문과 구분선 사이
                                 b"betweenNotes" => {
-                                    if let Ok(s) = std::str::from_utf8(&attr.value) {
+                                    if let Ok(s) =
+                                        std::str::from_utf8(attr.value.as_ref().as_bytes())
+                                    {
                                         if let Ok(v) = s.parse::<u16>() {
                                             shape.raw_unknown = v;
                                         }
                                     }
                                 }
                                 b"belowLine" => {
-                                    if let Ok(s) = std::str::from_utf8(&attr.value) {
+                                    if let Ok(s) =
+                                        std::str::from_utf8(attr.value.as_ref().as_bytes())
+                                    {
                                         if let Ok(v) = s.parse::<i16>() {
                                             shape.note_spacing = v;
                                         }
                                     }
                                 }
                                 b"aboveLine" => {
-                                    if let Ok(s) = std::str::from_utf8(&attr.value) {
+                                    if let Ok(s) =
+                                        std::str::from_utf8(attr.value.as_ref().as_bytes())
+                                    {
                                         if let Ok(v) = s.parse::<i16>() {
                                             shape.separator_margin_top = v;
                                             saw_above_line = true;
@@ -1282,9 +1304,11 @@ fn parse_note_pr_children(
                     }
                     b"numbering" => {
                         for attr in e.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"type" => {
-                                    if let Ok(s) = std::str::from_utf8(&attr.value) {
+                                    if let Ok(s) =
+                                        std::str::from_utf8(attr.value.as_ref().as_bytes())
+                                    {
                                         let numbering = match s {
                                             "CONTINUOUS" | "continue" => {
                                                 crate::model::footnote::FootnoteNumbering::Continue
@@ -1301,7 +1325,9 @@ fn parse_note_pr_children(
                                     }
                                 }
                                 b"newNum" => {
-                                    if let Ok(s) = std::str::from_utf8(&attr.value) {
+                                    if let Ok(s) =
+                                        std::str::from_utf8(attr.value.as_ref().as_bytes())
+                                    {
                                         if let Ok(v) = s.parse::<u16>() {
                                             shape.start_number = v;
                                         }
@@ -1313,9 +1339,11 @@ fn parse_note_pr_children(
                     }
                     b"placement" => {
                         for attr in e.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"place" => {
-                                    if let Ok(s) = std::str::from_utf8(&attr.value) {
+                                    if let Ok(s) =
+                                        std::str::from_utf8(attr.value.as_ref().as_bytes())
+                                    {
                                         // [#2779] OWPML 스키마(ParaList placement@place)의 정식
                                         // 토큰은 컨텍스트마다 다르지만 HWP5 attr bits 8-9 코드
                                         // 공간은 공유한다:
@@ -1454,7 +1482,7 @@ fn parse_page_border_fill_empty(e: &quick_xml::events::BytesStart) -> (PageBorde
     let mut footer_inside = false;
 
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"borderFillIDRef" => page_border_fill.border_fill_id = parse_u16(&attr),
             b"textBorder" => text_border = attr_str(&attr),
             b"fillArea" => fill_area = attr_str(&attr),
@@ -1489,7 +1517,7 @@ fn parse_page_border_fill_offset(
     page_border_fill: &mut PageBorderFill,
 ) {
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"left" => page_border_fill.spacing_left = parse_i16(&attr),
             b"right" => page_border_fill.spacing_right = parse_i16(&attr),
             b"top" => page_border_fill.spacing_top = parse_i16(&attr),
@@ -1530,7 +1558,7 @@ fn page_border_fill_attr(
 /// <hp:startNum> 요소 파싱
 fn parse_start_num(e: &quick_xml::events::BytesStart, sec_def: &mut SectionDef) {
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"page" => sec_def.page_num = parse_u16(&attr),
             b"pic" => sec_def.picture_num = parse_u16(&attr),
             b"tbl" => sec_def.table_num = parse_u16(&attr),
@@ -1552,7 +1580,7 @@ fn parse_start_num(e: &quick_xml::events::BytesStart, sec_def: &mut SectionDef) 
 /// <hp:visibility> 요소 파싱
 fn parse_visibility(e: &quick_xml::events::BytesStart, sec_def: &mut SectionDef) {
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"hideFirstHeader" => {
                 sec_def.hide_header = attr_str(&attr) == "1";
                 if sec_def.hide_header {
@@ -1628,7 +1656,7 @@ fn parse_visibility(e: &quick_xml::events::BytesStart, sec_def: &mut SectionDef)
 fn parse_col_pr(e: &quick_xml::events::BytesStart) -> ColumnDef {
     let mut cd = ColumnDef::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"type" => {
                 cd.column_type = match attr_str(&attr).as_str() {
                     "NEWSPAPER" => ColumnType::Normal,
@@ -1703,7 +1731,7 @@ fn parse_col_pr_with_children(
 
 fn parse_col_line(e: &quick_xml::events::BytesStart, cd: &mut ColumnDef) {
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"type" => cd.separator_type = parse_hwpx_line_type(&attr_str(&attr)),
             b"width" => cd.separator_width = parse_hwpx_line_width(&attr_str(&attr)),
             b"color" => cd.separator_color = parse_color(&attr),
@@ -1732,7 +1760,7 @@ fn parse_col_sz(e: &quick_xml::events::BytesStart, cd: &mut ColumnDef) {
     let mut width: HwpUnit16 = 0;
     let mut gap: HwpUnit16 = 0;
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"width" => width = parse_hwpunit16_saturating(&attr, "colSz@width"),
             // gap 은 스키마상 xs:nonNegativeInteger — 음수 폴백 없이 0 이상만 허용.
             b"gap" => gap = parse_hwpunit16_saturating(&attr, "colSz@gap").max(0),
@@ -1859,7 +1887,7 @@ fn parse_lineseg_array(reader: &mut Reader<&[u8]>, para: &mut Paragraph) -> Resu
 fn parse_lineseg_element(e: &quick_xml::events::BytesStart) -> LineSeg {
     let mut seg = LineSeg::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"textpos" => seg.text_start = parse_u32(&attr),
             b"vertpos" => seg.vertical_pos = parse_i32(&attr),
             b"vertsize" => seg.line_height = parse_i32(&attr),
@@ -1900,8 +1928,8 @@ fn decode_xml_general_ref(r: &BytesRef<'_>) -> String {
         return ch.to_string();
     }
 
-    let name = r.decode().unwrap_or_default();
-    match name.as_ref() {
+    let name = r.as_ref();
+    match name {
         "lt" => "<".to_string(),
         "gt" => ">".to_string(),
         "amp" => "&".to_string(),
@@ -1923,13 +1951,13 @@ fn read_text_content_with_tabs(
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Text(ref t)) => {
-                text.push_str(&t.decode().unwrap_or_default());
+                text.push_str(t.as_ref());
             }
             // 본문 런 텍스트가 CDATA 로 저장된 경우. 이 분기가 없으면 `_ => {}` 로
             // 버려져 문단 텍스트가 통째로 소실된다(#2916·#2951·#2974 와 같은 결함
             // 클래스이나, 여기는 수식·덧말이 아닌 일반 <hp:t> 경로다).
             Ok(Event::CData(ref cdata)) => {
-                text.push_str(&String::from_utf8_lossy(cdata.as_ref()));
+                text.push_str(cdata.as_ref());
             }
             Ok(Event::GeneralRef(ref r)) => {
                 text.push_str(&decode_xml_general_ref(r));
@@ -1976,9 +2004,9 @@ fn read_text_content_with_tabs(
                         let ignore = ce
                             .attributes()
                             .flatten()
-                            .find(|a| a.key.as_ref() == b"ignore")
+                            .find(|a| a.key.as_ref().as_bytes() == b"ignore")
                             .map(|a| {
-                                let v = String::from_utf8_lossy(&a.value).to_lowercase();
+                                let v = a.value.as_ref().to_lowercase();
                                 v == "1" || v == "true"
                             })
                             .unwrap_or(false);
@@ -2014,7 +2042,7 @@ fn parse_tab_extension(e: &quick_xml::events::BytesStart) -> [u16; 7] {
     let mut tab_type = 0u16;
 
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"width" => ext[0] = parse_u16(&attr),
             b"leader" => leader = parse_u16(&attr) & 0x00ff,
             b"type" => tab_type = parse_u16(&attr) & 0x00ff,
@@ -2051,7 +2079,7 @@ fn parse_table(
 
     // 표 기본 속성
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"id" | b"instid" => table.common.instance_id = parse_u32(&attr),
             b"zOrder" => table.common.z_order = parse_i32(&attr),
             b"rowCnt" => table.row_count = parse_u16(&attr),
@@ -2147,7 +2175,7 @@ fn parse_table(
                 match local {
                     b"sz" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"width" => {
                                     table.common.width = parse_u32(&attr);
                                 }
@@ -2172,7 +2200,7 @@ fn parse_table(
                     }
                     b"pos" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"treatAsChar" => {
                                     table.common.treat_as_char =
                                         attr_str(&attr) == "1" || attr_str(&attr) == "true";
@@ -2235,7 +2263,7 @@ fn parse_table(
                     }
                     b"outMargin" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"left" => table.outer_margin_left = parse_i16(&attr),
                                 b"right" => table.outer_margin_right = parse_i16(&attr),
                                 b"top" => table.outer_margin_top = parse_i16(&attr),
@@ -2247,7 +2275,7 @@ fn parse_table(
                     b"inMargin" => {
                         // 표 안쪽 여백 → table.padding
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"left" => table.padding.left = parse_i16(&attr),
                                 b"right" => table.padding.right = parse_i16(&attr),
                                 b"top" => table.padding.top = parse_i16(&attr),
@@ -2259,7 +2287,7 @@ fn parse_table(
                     b"cellzone" => {
                         let mut zone = crate::model::table::TableZone::default();
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"startColAddr" => zone.start_col = parse_u16(&attr),
                                 b"startRowAddr" => zone.start_row = parse_u16(&attr),
                                 b"endColAddr" => zone.end_col = parse_u16(&attr),
@@ -2454,7 +2482,7 @@ fn parse_caption_sub_list_attrs(
     use crate::model::shape::CaptionVertAlign;
 
     for attr in e.attributes().flatten() {
-        if attr.key.as_ref() == b"vertAlign" {
+        if attr.key.as_ref().as_bytes() == b"vertAlign" {
             caption.vert_align = match attr_str(&attr).as_str() {
                 "CENTER" => CaptionVertAlign::Center,
                 "BOTTOM" => CaptionVertAlign::Bottom,
@@ -2475,7 +2503,7 @@ fn parse_caption(
 
     let mut caption = Caption::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"side" => {
                 caption.direction = match attr_str(&attr).as_str() {
                     "LEFT" => CaptionDirection::Left,
@@ -2538,7 +2566,7 @@ fn parse_table_cell(
 
     // <hp:tc> 요소 자체의 속성 파싱
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"borderFillIDRef" => cell.border_fill_id = parse_u16(&attr),
             b"header" => cell.set_header(parse_bool(&attr)),
             b"hasMargin" => cell.set_apply_inner_margin(parse_bool(&attr)),
@@ -2567,7 +2595,7 @@ fn parse_table_cell(
                 match local {
                     b"cellAddr" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"colAddr" => {
                                     cell.col = parse_u16(&attr);
                                 }
@@ -2578,7 +2606,7 @@ fn parse_table_cell(
                     }
                     b"cellSpan" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"colSpan" => cell.col_span = parse_u16(&attr).max(1),
                                 b"rowSpan" => cell.row_span = parse_u16(&attr).max(1),
                                 _ => {}
@@ -2587,7 +2615,7 @@ fn parse_table_cell(
                     }
                     b"cellSz" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"width" => cell.width = parse_u32(&attr),
                                 b"height" => cell.height = parse_u32(&attr),
                                 _ => {}
@@ -2596,7 +2624,7 @@ fn parse_table_cell(
                     }
                     b"cellMargin" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"left" => cell.padding.left = parse_i16(&attr),
                                 b"right" => cell.padding.right = parse_i16(&attr),
                                 b"top" => cell.padding.top = parse_i16(&attr),
@@ -2608,7 +2636,7 @@ fn parse_table_cell(
                     b"tcPr" => {
                         // 셀 속성 (legacy format)
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"borderFillIDRef" => cell.border_fill_id = parse_u16(&attr),
                                 b"textDirection" => {
                                     let val = attr_str(&attr);
@@ -2628,7 +2656,7 @@ fn parse_table_cell(
                     b"subList" => {
                         // subList: vertAlign + textDirection 속성 파싱
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"vertAlign" => {
                                     cell.vertical_align = match attr_str(&attr).as_str() {
                                         "CENTER" => VerticalAlign::Center,
@@ -2659,7 +2687,7 @@ fn parse_table_cell(
                     }
                     b"cellPr" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"borderFillIDRef" => cell.border_fill_id = parse_u16(&attr),
                                 b"textDirection" => {
                                     let val = attr_str(&attr);
@@ -2690,7 +2718,7 @@ fn parse_table_cell(
                 match local {
                     b"cellAddr" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"colAddr" => {
                                     cell.col = parse_u16(&attr);
                                 }
@@ -2701,7 +2729,7 @@ fn parse_table_cell(
                     }
                     b"cellSpan" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"colSpan" => cell.col_span = parse_u16(&attr).max(1),
                                 b"rowSpan" => cell.row_span = parse_u16(&attr).max(1),
                                 _ => {}
@@ -2710,7 +2738,7 @@ fn parse_table_cell(
                     }
                     b"cellSz" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"width" => cell.width = parse_u32(&attr),
                                 b"height" => cell.height = parse_u32(&attr),
                                 _ => {}
@@ -2719,7 +2747,7 @@ fn parse_table_cell(
                     }
                     b"cellMargin" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"left" => cell.padding.left = parse_i16(&attr),
                                 b"right" => cell.padding.right = parse_i16(&attr),
                                 b"top" => cell.padding.top = parse_i16(&attr),
@@ -2775,7 +2803,7 @@ fn parse_picture(
 
     // <hp:pic> 요소 자체의 속성 파싱
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"id" => common.instance_id = parse_u32(&attr),
             b"zOrder" => common.z_order = parse_i32(&attr),
             b"textWrap" => {
@@ -2867,7 +2895,7 @@ fn parse_picture(
                     b"sz" => {
                         // 최종 표시 크기 (최우선)
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"width" => {
                                     let v = parse_u32(&attr);
                                     if v > 0 {
@@ -2900,7 +2928,7 @@ fn parse_picture(
                     b"curSz" => {
                         // 현재 크기 → common + shape_attr.current_width/height
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"width" => {
                                     let v = parse_u32(&attr);
                                     shape_attr.current_width = v;
@@ -2922,7 +2950,7 @@ fn parse_picture(
                     // [#1389] 원본 이미지 픽셀 크기 — verbatim 적재
                     b"imgDim" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"dimwidth" => img_dim.0 = parse_u32(&attr),
                                 b"dimheight" => img_dim.1 = parse_u32(&attr),
                                 _ => {}
@@ -2933,7 +2961,7 @@ fn parse_picture(
                         // 원본 크기 → shape_attr.original_width/height (렌더러 이미지 Fill 크기에 사용)
                         // curSz/sz가 없을 때 common.width/height 폴백으로도 사용
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"width" => {
                                     let v = parse_u32(&attr);
                                     shape_attr.original_width = v;
@@ -2957,7 +2985,7 @@ fn parse_picture(
                     b"pos" => {
                         has_pos = true;
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"treatAsChar" => {
                                     common.treat_as_char =
                                         attr_str(&attr) == "1" || attr_str(&attr) == "true";
@@ -3022,7 +3050,7 @@ fn parse_picture(
                     }
                     b"outMargin" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"left" => common.margin.left = parse_i16(&attr),
                                 b"right" => common.margin.right = parse_i16(&attr),
                                 b"top" => common.margin.top = parse_i16(&attr),
@@ -3033,7 +3061,7 @@ fn parse_picture(
                     }
                     b"inMargin" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"left" => padding.left = parse_i16(&attr),
                                 b"right" => padding.right = parse_i16(&attr),
                                 b"top" => padding.top = parse_i16(&attr),
@@ -3044,7 +3072,7 @@ fn parse_picture(
                     }
                     b"imgClip" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"left" => crop.left = parse_i32(&attr),
                                 b"right" => crop.right = parse_i32(&attr),
                                 b"top" => crop.top = parse_i32(&attr),
@@ -3055,7 +3083,7 @@ fn parse_picture(
                     }
                     b"img" | b"image" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"binaryItemIDRef" => {
                                     // "image1" → BinData ID 1
                                     let val = attr_str(&attr);
@@ -3090,7 +3118,7 @@ fn parse_picture(
                         // <pos>가 이미 파싱된 경우 페이지 레벨 좌표(vertOffset/horzOffset)는
                         // 덮어쓰지 않는다. <pos>가 없는 경우에만 폴백으로 적용한다.
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"x" => {
                                     let v = parse_i32_wrapping(&attr);
                                     shape_attr.offset_x = v;
@@ -3234,7 +3262,7 @@ fn parse_picture_transparency_attr(raw: &str) -> u8 {
 fn parse_picture_shadow_attrs(e: &quick_xml::events::BytesStart<'_>) -> PictureShadow {
     let mut shadow = PictureShadow::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"style" => shadow.style = Some(attr_str(&attr)),
             b"alpha" => shadow.alpha = Some(attr_str(&attr)),
             b"radius" => shadow.radius = Some(attr_str(&attr)),
@@ -3251,7 +3279,7 @@ fn parse_picture_shadow_attrs(e: &quick_xml::events::BytesStart<'_>) -> PictureS
 fn parse_effect_point(e: &quick_xml::events::BytesStart<'_>) -> EffectPoint {
     let mut point = EffectPoint::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"x" => point.x = Some(attr_str(&attr)),
             b"y" => point.y = Some(attr_str(&attr)),
             _ => {}
@@ -3286,7 +3314,7 @@ fn parse_effect_color(
 fn parse_effect_color_attrs(e: &quick_xml::events::BytesStart<'_>) -> EffectColor {
     let mut color = EffectColor::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"type" => color.color_type = Some(attr_str(&attr)),
             b"schemeIdx" => color.scheme_idx = Some(attr_str(&attr)),
             b"systemIdx" => color.system_idx = Some(attr_str(&attr)),
@@ -3300,7 +3328,7 @@ fn parse_effect_color_attrs(e: &quick_xml::events::BytesStart<'_>) -> EffectColo
 fn parse_effect_rgb(e: &quick_xml::events::BytesStart<'_>) -> EffectRgb {
     let mut rgb = EffectRgb::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"r" => rgb.r = Some(attr_str(&attr)),
             b"g" => rgb.g = Some(attr_str(&attr)),
             b"b" => rgb.b = Some(attr_str(&attr)),
@@ -3419,7 +3447,7 @@ fn parse_object_element_attrs(
     common.hwp5_gen_shape_attr_bit26 = true;
     let mut ids = ObjectElementIds::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"id" => common.instance_id = parse_u32(&attr),
             b"zOrder" => common.z_order = parse_i32(&attr),
             b"textWrap" => {
@@ -3489,7 +3517,7 @@ fn parse_object_layout_child(
     match local {
         b"sz" => {
             for attr in ce.attributes().flatten() {
-                match attr.key.as_ref() {
+                match attr.key.as_ref().as_bytes() {
                     b"width" => {
                         let v = parse_u32(&attr);
                         if v > 0 {
@@ -3515,7 +3543,7 @@ fn parse_object_layout_child(
         }
         b"curSz" => {
             for attr in ce.attributes().flatten() {
-                match attr.key.as_ref() {
+                match attr.key.as_ref().as_bytes() {
                     b"width" => {
                         let v = parse_u32(&attr);
                         shape_attr.current_width = v;
@@ -3538,7 +3566,7 @@ fn parse_object_layout_child(
         }
         b"orgSz" => {
             for attr in ce.attributes().flatten() {
-                match attr.key.as_ref() {
+                match attr.key.as_ref().as_bytes() {
                     b"width" => {
                         let v = parse_u32(&attr);
                         shape_attr.original_width = v;
@@ -3562,7 +3590,7 @@ fn parse_object_layout_child(
         b"pos" => {
             *has_pos = true;
             for attr in ce.attributes().flatten() {
-                match attr.key.as_ref() {
+                match attr.key.as_ref().as_bytes() {
                     b"treatAsChar" => {
                         common.treat_as_char = attr_str(&attr) == "1" || attr_str(&attr) == "true";
                     }
@@ -3620,7 +3648,7 @@ fn parse_object_layout_child(
         }
         b"offset" => {
             for attr in ce.attributes().flatten() {
-                match attr.key.as_ref() {
+                match attr.key.as_ref().as_bytes() {
                     b"x" => {
                         let v = parse_i32_wrapping(&attr);
                         shape_attr.offset_x = v;
@@ -3641,7 +3669,7 @@ fn parse_object_layout_child(
         }
         b"outMargin" => {
             for attr in ce.attributes().flatten() {
-                match attr.key.as_ref() {
+                match attr.key.as_ref().as_bytes() {
                     b"left" => common.margin.left = parse_i16(&attr),
                     b"right" => common.margin.right = parse_i16(&attr),
                     b"top" => common.margin.top = parse_i16(&attr),
@@ -3658,7 +3686,7 @@ fn parse_object_layout_child(
 
 fn parse_shape_flip(e: &quick_xml::events::BytesStart, shape_attr: &mut ShapeComponentAttr) {
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"horizontal" => shape_attr.horz_flip = parse_bool(&attr),
             b"vertical" => shape_attr.vert_flip = parse_bool(&attr),
             _ => {}
@@ -3684,7 +3712,7 @@ fn parse_shape_rotation_info(
     shape_attr: &mut ShapeComponentAttr,
 ) {
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"angle" => shape_attr.rotation_angle = parse_i16(&attr),
             b"centerX" => shape_attr.rotation_center.x = parse_i32(&attr),
             b"centerY" => shape_attr.rotation_center.y = parse_i32(&attr),
@@ -3714,7 +3742,7 @@ fn parse_picture_img_rect(
                 };
                 if let Some(index) = index {
                     for attr in ce.attributes().flatten() {
-                        match attr.key.as_ref() {
+                        match attr.key.as_ref().as_bytes() {
                             b"x" => pts[index].0 = parse_i32(&attr),
                             b"y" => pts[index].1 = parse_i32(&attr),
                             _ => {}
@@ -3780,7 +3808,7 @@ fn parse_rendering_info(
                 .parse()
                 .map(hwp5_matrix_value)
                 .unwrap_or(0.0);
-            match attr.key.as_ref() {
+            match attr.key.as_ref().as_bytes() {
                 b"e1" => m[0] = val,
                 b"e2" => m[1] = val,
                 b"e3" => m[2] = val,
@@ -3896,7 +3924,7 @@ fn parse_line_shape_attr(e: &quick_xml::events::BytesStart) -> ShapeBorderLine {
 
     let mut bl = ShapeBorderLine::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"color" => bl.color = parse_color(&attr),
             b"width" => bl.width = parse_i32(&attr),
             b"style" => {
@@ -3969,7 +3997,7 @@ fn parse_line_shape_attr(e: &quick_xml::events::BytesStart) -> ShapeBorderLine {
 
 fn parse_connect_line_type_attr(e: &quick_xml::events::BytesStart) -> LinkLineType {
     for attr in e.attributes().flatten() {
-        if attr.key.as_ref() == b"type" {
+        if attr.key.as_ref().as_bytes() == b"type" {
             return match attr_str(&attr).to_ascii_uppercase().as_str() {
                 "STRAIGHT_ONEWAY" => LinkLineType::StraightOneWay,
                 "STRAIGHT_BOTH" => LinkLineType::StraightBoth,
@@ -3994,7 +4022,7 @@ fn parse_connect_line_type_attr(e: &quick_xml::events::BytesStart) -> LinkLineTy
 /// 반드시 `<hp:arc>` 요소 자체(shape_type == b"arc")에서만 호출한다.
 fn parse_arc_type_attr(e: &quick_xml::events::BytesStart) -> u8 {
     for attr in e.attributes().flatten() {
-        if attr.key.as_ref() == b"type" {
+        if attr.key.as_ref().as_bytes() == b"type" {
             return match attr_str(&attr).to_ascii_uppercase().as_str() {
                 "PIE" => 1,
                 "CHORD" => 2,
@@ -4023,7 +4051,7 @@ fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError>
                             ..SolidFill::default()
                         };
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"faceColor" => solid.background_color = parse_color(&attr),
                                 b"hatchColor" => solid.pattern_color = parse_color(&attr),
                                 b"hatchStyle" => {
@@ -4047,7 +4075,7 @@ fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError>
                         fill.fill_type = FillType::Gradient;
                         let mut grad = GradientFill::default();
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"type" => {
                                     grad.gradient_type = parse_gradient_type(&attr_str(&attr))
                                 }
@@ -4073,7 +4101,7 @@ fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError>
                         // fillBrush needs the same color stop materialization for rendering.
                         if let Some(ref mut grad) = fill.gradient {
                             for attr in ce.attributes().flatten() {
-                                if attr.key.as_ref() == b"value" {
+                                if attr.key.as_ref().as_bytes() == b"value" {
                                     grad.colors.push(parse_color(&attr));
                                 }
                             }
@@ -4083,7 +4111,7 @@ fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError>
                         fill.fill_type = FillType::Image;
                         let mut img = ImageFill::default();
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 // [#2563] 헤더(borderFill) 파서와 동일한 12종 매핑.
                                 // 종전엔 4종만 받아 TOTAL 등 8종이 TILE 로 붕괴했다.
                                 b"mode" => {
@@ -4118,7 +4146,7 @@ fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError>
                     b"img" | b"image" => {
                         if let Some(ref mut img_fill) = fill.image {
                             for attr in ce.attributes().flatten() {
-                                match attr.key.as_ref() {
+                                match attr.key.as_ref().as_bytes() {
                                     b"binaryItemIDRef" => {
                                         let val = attr_str(&attr);
                                         let num: String =
@@ -4159,7 +4187,7 @@ fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError>
 /// [Task #1598] `<hc:center x="" y="">` 류 점 요소의 x/y 속성을 Point 로 읽는다.
 fn parse_xy(e: &quick_xml::events::BytesStart, p: &mut crate::model::Point) {
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"x" => p.x = parse_i32(&attr),
             b"y" => p.y = parse_i32(&attr),
             _ => {}
@@ -4175,7 +4203,7 @@ fn parse_shape_shadow_attr(e: &quick_xml::events::BytesStart) -> (u32, u32, i32,
     let mut shadow_alpha = 0_u8;
 
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"type" => {
                 shadow_type = match attr_str(&attr).as_str() {
                     "NONE" => 0,
@@ -4230,7 +4258,7 @@ fn parse_draw_text(reader: &mut Reader<&[u8]>, text_box: &mut TextBox) -> Result
                 match local {
                     b"subList" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"vertAlign" => {
                                     let align_code = match attr_str(&attr).as_str() {
                                         "CENTER" => 1_u32,
@@ -4276,7 +4304,7 @@ fn parse_draw_text(reader: &mut Reader<&[u8]>, text_box: &mut TextBox) -> Result
                     }
                     b"textMargin" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"left" => text_box.margin_left = parse_i16(&attr),
                                 b"right" => text_box.margin_right = parse_i16(&attr),
                                 b"top" => text_box.margin_top = parse_i16(&attr),
@@ -4394,7 +4422,7 @@ fn parse_shape_object(
                     }
                     b"pt0" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"x" => x_coords[0] = parse_i32(&attr),
                                 b"y" => y_coords[0] = parse_i32(&attr),
                                 _ => {}
@@ -4403,7 +4431,7 @@ fn parse_shape_object(
                     }
                     b"pt1" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"x" => x_coords[1] = parse_i32(&attr),
                                 b"y" => y_coords[1] = parse_i32(&attr),
                                 _ => {}
@@ -4412,7 +4440,7 @@ fn parse_shape_object(
                     }
                     b"pt2" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"x" => x_coords[2] = parse_i32(&attr),
                                 b"y" => y_coords[2] = parse_i32(&attr),
                                 _ => {}
@@ -4421,7 +4449,7 @@ fn parse_shape_object(
                     }
                     b"pt3" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"x" => x_coords[3] = parse_i32(&attr),
                                 b"y" => y_coords[3] = parse_i32(&attr),
                                 _ => {}
@@ -4434,7 +4462,7 @@ fn parse_shape_object(
                         let mut px: i32 = 0;
                         let mut py: i32 = 0;
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"x" => px = parse_i32(&attr),
                                 b"y" => py = parse_i32(&attr),
                                 _ => {}
@@ -4452,7 +4480,7 @@ fn parse_shape_object(
                         let mut x2: i32 = 0;
                         let mut y2: i32 = 0;
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"x1" => x1 = parse_i32(&attr),
                                 b"y1" => y1 = parse_i32(&attr),
                                 b"x2" => x2 = parse_i32(&attr),
@@ -4467,7 +4495,7 @@ fn parse_shape_object(
                     }
                     b"startPt" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"x" => x_coords[0] = parse_i32(&attr),
                                 b"y" => y_coords[0] = parse_i32(&attr),
                                 b"subjectIDRef" => connect_start_subject_id = parse_u32(&attr),
@@ -4478,7 +4506,7 @@ fn parse_shape_object(
                     }
                     b"endPt" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"x" => x_coords[1] = parse_i32(&attr),
                                 b"y" => y_coords[1] = parse_i32(&attr),
                                 b"subjectIDRef" => connect_end_subject_id = parse_u32(&attr),
@@ -4490,7 +4518,7 @@ fn parse_shape_object(
                     b"point" => {
                         let mut point = ConnectorControlPoint::default();
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"x" => point.x = parse_i32(&attr),
                                 b"y" => point.y = parse_i32(&attr),
                                 b"type" => point.point_type = parse_u16(&attr),
@@ -5013,7 +5041,7 @@ fn parse_field_end_attrs(e: &quick_xml::events::BytesStart) -> (u32, u32) {
     let mut begin_id_ref = 0u32;
     let mut field_id = 0u32;
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"beginIDRef" => begin_id_ref = parse_u32(&attr),
             b"fieldid" => field_id = parse_u32(&attr),
             _ => {}
@@ -5025,7 +5053,7 @@ fn parse_field_end_attrs(e: &quick_xml::events::BytesStart) -> (u32, u32) {
 fn parse_page_hiding_attrs(e: &quick_xml::events::BytesStart) -> PageHide {
     let mut ph = PageHide::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"hideHeader" => ph.hide_header = parse_bool_attr(&attr),
             b"hideFooter" => ph.hide_footer = parse_bool_attr(&attr),
             b"hideMasterPage" => ph.hide_master_page = parse_bool_attr(&attr),
@@ -5041,7 +5069,7 @@ fn parse_page_hiding_attrs(e: &quick_xml::events::BytesStart) -> PageHide {
 fn parse_page_num_attrs(e: &quick_xml::events::BytesStart) -> PageNumberPos {
     let mut pn = PageNumberPos::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"pos" => {
                 pn.position = match attr_str(&attr).as_str() {
                     "NONE" => 0,
@@ -5100,7 +5128,7 @@ fn parse_index_mark_element(reader: &mut Reader<&[u8]>) -> Result<IndexMark, Hwp
                 };
             }
             Ok(Event::Text(ref t)) => {
-                let v = t.decode().unwrap_or_default().to_string();
+                let v = t.as_ref().to_string();
                 match cur {
                     Some("first") => im.first_key.push_str(&v),
                     Some("second") => im.second_key.push_str(&v),
@@ -5127,9 +5155,9 @@ fn parse_index_mark_element(reader: &mut Reader<&[u8]>) -> Result<IndexMark, Hwp
 fn parse_page_num_ctrl_attrs(e: &quick_xml::events::BytesStart) -> PageNumCtrl {
     let mut pnc = PageNumCtrl::default();
     for attr in e.attributes().flatten() {
-        if attr.key.as_ref() == b"pageStartsOn" {
+        if attr.key.as_ref().as_bytes() == b"pageStartsOn" {
             pnc.page_starts_on =
-                PageStartsOn::from_hwpx(&String::from_utf8_lossy(&attr.value).to_uppercase());
+                PageStartsOn::from_hwpx(&attr.value.as_ref().to_owned().to_uppercase());
         }
     }
     pnc
@@ -5138,7 +5166,7 @@ fn parse_page_num_ctrl_attrs(e: &quick_xml::events::BytesStart) -> PageNumCtrl {
 fn parse_bookmark_attrs(e: &quick_xml::events::BytesStart) -> Bookmark {
     let mut bm = Bookmark::default();
     for attr in e.attributes().flatten() {
-        if attr.key.as_ref() == b"name" {
+        if attr.key.as_ref().as_bytes() == b"name" {
             bm.name = attr_str(&attr);
         }
     }
@@ -5148,7 +5176,7 @@ fn parse_bookmark_attrs(e: &quick_xml::events::BytesStart) -> Bookmark {
 fn parse_new_num_attrs(e: &quick_xml::events::BytesStart) -> NewNumber {
     let mut nn = NewNumber::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"num" => nn.number = parse_u16(&attr),
             b"numType" => nn.number_type = parse_num_type(&attr_str(&attr)),
             _ => {}
@@ -5160,7 +5188,7 @@ fn parse_new_num_attrs(e: &quick_xml::events::BytesStart) -> NewNumber {
 fn parse_autonum_attrs(e: &quick_xml::events::BytesStart) -> AutoNumber {
     let mut an = AutoNumber::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"num" => {
                 an.number = parse_u16(&attr);
                 an.assigned_number = an.number;
@@ -5178,7 +5206,7 @@ fn parse_field_begin_attrs(e: &quick_xml::events::BytesStart) -> Field {
     let mut id_attr: Option<u32> = None;
     let mut fieldid_attr: Option<u32> = None;
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"type" => {
                 let raw = attr_str(&attr);
                 f.field_type = parse_field_type(&raw);
@@ -5324,7 +5352,7 @@ fn parse_ctrl_header(
 ) -> Result<Control, HwpxError> {
     let mut header = Header::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"applyPageType" => {
                 header.apply_to = parse_apply_page_type(&attr_str(&attr));
             }
@@ -5353,7 +5381,7 @@ fn parse_ctrl_footer(
 ) -> Result<Control, HwpxError> {
     let mut footer = Footer::default();
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"applyPageType" => {
                 footer.apply_to = parse_apply_page_type(&attr_str(&attr));
             }
@@ -5386,12 +5414,12 @@ fn parse_ctrl_footnote(
     // instId → instance_id (UInt4)
     note.after_decoration_letter = 0x0029; // default ')'
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"number" => note.number = parse_u16(&attr),
             // [#1199] prefixChar(코드포인트 숫자) → before_decoration_letter
             // 누락 시 0 유지(접두 없음). 예: "47928" = 0xBB38 '문'
             b"prefixChar" => {
-                if let Ok(v) = std::str::from_utf8(&attr.value)
+                if let Ok(v) = std::str::from_utf8(attr.value.as_ref().as_bytes())
                     .unwrap_or("")
                     .parse::<u16>()
                 {
@@ -5399,7 +5427,7 @@ fn parse_ctrl_footnote(
                 }
             }
             b"suffixChar" => {
-                if let Ok(v) = std::str::from_utf8(&attr.value)
+                if let Ok(v) = std::str::from_utf8(attr.value.as_ref().as_bytes())
                     .unwrap_or("")
                     .parse::<u16>()
                 {
@@ -5410,7 +5438,7 @@ fn parse_ctrl_footnote(
             // (3-09월_교육_통합_2023) 각주/미주 46개 전수 대조에서 바이트 단위로 일치했다.
             // 값이 0 이면 한컴이 속성 자체를 생략하므로 default 0 유지.
             b"flag" => {
-                if let Ok(v) = std::str::from_utf8(&attr.value)
+                if let Ok(v) = std::str::from_utf8(attr.value.as_ref().as_bytes())
                     .unwrap_or("")
                     .parse::<u32>()
                 {
@@ -5418,7 +5446,7 @@ fn parse_ctrl_footnote(
                 }
             }
             b"instId" => {
-                if let Ok(v) = std::str::from_utf8(&attr.value)
+                if let Ok(v) = std::str::from_utf8(attr.value.as_ref().as_bytes())
                     .unwrap_or("")
                     .parse::<u32>()
                 {
@@ -5444,12 +5472,12 @@ fn parse_ctrl_endnote(
     // [Task #1050] Footnote 와 동일 매핑
     note.after_decoration_letter = 0x0029;
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"number" => note.number = parse_u16(&attr),
             // [#1199] prefixChar(코드포인트 숫자) → before_decoration_letter
             // 누락 시 0 유지(접두 없음). 예: "47928" = 0xBB38 '문'
             b"prefixChar" => {
-                if let Ok(v) = std::str::from_utf8(&attr.value)
+                if let Ok(v) = std::str::from_utf8(attr.value.as_ref().as_bytes())
                     .unwrap_or("")
                     .parse::<u16>()
                 {
@@ -5457,7 +5485,7 @@ fn parse_ctrl_endnote(
                 }
             }
             b"suffixChar" => {
-                if let Ok(v) = std::str::from_utf8(&attr.value)
+                if let Ok(v) = std::str::from_utf8(attr.value.as_ref().as_bytes())
                     .unwrap_or("")
                     .parse::<u16>()
                 {
@@ -5466,7 +5494,7 @@ fn parse_ctrl_endnote(
             }
             // [#2716] flag = HWP5 CTRL_ENDNOTE numberShape(UInt4). footNote 와 동일 계약.
             b"flag" => {
-                if let Ok(v) = std::str::from_utf8(&attr.value)
+                if let Ok(v) = std::str::from_utf8(attr.value.as_ref().as_bytes())
                     .unwrap_or("")
                     .parse::<u32>()
                 {
@@ -5474,7 +5502,7 @@ fn parse_ctrl_endnote(
                 }
             }
             b"instId" => {
-                if let Ok(v) = std::str::from_utf8(&attr.value)
+                if let Ok(v) = std::str::from_utf8(attr.value.as_ref().as_bytes())
                     .unwrap_or("")
                     .parse::<u32>()
                 {
@@ -5679,7 +5707,7 @@ fn parse_ctrl_autonum(
                 let local = local_name(cname.as_ref());
                 if local == b"autoNumFormat" {
                     for attr in ce.attributes().flatten() {
-                        match attr.key.as_ref() {
+                        match attr.key.as_ref().as_bytes() {
                             // autoNumFormat type 은 문자열 enum (DIGIT/CIRCLE_DIGIT/…).
                             // 과거 parse_u8 은 문자열을 0으로만 떨궈 DIGIT 외 형식을 잃었다.
                             // pageNum formatType 과 동일한 문자열→코드 매핑을 사용한다.
@@ -5755,7 +5783,7 @@ fn parse_ctrl_field_begin(
                     parse_field_parameters(ce, reader, &mut f)?;
                 } else if local == b"subList" && f.field_type == FieldType::Memo {
                     for attr in ce.attributes().flatten() {
-                        if attr.key.as_ref() == b"textDirection" {
+                        if attr.key.as_ref().as_bytes() == b"textDirection" {
                             let dir = attr_str(&attr);
                             if dir != "HORIZONTAL" {
                                 f.memo_text_direction = Some(dir);
@@ -5884,7 +5912,7 @@ fn open_param_frame<'a>(
     let mut name: Option<String> = None;
     let mut preserve_space = false;
     for attr in attrs {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"name" => name = Some(attr_str(&attr)),
             b"xml:space" if attr_str(&attr) == "preserve" => preserve_space = true,
             _ => {}
@@ -5956,7 +5984,7 @@ fn parse_field_parameters(
     let mut raw = String::from("<hp:parameters");
     for attr in start.attributes().flatten() {
         raw.push(' ');
-        raw.push_str(&String::from_utf8_lossy(attr.key.as_ref()));
+        raw.push_str(&String::from_utf8_lossy(attr.key.as_ref().as_bytes()));
         raw.push_str("=\"");
         raw.push_str(&escape_xml_text(&attr_str(&attr)));
         raw.push('"');
@@ -5969,7 +5997,7 @@ fn parse_field_parameters(
     let root_name = start
         .attributes()
         .flatten()
-        .find(|a| a.key.as_ref() == b"name")
+        .find(|a| a.key.as_ref().as_bytes() == b"name")
         .map(|a| attr_str(&a));
     let mut stack: Vec<ParamFrame> = vec![ParamFrame::List {
         name: root_name,
@@ -5982,12 +6010,12 @@ fn parse_field_parameters(
             Ok(Event::Start(ref ce)) => {
                 let cname = ce.name();
                 let local = local_name(cname.as_ref());
-                let tag = String::from_utf8_lossy(cname.as_ref()).to_string();
+                let tag = cname.as_ref().to_string();
                 raw.push('<');
                 raw.push_str(&tag);
                 for attr in ce.attributes().flatten() {
                     raw.push(' ');
-                    raw.push_str(&String::from_utf8_lossy(attr.key.as_ref()));
+                    raw.push_str(&String::from_utf8_lossy(attr.key.as_ref().as_bytes()));
                     raw.push_str("=\"");
                     raw.push_str(&escape_xml_text(&attr_str(&attr)));
                     raw.push('"');
@@ -5995,14 +6023,14 @@ fn parse_field_parameters(
                 raw.push('>');
                 if local == b"stringParam" {
                     for attr in ce.attributes().flatten() {
-                        if attr.key.as_ref() == b"name" && attr_str(&attr) == "Command" {
+                        if attr.key.as_ref().as_bytes() == b"name" && attr_str(&attr) == "Command" {
                             in_command = true;
                             field.command.clear();
                         }
                     }
                 } else if local == b"integerParam" {
                     for attr in ce.attributes().flatten() {
-                        if attr.key.as_ref() == b"name" && attr_str(&attr) == "Number" {
+                        if attr.key.as_ref().as_bytes() == b"name" && attr_str(&attr) == "Number" {
                             in_memo_number = true;
                         }
                     }
@@ -6018,10 +6046,10 @@ fn parse_field_parameters(
                 let cname = ce.name();
                 let local = local_name(cname.as_ref());
                 raw.push('<');
-                raw.push_str(&String::from_utf8_lossy(cname.as_ref()));
+                raw.push_str(cname.as_ref());
                 for attr in ce.attributes().flatten() {
                     raw.push(' ');
-                    raw.push_str(&String::from_utf8_lossy(attr.key.as_ref()));
+                    raw.push_str(&String::from_utf8_lossy(attr.key.as_ref().as_bytes()));
                     raw.push_str("=\"");
                     raw.push_str(&escape_xml_text(&attr_str(&attr)));
                     raw.push('"');
@@ -6029,7 +6057,7 @@ fn parse_field_parameters(
                 raw.push_str("/>");
                 if local == b"stringParam" {
                     for attr in ce.attributes().flatten() {
-                        if attr.key.as_ref() == b"name" && attr_str(&attr) == "Command" {
+                        if attr.key.as_ref().as_bytes() == b"name" && attr_str(&attr) == "Command" {
                             field.command.clear();
                         }
                     }
@@ -6045,7 +6073,7 @@ fn parse_field_parameters(
                 }
             }
             Ok(Event::Text(ref t)) => {
-                let decoded = t.decode().unwrap_or_default();
+                let decoded = t.as_ref();
                 raw.push_str(&escape_xml_text(&decoded));
                 if in_command {
                     field.command.push_str(&decoded);
@@ -6072,7 +6100,7 @@ fn parse_field_parameters(
             // 쿼리스트링 `&`, 수식 필드의 비교연산자 `<`/`>`) 처리하지 않으면 필드 명령
             // 문자열이 소실된다. #2916/#2927의 hp:script CDATA 누락과 동일한 패턴.
             Ok(Event::CData(ref cdata)) => {
-                let decoded = String::from_utf8_lossy(cdata.as_ref()).into_owned();
+                let decoded = cdata.as_ref().to_owned();
                 raw.push_str(&escape_xml_text(&decoded));
                 if in_command {
                     field.command.push_str(&decoded);
@@ -6095,7 +6123,7 @@ fn parse_field_parameters(
                 // 임의 깊이 중첩(listParam 안의 stringParam 등)에서도 균형 잡힌 XML 을
                 // 재조립하도록, 단일 open_param 추적 대신 End 이벤트 자신의 정규화 이름으로 닫는다.
                 // 종전엔 open_param 이 마지막 Start 로 덮여, 바깥 태그의 닫는 태그가 누락됐다.
-                let qn = String::from_utf8_lossy(eename.as_ref());
+                let qn = eename.as_ref();
                 raw.push_str("</");
                 raw.push_str(&qn);
                 raw.push('>');
@@ -6242,7 +6270,7 @@ fn parse_hwpx_sublist_layout_attrs(
     layout: &mut HwpxSubListLayout,
 ) {
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"vertAlign" => {
                 layout.list_attr |= match attr_str(&attr).as_str() {
                     "CENTER" => 1 << 21,
@@ -6269,7 +6297,7 @@ fn parse_compose(
     let mut co = CharOverlap::default();
     // 요소 속성 파싱
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"circleType" => {
                 co.border_type = match attr_str(&attr).as_str() {
                     "CHAR" => 0,
@@ -6315,7 +6343,7 @@ fn parse_compose(
                 let local = local_name(cname.as_ref());
                 if local == b"charPr" {
                     for attr in ce.attributes().flatten() {
-                        if attr.key.as_ref() == b"prIDRef" {
+                        if attr.key.as_ref().as_bytes() == b"prIDRef" {
                             co.char_shape_ids.push(parse_u32(&attr));
                         }
                     }
@@ -6343,7 +6371,7 @@ fn read_compose_text(reader: &mut Reader<&[u8]>) -> Result<String, HwpxError> {
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Text(ref t)) => {
-                text.push_str(&t.decode().unwrap_or_default());
+                text.push_str(t.as_ref());
             }
             Ok(Event::GeneralRef(ref r)) => {
                 text.push_str(&decode_xml_general_ref(r));
@@ -6351,7 +6379,7 @@ fn read_compose_text(reader: &mut Reader<&[u8]>) -> Result<String, HwpxError> {
             // [CDATA] composeText(글자겹치기) 본문이 CDATA로 인코딩된 경우 처리하지
             // 않으면 겹침 텍스트가 소실된다. #2916/#2935/#2951의 CDATA 누락과 동일한 패턴.
             Ok(Event::CData(ref cdata)) => {
-                text.push_str(&String::from_utf8_lossy(cdata.as_ref()));
+                text.push_str(cdata.as_ref());
             }
             Ok(Event::End(ref ee)) => {
                 let eename = ee.name();
@@ -6376,7 +6404,7 @@ fn parse_dutmal(
     let mut ruby = Ruby::default();
     // 요소 속성 (#1587 — posType/align 분리 보존 + szRatio/option/styleIDRef)
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"posType" => {
                 ruby.pos_type = match attr_str(&attr).as_str() {
                     "TOP" => 0,
@@ -6444,7 +6472,7 @@ fn read_dutmal_text(reader: &mut Reader<&[u8]>, end_tag: &[u8]) -> Result<String
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Text(ref t)) => {
-                text.push_str(&t.decode().unwrap_or_default());
+                text.push_str(t.as_ref());
             }
             Ok(Event::GeneralRef(ref r)) => {
                 text.push_str(&decode_xml_general_ref(r));
@@ -6453,7 +6481,7 @@ fn read_dutmal_text(reader: &mut Reader<&[u8]>, end_tag: &[u8]) -> Result<String
             // 않으면 덧말 텍스트가 소실된다. #2916/#2935의 hp:script/stringParam CDATA
             // 누락과 동일한 패턴.
             Ok(Event::CData(ref cdata)) => {
-                text.push_str(&String::from_utf8_lossy(cdata.as_ref()));
+                text.push_str(cdata.as_ref());
             }
             Ok(Event::End(ref ee)) => {
                 let eename = ee.name();
@@ -6504,7 +6532,7 @@ fn parse_equation(
     // 공통 개체 속성 + 수식 속성 파싱
     parse_object_element_attrs(e, &mut common, &mut shape_attr);
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"version" => version_info = attr_str(&attr),
             b"baseLine" => baseline = attr_str(&attr).parse().unwrap_or(85),
             b"textColor" => color = parse_color(&attr),
@@ -6555,9 +6583,7 @@ fn parse_equation(
             }
             Ok(Event::Text(ref txt)) => {
                 if in_script {
-                    if let Ok(s) = txt.decode() {
-                        script.push_str(&s);
-                    }
+                    script.push_str(txt.as_ref());
                 }
             }
             Ok(Event::CData(ref cdata)) => {
@@ -6565,15 +6591,15 @@ fn parse_equation(
                 // 예약 문자를 다량 포함해 엔티티 이스케이프 대신 CDATA 로 감싸는
                 // 케이스), 이 분기가 없으면 script 가 통째로 빈 문자열이 된다.
                 if in_script {
-                    script.push_str(&String::from_utf8_lossy(cdata.as_ref()));
+                    script.push_str(cdata.as_ref());
                 }
             }
             Ok(Event::GeneralRef(ref r)) => {
                 if in_script {
                     if let Ok(Some(ch)) = r.resolve_char_ref() {
                         script.push(ch);
-                    } else if let Ok(name) = r.decode() {
-                        match name.as_ref() {
+                    } else {
+                        match r.as_ref() {
                             "lt" => script.push('<'),
                             "gt" => script.push('>'),
                             "amp" => script.push('&'),
@@ -6581,7 +6607,7 @@ fn parse_equation(
                             "apos" => script.push('\''),
                             _ => {
                                 script.push('&');
-                                script.push_str(&name);
+                                script.push_str(r.as_ref());
                                 script.push(';');
                             }
                         }
@@ -6662,7 +6688,7 @@ fn parse_form_object(
     // 요소 속성 파싱 (AbstractFormObjectType + AbstractButtonObjectType)
     // [Task #852 Stage 2.4] HWP5 직렬화에 필요한 ComboBox/Edit/Button 속성 보존
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             b"name" => form.name = attr_str(&attr),
             b"caption" => form.caption = attr_str(&attr),
             b"foreColor" => form.fore_color = parse_color(&attr),
@@ -6793,14 +6819,12 @@ fn parse_form_object(
                         loop {
                             match reader.read_event_into(&mut tbuf) {
                                 Ok(Event::Text(ref t)) => {
-                                    if let Ok(s) = t.decode() {
-                                        form.text.push_str(&s);
-                                    }
+                                    form.text.push_str(t.as_ref());
                                 }
                                 // 양식 개체(edit 컨트롤) 텍스트의 CDATA 저장 형태.
                                 // #2916 과 같은 결함 클래스 — 없으면 form.text 가 빈다.
                                 Ok(Event::CData(ref cdata)) => {
-                                    form.text.push_str(&String::from_utf8_lossy(cdata.as_ref()));
+                                    form.text.push_str(cdata.as_ref());
                                 }
                                 Ok(Event::GeneralRef(ref r)) => {
                                     form.text.push_str(&decode_xml_general_ref(r));
@@ -6824,7 +6848,7 @@ fn parse_form_object(
                     b"sz" => {
                         // <hp:sz width="..." widthRelTo="..." height="..." heightRelTo="..." protect="..."/>
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"width" => {
                                     form.width = parse_u32(&attr);
                                     // [#6266] 배치 산식은 `common` 을 본다.
@@ -6853,7 +6877,7 @@ fn parse_form_object(
                     b"pos" => {
                         // <hp:pos .../> 앵커링 (표준 ShapePositionType 11속성) — 라운드트립 보존
                         for attr in ce.attributes().flatten() {
-                            let key = match attr.key.as_ref() {
+                            let key = match attr.key.as_ref().as_bytes() {
                                 b"treatAsChar" => "PosTreatAsChar",
                                 b"affectLSpacing" => "PosAffectLSpacing",
                                 b"flowWithText" => "PosFlowWithText",
@@ -6869,7 +6893,7 @@ fn parse_form_object(
                             };
                             // [#6266] 배치를 `common` 에도 싣는다 — 문자열
                             // properties 는 왕복 보존용이라 렌더러가 읽지 않는다.
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"treatAsChar" => form.common.treat_as_char = parse_bool(&attr),
                                 b"vertRelTo" => {
                                     form.common.vert_rel_to = match attr_str(&attr).as_str() {
@@ -6919,7 +6943,7 @@ fn parse_form_object(
                     b"outMargin" => {
                         // <hp:outMargin left=".." right=".." top=".." bottom=".."/> — 라운드트립 보존
                         for attr in ce.attributes().flatten() {
-                            let key = match attr.key.as_ref() {
+                            let key = match attr.key.as_ref().as_bytes() {
                                 b"left" => "OutMarginLeft",
                                 b"right" => "OutMarginRight",
                                 b"top" => "OutMarginTop",
@@ -6930,7 +6954,7 @@ fn parse_form_object(
                             let v = parse_i32_wrapping(&attr)
                                 .clamp(i32::from(i16::MIN), i32::from(i16::MAX))
                                 as i16;
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"left" => form.common.margin.left = v,
                                 b"right" => form.common.margin.right = v,
                                 b"top" => form.common.margin.top = v,
@@ -6945,7 +6969,7 @@ fn parse_form_object(
                         let mut value = String::new();
                         let mut display = String::new();
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"value" => value = attr_str(&attr),
                                 b"displayText" => display = attr_str(&attr),
                                 _ => {}
@@ -6957,7 +6981,7 @@ fn parse_form_object(
                         // <hp:formCharPr charPrIDRef="0" followContext="0" autoSz="1" wordWrap="0"/>
                         // [Task #852 Stage 2.4] HWP5 CharShapeSet 직렬화에 필요한 속성 보존
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"charPrIDRef" => {
                                     form.properties
                                         .insert("CharShapeID".to_string(), attr_str(&attr));
@@ -7089,7 +7113,7 @@ fn parse_hp_chart_element(
     let mut numbering_type_picture = false;
 
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             // [#2882] common.numbering_type(ObjectNumberingType) 도 함께 채운다.
             // 직렬화기(numbering_type_str, serializer/hwpx/shape.rs)가 참조하는
             // 필드는 이것뿐이라, bool 지역 변수만으로는 저장 시 항상 NONE 으로
@@ -7218,7 +7242,7 @@ fn parse_hp_ole_element(
     let mut group_level: u16 = 0;
 
     for attr in e.attributes().flatten() {
-        match attr.key.as_ref() {
+        match attr.key.as_ref().as_bytes() {
             // [#2882] common.numbering_type(ObjectNumberingType) 도 함께 채운다.
             // 직렬화기(numbering_type_str, serializer/hwpx/shape.rs)가 참조하는
             // 필드는 이것뿐이라, bool 지역 변수만으로는 저장 시 항상 NONE 으로
@@ -7407,7 +7431,7 @@ fn parse_common_shape_children(
                         let mut x = 0i32;
                         let mut y = 0i32;
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"x" => x = parse_i32(&attr),
                                 b"y" => y = parse_i32(&attr),
                                 _ => {}
@@ -7436,7 +7460,7 @@ fn parse_common_shape_children(
                     }
                     b"sz" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"width" => common.width = parse_u32(&attr),
                                 b"height" => common.height = parse_u32(&attr),
                                 // [#2726] 공용 자식 파서(차트·OLE)만 크기 기준 arm 이 없어
@@ -7460,7 +7484,7 @@ fn parse_common_shape_children(
                     b"pos" => {
                         has_pos = true;
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"vertRelTo" => {
                                     common.vert_rel_to = match attr_str(&attr).as_str() {
                                         "PAPER" => VertRelTo::Paper,
@@ -7522,7 +7546,7 @@ fn parse_common_shape_children(
                     }
                     b"outMargin" => {
                         for attr in ce.attributes().flatten() {
-                            match attr.key.as_ref() {
+                            match attr.key.as_ref().as_bytes() {
                                 b"left" => common.margin.left = parse_i32(&attr) as i16,
                                 b"right" => common.margin.right = parse_i32(&attr) as i16,
                                 b"top" => common.margin.top = parse_i32(&attr) as i16,

--- a/src/parser/hwpx/utils.rs
+++ b/src/parser/hwpx/utils.rs
@@ -7,9 +7,36 @@ use quick_xml::Reader;
 
 use super::HwpxError;
 
+/// XML 이름을 바이트 태그 비교에 쓰기 위한 공통 입력 경계.
+///
+/// quick-xml 0.42부터 이벤트 이름이 UTF-8 문자열이므로, 기존 HWPX 파서의 바이트
+/// 태그 매치 계약은 이 경계에서만 유지한다. 테스트의 바이트 리터럴도 계속 받는다.
+pub trait XmlNameBytes {
+    fn xml_name_bytes(&self) -> &[u8];
+}
+
+impl XmlNameBytes for str {
+    fn xml_name_bytes(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl XmlNameBytes for [u8] {
+    fn xml_name_bytes(&self) -> &[u8] {
+        self
+    }
+}
+
+impl<const N: usize> XmlNameBytes for [u8; N] {
+    fn xml_name_bytes(&self) -> &[u8] {
+        self
+    }
+}
+
 /// XML 네임스페이스 접두사를 제거하고 로컬 이름만 반환
 /// 예: b"hp:p" → b"p", b"tbl" → b"tbl"
-pub fn local_name(name: &[u8]) -> &[u8] {
+pub fn local_name<T: XmlNameBytes + ?Sized>(name: &T) -> &[u8] {
+    let name = name.xml_name_bytes();
     if let Some(pos) = name.iter().position(|&b| b == b':') {
         &name[pos + 1..]
     } else {
@@ -27,16 +54,16 @@ pub fn local_name(name: &[u8]) -> &[u8] {
 /// 숫자/열거형 속성은 엔티티가 없어 unescape 가 no-op 이라 무영향. 미정의 엔티티/
 /// malformed 입력은 원문 lossy 로 안전 폴백한다.
 pub fn attr_str(attr: &quick_xml::events::attributes::Attribute) -> String {
-    let raw = String::from_utf8_lossy(&attr.value);
-    match quick_xml::escape::unescape(&raw) {
+    let raw = attr.value.as_ref();
+    match quick_xml::escape::unescape(raw) {
         Ok(value) => value.into_owned(),
-        Err(_) => raw.into_owned(),
+        Err(_) => raw.to_owned(),
     }
 }
 
 /// 속성 값이 특정 문자열과 일치하는지 확인 (비교용)
 pub fn attr_eq(attr: &quick_xml::events::attributes::Attribute, val: &str) -> bool {
-    attr.value.as_ref() == val.as_bytes()
+    attr.value.as_ref() == val
 }
 
 pub fn parse_u8(attr: &quick_xml::events::attributes::Attribute) -> u8 {

--- a/src/serializer/hml/raw_fragment.rs
+++ b/src/serializer/hml/raw_fragment.rs
@@ -68,12 +68,10 @@ fn validate_subtree(xml: &str, limits: &HmlLimits) -> Result<String, String> {
             Event::Empty(element) => state.empty(&element, &reader, limits)?,
             Event::End(_) => state.end()?,
             Event::Text(text) => {
-                let decoded = text.decode().map_err(|error| error.to_string())?;
-                state.text(&decoded, text.len(), limits)?;
+                state.text(text.as_ref(), text.len(), limits)?;
             }
             Event::CData(text) => {
-                let decoded = text.decode().map_err(|error| error.to_string())?;
-                state.text(&decoded, text.len(), limits)?;
+                state.text(text.as_ref(), text.len(), limits)?;
             }
             Event::GeneralRef(reference) => state.reference(&reference)?,
             Event::Decl(_) | Event::DocType(_) => {
@@ -134,11 +132,7 @@ impl SubtreeState {
         if self.roots > 1 {
             return Err("raw fragment must contain exactly one root subtree".to_string());
         }
-        self.root_name = Some(
-            std::str::from_utf8(element.name().as_ref())
-                .map_err(|_| "raw fragment root name is not UTF-8".to_string())?
-                .to_string(),
-        );
+        self.root_name = Some(element.name().as_ref().to_string());
         Ok(())
     }
 
@@ -170,8 +164,8 @@ impl SubtreeState {
         {
             return validate_xml_chars(&character.to_string());
         }
-        let name = reference.decode().map_err(|error| error.to_string())?;
-        if matches!(name.as_ref(), "lt" | "gt" | "amp" | "quot" | "apos") {
+        let name = reference.as_ref();
+        if matches!(name, "lt" | "gt" | "amp" | "quot" | "apos") {
             Ok(())
         } else {
             Err(format!("unsupported entity reference &{name};"))
@@ -189,7 +183,7 @@ impl SubtreeState {
 
 fn validate_attributes(
     element: &BytesStart<'_>,
-    reader: &Reader<&[u8]>,
+    _reader: &Reader<&[u8]>,
     limits: &HmlLimits,
 ) -> Result<(), String> {
     let mut count = 0usize;
@@ -200,7 +194,7 @@ fn validate_attributes(
         }
         let attribute = attribute.map_err(|error| error.to_string())?;
         let value = attribute
-            .decoded_and_normalized_value(quick_xml::XmlVersion::Explicit1_0, reader.decoder())
+            .normalized_value(quick_xml::XmlVersion::Explicit1_0)
             .map_err(|error| error.to_string())?;
         validate_xml_chars(&value)?;
     }

--- a/tests/doclang_export.rs
+++ b/tests/doclang_export.rs
@@ -62,14 +62,14 @@ fn assert_wellformed_doclang_root(xml: &str) {
             Ok(quick_xml::events::Event::Start(e)) if !root_checked => {
                 assert_eq!(
                     e.name().as_ref(),
-                    b"doclang",
+                    "doclang",
                     "root element must be <doclang>"
                 );
                 let mut version: Option<String> = None;
                 for attr in e.attributes() {
                     let attr = attr.expect("parse root attribute");
-                    if attr.key.as_ref() == b"version" {
-                        version = Some(String::from_utf8_lossy(&attr.value).into_owned());
+                    if attr.key.as_ref() == "version" {
+                        version = Some(attr.value.as_ref().to_owned());
                     }
                 }
                 assert_eq!(

--- a/tests/export_doclang_json_contract.rs
+++ b/tests/export_doclang_json_contract.rs
@@ -51,13 +51,13 @@ fn assert_consumable_doclang(path: &Path) {
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(quick_xml::events::Event::Start(e)) if !root_checked => {
-                assert_eq!(e.name().as_ref(), b"doclang", "루트 요소");
+                assert_eq!(e.name().as_ref(), "doclang", "루트 요소");
                 let version = e
                     .attributes()
                     .flatten()
-                    .find(|a| a.key.as_ref() == b"version")
+                    .find(|a| a.key.as_ref() == "version")
                     .expect("version 속성");
-                assert_eq!(version.value.as_ref(), b"0.6", "DocLang 버전");
+                assert_eq!(version.value.as_ref(), "0.6", "DocLang 버전");
                 root_checked = true;
             }
             Ok(quick_xml::events::Event::Eof) => break,

--- a/tests/hwpx_to_hwp_adapter.rs
+++ b/tests/hwpx_to_hwp_adapter.rs
@@ -6242,16 +6242,12 @@ struct Task903Stage52ParaPrInfo {
     auto_spacing_e_asian_num: String,
 }
 
-fn task903_stage52_local_name(name: &[u8]) -> &[u8] {
-    if let Some(pos) = name.iter().position(|&b| b == b':') {
-        &name[pos + 1..]
-    } else {
-        name
-    }
+fn task903_stage52_local_name(name: &str) -> &[u8] {
+    name.rsplit(':').next().unwrap_or(name).as_bytes()
 }
 
 fn task903_stage52_attr_value(attr: &quick_xml::events::attributes::Attribute) -> String {
-    String::from_utf8_lossy(attr.value.as_ref()).to_string()
+    attr.value.as_ref().to_string()
 }
 
 fn task903_stage52_read_header_xml() -> String {

--- a/tests/issue_937.rs
+++ b/tests/issue_937.rs
@@ -19,14 +19,14 @@ fn svg_text_content(svg: &str) -> String {
 
     loop {
         match reader.read_event_into(&mut buf) {
-            Ok(quick_xml::events::Event::Start(e)) if e.name().as_ref() == b"text" => {
+            Ok(quick_xml::events::Event::Start(e)) if e.name().as_ref() == "text" => {
                 in_text = true;
             }
-            Ok(quick_xml::events::Event::End(e)) if e.name().as_ref() == b"text" => {
+            Ok(quick_xml::events::Event::End(e)) if e.name().as_ref() == "text" => {
                 in_text = false;
             }
             Ok(quick_xml::events::Event::Text(e)) if in_text => {
-                out.push_str(&e.decode().expect("decode SVG text node"));
+                out.push_str(e.as_ref());
             }
             Ok(quick_xml::events::Event::Eof) => break,
             Ok(_) => {}


### PR DESCRIPTION
## 요약
- Dependabot 의존성 갱신 PR #6499~#6510을 최신 `devel` 위에 provenance-preserving cherry-pick으로 통합합니다.
- `quick-xml` 0.42의 문자열 기반 XML API 변경에 맞춰 HWPX, HML, OOXML 및 암호화 파서의 호환 보정을 포함합니다.
- Studio의 `@types/chrome`와 `puppeteer-core` 동시 갱신 충돌은 두 갱신을 모두 유지하도록 해소했습니다.

## 검증
- `node scripts/rust-test-suite-manifest.mjs --prepare && cargo fmt --all && cargo fmt --all -- --check`
- Rust clippy, wasm clippy, workspace build, all-target clippy 및 manifest check
- `cargo nextest run --locked --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 8 --no-fail-fast`: 8,862 passed, 46 skipped
- Studio 격리 `npm ci`, `npm test`: 1,324 passed, production build
- Chrome 확장 격리 build, VS Code 확장 격리 typecheck 및 webpack compile
- Studio production `npm audit --omit=dev --json`: 취약점 0건

## 참고
- Studio 전체 개발 의존성 그래프에는 간접 취약점 3건이 남아 있으나, production 의존성 범위에는 없습니다.
- 별도 PR review 문서는 만들지 않았습니다.
