### PR TITLE
fix(ci): validate canonical devel promotion baseline (#6584)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -978,11 +978,45 @@ jobs:
 
       - name: Validate Rust test suite manifest
         env:
-          RHWP_TEST_POLICY_BASE_REF: ${{ github.event.pull_request.base.sha || '' }}
+          RHWP_TEST_POLICY_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          RHWP_TEST_POLICY_BASE_BRANCH: ${{ github.event.pull_request.base.ref || '' }}
+          RHWP_TEST_POLICY_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          RHWP_TEST_POLICY_HEAD_BRANCH: ${{ github.event.pull_request.head.ref || '' }}
+          RHWP_TEST_POLICY_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
+          RHWP_REPOSITORY: ${{ github.repository }}
         run: |
+          policy_base_ref="$RHWP_TEST_POLICY_BASE_SHA"
+
+          # main이 현행 test-policy 도입 전 release라면 canonical devel -> main
+          # promotion에서 누적된 검증 완료 source를 모두 신규 위반으로 오판한다. 같은
+          # 저장소의 exact promotion이고 base가 head의 조상이며 synthetic merge tree가
+          # head tree와 같을 때만 증분 기준을 devel head로 전환한다. 전체 manifest와
+          # unit-tier 검사는 아래에서 그대로 실행한다.
+          if [[ "$RHWP_TEST_POLICY_BASE_BRANCH" == "main" \
+            && "$RHWP_TEST_POLICY_HEAD_BRANCH" == "devel" \
+            && "$RHWP_TEST_POLICY_HEAD_REPOSITORY" == "$RHWP_REPOSITORY" ]]; then
+            if [[ -z "$RHWP_TEST_POLICY_BASE_SHA" || -z "$RHWP_TEST_POLICY_HEAD_SHA" ]]; then
+              echo "::error::canonical devel -> main promotion SHA가 비어 있습니다."
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor \
+              "$RHWP_TEST_POLICY_BASE_SHA" "$RHWP_TEST_POLICY_HEAD_SHA"; then
+              echo "::error::main은 canonical devel promotion head의 조상이어야 합니다."
+              exit 1
+            fi
+            checkout_tree="$(git rev-parse 'HEAD^{tree}')"
+            head_tree="$(git rev-parse "${RHWP_TEST_POLICY_HEAD_SHA}^{tree}")"
+            if [[ "$checkout_tree" != "$head_tree" ]]; then
+              echo "::error::devel -> main synthetic merge tree가 canonical head tree와 다릅니다."
+              exit 1
+            fi
+            policy_base_ref="$RHWP_TEST_POLICY_HEAD_SHA"
+            echo "canonical devel -> main promotion: incremental policy base=$policy_base_ref"
+          fi
+
           base_args=()
-          if [[ -n "$RHWP_TEST_POLICY_BASE_REF" ]]; then
-            base_args=(--base-ref "$RHWP_TEST_POLICY_BASE_REF")
+          if [[ -n "$policy_base_ref" ]]; then
+            base_args=(--base-ref "$policy_base_ref")
           fi
           node --test scripts/tests/rust-test-suite-manifest.test.mjs
           node scripts/rust-test-suite-manifest.mjs --check "${base_args[@]}"

--- a/mydocs/orders/20260902.md
+++ b/mydocs/orders/20260902.md
@@ -169,3 +169,11 @@
   synthetic merge tree와 head tree 동일 조건을 모두 만족할 때만 증분 기준을 exact devel head로 바꾸고,
   일반 PR의 base 비교와 현행 manifest·unit-tier 전체 검사는 유지한다. 전용 branch
   `task_m100_6584_r6_ci_gate`에서 correction PR을 준비한다.
+- correction code head `fa194b820`은 workflow와 manifest 계약을 보강했다. YAML·Bash syntax, manifest
+  21/21, unit-tier 12/12, CI 영향도 33/33, 문서 링크와 diff 검사가 통과했다.
+- exact promotion 격리 재현에서 synthetic merge tree와 head tree가 일치했고, integration 1,110 sources·
+  48/48 targets·nextest 최소 6,559 cases 및 unit-tier 4,221 tests/299 modules가 모두 통과했다. fork의
+  동명 devel과 일반 feature branch는 실제 base를 유지하고 tree 불일치는 fail-closed 함을 확인했다.
+- [Stage R6 CI gate 결과](../working/task_m100_6584_stage_r6_ci_gate.md)에 원인·불변식·검증을 고정했다.
+  다음은 이 trailing 결과를 local commit한 뒤 별도 승인을 받아 correction branch push와 devel 대상 PR을
+  진행하는 것이다. PR #6592는 수정 PR 병합과 새 exact head의 Full CI 전까지 OPEN·blocked로 유지한다.

--- a/mydocs/orders/20260902.md
+++ b/mydocs/orders/20260902.md
@@ -156,3 +156,16 @@
 - 차단 발견 사항 없이 [PR #6588 검토 기록](../pr/archives/pr_6588_review.md)을 `승인`으로 남겼다.
   review·오늘할일 trailing 변경은 `mydocs/`만 포함한다. 로컬 commit 뒤 원격 push, latest-head CI 확인과
   merge는 각각 별도 승인 게이트다.
+- PR #6588을 일반 merge commit `bd8cdd0a1`로 `devel`에 병합했다. exact merge SHA의 Proptest·Adapter와
+  issue-state controller가 성공했고 #6584는 OPEN으로 유지됐다. 로컬 `devel`을 동기화하고 병합 완료
+  local task branch만 삭제했으며 remote branch와 기존 review worktree는 보존했다.
+- Stage R6 최종 대사에서 `upstream/main@496333b27`이 `upstream/devel@bd8cdd0a1`의 조상이고 merge-tree가
+  devel tree `7075796cc33b415cd41054d816631a2d63b02400`와 같음을 확인했다. 실제 범위는 2,232 commits이며,
+  열린 main 대상 PR과 v0.8.6 tag·Release는 없었다.
+- `devel -> main` release PR #6592를 열었다. 최초 Full CI Lint는 현행 Rust test manifest 정책 도입 전
+  `main`을 증분 기준으로 사용해, devel에서 이미 검증·병합된 최상위 integration source 33개를 신규
+  위반으로 오판했다. main에는 unit-tier 정책도 없어 같은 기준으로는 후속 검사도 통과할 수 없다.
+- 메인테이너가 Stage R6 CI blocker 수정 계획을 승인했다. same-repository `devel -> main`, base ancestor,
+  synthetic merge tree와 head tree 동일 조건을 모두 만족할 때만 증분 기준을 exact devel head로 바꾸고,
+  일반 PR의 base 비교와 현행 manifest·unit-tier 전체 검사는 유지한다. 전용 branch
+  `task_m100_6584_r6_ci_gate`에서 correction PR을 준비한다.

--- a/mydocs/orders/20260902.md
+++ b/mydocs/orders/20260902.md
@@ -177,3 +177,12 @@
 - [Stage R6 CI gate 결과](../working/task_m100_6584_stage_r6_ci_gate.md)에 원인·불변식·검증을 고정했다.
   다음은 이 trailing 결과를 local commit한 뒤 별도 승인을 받아 correction branch push와 devel 대상 PR을
   진행하는 것이다. PR #6592는 수정 PR 병합과 새 exact head의 Full CI 전까지 OPEN·blocked로 유지한다.
+- correction PR #6594를 exact head `65cb562c1`로 열었다. Full CI·CodeQL·Proptest·Adapter는
+  26 success·3 conditional skip·0 failure/cancelled/pending으로 완료됐고, 기존 실패 지점인 manifest
+  정책 검사와 후속 unit-tier·Rust lint·archive가 실제 GitHub runner에서 통과했다.
+- self-review에서 일반 PR base 유지, same-repository `devel -> main`, ancestry와 synthetic tree guard,
+  fail-closed 반례 및 live `Build & Test` required context를 다시 대사했다. manifest 21/21, unit-tier
+  12/12, CI 영향도 33/33과 YAML·diff 검사가 통과했고 차단 사항을 발견하지 못했다.
+- [PR #6594 검토 기록](../pr/archives/pr_6594_review.md)의 최종 판정은 `승인`이다. 후행 review·오늘할일은
+  `mydocs/`만 바꾸며, 별도 승인 뒤 local commit과 remote push를 진행한다. latest-head CI·mergeability와
+  merge 승인은 독립 게이트다.

--- a/mydocs/plans/task_m100_6584.md
+++ b/mydocs/plans/task_m100_6584.md
@@ -159,6 +159,25 @@ editor 모두 0.8.6이 아직 없으므로 정상 신규 게시 대상이다.
 
 **종료 게이트**: 승인된 exact merge commit이 `main`에 포함되고 Pages와 필수 post-merge check가 성공한다.
 
+#### Stage R6 CI blocker 정정 — canonical promotion의 증분 정책 기준
+
+PR #6592의 최초 Full CI에서 현행 Rust test manifest 정책 도입 전 `main`을 증분 기준으로 읽어, `devel`에
+이미 개별 검증·병합된 integration source를 모두 신규 위반으로 오판했다. `main`에는 unit-tier 정책도
+없으므로 단순 재실행이나 특정 source 예외 등록으로 우회하지 않는다.
+
+별도 correction PR은 다음 조건을 모두 만족하는 canonical promotion에서만 integration manifest와
+unit-tier의 **증분 비교 기준**을 exact `devel` head로 전환한다.
+
+1. base branch는 `main`, head branch는 `devel`이다.
+2. head repository는 현재 repository와 같다. 같은 이름의 fork branch는 허용하지 않는다.
+3. exact `main` base SHA가 exact `devel` head SHA의 조상이다.
+4. GitHub synthetic merge checkout tree가 exact `devel` head tree와 같다.
+5. 위 조건 밖의 일반 PR은 계속 실제 PR base SHA와 비교한다.
+6. 증분 기준만 전환하며 현행 manifest 전체 정합과 unit-tier 전체 inventory 검사는 생략하지 않는다.
+
+correction PR을 `devel`에 정상 병합한 뒤 갱신된 PR #6592 exact head에서 Full CI를 처음부터 다시 통과해야
+Stage R6 self-review와 merge 승인으로 진행할 수 있다.
+
 ### Stage R7 — 태그·GitHub Release·자동 게시
 
 1. 태그·Release 생성 직전 `main` exact SHA, 버전, 미게시 npm 0.8.6과 draft notes를 재확인한다.

--- a/mydocs/pr/archives/pr_6594_review.md
+++ b/mydocs/pr/archives/pr_6594_review.md
@@ -1,0 +1,125 @@
+# PR #6594 검토 기록 — canonical devel promotion test-policy 기준 정정
+
+- PR: [#6594](https://github.com/edwardkim/rhwp/pull/6594)
+- 이슈: [#6584](https://github.com/edwardkim/rhwp/issues/6584)
+- 선행 release PR: [#6592](https://github.com/edwardkim/rhwp/pull/6592)
+- 작성자·검토자: `edwardkim` collaborator self-review
+- base: `devel@bd8cdd0a1ab476ef401e51e70b2436ff012c33ae`
+- 검토 대상 head: `65cb562c11804ca6f0b054179c3abb86720bca64`
+- 핵심 workflow commit: `fa194b820eb6bfca91d819399ec6d3de5a524788`
+- 규모: 5 files, +186 / -5, 2 commits
+- 검토일: 2026-09-02 KST
+
+## 1. 리뷰 라우팅
+
+- base route: `collaborator_self_merge.md`
+- modifiers: `intake_and_review.md`, `local_validation.md`, `review_only_fast_pass.md`
+- loaded documents: `pr_review_workflow.md`, `pr_review/README.md`,
+  `pr_review/collaborator_self_merge.md`, `pr_review/intake_and_review.md`,
+  `pr_review/local_validation.md`, `pr_review/review_only_fast_pass.md`,
+  `github_operations.md`
+- 작성자 본인의 self-review이므로 reviewer를 지정하지 않았다.
+
+## 2. 문제와 변경 범위
+
+release PR #6592의 최초 Lint는 제품 source나 Clippy 실패가 아니라, test-policy가 도입되기 전
+`main@496333b27`을 증분 기준으로 사용해 `devel`에서 이미 개별 검증·병합된 integration source를 모두
+신규 위반으로 오판하면서 실패했다. `main`에는 unit-tier 정책도 없으므로 manifest 첫 오류만 우회해도
+후속 unit-tier 검사가 같은 구조로 실패한다.
+
+이 PR은 일반 PR의 실제 base 비교를 유지하면서, 아래 조건의 교집합을 만족하는 canonical promotion에서만
+manifest와 unit-tier의 증분 기준을 exact head로 바꾼다.
+
+1. base branch는 `main`, head branch는 `devel`이다.
+2. head repository와 현재 repository가 같다.
+3. exact base SHA가 exact head SHA의 조상이다.
+4. checkout한 synthetic merge tree가 exact head tree와 같다.
+
+SHA 공백, ancestry 위반과 tree 불일치는 fail-closed 한다. 예외를 통과해도 현재 manifest 전체 정합과
+unit-tier 전체 inventory 검사는 그대로 실행한다. 제품 Rust source, renderer, WASM API, fixture·baseline,
+sample, 배포 manifest와 required-check 이름·권한은 바꾸지 않는다.
+
+PR 본문은 #6584와 #6592를 참조한다. 실제 release promotion, tag·GitHub Release와 공식 채널 정산이
+남았으므로 #6594 병합만으로 #6584를 닫지 않는다.
+
+## 3. 코드·운영 계약 self-review
+
+### 3.1 예외 경계와 fail-closed 동작
+
+- 일반 PR은 `github.event.pull_request.base.sha`를 manifest와 unit-tier 양쪽의 공통 증분 기준으로 유지한다.
+- fork의 동명 `devel`은 repository 일치 조건에서 제외되고, same-repository 일반 feature branch도 branch
+  조건에서 제외된다.
+- canonical branch 조합이라도 base/head SHA가 비거나 ancestry가 끊기면 즉시 실패한다.
+- GitHub가 checkout한 PR synthetic merge tree와 event의 exact head tree가 다르면 즉시 실패한다.
+- 예외가 선택돼도 `--prepare` 뒤 manifest 전체 검사, unit-tier 전체 검사와 target resolution은 생략되지
+  않는다.
+
+### 3.2 GitHub Actions 영향
+
+GitHub 운영 등급은 job command와 release PR 라우팅을 바꾸는 O3 실행·보안 계약으로 판정했다. workflow의
+trigger, permissions, action pin, job·required context 이름은 바뀌지 않았다. 2026-09-02 live branch
+protection 조회에서 `devel`과 `main`의 required context는 모두 기존 `Build & Test`였다.
+
+PR head가 바꾸는 workflow를 스스로 신뢰해 review-only 후행 실행을 생략해서는 안 된다. 이 review 기록을
+push한 뒤에는 기본 branch의 trusted controller가 exact Full candidate와 single-parent `mydocs/` tail을
+증명한 경우에만 재사용하며, status가 없거나 불완전하면 Full CI fallback 결과를 기다린다.
+
+### 3.3 렌더 영향과 시각 검증
+
+renderer/layout/typeset/paint, WASM API, Studio 화면, HWP/HWPX/PDF fixture와 시각 기준 자료를 변경하지
+않는다. 따라서 이 PR에는 visual sweep이 필요하지 않다.
+
+## 4. 검증
+
+### 4.1 로컬·격리 검증
+
+- workflow YAML parse와 manifest step Bash syntax가 통과했다.
+- `rust-test-suite-manifest.test.mjs`: 21/21 통과.
+- `rust-unit-test-tiers.test.mjs`: 12/12 통과.
+- `test_ci_impact_workflow.py`: 33/33 통과.
+- exact promotion 격리 재현에서 synthetic merge tree와 head tree가 일치했고, integration 1,110 sources,
+  48/48 targets, nextest 최소 6,559 cases와 unit-tier 4,221 tests / 299 modules가 통과했다.
+- fork의 동명 `devel`과 일반 feature branch는 실제 base를 유지했고, tree mismatch 반례는 실패했다.
+- `git diff --check upstream/devel...65cb562c11804ca6f0b054179c3abb86720bca64`가 통과했다.
+
+상세 원인·명령·계측값은 [Stage R6 CI gate 결과](../../working/task_m100_6584_stage_r6_ci_gate.md)에
+고정했다.
+
+### 4.2 exact PR head GitHub 검증
+
+검토 대상 head `65cb562c11804ca6f0b054179c3abb86720bca64`의 PR-triggered check는 성공 26,
+정책상 생략 3, 실패·취소·대기 0으로 종료됐다.
+
+- CI [run #33576546357](https://github.com/edwardkim/rhwp/actions/runs/33576546357): Lint, Native Skia,
+  frontend package, archive A/B/C/D build·shard와 `Build & Test` 성공.
+- CodeQL [run #33576546394](https://github.com/edwardkim/rhwp/actions/runs/33576546394): JavaScript/TypeScript,
+  Python, Rust 분석과 GHAS `CodeQL` check 성공.
+- Proptest [run #33576546464](https://github.com/edwardkim/rhwp/actions/runs/33576546464): 성공.
+- Adapter inter-diff [run #33576546484](https://github.com/edwardkim/rhwp/actions/runs/33576546484): 성공.
+
+이 exact head에서 GitHub Full CI가 완료됐고 self-review 중 code·test·fixture·workflow 보정을 추가하지
+않았으므로 동일한 광범위 Rust 회귀를 로컬에서 다시 실행하지 않았다. 대신 변경 범위의 focused 계약과
+live required context를 독립 재확인했다.
+
+## 5. 발견 사항과 잔여 위험
+
+- 차단 발견 사항은 없다.
+- #6594 자체는 `devel` 대상이므로 canonical `devel -> main` 조건의 실제 GitHub event를 직접 실행하지
+  않는다. 이 경로의 최종 live E2E는 #6594 병합으로 head가 갱신된 #6592의 Full Lint·CodeQL·Pages에서
+  확인해야 한다.
+- #6592의 새 exact head가 실패하면 main 병합, tag와 Release를 진행하지 않고 #6594의 가정과 로그를 다시
+  조사한다.
+- #6584는 필수 배포 채널과 기록 정산 뒤, #5949는 실제 Linux AArch64 release asset 확인 뒤, #6243은
+  post-release Render Diff canary 성공 뒤에만 닫는다.
+- 이 review·오늘할일 후행 변경은 `mydocs/`만 포함한다. push 뒤 최신 head의 trusted reuse 또는 Full CI
+  결과와 mergeability를 다시 확인해야 한다.
+
+## 6. 최종 판정
+
+- 판정: 승인
+- 검증 대상: head `65cb562c11804ca6f0b054179c3abb86720bca64`.
+- merge 전 조건: 이 review 기록을 포함한 최신 trailing head의 GitHub Actions 성공, 최신 `devel` 대사,
+  `MERGEABLE / CLEAN` 재확인과 메인테이너의 별도 merge 승인.
+- merge 후 조건: 갱신된 release PR #6592의 exact head에서 Full CI·CodeQL·Pages와 별도 self-review를
+  처음부터 다시 통과한다.
+- 이 기록 자체는 GitHub review comment, 원격 push 또는 merge를 수행하지 않는다.

--- a/mydocs/working/task_m100_6584_stage_r6_ci_gate.md
+++ b/mydocs/working/task_m100_6584_stage_r6_ci_gate.md
@@ -1,0 +1,82 @@
+# Task M100 #6584 Stage R6 결과 — canonical promotion Rust test-policy gate 정정
+
+- Issue: [#6584](https://github.com/edwardkim/rhwp/issues/6584)
+- release PR: [#6592](https://github.com/edwardkim/rhwp/pull/6592)
+- 최초 실패 head: `bd8cdd0a1ab476ef401e51e70b2436ff012c33ae`
+- correction code head: `fa194b820eb6bfca91d819399ec6d3de5a524788`
+- 최초 CI: [run #33575299570](https://github.com/edwardkim/rhwp/actions/runs/33575299570)
+- 작성일: 2026-09-02 KST
+
+## 1. 실패 원인
+
+PR #6592의 최초 Lint는 `Validate Rust test suite manifest`에서 종료됐다. Clippy·WASM compiler나 제품
+source 오류가 아니라, 현행 Rust test-policy 도입 전 `main@496333b27`을 증분 비교 기준으로 사용한 것이
+원인이다.
+
+- `main`에는 `tests/suites/suite-policy.json`과 `tests/suites/unit-test-tier-policy.json`이 없다.
+- `main..devel`에는 최상위 integration source 33개, `tests/cases/` source 545개와 그 밖의 source 2개가
+  누적됐다.
+- 이 source들은 `devel`에서 개별 PR마다 검증·병합됐지만 release promotion의 단일 diff에서는 모두
+  “PR base에 없는 신규 source”로 보인다.
+- manifest 단계의 첫 실패가 없더라도 unit-tier 단계는 base 정책 부재로 이어서 실패한다.
+
+따라서 source를 이동하거나 예외 목록을 늘리는 것은 이미 검증된 이력을 훼손하는 우회이며 정답이 아니다.
+
+## 2. 정정 정책과 보호 불변식
+
+일반 PR의 실제 base 비교를 기본값으로 유지한다. 다음 조건을 모두 만족하는 canonical promotion에서만
+manifest와 unit-tier의 **증분 비교 기준**을 exact head SHA로 전환한다.
+
+1. base branch `main`, head branch `devel`이다.
+2. head repository가 현재 repository와 같다. fork의 동명 branch는 해당하지 않는다.
+3. exact base SHA가 exact head SHA의 조상이다.
+4. checkout한 synthetic merge tree가 exact head tree와 같다.
+
+SHA 공백, ancestry 위반과 tree 불일치는 fail-closed 한다. 위 조건을 통과해도
+`rust-test-suite-manifest.mjs --check`와 `rust-unit-test-tiers.mjs --check`의 현재 전체 정합 검사는 그대로
+실행한다. 바뀌는 것은 이미 `devel`에서 통과한 누적 변경의 증분 기준뿐이다.
+
+## 3. 구현
+
+- `.github/workflows/ci.yml`이 PR base/head branch·SHA·repository를 명시적으로 받는다.
+- canonical promotion이면 `git merge-base --is-ancestor`와 두 tree SHA를 검사한 뒤 head SHA를
+  `--base-ref`로 전달한다.
+- 일반 PR은 기존과 같이 PR base SHA를 manifest와 unit-tier 검사에 함께 전달한다.
+- workflow 계약 테스트는 기본 base 보존, same-repository branch 조건, ancestry와 tree guard,
+  head 기준 전환을 고정한다.
+
+## 4. 검증
+
+### 4.1 focused 계약
+
+- workflow YAML parse와 `Validate Rust test suite manifest` Bash syntax: 통과
+- `rust-test-suite-manifest.test.mjs`: 21/21
+- `rust-unit-test-tiers.test.mjs`: 12/12
+- `test_ci_impact_workflow`: 33/33
+- 변경 문서 2개 내부 링크와 `git diff --check`: 통과
+
+### 4.2 exact promotion 재현
+
+`upstream/main@496333b27`과 correction head의 merge-tree가 correction head tree
+`aaf3627796c7a07c479f00a606aa5def2f1312e4`와 같음을 먼저 확인했다. 격리 worktree에서 CI의 manifest
+step을 동일 환경값으로 실행한 결과는 다음과 같다.
+
+- integration: 1,110 sources, 4,777 static test attributes
+- generated/exception targets: 28 suites + 20 exceptions = 48/48
+- nextest minimum cases: 6,559
+- unit-tier: 4,221 tests / 299 modules / cfg support items 28
+- `issue_1035_alignment` target resolution: 성공
+
+### 4.3 fail-closed 반례
+
+- fork repository의 `devel`: promotion 예외를 타지 않고 실제 `main` base 유지
+- 같은 repository의 일반 feature branch: 실제 `main` base 유지
+- same-repository `devel`이라도 checkout tree와 지정 head tree 불일치: 즉시 실패
+
+## 5. 영향과 다음 게이트
+
+- 제품 Rust source, renderer, WASM API, fixture·baseline과 배포 manifest는 바꾸지 않는다.
+- 시각 결과에 영향이 없어 별도 visual sweep은 필요하지 않다.
+- correction PR을 `devel`에 정상 병합한 뒤 PR #6592가 새 exact head로 갱신돼야 한다.
+- 갱신된 release PR의 Full CI·CodeQL·Pages와 self-review가 성공하기 전에는 `main` 병합, tag와 Release를
+  진행하지 않는다.

--- a/scripts/tests/rust-test-suite-manifest.test.mjs
+++ b/scripts/tests/rust-test-suite-manifest.test.mjs
@@ -413,11 +413,15 @@ test('검토·개발 가이드는 파생 suite 준비 경로를 안내한다', (
   }
 });
 
-test('CI가 PR base를 integration과 source unit 정책 검사에 전달한다', () => {
+test('CI가 일반 PR base를 integration과 source unit 정책 검사에 전달한다', () => {
   const workflow = readFileSync(path.join(ROOT, '.github/workflows/ci.yml'), 'utf8');
   assert.match(
     workflow,
-    /RHWP_TEST_POLICY_BASE_REF: \$\{\{ github\.event\.pull_request\.base\.sha \|\| '' \}\}/,
+    /RHWP_TEST_POLICY_BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \|\| '' \}\}/,
+  );
+  assert.match(
+    workflow,
+    /policy_base_ref="\$RHWP_TEST_POLICY_BASE_SHA"/,
   );
   assert.match(
     workflow,
@@ -431,6 +435,27 @@ test('CI가 PR base를 integration과 source unit 정책 검사에 전달한다'
     workflow,
     /rust-unit-test-tiers\.mjs --check "\$\{base_args\[@\]\}"/,
   );
+});
+
+test('CI는 same-repository devel-to-main exact promotion에서만 head를 정책 기준으로 쓴다', () => {
+  const workflow = readFileSync(path.join(ROOT, '.github/workflows/ci.yml'), 'utf8');
+  for (const expected of [
+    /RHWP_TEST_POLICY_BASE_BRANCH: \$\{\{ github\.event\.pull_request\.base\.ref \|\| '' \}\}/,
+    /RHWP_TEST_POLICY_HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \|\| '' \}\}/,
+    /RHWP_TEST_POLICY_HEAD_BRANCH: \$\{\{ github\.event\.pull_request\.head\.ref \|\| '' \}\}/,
+    /RHWP_TEST_POLICY_HEAD_REPOSITORY: \$\{\{ github\.event\.pull_request\.head\.repo\.full_name \|\| '' \}\}/,
+    /RHWP_REPOSITORY: \$\{\{ github\.repository \}\}/,
+    /"\$RHWP_TEST_POLICY_BASE_BRANCH" == "main"/,
+    /"\$RHWP_TEST_POLICY_HEAD_BRANCH" == "devel"/,
+    /"\$RHWP_TEST_POLICY_HEAD_REPOSITORY" == "\$RHWP_REPOSITORY"/,
+    /git merge-base --is-ancestor/,
+    /checkout_tree="\$\(git rev-parse 'HEAD\^\{tree\}'\)"/,
+    /head_tree="\$\(git rev-parse "\$\{RHWP_TEST_POLICY_HEAD_SHA\}\^\{tree\}"\)"/,
+    /if \[\[ "\$checkout_tree" != "\$head_tree" \]\]/,
+    /policy_base_ref="\$RHWP_TEST_POLICY_HEAD_SHA"/,
+  ]) {
+    assert.match(workflow, expected);
+  }
 });
 
 test('CI lint checkout은 PR base 3-way diff를 위해 전체 Git 계보를 가져온다', () => {


### PR DESCRIPTION
## 문제

`devel → main` release PR #6592의 최초 Lint가 Rust test manifest 정책 검사에서 실패했습니다.
제품 코드나 Clippy 오류가 아니라, 현행 test-policy 도입 전
`main@496333b27d21ddb9114ba9ae340bcb895870c9a7`을 증분 기준으로 사용해 `devel`에서 이미 개별
검증·병합된 integration source를 모두 신규 위반으로 오판한 것이 원인입니다. `main`에는 unit-tier
정책도 없어 첫 오류만 우회하면 후속 단계가 다시 실패합니다.

## 정정

일반 PR은 기존처럼 실제 PR base SHA와 비교합니다. 다음 조건을 모두 만족하는 canonical promotion에서만
manifest와 unit-tier의 증분 기준을 exact `devel` head로 전환합니다.

1. base branch가 `main`, head branch가 `devel`
2. head repository가 현재 repository와 동일
3. exact base SHA가 exact head SHA의 조상
4. synthetic merge checkout tree가 exact head tree와 동일

SHA 공백, ancestry 위반과 tree 불일치는 fail-closed 합니다. 증분 기준만 전환하며 현행 manifest 전체
정합과 unit-tier 전체 inventory 검사는 그대로 실행합니다. fork의 동명 `devel`이나 일반 feature branch는
promotion 경로를 사용할 수 없습니다.

## 변경 범위

- `.github/workflows/ci.yml`: canonical promotion 탐지와 ancestry/tree guard
- `scripts/tests/rust-test-suite-manifest.test.mjs`: 일반 PR base 유지와 promotion 불변식 계약
- `mydocs/plans/task_m100_6584.md`: Stage R6 correction 계획 현행화
- `mydocs/working/task_m100_6584_stage_r6_ci_gate.md`: 원인·재현·검증 결과
- `mydocs/orders/20260902.md`: 운영 기록

제품 Rust source, renderer, WASM API, fixture·baseline과 배포 manifest는 변경하지 않습니다.

## 검증

- [x] workflow YAML parse와 manifest step Bash syntax
- [x] Rust test suite manifest 계약 21/21
- [x] Rust unit-tier 계약 12/12
- [x] CI impact workflow 계약 33/33
- [x] 변경 Markdown 내부 링크와 `git diff --check`
- [x] exact promotion 격리 재현: 1,110 sources, 48/48 targets, nextest 최소 6,559 cases
- [x] unit-tier 전체 검사: 4,221 tests / 299 modules
- [x] fork·일반 branch는 실제 base 유지, tree 불일치는 fail-closed
- [x] local·remote exact head `65cb562c11804ca6f0b054179c3abb86720bca64` 일치

## 후속

이 correction을 `devel`에 정상 병합하면 release PR #6592가 새 exact head로 갱신됩니다. #6592의 Full
CI·CodeQL·Pages와 self-review를 처음부터 다시 통과하기 전에는 `main` 병합, tag와 Release를 진행하지
않습니다.

Refs #6584
Follow-up for #6592
