### PR TITLE
docs(pr): #6522 병합 후 검증 기록

### DIFF
--- a/mydocs/orders/20260831.md
+++ b/mydocs/orders/20260831.md
@@ -6,6 +6,18 @@ date: 2026-08-31
 
 # 오늘 할 일 - 2026년 8월 31일
 
+## #6522 Dependabot 12건 통합과 quick-xml 0.42 호환
+
+- [x] Dependabot 원 PR #6499~#6510을 provenance-preserving cherry-pick으로 통합하고,
+  quick-xml 0.42 문자열 XML API 호환 보정을 `f7ebe3366`에 반영했다.
+- [x] 통합 PR #6522를 merge commit `15ea9ab0a8aaa09cd6692b1700f73fe14a308e20`으로 병합했다.
+  PR head CI·CodeQL·Render Diff·Adapter inter-diff·Proptest와 로컬 full nextest
+  8,862 passed, 46 skipped를 확인했다.
+- [x] merge SHA의 devel CI와 CodeQL은 성공했다. Adapter·Proptest aggregate 취소는 후속
+  `devel` push 때문이며 해당 실제 worker 두 건은 성공했다.
+- [ ] 옵션 2 문서 기록 PR 병합 뒤 원 Dependabot PR별 수용 comment·close와 temporary branch 정리를
+  `post_merge.md`에 따라 완료한다.
+
 ## CI 녹색 외부 PR 통합 검토
 
 - [x] reviewer `postmelee`가 지정된 PR은 제외하고 #6482, #6483, #6484, #6487만 최신

--- a/mydocs/pr/archives/pr_6522_review.md
+++ b/mydocs/pr/archives/pr_6522_review.md
@@ -1,0 +1,58 @@
+---
+kind: pr-review
+status: merged-post-merge-record
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-31
+pr: 6522
+author: jangster77
+---
+
+# PR #6522 병합 후 검토 기록 - Dependabot 12건 통합 및 quick-xml 0.42 보정
+
+## 범위와 통합 이력
+
+- 통합 PR: [#6522](https://github.com/edwardkim/rhwp/pull/6522), base `devel`, 작성자
+  `jangster77`.
+- Dependabot 원 PR [#6499](https://github.com/edwardkim/rhwp/pull/6499)부터
+  [#6510](https://github.com/edwardkim/rhwp/pull/6510)까지 12건을 최신 `devel` 위에
+  `cherry-pick -x`로 누적했다. 원 source branch는 보존한다.
+- Studio lockfile 충돌은 `@types/chrome`와 `puppeteer-core`의 두 Dependabot 갱신을 모두
+  유지하도록 해소했다.
+- `quick-xml` 0.42의 문자열 기반 XML API에 맞춘 HWPX, HML, OOXML 및 암호화 파서 호환 보정은
+  maintainer commit `f7ebe3366eb41eb068edf2b4cfe9de865227ddad`에 반영했다.
+- 병합 commit은 `15ea9ab0a8aaa09cd6692b1700f73fe14a308e20`이며, PR 본문에는 closing
+  issue keyword가 없다.
+
+## 검증
+
+- code head `f7ebe3366eb41eb068edf2b4cfe9de865227ddad`의 PR CI는
+  [CI](https://github.com/edwardkim/rhwp/actions/runs/33368865465),
+  [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33368865184),
+  [Render Diff](https://github.com/edwardkim/rhwp/actions/runs/33368865017),
+  [Adapter inter-diff](https://github.com/edwardkim/rhwp/actions/runs/33368865305),
+  [Proptest](https://github.com/edwardkim/rhwp/actions/runs/33368865140)가 모두 성공했다.
+- 로컬에서는 Rust format, manifest, native/wasm clippy, workspace build와 all-target clippy를
+  통과했고, `cargo nextest run --locked --cargo-profile release-test --target-dir target/pr-review
+  --tests --test-threads 8 --no-fail-fast`는 8,862 passed, 46 skipped였다.
+- 격리된 Studio `npm ci`, test 1,324건과 production build, Chrome extension build, VS Code
+  extension typecheck 및 webpack compile을 통과했다. Studio production dependency audit은
+  취약점 0건이었다.
+- merge commit의 devel push [CI](https://github.com/edwardkim/rhwp/actions/runs/33370035962)와
+  [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33370035915)는 성공했다. Rust CodeQL
+  worker [job 99418880973](https://github.com/edwardkim/rhwp/actions/runs/33370035915/job/99418880973)도
+  성공했다.
+- devel이 후속 PR #6461의 `cfa4ccacab63b470771720ebed33503cdd62adb6`으로 전진하면서
+  [Adapter](https://github.com/edwardkim/rhwp/actions/runs/33370035936)와
+  [Proptest](https://github.com/edwardkim/rhwp/actions/runs/33370036003)의 aggregate는 취소됐다.
+  그러나 실제 `adapter inter-diff` worker와 `prop roundtrip` worker는 각각 성공했으며, 이는
+  테스트 실패가 아니라 superseding `devel` push에 따른 controller 취소다.
+
+## 시각 증적과 판단
+
+- parser/의존성 호환과 lockfile을 다루는 통합이며 신규 fixture, 기준 PDF, renderer golden 또는
+  제품 UI 시각 계약을 추가하지 않는다. 따라서 새 visual sweep asset은 만들지 않았다.
+- PR head의 Render Diff 성공은 renderer 회귀 탐지 결과로만 기록하며, 이 기록은 별도 PDF/SVG
+  충실도 수용 근거를 주장하지 않는다.
+- **수용 완료.** 원 Dependabot PR은 직접 merge하지 않고 #6522의 provenance-preserving 통합으로
+  수용한다. 원 PR별 후속 comment와 close는 이 문서 기록 PR이 `devel`에 반영되고 그 검증이 끝난 뒤
+  한 번만 처리한다.


### PR DESCRIPTION
## 목적
- 병합된 [#6522](https://github.com/edwardkim/rhwp/pull/6522)의 merge SHA와 실제 PR/devel 검증 결과를 옵션 2 후속 기록으로 보존합니다.
- 원 Dependabot PR #6499~#6510의 수용 comment 및 close는 이 문서 PR의 merge와 devel 검증이 끝난 뒤에만 수행합니다.

## 범위
- `mydocs/pr/archives/pr_6522_review.md`
- `mydocs/orders/20260831.md`

source, test, workflow, golden/baseline, 기존 sample, 신규 LFS는 변경하지 않습니다.

## 사실 기록
- #6522 merge: `15ea9ab0a8aaa09cd6692b1700f73fe14a308e20`.
- #6522 devel CI와 CodeQL은 성공했습니다.
- Adapter/Proptest aggregate 취소는 후속 `devel` push(#6461) 때문이며, 두 실제 worker는 성공했습니다.
