### PR TITLE
docs: PR 검토 판정 용어를 정본으로 통일

### DIFF
--- a/mydocs/manual/pr_review/intake_and_review.md
+++ b/mydocs/manual/pr_review/intake_and_review.md
@@ -72,13 +72,13 @@ Cargo 성공은 시각 검증 판정을 대체하지 않는다. 다음 중 하�
 - PR 설명이 특정 문서의 페이지, 표, 줄바꿈, clipping, 겹침, 여백, z-order, 그림·도형 배치 개선을
   주장한다.
 
-이 경우 review 문서의 최종 권고를 `merge` 또는 `수용`으로 쓰기 전에 다음 중 하나를 완료해야 한다.
+이 경우 review 문서의 최종 판정을 `승인`으로 쓰기 전에 다음 중 하나를 완료해야 한다.
 
 - `rhwp info --json`으로 원본 HWP/HWPX의 저장 버전을 확인하고, 버전에 맞는 MCP 기준 PDF를 만든 뒤,
   visual sweep 대표 PNG와 요약 지표를 실제로 열어 확인한다.
 - 이미 PR branch에 포함된 기준 PDF/PNG를 쓰는 경우에도, 그 파일을 직접 열어 PR 주장의 페이지·영역이
   해결됐는지 확인하고, 원본·기준·검토 asset의 경로와 SHA-256을 review 문서에 적는다.
-- 직접 시각 검증을 수행하지 못하면 최종 권고는 `보류` 또는 `조건부 보류`로 적고, "원 PR 제공
+- 직접 시각 검증을 수행하지 못하면 최종 판정은 `머지 보류`로 적고, "원 PR 제공
   before/after만 확인했고 maintainer visual sweep은 미실행"처럼 누락 범위를 명시한다.
 
 원 PR이 before/after 이미지나 수치를 제공했더라도 maintainer가 직접 확인한 visual sweep 또는 동등한
@@ -117,7 +117,7 @@ review 문서에는 최소한 다음을 포함한다.
 - 판정 근거와 다음 조건: `승인`이면 merge 전 게이트, `머지 보류`면 해제 조건,
   `메인터너 보정 후 수용 가능`이면 원 head·보정 SHA·통합 검증 경로
 
-시각 검증을 최종 권고의 근거로 썼다면 `Merge 후 contributor PR comment 계획`도 review 문서에 포함한다.
+시각 검증을 최종 판정의 근거로 썼다면 `Merge 후 contributor PR comment 계획`도 review 문서에 포함한다.
 계획에는 Visual Sweep 정본 direct link, 실제 페이지·후보 수·지표와 사람의 판정, representative PNG의
 `mydocs/pr/assets/` 안정 경로, `<merge-commit-sha>` 고정 raw image URL 형식, merge 뒤 `--body-file` 게시 및
 API 재조회 조건을 적는다. 이는 게시 승인이나 사전 comment를 뜻하지 않는다. asset이 devel에 반영되고 merge

--- a/mydocs/manual/pr_review/visual_fixture_evidence.md
+++ b/mydocs/manual/pr_review/visual_fixture_evidence.md
@@ -20,7 +20,7 @@ renderer/layout/typeset/paint 등 사용자-visible 렌더링 경로가 바뀌�
 reviewer는 source PR이 첨부한 before/after나 수치만으로 "시각 검증 완료"라고 쓰지 않는다. 통합 head에서
 직접 만든 기준 PDF·visual sweep 또는 reviewer가 직접 연 기준 PDF/PNG 판정이 있어야 수용 근거가 된다.
 
-직접 visual sweep 또는 동등한 판정을 수행하지 못한 경우 review 문서의 최종 권고는 다음처럼 제한한다.
+직접 visual sweep 또는 동등한 판정을 수행하지 못한 경우 review 문서의 최종 판정은 다음처럼 제한한다.
 
 - `머지 보류`: PR 주장이 시각 결과 자체인데 기준 산출물 또는 maintainer 직접 판정이 없다.
   코드·회귀 테스트만 통과했거나 원 PR 증적만 확인한 경우도 이 판정이다.
@@ -119,7 +119,7 @@ visual sweep을 실제 merge 판단에 썼으면 merge 가능 또는 승인 요�
   direct link로 남긴다. output 경로 link만 남기지 않고, merge commit에 반영된 asset의 **commit SHA 고정**
   raw URL을 Markdown image로 실제 표시한다. raw URL은 PNG 표시용 증적이며 문서 비교 방법의 인용은
   Visual Sweep 정본과 review 문서가 담당한다.
-- 시각 검증을 `수용` 또는 `merge 권고` 근거로 쓰면, merge 전 개별 review 문서에 `Merge 후 contributor PR
+- 시각 검증을 `승인`의 근거로 쓰면, merge 전 개별 review 문서에 `Merge 후 contributor PR
   comment 계획`을 작성한다. 계획에는 실제 확인 페이지·후보 수·지표·사람의 결론과 한계, representative PNG의
   안정 경로, `<merge-commit-sha>` 고정 raw URL 형식, merge 뒤 `--body-file` 게시·API 재조회 조건을 넣는다.
   이 계획이 없으면 merge 뒤 임시 산출물에서 수치를 추정해 comment하지 않고 review 기록부터 보완한다.

--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -325,12 +325,12 @@ link와 review 문서의 실제 수치·결론을 함께 남기며, PNG는 merge
 renderer/layout/typeset/paint 등 사용자-visible 렌더링 변경에 HWP/HWPX/PDF fixture가 붙어 있으면
 "시각 검증을 판단 근거로 사용한 경우"가 아니라 **시각 검증 필요 후보**로 먼저 분류한다. 이때 원 PR의
 before/after 이미지나 한컴 수치만 확인하고 maintainer의 직접 visual sweep 또는 동등한 판정 없이
-`수용`·`merge 권고`로 결론 내리지 않는다. 직접 수행하지 못했으면 review 문서와 PR comment에
+최종 판정을 `승인`으로 내리지 않는다. 직접 수행하지 못했으면 review 문서와 PR comment에
 `visual sweep 미실행`, `원 PR 증적만 확인`, `보류/조건부 보류` 중 하나를 명시한다.
 
 ### 4.2 시각 증적 PR comment 계획
 
-시각 검증을 `수용` 또는 `merge 권고`의 근거로 사용한 개별 review 문서는 최종 권고 전에
+시각 검증을 `승인`의 근거로 사용한 개별 review 문서는 최종 판정 전에
 `Merge 후 contributor PR comment 계획` 절을 포함해야 한다. 이 절은 merge 뒤 새로 추정하거나 임시
 output에서 수치를 옮기는 일을 막기 위한 사전 기록이며, 최소한 다음을 적는다.
 
@@ -341,7 +341,7 @@ output에서 수치를 옮기는 일을 막기 위한 사전 기록이며, 최�
    게시 뒤 API 재조회로 실제 Markdown과 이미지를 확인한다는 조건
 
 시각 검증을 실행하지 못한 경우에도 같은 절에 미실행 범위와 보류 사유를 적는다. 이 상태에서는 없는 수치나
-이미지 URL을 계획으로 만들지 않으며, 최종 권고를 `수용`으로 쓸 수 없다. 임시 `output/` 경로만 적거나
+이미지 URL을 계획으로 만들지 않으며, 최종 판정을 `승인`으로 쓸 수 없다. 임시 `output/` 경로만 적거나
 merge 뒤 게시할 comment를 review 기록에 남기지 않는 것은 완료된 시각 증적으로 인정하지 않는다.
 
 ## 5. 기존 절 번호 대응

--- a/mydocs/orders/20260902.md
+++ b/mydocs/orders/20260902.md
@@ -1,0 +1,9 @@
+# 2026-09-02
+
+## PR #6579 - PR 검토 판정어 정본화
+
+- 완료: code candidate `ea705108e`의 초기 CI가 성공 또는 문서-only skipped로 종료됐다.
+- 완료: `edwardkim` reviewer 요청을 등록했다.
+- 완료: `mydocs/pr/archives/pr_6579_review.md`를 trailing review 기록으로 추가했다.
+- 다음: 이 trailing commit의 최신 head CI와 mergeability를 확인한다.
+- 조건 충족 뒤: #6579을 병합하고 devel 반영, 문서 archive, issue/PR 상태, branch 정리를 포함한 merge 후속 처리를 수행한다.

--- a/mydocs/pr/archives/pr_6579_review.md
+++ b/mydocs/pr/archives/pr_6579_review.md
@@ -1,0 +1,32 @@
+# PR #6579 검토 기록 - PR 검토 판정어 정본화
+
+- PR: [#6579](https://github.com/edwardkim/rhwp/pull/6579)
+- base: `devel`
+- 검토 대상 코드 head: `ea705108e9f1355082e67aff8763ee283034e9c3`
+- reviewer 요청: `edwardkim`
+- 검토일: 2026-09-02
+
+## 범위
+
+- `mydocs/manual/pr_review_workflow.md`의 시각 증적 최종 판단 표현을 정본 판정어 `승인`으로 통일한다.
+- `mydocs/manual/pr_review/intake_and_review.md`의 `수용`, `보류/조건부 보류` 표현을 `승인`, `머지 보류`로 통일한다.
+- `mydocs/manual/pr_review/visual_fixture_evidence.md`의 최종 권고와 `수용`/`merge 권고` 표현을 정본 판정어로 통일한다.
+
+## 초기 CI와 검증
+
+- code candidate `ea705108e`의 GitHub Actions `Build & Test`, `CI preflight`, `adapter inter-diff preflight`, `CodeQL preflight`, `Proptest preflight` 및 trusted post-merge reuse 검증은 성공했다.
+- Rust lint, Native Skia, WASM, frontend, archive shard job은 문서-only 변경으로 skipped였다.
+- 문서-only 변경이므로 별도 로컬 테스트는 실행하지 않았다.
+
+## 검토 결과
+
+- 차단 문제 없음. 정본 표의 세 판정어와 workflow·하위 가이드의 최종 판단 표현을 일치시킨다.
+- #6540 검토 코멘트가 지적한 비정규 `수용 가능` 판정 표현의 재발 여지를 제거한다.
+
+## 최종 판정
+
+- 판정: 승인
+- 검증 대상: `ea705108e9f1355082e67aff8763ee283034e9c3`의 문서 변경.
+- trailing review 기록 commit은 이 기록을 포함한 최신 head의 CI를 다시 확인하는 merge 전 조건이다.
+- merge 전 조건: 최신 PR head의 GitHub Actions 통과, mergeability 재확인, 작업지시자 승인.
+- 원격 조치: reviewer 요청은 완료했다. merge와 merge 후속 처리는 위 조건 충족 뒤에만 수행한다.


### PR DESCRIPTION
## 변경

- `pr_N_review.md`의 정본 최종 판정어를 `승인`, `머지 보류`, `메인터너 보정 후 수용 가능`으로 유지합니다.
- workflow와 시각 검증 하위 가이드에서 최종 판단처럼 쓰이던 `수용`, `merge 권고`, `보류/조건부 보류`를 정본 용어로 통일합니다.
- [#6540 검토 코멘트](https://github.com/edwardkim/rhwp/pull/6540#issuecomment-5486409268)가 지적한 비정규 판정어 재발 여지를 제거합니다.

## 검증

- 문서만 변경했습니다. 테스트는 실행하지 않았습니다.
