### PR TITLE
docs: #6243 post-release canary 및 v0.8.5 기록 게이트 정정

### DIFF
--- a/mydocs/orders/20260902.md
+++ b/mydocs/orders/20260902.md
@@ -38,4 +38,8 @@
 - 메인테이너 요구에 따라 v0.8.5 릴리즈 준비의 필수 게이트를 기여자 목록,
   `CHANGELOG.md`·`CHANGELOG_EN.md`, GitHub 릴리즈 노트 초안으로 고정했다. GitHub PR author와 Git author를
   교차 대사해 cherry-pick 기여자를 누락하지 않고, 세 산출물의 기여자 집합이 일치해야 한다.
-- 현재 상태: 수정 수행계획 검토·승인 대기. GitHub comment, commit, push는 수행하지 않았다.
+- 수정 수행계획을 메인테이너가 승인했고 commit `9601c121c`로 원격 branch에 push한 뒤 PR #6583을 열었다.
+  정확한 code head의 CI·CodeQL·Proptest·Adapter는 문서-only fast-pass로 성공했다.
+- self-review에서 기존 계획의 과거 Python 계약 수 `18/18`이 현행 기준처럼 남은 점을 발견했다. 현재
+  `scripts.tests.test_review_only_fast_pass_workflows` 24/24 통과를 재확인하고 역사값과 현행값을 구분했다.
+- 현재 상태: PR #6583 self-review 승인. review 기록 trailing commit·push와 최신 head CI 재확인은 별도 승인 대기.

--- a/mydocs/orders/20260902.md
+++ b/mydocs/orders/20260902.md
@@ -24,3 +24,18 @@
 - 메인터너 보정: #6576 IR baseline canonical 정렬 `77618ecf4`; #6580 실제 Hancom 좌표와 단 상단 반례를 고정한 `b63ab2cd6`.
 - 검증: full nextest `8923 passed, 46 skipped`, Native Skia, IR/overflow baseline, native/WASM clippy, workspace build, manual `rhwp-wasm-build`, 한글 PDF 기반 visual sweep을 완료했다.
 - 판정: #6572 승인; #6576 및 #6580 메인터너 보정 후 수용 가능. 원 PR은 직접 병합하지 않고, 별도 승인 뒤 통합 PR로만 수용한다. #6580 본문의 code-span `#6551` 문구는 closing keyword가 아니므로 issue close는 merge 후 검증 완료 시점까지 보류한다.
+
+## #6243 post-release canary 수정 계획
+
+- #6243 구현은 PR #6297로 `devel`에 병합됐지만 `main` trusted controller 활성화와 실제 canary가 남아
+  이슈는 OPEN 상태다.
+- 종전 후행 canary #6215는 PR #6473으로 `devel`에 먼저 병합되고 2026-08-30 종료되어, v0.8.5 이후
+  canary PR로 사용할 수 없다. #5949 Release Binary dry-run도 Render Diff 비대상이므로 대체 증적이 아니다.
+- 최신 `upstream/devel@8eab87ce1`에서 `task_m100_6243_canary`를 만들고
+  `mydocs/plans/task_m100_6243.md`의 Stage O2-5를 실제 post-release PR 선택 절차로 수정했다.
+- 실제 Render Diff 대상 code candidate가 성공한 뒤 현재 base 전진분을 한 번 병합하고 `mydocs/`
+  review-only tail을 추가하는 세 SHA 계보가 없으면 #6243을 닫지 않는다. 의미 없는 no-op canary는 만들지 않는다.
+- 메인테이너 요구에 따라 v0.8.5 릴리즈 준비의 필수 게이트를 기여자 목록,
+  `CHANGELOG.md`·`CHANGELOG_EN.md`, GitHub 릴리즈 노트 초안으로 고정했다. GitHub PR author와 Git author를
+  교차 대사해 cherry-pick 기여자를 누락하지 않고, 세 산출물의 기여자 집합이 일치해야 한다.
+- 현재 상태: 수정 수행계획 검토·승인 대기. GitHub comment, commit, push는 수행하지 않았다.

--- a/mydocs/plans/task_m100_6243.md
+++ b/mydocs/plans/task_m100_6243.md
@@ -1,16 +1,22 @@
 # 수행계획 — Task M100 #6243 Render Diff merge bridge 뒤 review tail 재사용
 
 - **이슈**: [#6243](https://github.com/edwardkim/rhwp/issues/6243)
-- **브랜치**: `task_m100_6243`
+- **구현 브랜치**: `task_m100_6243` (PR #6297 병합 완료)
+- **후속 canary 계획 브랜치**: `task_m100_6243_canary`
 - **기준 commit**: `upstream/devel` `1a43a507c9daa3bfab799d443bd982d5e3dd6d59`
 - **WIP 보존 commit**: `00830286aee4e652a8461993244160b3a15995b9`
 - **devel 동기화 merge**: `396abf4dd506f97062ec13318041c3d3a2356aae`
-- **작성·재검토일**: 2026-08-27 · 2026-08-28 KST
+- **후속 계획 기준**: `upstream/devel` `8eab87ce16ac667766b65032132c5a605898449a`
+- **작성·재검토일**: 2026-08-27 · 2026-08-28 · 2026-09-02 KST
 - **운영 등급**: O2 — Actions 라우팅·비용
 - **선행 증적**: PR #6214, Render Diff run `33071270488`
 - **릴리즈 전제**: 기본 브랜치 `main`에는 아직 trusted controller가 없으므로 #6243을 `devel`에서 먼저
   완료한 뒤 정상 `devel -> main` 릴리즈로 controller와 수정 workflow를 함께 활성화한다.
-- **후행 canary**: #6215 exact kerning fixture generator 선택 분류
+- **구현 상태**: PR #6297 merge commit `96da78a9c3e5ee78dd14109f8fdd9eef7c42b560`으로
+  Stage O2-1~O2-4 완료
+- **후행 canary 정정**: #6215는 PR #6473으로 `devel`에 먼저 병합되고 2026-08-30 종료됐다. 따라서
+  `main` controller 활성화 뒤 #6215 PR을 사용한다는 종전 O2-5 절차는 실행할 수 없으며, 아래 기준을
+  만족하는 별도 실제 PR을 선택해야 한다.
 
 ## 1. 목표
 
@@ -40,6 +46,18 @@ merge-tree 보호를 유지하면서 이 비대칭만 해소한다.
   required context는 `Build & Test`이며 #6243 assignee와 열린 PR은 없다.
 
 따라서 원인·수정 경계는 유효하다. 범위를 넓히지 않고 O2-1에 실행 가능한 Render Diff red 계약을 보강한다.
+
+### 1.2 2026-09-02 후속 절차 재검토
+
+- #6243 구현과 계약은 `devel`에 포함됐지만 기본 브랜치 `main`은 아직 v0.8.4 commit
+  `496333b27d21ddb9114ba9ae340bcb895870c9a7`에 머물러 있다. trusted controller와 수정 Render Diff는
+  정상 `devel -> main` 릴리즈 전까지 live 판정 근거가 아니다.
+- 종전 canary #6215는 `main` 활성화 전에 이미 병합·종료되어 post-release PR 계보를 만들 수 없다.
+  이를 완료 증적으로 소급 사용하지 않는다.
+- #5949의 Release Binary dry-run은 Render Diff trigger가 아니므로 #6243 canary가 아니다.
+- 따라서 #6243은 구현 완료와 운영 완료를 분리한다. v0.8.5 릴리즈로 controller가 활성화된 뒤, 실제
+  Render Diff 대상 PR에서 `code candidate -> current-base merge bridge -> review-only tail`을 새로 관찰할
+  때까지 OPEN을 유지한다.
 
 ## 2. 원인과 최소 수정 경계
 
@@ -82,6 +100,11 @@ fast-pass가 된다.
    기존대로 Full 실행으로 닫힌다.
 6. required `Render Diff / Canvas visual diff` check 이름과 생성 주체를 바꾸지 않는다.
 7. privileged event·permission을 추가하지 않고 PR head script를 write token으로 실행하지 않는다.
+8. 이미 병합·종료된 #6215나 Render Diff 비대상 #5949 run을 post-release canary로 소급 인정하지 않는다.
+9. canary를 위해 의미 없는 제품 변경이나 no-op commit을 만들지 않는다. 실제 유지보수 가치가 있고 Render Diff를
+   정상 trigger하는 PR만 사용한다.
+10. v0.8.5 릴리즈 후보는 기여자 목록, `CHANGELOG.md`·`CHANGELOG_EN.md`, GitHub 릴리즈 노트 초안이 모두
+    존재하고 서로 대사되기 전에는 `main` 병합 준비 완료로 판정하지 않는다.
 
 ## 5. 단계별 수행
 
@@ -140,23 +163,57 @@ workflow YAML의 inline JavaScript syntax, event·permission·required check 이
 
 ### Stage O2-5 — 정상 릴리즈와 post-release canary
 
-1. 릴리즈 절차의 전체 검증과 별도 승인을 거쳐 `devel -> main` release PR을 처리한다. #6243만 `main`에 직접
-   cherry-pick하거나 admin push하지 않는다.
-2. `main` 병합 뒤 `CI Impact Policy Controller`의 `pull_request_target`·`workflow_run` 등록과 최소 권한을
-   live 조회한다.
-3. 후행 #6215 workflow 변경 PR을 실제 canary로 사용한다. Full code candidate가 성공한 뒤 review-only tail을
-   추가하고, 필요하면 그 사이 발생한 current-base bridge까지 포함해 trusted status와 Render Diff를 관찰한다.
-4. `current-base-update-merge-tree-green:*` 또는 `current-base-update-merge-resolution-mydocs-only-green:*`,
-   Canvas worker skip, required check success를 실제 run에서 확인한다.
-5. canary가 성공하면 #6243에 run URL과 SHA를 기록하고 close한다. 실패하면 #6215를 Full fallback 상태로 두고
-   #6243을 다시 열어 둔 채 원인 수정 또는 release commit revert를 판단한다.
+1. v0.8.5 릴리즈 준비 이슈·작업 브랜치에서 버전, 배포물, 회귀 검증과 아래 릴리즈 기록 게이트를 함께
+   완료한다. #6243만 `main`에 직접 cherry-pick하거나 admin push하지 않는다.
+2. 별도 승인을 거쳐 정상 `devel -> main` release PR을 처리한다. release PR 자체는 아직 이전 `main`
+   controller가 판정하므로 #6243 canary로 세지 않는다.
+3. `main` 병합 뒤 `CI Impact Policy Controller`의 `pull_request_target`·`workflow_run` 등록, workflow SHA와
+   최소 권한을 live 조회한다.
+4. `main` 활성화 뒤 처음 등장하는 **실제 유지보수 목적의 Render Diff 대상 PR** 중 current-base bridge
+   계보를 만들 수 있는 후보를 선택한다. 적격 PR이 없으면 임의 no-op을 만들지 않고 #6243을 OPEN으로 둔다.
+   전용 canary PR이 필요하면 별도 이슈·계획·승인을 먼저 받는다.
+5. 선택한 PR의 Full code candidate가 성공한 뒤 실제 `devel` 전진분을 정확히 한 번 병합하고, 그 위에
+   `mydocs/` review-only single-parent tail을 추가한다. base가 전진하지 않았다면 bridge 계약을 검증한 것이
+   아니므로 종료 증적으로 인정하지 않는다.
+6. trusted preflight에서
+   `current-base-update-merge-tree-green:*` 또는
+   `current-base-update-merge-resolution-mydocs-only-green:*`, Canvas worker skip, required check success와
+   동일 PR·branch·repository identity를 실제 run으로 확인한다.
+7. canary가 성공하면 #6243에 PR, 세 SHA, run URL, preflight reason을 기록하고 close한다. Full fallback이면
+   안전 동작으로 간주해 대상 PR은 정상 Full 검증을 계속하되 #6243은 OPEN으로 유지하고 원인을 별도 수정한다.
+   잘못된 fast-pass나 권한 확대가 관찰된 경우에만 workflow rollback과 릴리즈 영향 판단을 시작한다.
 
-**완료 조건**: `main`의 trusted controller와 수정 Render Diff가 함께 활성화되고, 실제 후행 workflow PR에서
+**완료 조건**: `main`의 trusted controller와 수정 Render Diff가 함께 활성화되고, 실제 후행 Render Diff 대상 PR에서
 중복 Canvas가 억제되며 모든 required check가 성공한다.
+
+### Stage O2-5R — v0.8.5 릴리즈 기록 게이트
+
+릴리즈 준비 작업은 다음 세 산출물을 서로 독립적으로 작성하고 교차 대사한다.
+
+1. **기여자 목록**
+   - 기준 범위는 `v0.8.4..최종 릴리즈 후보`로 고정한다.
+   - Git commit author·co-author만 세지 않고, 범위 안 merge commit과 연결된 GitHub PR author를 함께
+     수집한다. maintainer가 provenance를 보존해 cherry-pick한 외부 PR author도 포함한다.
+   - GitHub에서 `merged`로 표시되지 않는 provenance-preserving 통합 PR도 놓치지 않도록 commit message의
+     PR 참조, `mydocs/pr/archives/`의 원 PR 목록과 오늘할일의 cherry-pick 기록을 교차 대사한다.
+   - 보안 제보자는 익명 요청 여부를 확인하고, bot은 사람 기여자 수와 분리한다.
+   - GitHub handle을 정규화·중복 제거한 알파벳순 명단, 총 인원과 `handle -> PR 번호` 근거표를 릴리즈
+     작업 기록에 남긴다.
+2. **CHANGELOG**
+   - `CHANGELOG.md`와 `CHANGELOG_EN.md`에 v0.8.5 절, 날짜, 사용자 영향별 주요 변경, 호환성·알려진 문제,
+     기여자 절을 함께 작성한다.
+   - `Unreleased` 항목은 v0.8.5로 이동한 것과 다음 사이클에 남길 것을 명시적으로 분리한다.
+3. **GitHub 릴리즈 노트**
+   - CHANGELOG를 단순 복사하지 않고 설치·업데이트 사용자가 알아야 할 핵심, 배포 채널, 알려진 문제,
+     관련 이슈와 기여자 감사를 포함한 초안을 PR 단계에서 준비한다.
+   - CHANGELOG의 기여자 집합과 릴리즈 노트의 기여자 집합이 일치하는지 기계 또는 명시적 표로 확인한다.
+
+세 산출물 중 하나라도 없거나 기여자 집합이 불일치하면 release PR을 merge-ready로 판정하지 않는다.
 
 ## 6. 예상 변경과 rollback
 
-- 예상 변경: workflow 조건 1곳, Render Diff preflight 계약 test와 이 계획·운영 기록
+- 구현 완료 변경: workflow 조건 1곳, Render Diff preflight 계약 test
+- 후속 예상 변경: 이 계획·운영 기록, v0.8.5 릴리즈 기록, 별도 승인된 실제 canary 증적
 - 비용 효과: 해당 계보마다 Canvas worker 약 5분대 중복 실행 제거(PR #6214 관측 기준이며 보장값 아님)
 - rollback 조건: merge bridge가 없는데 prior base를 허용하거나 merge-tree 검증 전 fast-pass가 확정되는 경우
 - devel rollback: 수정 commit revert 후 모든 입력을 기존 Full fallback으로 복원

--- a/mydocs/plans/task_m100_6243.md
+++ b/mydocs/plans/task_m100_6243.md
@@ -145,7 +145,8 @@ git diff --check
 
 workflow YAML의 inline JavaScript syntax, event·permission·required check 이름, 변경 파일 범위를 함께 대사한다.
 제품 명령이나 renderer 구현을 바꾸지 않으므로 Cargo 전체 회귀, Native Skia, WASM, Studio, 시각 검증은 수행하지
-않는다. 재검토 기준선은 Python 계약 18/18 통과다.
+않는다. 최초 계획 재검토 당시 Python 계약은 18/18이었고, 구현 병합과 후속 계약 보강 뒤 2026-09-02
+현행 기준은 24/24 통과다.
 
 **종료 게이트**: 집중 계약과 형식 검증이 모두 통과하고 rollback이 해당 workflow·test commit revert 한 번으로
 가능하다.

--- a/mydocs/pr/archives/pr_6583_review.md
+++ b/mydocs/pr/archives/pr_6583_review.md
@@ -1,0 +1,69 @@
+# PR #6583 검토 기록 — #6243 post-release canary 계획 정정
+
+- PR: [#6583](https://github.com/edwardkim/rhwp/pull/6583)
+- 이슈: [#6243](https://github.com/edwardkim/rhwp/issues/6243)
+- 역할: `maintainer_general` self-review
+- base: `devel@8eab87ce16ac667766b65032132c5a605898449a`
+- 검토 대상 code head: `9601c121c47093c35092f558d15835607b36fe3f`
+- 검토일: 2026-09-02 KST
+
+## 1. 변경 범위
+
+- `mydocs/plans/task_m100_6243.md`: 이미 종료된 #6215를 후행 canary로 사용하는 실행 불가능한 절차를
+  실제 post-release Render Diff 대상 PR 관찰 절차로 정정한다.
+- `mydocs/orders/20260902.md`: 원인, 수정 계획, v0.8.5 릴리즈 기록 게이트와 현재 상태를 기록한다.
+- source, test, workflow, 버전, 배포물과 GitHub 권한은 바꾸지 않는다.
+
+## 2. 사실 관계 대사
+
+- #6243 구현 PR #6297은 merge commit `96da78a9c3e5ee78dd14109f8fdd9eef7c42b560`으로
+  `devel`에 반영됐다.
+- 종전 canary #6215는 통합 PR #6473으로 `devel`에 반영된 뒤 2026-08-30 종료됐다. `main` controller
+  활성화 뒤 살아 있는 PR 계보를 만들 수 없으므로 post-release 증적으로 소급 사용할 수 없다.
+- `main`은 검토 시점에 v0.8.4 commit `496333b27d21ddb9114ba9ae340bcb895870c9a7`이고,
+  #6243의 trusted controller와 수정 Render Diff는 아직 live 기본 브랜치 정책이 아니다.
+- #5949 Release Binary는 Render Diff trigger가 아니며, 그 dry-run을 #6243 canary로 세지 않는 구분이
+  계획에 명시돼 있다.
+
+## 3. 보호 불변식 검토
+
+- 실제 Full code candidate, current-base merge bridge 1개, review-only tail의 세 SHA가 모두 있어야 한다.
+- base가 전진하지 않았거나 Canvas worker가 실제 실행된 경우 #6243 완료 증적으로 세지 않는다.
+- Full fallback은 안전 동작이며, 잘못된 fast-pass나 권한 확대가 아니면 릴리즈 rollback 조건으로 과장하지 않는다.
+- 의미 없는 no-op canary를 금지하고 실제 유지보수 가치가 있는 Render Diff 대상 PR만 사용한다.
+- #6243만 `main`에 cherry-pick하거나 admin push하지 않고 정상 v0.8.5 release PR로 controller를 활성화한다.
+
+## 4. v0.8.5 기록 게이트 검토
+
+- 기여자는 `v0.8.4..최종 릴리즈 후보`의 Git author·co-author와 GitHub PR author를 함께 수집한다.
+- provenance-preserving cherry-pick·통합 PR은 commit message, `mydocs/pr/archives/`, 오늘할일을 교차 대사해
+  원 PR author를 보존한다.
+- `handle -> PR 번호` 근거표, `CHANGELOG.md`·`CHANGELOG_EN.md`의 기여자 절, GitHub 릴리즈 노트의
+  기여자 집합이 일치해야 한다.
+- 세 산출물 중 하나라도 없거나 집합이 다르면 release PR을 merge-ready로 판정하지 않는다.
+
+## 5. 검증
+
+- `git diff --check upstream/devel...9601c121c` — 통과
+- `python3 scripts/check_markdown_links.py mydocs/plans/task_m100_6243.md mydocs/orders/20260902.md` — 2문서 통과
+- `python3 -m unittest scripts.tests.test_review_only_fast_pass_workflows` — 24/24 통과
+- exact head GitHub Actions:
+  - CI run `33544833111` — 성공, 문서-only `Build & Test` 성공
+  - CodeQL run `33544833068` — 성공, 분석 job 정상 생략
+  - Proptest run `33544833109` — 성공
+  - Adapter inter-diff run `33544833196` — 성공
+- PR 상태: `MERGEABLE / CLEAN`, 실패·대기 check 없음
+
+## 6. 발견 사항과 정정
+
+- 비차단 정정 1건: 기존 Stage O2-3의 과거 Python 계약 수 `18/18`이 현재 기준처럼 읽혔다.
+- trailing review 변경에서 최초 계획 당시 18/18과 2026-09-02 현행 24/24를 구분했다.
+- 그 밖의 차단 문제, 과도한 범위 확장, 이슈 조기 종료 경로는 발견하지 못했다.
+
+## 7. 최종 판정
+
+- 판정: 승인
+- 검증 대상: code head `9601c121c47093c35092f558d15835607b36fe3f`와 위 비차단 문서 정정
+- #6243은 v0.8.5 `main` 활성화와 실제 후행 canary 성공 전까지 OPEN으로 유지한다.
+- merge 전 조건: 이 review 기록을 포함한 최신 trailing head의 CI 성공, 최신 `devel` 대사,
+  `MERGEABLE / CLEAN` 재확인과 메인테이너의 별도 merge 승인


### PR DESCRIPTION
## 변경 요약

- #6243 구현은 PR #6297로 `devel`에 반영됐지만, 종전 post-release canary였던 #6215가 `main` controller 활성화 전에 이미 병합·종료된 상태를 계획에 반영합니다.
- v0.8.5 이후 실제 Render Diff 대상 PR에서 `Full code candidate -> current-base merge bridge -> review-only tail` 계보를 관찰해야만 #6243을 종료하도록 Stage O2-5를 정정합니다.
- 의미 없는 no-op canary를 금지하고, Full fallback은 안전 동작으로 유지합니다.
- v0.8.5 릴리스 준비의 필수 기록 게이트로 기여자 목록, `CHANGELOG.md`·`CHANGELOG_EN.md`, GitHub 릴리스 노트 초안과 상호 대사를 추가합니다.

## 관련 이슈

Refs #6243

#6243은 v0.8.5가 `main`에 반영된 뒤 trusted controller 활성화와 실제 후행 canary가 성공할 때까지 OPEN으로 유지합니다.

## 검증

- [x] `git diff --check upstream/devel...HEAD`
- [x] `python3 scripts/check_markdown_links.py mydocs/plans/task_m100_6243.md mydocs/orders/20260902.md`
- [x] 최신 `upstream/devel@8eab87ce1` 기준, source·test·workflow 변경 없음

## 보호 불변식

- 이미 종료된 #6215나 Render Diff 비대상 #5949를 canary 증적으로 소급 사용하지 않습니다.
- 실제 current-base merge bridge가 없는 review tail은 #6243 완료 증적으로 세지 않습니다.
- 기여자 집합이 CHANGELOG와 릴리스 노트에서 일치하지 않으면 v0.8.5 release PR을 merge-ready로 판정하지 않습니다.
