### PR TITLE
docs: PR #6537 병합 기록 보존

### DIFF
--- a/mydocs/orders/20260831.md
+++ b/mydocs/orders/20260831.md
@@ -171,3 +171,4 @@ date: 2026-08-31
 - #6530은 원 PR 충돌을 메인 터너 보정 commit `b0109a1f6`으로 승계하며 원 PR 직접 merge 금지.
 - 검토 기록: `mydocs/pr/pr_6526_6528_6529_6530_6532_review_impl.md` 및 개별 PR review 5건.
 - 결과: Rust lint/build/전체 nextest, focused regression, Studio contract, Hancom 2020 direct visual sweep 통과. remote push/PR 생성은 미수행.
+- 통합 PR #6537은 `2026-08-31T14:23:48Z`에 merge SHA `1636910809ce9d1a394b30144fff19cc5fc32826`으로 병합됐고 `upstream/devel` 포함을 확인했다. review archive 반영 뒤 관련 issue와 source PR comment 후속 처리를 진행한다.

--- a/mydocs/pr/archives/pr_6526_6528_6529_6530_6532_review_impl.md
+++ b/mydocs/pr/archives/pr_6526_6528_6529_6530_6532_review_impl.md
@@ -59,5 +59,5 @@
 - 확인된 차단 결함은 없다.
 - #6526, #6528, #6529, #6532는 통합 검증본에서 승인한다.
 - #6530은 메인 터너 보정이 포함된 통합본으로 수용하며, 원 PR 직접 merge는 금지한다.
-- 현재 작업은 로컬 integration branch까지만 생성했다. remote push, 통합 PR 생성, GitHub comment는 수행하지 않았다.
-- 원격 상태는 변동 가능하므로, 다음 상태 변경 직전에 각 원 PR head와 CI green, 통합 branch head를 재확인해야 한다.
+- [통합 PR #6537](https://github.com/edwardkim/rhwp/pull/6537)은 `2026-08-31T14:23:48Z`에 merge SHA `1636910809ce9d1a394b30144fff19cc5fc32826`으로 병합됐고, `upstream/devel` 포함을 확인했다.
+- active review 문서는 이 기록 PR에서 archive로 이동한다. 관련 issue 상태와 contributor PR comment는 archive asset이 `devel`에 반영된 뒤 후속 처리한다.

--- a/mydocs/pr/archives/pr_6526_review.md
+++ b/mydocs/pr/archives/pr_6526_review.md
@@ -5,7 +5,7 @@
 - base: `devel` (`upstream/devel@887b4ce15`로 rebase)
 - 원 PR head: `76a7e0e62edcad0207a0d543f68ef450359830b8`
 - 통합 commit: `a068fb329`, `7fc0dce9f`
-- 상태: 승인 (통합 검증본 기준)
+- 상태: [통합 PR #6537](https://github.com/edwardkim/rhwp/pull/6537) 병합 완료 (`1636910809ce9d1a394b30144fff19cc5fc32826`)
 
 ## 범위
 

--- a/mydocs/pr/archives/pr_6528_review.md
+++ b/mydocs/pr/archives/pr_6528_review.md
@@ -5,7 +5,7 @@
 - base: `devel` (`upstream/devel@887b4ce15`로 rebase)
 - 원 PR head: `7eed781260257c1f54cd79b9d72bb57d1ceab0b5`
 - 통합 commit: `ee3fd7a4f`
-- 상태: 승인 (통합 검증본 기준)
+- 상태: [통합 PR #6537](https://github.com/edwardkim/rhwp/pull/6537) 병합 완료 (`1636910809ce9d1a394b30144fff19cc5fc32826`)
 
 ## 범위
 

--- a/mydocs/pr/archives/pr_6529_review.md
+++ b/mydocs/pr/archives/pr_6529_review.md
@@ -5,7 +5,7 @@
 - base: `devel` (`upstream/devel@887b4ce15`로 rebase)
 - 원 PR head: `02ccd4bb70884ae3cb6726e69b8a6f907fe46a75`
 - 통합 commit: `baa8179bb`
-- 상태: 승인 (통합 검증본 기준)
+- 상태: [통합 PR #6537](https://github.com/edwardkim/rhwp/pull/6537) 병합 완료 (`1636910809ce9d1a394b30144fff19cc5fc32826`)
 
 ## 범위
 

--- a/mydocs/pr/archives/pr_6530_review.md
+++ b/mydocs/pr/archives/pr_6530_review.md
@@ -5,7 +5,7 @@
 - base: `devel` (`upstream/devel@887b4ce15`로 rebase)
 - 원 PR head: `e374be85c554c8b4b502f1f253aaa7c3d7b425f0`
 - 통합 보정 commit: `b0109a1f6`
-- 상태: 메인 터너 보정을 포함한 통합본 수용. 원 PR 직접 병합 금지.
+- 상태: [통합 PR #6537](https://github.com/edwardkim/rhwp/pull/6537)로 병합 완료 (`1636910809ce9d1a394b30144fff19cc5fc32826`). 원 PR 직접 병합은 하지 않았다.
 
 ## 범위와 충돌 보정
 

--- a/mydocs/pr/archives/pr_6532_review.md
+++ b/mydocs/pr/archives/pr_6532_review.md
@@ -5,7 +5,7 @@
 - base: `devel` (`upstream/devel@887b4ce15`로 rebase)
 - 원 PR head: `ef0d03fc74ac34bae709f5e24c61c51f4b412fcf`
 - 통합 commit: `f535a4636`
-- 상태: 승인 (통합 검증본 기준)
+- 상태: [통합 PR #6537](https://github.com/edwardkim/rhwp/pull/6537) 병합 완료 (`1636910809ce9d1a394b30144fff19cc5fc32826`)
 
 ## 범위
 


### PR DESCRIPTION
## 목적

[PR #6537](https://github.com/edwardkim/rhwp/pull/6537)의 병합 완료 기록을 보존하는 문서 전용 fast-pass입니다.

## 변경 범위

- active review 문서 5개와 단일 통합 기록을 `mydocs/pr/archives/`로 이동
- `mydocs/orders/20260831.md`에 실제 merge SHA와 `upstream/devel` 포함 확인 기록

## 근거

- 원 PR merge SHA: `1636910809ce9d1a394b30144fff19cc5fc32826`
- `git merge-base --is-ancestor 1636910809ce9d1a394b30144fff19cc5fc32826 upstream/devel` 성공
- code, test, workflow, golden, fixture, PDF는 변경하지 않음
- `git diff --check` 통과

## 후속 처리

이 기록 PR 병합 뒤 #6524, #6181, #6180, #6171, #6263 issue 상태와 source PR #6526, #6528, #6529, #6530, #6532의 maintainer 완료 comment를 처리합니다.
