### PR TITLE
docs: PR #6578 merge 후속 기록

### DIFF
--- a/mydocs/orders/20260902.md
+++ b/mydocs/orders/20260902.md
@@ -8,13 +8,14 @@
 - 다음: 이 trailing commit의 최신 head CI와 mergeability를 확인한다.
 - 조건 충족 뒤: #6579을 병합하고 devel 반영, 문서 archive, issue/PR 상태, branch 정리를 포함한 merge 후속 처리를 수행한다.
 
-## PR #6578 - 빈 줄 TAC Picture 상단 배치
+## PR #6578 - 빈 줄 TAC Picture 상단 배치 (`jeong-sik`)
 
 - 완료: contributor head `c1f3c7bf1`에 메인터너 보정 commit `53282aa5e`를 rebase 후 반영했다. 기준은 `upstream/devel` `89db03103`이다.
 - 완료: 동일 TAC Picture baseline 경로의 객체 상자 높이 보정과 대상 그림 유일성 단언을 반영했다. full nextest, Native Skia, WASM, Rust lint 검증은 동일 rebase head에서 통과했다.
 - 판정: 원본 PR 변경 범위 기준으로 `메인터너 보정 됨 수용 가능`이다. 페이지 5의 캡션·표 흐름 시각 차이는 이 PR과 분리된 renderer 과제로 관리한다.
-- 다음: 갱신된 head의 필수 CI와 Render Diff 결과가 모두 green인지 확인한다.
-- 조건 충족 뒤: #6578을 수용하고 mergeability/head를 재확인한 뒤 admin merge와 devel 반영, PR·issue 기록, branch·검토 산출물 정리를 포함한 merge 후속 처리를 수행한다.
+- 완료: 문서 trailing head `556653609`의 CI까지 green을 확인하고, [#6578](https://github.com/edwardkim/rhwp/pull/6578)을 [merge commit `59bde68e`](https://github.com/edwardkim/rhwp/commit/59bde68e66e3dfe3fdf9b5bb9a7daa311e7c73e7)로 병합했다.
+- 완료: `upstream/devel`에 merge SHA 포함을 확인했다. [#6575](https://github.com/edwardkim/rhwp/issues/6575)는 closing keyword로 자동 종료됐다.
+- 다음: archive review·오늘할일 운영 기록을 devel에 반영한 뒤, review 문서의 계획대로 maintainer issue/PR comment와 local review branch 정리를 완료한다.
 
 ## planet6897 PR #6572, #6576, #6580 통합 후보 검토
 

--- a/mydocs/pr/archives/pr_6578_review.md
+++ b/mydocs/pr/archives/pr_6578_review.md
@@ -60,3 +60,23 @@ Hancom Office 2020 기준 PDF와 rhwp SVG PDF의 전 8페이지 visual sweep도 
 - 로컬 검증: full nextest 8925 passed, Native Skia 3946 passed, WASM package build 완료
 - 후속 작업: #6575 auto-close 상태 <OPEN/CLOSED> 확인; PR 범위 내 추가 작업 없음
 ~~~
+
+## Merge 후 확정 기록
+
+- merge: [#6578](https://github.com/edwardkim/rhwp/pull/6578)은 [merge commit `59bde68e`](https://github.com/edwardkim/rhwp/commit/59bde68e66e3dfe3fdf9b5bb9a7daa311e7c73e7)로 2026-09-01T18:07:40Z에 병합됐다.
+- devel: `git merge-base --is-ancestor 59bde68e upstream/devel` 성공으로 포함을 확인했다.
+- issue: [#6575](https://github.com/edwardkim/rhwp/issues/6575)는 2026-09-01T18:07:58Z에 closing keyword로 자동 종료됐다. 기존 maintainer 종료 기록은 없었다.
+- CI: code head `53282aa5e`의 Lint, Native Skia, Render Diff, CodeQL, Proptest, test archive가 성공했다. 문서 trailing head `556653609`은 Build & Test와 preflight가 성공했고 code-heavy job은 trusted post-merge reuse 또는 skip으로 종료됐다.
+
+### 게시할 maintainer comment
+
+PR과 issue에는 아래 본문을 `--body-file`로 각각 게시한다. 이 PR은 시각 asset을 merge 판단 근거로 쓰지 않았으므로 raw asset URL이나 이미지를 넣지 않는다.
+
+~~~markdown
+검토 및 머지 완료했습니다. 감사합니다.
+
+- merge: [#6578](https://github.com/edwardkim/rhwp/pull/6578) -> [59bde68e](https://github.com/edwardkim/rhwp/commit/59bde68e66e3dfe3fdf9b5bb9a7daa311e7c73e7)
+- CI: code head의 Build & Test, Lint, Native Skia tests, Render Diff, CodeQL, Proptest roundtrip, test archive 성공 확인; 문서 trailing head의 preflight와 Build & Test 성공 확인
+- 로컬 검증: full nextest 8925 passed, Native Skia 3946 passed, WASM package build 완료
+- issue: [#6575](https://github.com/edwardkim/rhwp/issues/6575) auto-close 상태를 확인했으며, PR 범위 내 추가 작업은 없습니다.
+~~~


### PR DESCRIPTION
## 목적

[#6578](https://github.com/edwardkim/rhwp/pull/6578) 병합 뒤 검토 기록을 archive로 보존하고 오늘할일을 완료 상태로 정리합니다.

## 변경

- `mydocs/pr/archives/pr_6578_review.md`: merge SHA, CI 및 maintainer comment 계획을 확정 기록으로 보존
- `mydocs/orders/20260902.md`: #6578 병합·자동 이슈 종료 상태와 남은 후속처리 기록

## 범위

문서 전용 후속 PR입니다. renderer 코드, 테스트, PDF 증적 파일은 변경하지 않습니다.
