### PR TITLE
문서: #6544 핀 정정 주석의 오라클 판 표기를 2022 → 2024 로 바로잡는다

### DIFF
--- a/tests/issue_1139_inline_picture_duplicate.rs
+++ b/tests/issue_1139_inline_picture_duplicate.rs
@@ -2167,20 +2167,20 @@ fn issue_1284_2023_sep_page20_question30_title_stays_in_left_tail() {
     let q30_continuation = page20
         .find("FullParagraph[미주]  pi=976")
         .expect("page 20 question 30 right-column continuation");
-    // [#6544] 한글 2022 오라클 재측정으로 기대값을 정정한다.
+    // [#6544] 한글 2024 오라클 재측정으로 기대값을 정정한다.
     //
     // 종전 기대("식 줄은 오른쪽 단")는 위험 휴리스틱이 저장 사다리를 뚫던 시절의 동작을
     // 고정한 것이고 한컴 PDF 와 어긋난다. 저장 사다리의 단 경계 신호(vpos 되감김)는
     // pi=976 에서 나고(1213345 -> 1209109), 이 쪽 저장 회계도 단 0 `diff = -0.0px` 다.
     //
-    // 한글 2022 PDF p20: `9b PQ=4a AB …… ㉠` 이 **왼쪽 단 하단** y=810.0pt 에 있고,
+    // 한글 2024 PDF p20: `9b PQ=4a AB …… ㉠` 이 **왼쪽 단 하단** y=810.0pt 에 있고,
     // 오른쪽 단은 `, 이므로 ㉠에서` y=68.1pt 로 시작한다.
     assert!(
         q30_title < page20_col1
             && q30_intro < page20_col1
             && q30_equation < page20_col1
             && q30_continuation > page20_col1,
-        "문30 은 page 20 왼쪽 단 하단에 제목·풀이·식까지 남기고 오른쪽 단으로 이어져야 함 (한글 2022 오라클)\n{page20}"
+        "문30 은 page 20 왼쪽 단 하단에 제목·풀이·식까지 남기고 오른쪽 단으로 이어져야 함 (한글 2024 오라클)\n{page20}"
     );
 
     let tree = doc.build_page_render_tree(19).expect("page 20 render tree");
@@ -2207,7 +2207,7 @@ fn issue_1284_2023_sep_page20_question30_title_stays_in_left_tail() {
     );
     assert!(
         q30_equation_bbox.x < 80.0 && (1068.0..=1090.0).contains(&q30_equation_bbox.y),
-        "문30 식 줄은 한글 2022 처럼 왼쪽 단 하단(약 y=1080px = 810.0pt)에 남아야 함: {:?}",
+        "문30 식 줄은 한글 2024 처럼 왼쪽 단 하단(약 y=1080px = 810.0pt)에 남아야 함: {:?}",
         q30_equation_bbox
     );
     assert!(
@@ -3142,7 +3142,7 @@ fn issue_1274_2022_oct_page11_question20_equation_tail_keeps_pdf_bleed() {
     let equation_bottom =
         max_equation_visual_bottom_in_region(&tree.root, 395.0, 700.0, 1020.0, 1100.0)
             .expect("문20 하단 수식");
-    // [#6544] 한글 2022 오라클 재측정으로 기대값을 정정한다.
+    // [#6544] 한글 2024 오라클 재측정으로 기대값을 정정한다.
     //
     // 종전 하한(>= 1118.0px = 838.5pt)은 단 하단 819.21pt 를 **20.3pt 넘는 bleed** 를
     // 요구했다. 한컴 PDF 는 그 bleed 를 만들지 않는다 — 오른쪽 단 마지막 잉크 하단이
@@ -3329,14 +3329,14 @@ fn issue_1274_2022_oct_page16_question30_title_tail_continues_next_column() {
         (1060.0..=1085.0).contains(&title.y),
         "문30 제목은 한컴/PDF처럼 16쪽 하단에 남아야 함: title={title:?}"
     );
-    // [#6544] 한글 2022 오라클 재측정으로 기대값을 정정한다.
+    // [#6544] 한글 2024 오라클 재측정으로 기대값을 정정한다.
     //
     // 한컴 PDF p16 은 `함수 …의 한 부정적분을 …라 하자.` 를 **왼쪽 단** y=809.7pt 에
     // 두고, 오른쪽 단은 `조건 (가)에서` y=68.0pt 로 시작한다. 종전 기대(첫 본문 줄이
     // 다음 단 상단)는 휴리스틱이 저장 사다리를 뚫던 시절의 동작이다.
     assert!(
         first_line.x < 80.0 && (1078.0..=1094.0).contains(&first_line.y),
-        "문30 첫 본문 줄은 한글 2022 처럼 제목 바로 아래 왼쪽 단에서 이어져야 함: title={title:?}, first_line={first_line:?}"
+        "문30 첫 본문 줄은 한글 2024 처럼 제목 바로 아래 왼쪽 단에서 이어져야 함: title={title:?}, first_line={first_line:?}"
     );
 }
 


### PR DESCRIPTION
PR #6554(`#6544`)에서 핀 세 건의 기대값을 오라클 재측정으로 정정하면서 주석·assert 메시지에
**"한글 2022"** 라고 적었는데, **실제 측정은 한글 2024 로 했습니다.** 표기만 바로잡습니다.

이 장비는 COM ProgID 가 전부 2024 CLSID 로 해석됩니다 — 2022 도 설치돼 있지만 COM 등록이
안 돼 있어 선택할 수 없습니다.

```
한컴오피스 2022 한글  12.0.0.1    (COM 미등록)
한컴오피스 2024 한글  13.0.0.223  ← HWPFrame.HwpObject 가 붙는 판
HWPFrame.HwpObject / .1 / .2  →  모두 {2291CF00-64A1-4877-A9B4-68CFE89612D6}
```

측정값과 판정은 **그대로 유효**합니다 — 프로젝트 표준 오라클이 한글 2024 이고 그것으로 잰
값입니다. 잘못된 것은 판 이름 표기뿐입니다.

동작 변경 없음(주석·assert 메시지 문자열만). 같은 정정을 `#6544`·`#6550`·`#3386` 코멘트에도
남겼습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
