### PR TITLE
수정(studio): legacy 한양 face 해석이 선언 altType 에 좌우되지 않게 한다 (#6263)

### DIFF
--- a/rhwp-studio/src/core/font-substitution.ts
+++ b/rhwp-studio/src/core/font-substitution.ts
@@ -220,6 +220,20 @@ function installedSubstituteFace(
     const installed = installedFaceName(target.face, confirmedLocalFonts);
     if (installed) return { fontName: installed, ruleId: target.ruleId };
   }
+  // [#6263] 치환표 항목에는 altType 조건이 붙어 있다(`한양중고딕`은 `source:2->target:1`
+  // 하나뿐). 문서가 같은 legacy 이름을 altType=1 로 선언하면 조회가 통째로 비어, 호스트에
+  // `HY견고딕`이 설치돼 있는데도 체인이 곧바로 generic(`Malgun Gothic`)으로 떨어진다
+  // (`한양견고딕` altType=1 은 원 이름조차 체인에서 사라진다).
+  //
+  // 여기서 하는 일은 **설치 face 를 다른 이름으로 찾는 것**뿐이라 선언 altType 과 무관하다.
+  // 타입 지정 조회가 비면 타입-무관(0) 탐색으로 한 번 더 본다 — `projectedSubstituteTargets`
+  // 가 0 에서 1·2 를 차례로 훑는 기존 규약을 그대로 쓴다.
+  if (altType !== 0) {
+    for (const target of projectedSubstituteTargets(fontName, 0, langId)) {
+      const installed = installedFaceName(target.face, confirmedLocalFonts);
+      if (installed) return { fontName: installed, ruleId: target.ruleId };
+    }
+  }
   return null;
 }
 

--- a/rhwp-studio/tests/issue-6263-legacy-face-alttype.test.ts
+++ b/rhwp-studio/tests/issue-6263-legacy-face-alttype.test.ts
@@ -1,0 +1,66 @@
+// [#6263] legacy 한양 face 를 설치 face 이름으로 해석하는 경로가 **선언 altType 에
+// 좌우되면 안 된다**.
+//
+// 치환표 항목에는 altType 조건이 붙어 있다 — `한양중고딕` 은 `source:2->target:1` 하나뿐이다.
+// 신고된 세 문서는 전부 `altType=2` 라 `ce1f87f88` 로 닫혔지만, 같은 코퍼스에는 같은 계열
+// 이름을 `altType=1` 로 선언한 face 도 있다(`HY중고딕(altType=1)`·`HY헤드라인M(altType=1)`).
+//
+// 그 경우 조회가 통째로 비어 호스트에 `HY견고딕` 이 설치돼 있는데도 체인이 곧바로
+// generic 으로 떨어졌다 — `한양견고딕` 은 **원 이름조차 체인에서 사라졌다**:
+//
+//   한양견고딕 alt=1 →  Malgun Gothic | Apple SD Gothic Neo | Noto Sans KR | …
+//   한양견고딕 alt=2 →  HY견고딕 | Malgun Gothic | …
+//
+// 설치 face 를 다른 이름으로 찾는 일은 선언 altType 과 무관하므로, 타입 지정 조회가 비면
+// 타입-무관 탐색으로 한 번 더 본다.
+//
+// **표면 범위.** Canvas2D paint 는 `fontFamilyChainForDisplay(name, 0, 0)` 로 altType 0 을
+// 넘겨 이미 자동 탐색을 타므로 화면 결과는 바뀌지 않는다. 문서의 실제 altType 을 넘기는
+// 곳은 폰트 판정 트레이스(`font-decision-trace.ts`)뿐이라, 이 수정은 **트레이스가 paint 와
+// 같은 사슬을 보고하게** 만드는 정합 수정이다. 두 층이 갈리면 진단이 잘못된 원인을 가리킨다.
+//
+// 참고 — `Malgun Gothic` 으로 떨어지는 것이 왜 눈에 띄는지: 글꼴 파일 실측상 `Malgun Gothic`
+// 만 `『`(U+300E)·`【`·`「` 를 **반각**으로 두고 잉크를 em 왼쪽 절반에 그린다
+// (`『` advance 0.517em, 잉크 0.152..0.463 — 한양/HY/Batang/Dotum 은 모두 1.000em).
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { fontFamilyCandidatesForDisplay } from '../src/core/font-substitution.ts';
+
+/** 이 호스트에 한컴 legacy face 가 설치돼 있다고 가정한 목록. */
+const INSTALLED = ['HY중고딕', 'HY견고딕', 'HY신명조', 'HY견명조', 'Malgun Gothic', 'Batang'];
+
+const PAIRS: readonly (readonly [string, string])[] = [
+  ['한양중고딕', 'HY중고딕'],
+  ['한양견고딕', 'HY견고딕'],
+  ['한양신명조', 'HY신명조'],
+  ['한양견명조', 'HY견명조'],
+];
+
+test('legacy 한양 face 는 altType 과 무관하게 설치 face 를 체인 맨 앞에 둔다', () => {
+  for (const [legacy, installed] of PAIRS) {
+    for (const altType of [0, 1, 2]) {
+      const chain = fontFamilyCandidatesForDisplay(legacy, altType, 0, {
+        confirmedLocalFonts: INSTALLED,
+      }) as string[];
+      assert.equal(
+        chain[0],
+        installed,
+        `${legacy}(altType=${altType}) 의 첫 후보가 ${installed} 여야 한다: ${chain.join(' | ')}`,
+      );
+    }
+  }
+});
+
+test('설치 face 가 없으면 종전 체인을 그대로 유지한다', () => {
+  // 이 수정은 "설치돼 있는데 못 찾는" 구멍만 막는다 — 없는 호스트의 동작은 바뀌지 않는다.
+  const chain = fontFamilyCandidatesForDisplay('한양중고딕', 1, 0, {
+    confirmedLocalFonts: [],
+  }) as string[];
+  assert.equal(chain[0], '한양중고딕');
+  assert.ok(
+    chain.includes('Malgun Gothic'),
+    `설치 face 가 없으면 종전 generic 폴백이 남아야 한다: ${chain.join(' | ')}`,
+  );
+});


### PR DESCRIPTION
Refs #6263

> **⚠ 이슈가 신고한 증상은 `ce1f87f88` 로 이미 닫혔다.** 이 PR 은 그 옆에 남아 있던
> altType 의존성을 없애는 **정합 수정**이고, **화면 결과는 바뀌지 않는다.** 아래에 근거를
> 전부 적었으니 이슈를 닫을지 여부는 검토 후 판단해 주기 바란다.

## 신고 문서 셋은 왜 이미 닫혔나

세 문서의 FaceName 속성(`attr & 0x03`)을 파일에서 직접 읽었다:

| 문서 | 한양 계열 face (altType) |
|---|---|
| `3227495` | 한양중고딕(**2**) 한양그래픽(2) 한양신명조(2) / HY헤드라인M(1) |
| `30213` | 한양중고딕(**2**) 한양신명조(2) 한양견고딕(2) / HY중고딕(1) HY울릉도M(1) |
| `30442` | 한양중고딕(**2**) 한양신명조(2) 한양견명조(2) 한양견고딕(2) / HY중고딕(1) |

`altType=2` 갈래는 `ce1f87f88` 이 넣은 `installedSubstituteFace` 가 설치 face 를 사슬 맨
앞에 둔다(실측):

```
한양중고딕 alt=2  →  HY중고딕 | 한양중고딕 | Malgun Gothic | …
한양신명조 alt=2  →  HY신명조 | Batang | AppleMyungjo | …
한양견고딕 alt=2  →  HY견고딕 | Malgun Gothic | …
```

## 남아 있던 구멍

치환표 항목에는 altType 조건이 붙어 있다 — `한양중고딕` 은 `source:2->target:1` 하나뿐이다.
같은 legacy 이름을 **altType=1** 로 선언하면 조회가 통째로 비어, 호스트에 `HY견고딕` 이
설치돼 있는데도 사슬이 곧바로 generic 으로 떨어진다. `한양견고딕` 은 **원 이름조차** 사슬에서
사라진다:

```
한양견고딕 alt=1  →  Malgun Gothic | Apple SD Gothic Neo | Noto Sans KR | …   ← HY견고딕 설치돼 있는데도
한양견고딕 alt=2  →  HY견고딕 | Malgun Gothic | …
```

같은 코퍼스가 `HY중고딕(altType=1)`·`HY헤드라인M(altType=1)` 을 실제로 담고 있으므로
가정된 형상이 아니다.

**설치 face 를 다른 이름으로 찾는 일은 선언 altType 과 무관하다.** 타입 지정 조회가 비면
타입-무관(0) 탐색으로 한 번 더 본다 — `projectedSubstituteTargets` 가 0 에서 1·2 를 차례로
훑는 기존 규약을 그대로 쓴다.

## 표면 범위 — 화면은 바뀌지 않는다

| 경로 | altType | 영향 |
|---|---|---|
| Canvas2D paint (`wasm-bridge.ts`) | `fontFamilyChainForDisplay(name, **0**, 0)` | 이미 자동 탐색 — **불변** |
| CanvasKit 폰트 계획 (`font-loader.ts`) | altType 미사용 | 불변 |
| 폰트 판정 트레이스 (`font-decision-trace.ts`) | **문서의 실제 altType** | 이 PR 로 paint 와 같은 사슬을 보고 |

즉 이 수정은 **트레이스가 paint 와 갈리지 않게** 한다. 두 층이 갈리면 진단이 잘못된 원인을
가리킨다. 시각 증적을 붙이지 않은 이유가 이것이다 — 붙이면 화면이 바뀐다는 오해를 준다.

## 검증

- 잠금 시험 `rhwp-studio/tests/issue-6263-legacy-face-alttype.test.ts` — 네 legacy face 가
  altType **0·1·2 전부**에서 설치 face 를 첫 후보로 두고, 설치 face 가 없는 호스트의 사슬은
  종전대로임을 함께 고정
- **음성 대조**: 되돌리면 altType=1 에서 FAIL
- `npm test` 1330건 중 실패 7건 — 이 변경 **전**(1328건 중 7건)과 같은 기존 실패다
- Rust 파일은 한 줄도 바뀌지 않았다

## 곁가지 — 왜 하필 괄호가 눈에 띄나

글꼴 파일 실측(`fontTools`, em 단위)상 **`Malgun Gothic` 만** 모서리 괄호를 반각으로 둔다.

| face | `『` advance | `『` 잉크 |
|---|---:|---|
| **Malgun Gothic** | **0.517em** | 0.152..0.463 ← 반각 + 잉크가 왼쪽 절반 |
| HY중고딕 / HY견고딕 | 1.000em | 0.60..0.94 |
| Batang / Gulim / Dotum | 1.000em | 0.63..0.94 |

조판은 전각 advance 로 다음 글자 자리를 고정하므로 괄호 뒤에 공백이 남는다. 번들
`NotoSansKR-Regular.woff2` stand-in 에는 `『`·`【`·`「` 글리프가 **아예 없어** 그 다음
family 로 넘어가는 것도 확인했다. (SVG/PDF 쪽 같은 축은 #6530 에서 다뤘다.)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
