### PR TITLE
fix(studio): 병합 셀 마우스 드래그 리사이즈에서 하위 행/열 선택 시 병합 셀 누락을 고친다

### DIFF
--- a/rhwp-studio/src/engine/input-handler-table.ts
+++ b/rhwp-studio/src/engine/input-handler-table.ts
@@ -10,6 +10,7 @@ import {
   buildColumnResizeUpdates,
   buildLocalResizeUpdates,
   buildBoundaryResizeUpdates,
+  cellOverlapsSelectionRange,
   type CellSelectionRange,
   type LocalResizeUpdate,
   type ResizeArrowKey,
@@ -878,13 +879,10 @@ export function finishResizeDrag(this: any, e: MouseEvent): void {
       return;
     }
   } else if (state.edge.type === 'col' && inCellSel && range) {
-    // 선택 셀만 추출
+    // 선택 셀만 추출 — 병합 셀은 시작 좌표가 아니라 겹침으로 판정한다 (PK-38529)
     const selectedBboxes = state.affectedCellIndices
       .map((cellIdx: any) => state.bboxes.find((b: any) => b.cellIdx === cellIdx))
-      .filter((b: any): b is CellBbox =>
-        b !== undefined &&
-        b.row >= range.startRow && b.row <= range.endRow &&
-        b.col >= range.startCol && b.col <= range.endCol);
+      .filter((b: any): b is CellBbox => b !== undefined && cellOverlapsSelectionRange(b, range));
     if (selectedBboxes.length === 0) {
       this.cleanupResizeDrag();
       return;

--- a/rhwp-studio/src/engine/table-resize-updates.ts
+++ b/rhwp-studio/src/engine/table-resize-updates.ts
@@ -72,15 +72,24 @@ function overlapCount(b: CellBbox, isHoriz: boolean, start: number, end: number)
   return Math.max(0, Math.min(axisEnd(b, isHoriz), end) - Math.max(axisStart(b, isHoriz), start) + 1);
 }
 
+/**
+ * 셀 선택 범위와 셀이 실제로 겹치는지 판정한다. 병합 셀은 bbox에 시작 행/열만
+ * 저장되므로 시작 좌표를 범위와 직접 비교하면 선택 범위가 병합 셀의 하위 행/열일 때
+ * 그 병합 셀이 통째로 누락된다 (PK-38529). F5 키보드 경로(selectedAxisRange)와
+ * 마우스 드래그 경로(finishResizeDrag)가 이 판정 하나를 공유한다.
+ */
+export function cellOverlapsSelectionRange(b: CellBbox, range: CellSelectionRange): boolean {
+  return overlapCount(b, true, range.startCol, range.endCol) > 0
+    && overlapCount(b, false, range.startRow, range.endRow) > 0;
+}
+
 /** F5는 병합 셀의 시작 좌표만 보관하므로 실제 병합 범위까지 선택 축을 확장한다. */
 function selectedAxisRange(
   cells: CellBbox[],
   range: CellSelectionRange,
   isHoriz: boolean,
 ): { start: number; end: number } | null {
-  const selected = cells.filter(cell =>
-    overlapCount(cell, true, range.startCol, range.endCol) > 0
-      && overlapCount(cell, false, range.startRow, range.endRow) > 0);
+  const selected = cells.filter(cell => cellOverlapsSelectionRange(cell, range));
   if (selected.length === 0) return null;
   return {
     start: Math.min(...selected.map(cell => axisStart(cell, isHoriz))),

--- a/rhwp-studio/tests/table-mouse-resize-1491.test.ts
+++ b/rhwp-studio/tests/table-mouse-resize-1491.test.ts
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { cellOverlapsSelectionRange } from '../src/engine/table-resize-updates.ts';
+import type { CellBbox } from '../src/core/types.ts';
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 
@@ -175,4 +177,46 @@ test('Shift 세로 resize는 가로처럼 단일 셀 local height 경로를 사�
   );
   assert.match(finish, /heightDelta:\s*0,[\s\S]*renderHeight: targetDesiredSize,/, '세로 Shift는 모델 행 높이가 아니라 target renderHeight만 바꿔야 함');
   assert.match(finish, /heightDelta:\s*0,[\s\S]*renderHeight: neighborDesiredSize,/, '세로 Shift 보상 셀도 모델 행 높이가 아니라 renderHeight만 바꿔야 함');
+});
+
+// PK-38529: 병합 셀이 섞인 표에서 마우스 드래그 리사이즈가 셀 선택 범위 내 병합 셀을
+// 누락시키지 않는다. 이 파일의 다른 테스트와 달리 finishResizeDrag 가 실제로 쓰는
+// cellOverlapsSelectionRange 를 직접 호출해 검증한다.
+
+function pk38529Bbox(row: number, col: number, rowSpan: number, colSpan: number): CellBbox {
+  return { cellIdx: row * 100 + col, row, col, rowSpan, colSpan, pageIndex: 0, x: 0, y: 0, w: 40, h: 20 };
+}
+
+test('PK-38529: 세로 병합 셀은 시작 행이 선택 범위 밖이어도 하위 행 선택과 겹친다', () => {
+  // row0~1 세로 병합 셀(col0). 사용자가 row1 만 셀 선택한 채 열 경계를 드래그하는 시나리오 —
+  // 시작 좌표 비교(row >= startRow)라면 이 병합 셀이 통째로 빠진다.
+  const merged = pk38529Bbox(0, 0, 2, 1);
+  const range = { startRow: 1, startCol: 0, endRow: 1, endCol: 0 };
+  assert.equal(cellOverlapsSelectionRange(merged, range), true);
+});
+
+test('PK-38529: 가로 병합 셀은 시작 열이 선택 범위 밖이어도 하위 열 선택과 겹친다', () => {
+  const merged = pk38529Bbox(0, 0, 1, 3);
+  const range = { startRow: 0, startCol: 2, endRow: 0, endCol: 2 };
+  assert.equal(cellOverlapsSelectionRange(merged, range), true);
+});
+
+test('PK-38529: 선택 범위와 겹치지 않는 셀은 여전히 제외된다', () => {
+  const plain = pk38529Bbox(2, 2, 1, 1);
+  const range = { startRow: 0, startCol: 0, endRow: 1, endCol: 1 };
+  assert.equal(cellOverlapsSelectionRange(plain, range), false);
+});
+
+test('PK-38529: finishResizeDrag 선택 셀 필터는 overlap 판정을 사용한다', () => {
+  const finish = finishResizeDragBlock();
+  assert.match(
+    finish,
+    /cellOverlapsSelectionRange\(b, range\)/,
+    '마우스 경로 선택 필터는 시작 좌표 비교가 아니라 cellOverlapsSelectionRange 를 써야 함 (PK-38529)',
+  );
+  assert.doesNotMatch(
+    finish,
+    /b\.row >= range\.startRow/,
+    '시작 좌표 직접 비교가 남아 있으면 병합 셀 누락이 재발한다',
+  );
 });


### PR DESCRIPTION
### 현상

칸 병합이 섞인 표에서 셀 선택 후 마우스로 경계를 드래그해 크기를 바꾸면 표가 깨지는 경우가 있습니다. 선택 범위가 병합 셀의 시작 행/열이 아니라 하위 행/열만 걸칠 때 재현됩니다.

(키즈노트 전환 검증 T/C의 P0 항목입니다 — 내부 티켓 PK-38529, 재현 문서 "[추천서식] 부모동의 및 조사서.hwp")

### 원인

병합 셀은 bbox에 시작 행/열만 저장되는데, `finishResizeDrag`의 선택 셀 필터가 시작 좌표를 선택 범위와 직접 비교합니다(`b.row >= range.startRow && …`). 선택 범위가 병합 셀의 하위 행/열이면 그 병합 셀이 통째로 빠지고, 빠진 셀은 폭/높이 delta를 받지 못해 이웃 셀과 어긋납니다.

F5 키보드 경로(`selectedAxisRange`)는 이미 `overlapCount`로 겹침을 판정하고 있어서, 같은 표에서 키보드는 정상·마우스만 깨지는 비대칭이 있었습니다.

### 수정

- `table-resize-updates.ts`: 두 축 겹침 판정을 `cellOverlapsSelectionRange`로 추출해 export. `selectedAxisRange` 내부 필터도 이 함수로 교체 (동작 동일, 정의 한 곳).
- `input-handler-table.ts`: `finishResizeDrag`의 시작 좌표 비교 필터를 `cellOverlapsSelectionRange`로 교체.

### 검증

- `npx tsc --noEmit`: 신규 오류 없음 (`@wasm/rhwp.js` 부재 오류는 WASM 산출물 없는 로컬 환경 기존 사항)
- `npm test`: 1,335개 중 1,334 pass · 0 fail · 1 skip
- 신규 테스트 4개: 세로/가로 병합 셀이 하위 행/열 선택과 겹침 판정되는지, 비겹침 셀 제외 유지, `finishResizeDrag`가 overlap 판정을 실제로 쓰는지(시작 좌표 비교 잔존 시 실패)

브라우저 수동 확인은 아직 못 했습니다. 병합 셀 표에서 하위 행/열 선택 후 드래그 시나리오를 재현 문서로 확인해 주시면 좋겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qep92aP5nwzKMAsyou1ZJN