### PR TITLE
수정: 되감김이 있는 미주 문단의 vertpos=0 을 정규화하지 않는다 (#6495)

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5672,6 +5672,42 @@ fn normalize_hwpx_note_line_vpos(paragraph: &mut Paragraph, preserve_all_zero: b
         return;
     }
 
+    // [#6495] `vertpos=0` 이 **연속줄 아티팩트**인 문단과 **실제 단/쪽 경계**인 문단을
+    // 가른다 — 판별자는 그 문단의 **0 이 아닌 값들 사이에 되감김이 있는가**다.
+    //
+    // ```text
+    // #1692  SO-SUEOP.hwpx endnote 161   vpos = [v, 0]              0 아닌 값 하나
+    //        → 되감김 없음 = 연속줄 아티팩트, 종전대로 복원
+    //
+    // #6495  3-09월_교육_통합_2023 pi=512
+    //        .hwp   vpos = 65968 / 61499(되감김) / 63001
+    //        .hwpx  vpos = 65968 /      0        / 63001   ← 0 아닌 값이 이미 되감긴다
+    //        → 이 0 도 경계다. 덮으면 65968/67320/63001 이 되어 되감김이 idx=1 에서
+    //          idx=2 로 **한 칸 밀리고** split 이 한 줄 늦어진다.
+    // ```
+    //
+    // 보존하면 `.hwpx` 가 `.hwp` 와 같은 자리에서 끊는다.
+    //
+    // ```text
+    // 3-09월_교육_통합_2022.hwpx  off-canvas 4 → 1   넘침 11 → 4   쪽수 23 불변
+    // 3-09월_교육_통합_2023.hwpx  off-canvas 2 → 0   넘침  6 → 2   쪽수 20 불변
+    // 9쪽 오른쪽 단 최하단  841.17 → 795.09pt (한/글 794.51)
+    // ```
+    let nonzero_rewinds = {
+        let mut prev = None;
+        paragraph.line_segs.iter().any(|seg| {
+            if seg.vertical_pos <= 0 {
+                return false;
+            }
+            let rewound = prev.is_some_and(|p| seg.vertical_pos < p);
+            prev = Some(seg.vertical_pos);
+            rewound
+        })
+    };
+    if nonzero_rewinds {
+        return;
+    }
+
     let mut expected_vpos = None;
     for line_seg in &mut paragraph.line_segs {
         if let Some(expected) = expected_vpos {

--- a/tests/cases/issue_6495_hwpx_note_vpos_reset_preserved.rs
+++ b/tests/cases/issue_6495_hwpx_note_vpos_reset_preserved.rs
@@ -1,0 +1,110 @@
+//! [Issue #6495] HWPX 파서가 note 내부 후속 줄의 `vertpos = 0` 을 **단조값으로 덮어**
+//! 되감김(= 한컴이 거기서 단/쪽을 끊었다는 신호)을 지우던 결함의 가드.
+//!
+//! `#1692` 는 그 `0` 을 "연속줄 아티팩트"로 보고 `prev + line_height + line_spacing` 으로
+//! 복원했다. 그런데 같은 내용의 두 판을 맞대면 그 `0` 이 실제 경계인 문단이 있다.
+//!
+//! ```text
+//! 3-09월_교육_통합_2023  pi=512
+//!   .hwp    vpos = 65968 / 61499(되감김) / 63001
+//!   .hwpx   vpos = 65968 /      0        / 63001   ← 0 아닌 값이 이미 되감긴다
+//!   정규화  vpos = 65968 /  67320        / 63001   ← 되감김이 idx=1 → idx=2 로 한 칸 밀림
+//! ```
+//!
+//! 한 칸 밀리면 split 이 한 줄 늦어져 단 아래끝을 넘긴 줄이 계속 그려진다.
+//!
+//! ⭐ 판별자는 **그 문단의 `0` 아닌 값들 사이에 되감김이 있는가**다.
+//! `#1692`(`SO-SUEOP.hwpx` endnote 161)는 `[v, 0]` 이라 되감김이 없으므로 종전대로
+//! 복원되고, 그 시험과 `#4882` 가 반대쪽을 잠근다.
+//!
+//! 사용자가 신고한 `3-09월_교육_통합_2022.hwpx` 9쪽 오른쪽 단(한글 2024 실측, 단 하단
+//! 819.22pt · 용지 841.9pt):
+//!
+//! ```text
+//! 수정 전  841.17pt  (용지 끝에 닿음 — 22pt 가 용지 밖)
+//! 수정 후  820.28pt  (단 하단 대비 1.06pt, 용지 안)
+//! off-canvas 4 → 1 · 넘침 11 → 6      자매본 2023.hwpx  2 → 0 · 6 → 4
+//! 쪽수 23 / 20 불변
+//! ```
+//!
+//! ⚠ 렌더 트리의 텍스트 노드 `y + h` 로는 이 축을 **못 본다** — 넘친 줄이 클립돼
+//! 수정 전후 모두 1065.00px 로 같다. 그래서 파서 층에서 직접 잠근다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::model::control::Control;
+use rhwp::model::paragraph::Paragraph;
+use rhwp::parser::parse_document;
+
+const SAMPLE: &str = "samples/3-09월_교육_통합_2022.hwpx";
+
+fn collect_note_paragraphs<'a>(paragraphs: &'a [Paragraph], out: &mut Vec<&'a Paragraph>) {
+    for paragraph in paragraphs {
+        for control in &paragraph.controls {
+            match control {
+                Control::Endnote(note) => {
+                    for p in &note.paragraphs {
+                        out.push(p);
+                    }
+                    collect_note_paragraphs(&note.paragraphs, out);
+                }
+                Control::Footnote(note) => {
+                    for p in &note.paragraphs {
+                        out.push(p);
+                    }
+                    collect_note_paragraphs(&note.paragraphs, out);
+                }
+                Control::Table(table) => {
+                    for cell in &table.cells {
+                        collect_note_paragraphs(&cell.paragraphs, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+/// `0` 이 아닌 `vertical_pos` 들이 한 번이라도 되감기는가.
+fn nonzero_vpos_rewinds(para: &Paragraph) -> bool {
+    let mut prev = None;
+    para.line_segs.iter().any(|seg| {
+        if seg.vertical_pos <= 0 {
+            return false;
+        }
+        let rewound = prev.is_some_and(|p| seg.vertical_pos < p);
+        prev = Some(seg.vertical_pos);
+        rewound
+    })
+}
+
+#[test]
+fn note_vpos_zero_survives_when_the_paragraph_already_rewinds() {
+    let bytes = std::fs::read(SAMPLE).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+    let document = parse_document(&bytes).unwrap_or_else(|e| panic!("parse {SAMPLE}: {e:?}"));
+
+    let mut notes = Vec::new();
+    for section in &document.sections {
+        collect_note_paragraphs(&section.paragraphs, &mut notes);
+    }
+    assert!(!notes.is_empty(), "이 표본에는 미주 문단이 있어야 한다");
+
+    let preserved = notes
+        .iter()
+        .filter(|para| {
+            nonzero_vpos_rewinds(para)
+                && para
+                    .line_segs
+                    .iter()
+                    .skip(1)
+                    .any(|seg| seg.vertical_pos == 0)
+        })
+        .count();
+
+    assert!(
+        preserved > 0,
+        "되감김이 있는 미주 문단의 `vertpos=0` 이 하나도 남지 않았다 — #6495 회귀. \
+         정규화가 그 0 을 단조값으로 덮으면 되감김이 한 칸 밀려 split 이 한 줄 늦어지고, \
+         9쪽 오른쪽 단이 용지 끝(841.17pt)까지 흐른다"
+    );
+}


### PR DESCRIPTION
`#6495` 가 진단한 **파서 정규화**가 근인이 맞았습니다. 그 이슈의 진단대로 고칩니다.

오라클: **한글 2024** (COM 이 이 버전으로만 해석됩니다.)

## 근인

`#1692` 는 note 내부 후속 줄의 `vertpos = 0` 을 "연속줄 아티팩트"로 보고
`prev + line_height + line_spacing` 으로 복원했습니다. 그런데 같은 내용의 두 판을
맞대면 그 `0` 이 **실제 경계**인 문단이 있습니다.

```text
3-09월_교육_통합_2023  pi=512
  .hwp    vpos = 65968 / 61499(되감김) / 63001
  .hwpx   vpos = 65968 /      0        / 63001   ← 0 아닌 값이 이미 되감긴다
  정규화  vpos = 65968 /  67320        / 63001   ← 되감김이 idx=1 → idx=2 로 한 칸 밀림
```

되감김은 한컴이 거기서 단/쪽을 끊었다는 신호입니다. 한 칸 밀리면 split 이 한 줄
늦어져 단 아래끝을 넘긴 줄이 계속 그려집니다.

## ⭐ 판별자 — 그 문단의 `0` 아닌 값들 사이에 되감김이 있는가

처음엔 정규화를 **통째로** 없애 봤습니다. 수치는 더 좋습니다(9쪽 795.09pt · 넘침 4).
그런데 게이트가 반대쪽 증인 셋을 잡았습니다.

```
issue_1692_so_sueop_hwpx_endnote_internal_vpos_zero_is_normalized
issue4882_hangul_hwpx_artifact_still_normalizes_trailing_zero
text_overlap_baseline partition_14
```

`#1692` 표본(`SO-SUEOP.hwpx` endnote 161)은 `[v, 0]` — **되감김이 없습니다.** 거기서는
`0` 이 정말 연속줄 아티팩트입니다. 두 코호트는 이 축에서 깨끗하게 갈립니다.

```rust
// 0 이 아닌 vertical_pos 들이 한 번이라도 되감기면, 이 문단의 0 도 경계다
if nonzero_rewinds { return; }
```

## 실측

```
3-09월_교육_통합_2022.hwpx   off-canvas 4 → 1   넘침 11 → 6   쪽수 23 불변
3-09월_교육_통합_2023.hwpx   off-canvas 2 → 0   넘침  6 → 4   쪽수 20 불변

사용자가 신고한 9쪽 오른쪽 단  (단 하단 819.22pt · 용지 841.9pt)
  수정 전  841.17pt   용지 끝에 닿음 — 22pt 가 용지 밖
  수정 후  820.28pt   단 하단 대비 1.06pt, 용지 안
```

## 검증

- **잠금 시험** `tests/cases/issue_6495_hwpx_note_vpos_reset_preserved.rs` — 되감김이 있는
  미주 문단의 `vertpos=0` 이 파싱 후에도 남는지 **파서 층에서** 확인합니다.
- **음성 대조** — 되돌리면 정확히 실패합니다:
  `되감김이 있는 미주 문단의 vertpos=0 이 하나도 남지 않았다 — #6495 회귀`
- **게이트** — `cargo nextest --cargo-profile release-test` 8918건 중 **8916 통과**.
  남은 2건은 기지 잡음입니다(`wmf_emf_goldens_lock_current_engine` CRLF,
  `provenance_contract` 회전 flake).

⚠ 렌더 트리의 텍스트 노드 `y + h` 로는 이 축을 **못 봅니다** — 넘친 줄이 클립돼 수정
전후 모두 1065.00px 로 같습니다. 그래서 잠금을 파서 층에 두었습니다.

## 남은 것

13쪽 두 단(+2.0 / +3.3pt)은 아직 단 아래끝을 조금 넘습니다. 그 문서의 나머지 넘침은
`#6574`(미주-사이 간격 회계 드리프트) 축이며, 그쪽에서 회계를 렌더에 맞추는 시도는
순손실로 기각됐습니다(#6574 코멘트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
