### PR TITLE
[renderer] 글자처럼 그림의 아래 캡션을 그림 상자 바닥에 붙인다 (#6593)

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -11930,17 +11930,14 @@ impl LayoutEngine {
                             use crate::model::shape::CaptionDirection;
                             let caption_spacing = hwpunit_to_px(caption.spacing as i32, self.dpi);
                             let caption_h = self.calculate_caption_height(&pic.caption, styles);
-                            // [Task #864 Stage E v2] paragraph_layout 가 inline TAC image 를
-                            // baseline-aligned (y = pic_y + baseline - pic_h) 위치에 emit
-                            // 함. caption 은 image 바로 아래 (image_bottom = pic_y + baseline)
-                            // 에 위치해야 함. 기존 pic_y + pic_h 사용 시 image 영역 안에
-                            // 그려져 가려짐.
-                            let baseline_px = para
-                                .line_segs
-                                .first()
-                                .map(|ls| hwpunit_to_px(ls.baseline_distance, self.dpi))
-                                .unwrap_or(effective_pic_h);
-                            let image_bottom = effective_pic_y + baseline_px.max(effective_pic_h);
+                            // 캡션은 실제로 그려진 그림 상자 바로 아래에 붙는다.
+                            // `effective_pic_y` 는 emit 된 ImageNode 의 상단이므로 상자 바닥은
+                            // 그 높이를 더한 값이다. 종전에는 상단에 `max(baseline, 높이)` 를
+                            // 더했는데, 저장 줄이 그림+캡션을 통째로 예약해 baseline 이 그림보다
+                            // 큰 줄에서는 (baseline − 그림 높이)만큼 캡션이 내려가 줄을 넘고,
+                            // 그 아래 내용이 전부 밀렸다 (156489219 5쪽: 캡션 +25.5pt, 뒤따르는
+                            // 표·그림 +17.9pt). 보통 줄은 baseline < 그림 높이라 두 식이 같다.
+                            let image_bottom = effective_pic_y + effective_pic_h;
                             let cap_y = match caption.direction {
                                 CaptionDirection::Bottom => image_bottom + caption_spacing,
                                 CaptionDirection::Top => effective_pic_y,

--- a/tests/cases/issue_6593_tac_caption_follows_image_bottom.rs
+++ b/tests/cases/issue_6593_tac_caption_follows_image_bottom.rs
@@ -1,0 +1,113 @@
+//! Issue #6593: 캡션 붙은 글자처럼(TAC) 그림의 아래 캡션이 그림 바닥이 아니라
+//! `그림 상단 + baseline` 에 붙어, 저장 줄을 넘고 뒤 내용을 18pt 밀던 결함의 가드.
+//!
+//! `layout_shape_item` 은 캡션 y 를 `image_bottom + spacing` 으로 잡는데, 종전에는
+//! `image_bottom = 그림 상단 + max(baseline, 그림 높이)` 였다. 저장 줄이 그림 + 캡션을
+//! 통째로 예약한 줄은 baseline 이 그림 높이보다 커서, 캡션이 `baseline − 그림 높이`
+//! 만큼 내려가 줄 바닥을 넘고 `result_y` 가 캡션 끝으로 밀린다.
+//!
+//! 재현 문서 `samples/issue6575/156489219_satellite_pm_release.hwp` 5쪽
+//! (한글 2020 PDF `pdf/156489219_satellite_pm_release-2020.pdf` 대조, px = pt × 96/72):
+//!
+//! ```text
+//! 그림 pi=43   y=233.7  h=205.7  baseline=240.7  raw_lh=283.1  caption=Bottom(spacing 850HU)
+//!
+//!                     수정 전     수정 후    한/글 2020
+//! 캡션 첫 줄          492.3       457.3      458.3
+//! 다음 표 pi=44       553.7       529.1      529.9
+//! ```
+//!
+//! 수정 전 캡션 블록 끝(551.8)이 줄 바닥(516.8)을 35px 넘겨 표가 24.6px 내려갔다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::fs;
+use std::path::Path;
+
+const SAMPLE: &str = "samples/issue6575/156489219_satellite_pm_release.hwp";
+/// 쪽 상단 제목표에도 같은 문구가 있어 꺾쇠까지 포함해 캡션만 고른다.
+const CAPTION_TEXT: &str = "< 환경위성센터 누리집 주요 화면 >";
+const TABLE_PARA_INDEX: u64 = 44;
+
+/// 한/글 2020 실측 458.3px. 결함 시 492.3px (baseline − 그림 높이 = +35.0).
+const EXPECTED_CAPTION_Y: f64 = 457.3;
+/// 한/글 2020 실측 529.9px. 결함 시 553.7px (캡션 넘침 +24.6).
+const EXPECTED_TABLE_Y: f64 = 529.1;
+const TOLERANCE_PX: f64 = 1.5;
+
+#[derive(Default)]
+struct Found {
+    caption_ys: Vec<(String, f64)>,
+    table_y: Option<f64>,
+}
+
+fn walk(node: &serde_json::Value, found: &mut Found) {
+    let ty = node.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    let y = node
+        .get("bbox")
+        .and_then(|b| b.get("y"))
+        .and_then(|v| v.as_f64());
+    match ty {
+        "TextRun" => {
+            let text = node.get("text").and_then(|t| t.as_str()).unwrap_or("");
+            if text.contains(CAPTION_TEXT) {
+                found
+                    .caption_ys
+                    .push((text.to_string(), y.unwrap_or(f64::NAN)));
+            }
+        }
+        "Table" => {
+            if node.get("pi").and_then(|v| v.as_u64()) == Some(TABLE_PARA_INDEX) {
+                assert!(
+                    found.table_y.is_none(),
+                    "표 pi={TABLE_PARA_INDEX} 가 5쪽에 두 번 나온다"
+                );
+                found.table_y = y;
+            }
+        }
+        _ => {}
+    }
+    for child in node
+        .get("children")
+        .and_then(|c| c.as_array())
+        .into_iter()
+        .flatten()
+    {
+        walk(child, found);
+    }
+}
+
+#[test]
+fn bottom_caption_of_tac_picture_starts_right_below_the_drawn_picture() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+    let document = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {SAMPLE}: {e}"));
+    let json = document
+        .get_page_render_tree(4)
+        .expect("render tree page 5");
+    let tree: serde_json::Value = serde_json::from_str(&json).expect("parse render tree json");
+
+    let mut found = Found::default();
+    walk(&tree, &mut found);
+
+    assert_eq!(
+        found.caption_ys.len(),
+        1,
+        "캡션 글줄 `{CAPTION_TEXT}` 은 5쪽에 한 번 있어야 한다: {:?}",
+        found.caption_ys
+    );
+    let caption_y = found.caption_ys[0].1;
+    assert!(
+        (caption_y - EXPECTED_CAPTION_Y).abs() < TOLERANCE_PX,
+        "캡션 첫 줄 y={caption_y:.1}px — 그림 바닥(439.4) + 간격 아래 {EXPECTED_CAPTION_Y:.1} 이어야 한다. \
+         결함 시 492.3 (그림 상단 + baseline 기준, +35.0px)"
+    );
+
+    let table_y = found.table_y.expect("5쪽에 표 pi=44 가 있어야 한다");
+    assert!(
+        (table_y - EXPECTED_TABLE_Y).abs() < TOLERANCE_PX,
+        "표 pi=44 y={table_y:.1}px — 저장 줄 바닥 + gap + outer margin 인 {EXPECTED_TABLE_Y:.1} 이어야 한다. \
+         결함 시 553.7 (넘친 캡션 끝을 따라 +24.6px)"
+    );
+}


### PR DESCRIPTION
> **PR base: `devel`** · 작업 브랜치는 최신 `upstream/devel`(a5f3bf695)에서 생성했습니다.

## 변경 요약

캡션이 붙은 글자처럼(TAC) 그림에서 **아래 캡션이 그림 바닥이 아니라 `그림 상단 + baseline` 에 붙어** 저장 줄을 넘치고, 그 아래 표·그림이 통째로 18pt 밀리던 문제를 고칩니다. #6575(#6576·#6578)가 그림 자체를 줄 상단에 앉힌 뒤에도 남아 있던 잔차입니다.

- **증상** (`samples/issue6575/156489219_satellite_pm_release.hwp` 5쪽, 한글 2020 PDF 대조): 캡션 글줄 **+25.5pt**, 뒤따르는 표 상단·표 안 그림 세 장 **+17.9~18.2pt**.
- **원인**: `layout_shape_item` 의 캡션 배치가 `image_bottom = 그림 상단 + max(baseline, 그림 높이)` 였습니다. `그림 상단` 은 paragraph_layout 이 emit 한 ImageNode 의 상단(줄 상단)인데 거기에 저장 lineseg 의 baseline 을 더합니다. 이 줄은 저장 lineseg 가 그림(205.7px)+캡션 간격+캡션을 통째로 예약해(lh 283.1px) baseline(240.7px)이 그림보다 크므로, 캡션이 그림 바닥보다 **35.0px 아래**에서 시작해 줄 바닥(516.8px)을 35px 넘기고, `result_y` 가 캡션 끝(551.8px)으로 밀려 다음 표가 24.6px(18.5pt) 내려갑니다. 보통 줄은 baseline < 그림 높이라 `max` 가 그림 높이를 골라 같은 답이 되므로 대부분 문서에서 침묵합니다.
- **수정**: 캡션 기준을 실제 emit 된 상자 바닥 `effective_pic_y + effective_pic_h` 로 바꿉니다. 위/아래 캡션의 Top 분기와 `pic_content_bottom` 은 이미 같은 정의를 쓰고 있어 그대로입니다.

### 실측 (5쪽, pt · 오라클 `pdf/156489219_satellite_pm_release-2020.pdf`, producer Hancom PDF 1.3.0.550)

| 항목 | 한/글 2020 | 수정 전 | 수정 후 |
|---|---:|---:|---:|
| 첫 그림 (pi=43) | 176.0 | 175.3 | 175.3 |
| 캡션 글줄 `< 환경위성센터 누리집 주요 화면 >` | 343.7 | 369.2 (+25.5) | **343.0 (−0.7)** |
| 둘째 표 상단 괘선 (pi=44) | 397.4 | 415.3 (+17.9) | **396.8 (−0.6)** |
| 둘째 그림 (표 안) | 407.9 | 425.8 (+17.9) | **407.4 (−0.5)** |
| 셋째·넷째 그림 (표 안) | 516.0 | 534.2 (+18.2) | **515.7 (−0.3)** |

쪽수 8/8 불변. `samples/`↔`pdf/` 한컴 PDF 쌍 215문서·그림 1,124건의 render-tree 그림 위치를 수정 전후로 전수 대조했을 때 **변한 행 0** — 이 형상(캡션 붙은 TAC 그림 + 그림보다 큰 저장 줄)은 그 코퍼스에 없어 다른 문서는 움직이지 않습니다.

## 관련 이슈

closes #6593

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] 새 integration test 는 원본을 `tests/cases/issue_6593_tac_caption_follows_image_bottom.rs` 에만 추가 (`tests/generated/` 미포함)
- [x] `src/**` 의 `#[cfg(test)]` 변경 없음
- [x] `cargo test` — focused (release-test, `target/pr-review`): `regression_suite_022 issue_6593` 1/1 · `regression_suite_002 issue_6575_tac_caption_box_baseline` 1/1 · `regression_suite_005 issue_6575_tac_picture_line_top` 1/1 · `regression_suite_001 issue_6284`(위 캡션) 2/2 · `regression_suite_019 issue_6122`(셀 안 TAC 그림) 1/1 · `regression_suite_021 oracle_page_count_baseline` 16/16 · `--lib caption` 85/85
- [x] 음성 대조 — 같은 테스트를 `upstream/devel`(a5f3bf695) 트리에 넣고 돌리면 `캡션 첫 줄 y=492.3px — … 결함 시 492.3 (그림 상단 + baseline 기준, +35.0px)` 로 실패합니다 (`regression_suite_014 issue_6593` 0/1)
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] 관련 샘플 파일로 SVG 내보내기 확인 (5쪽 전후·오라클 스크린샷 아래)
- [x] 웹(WASM) 렌더링 확인 — 호스트에 Docker 표준 WASM 경로가 없어 `local_validation.md` 안내대로 `--no-opt` 진단 경로(`CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg --no-opt`)로 빌드했고, headless Chrome 의 studio 에서 재현 문서를 열어 WASM 엔진의 5쪽 SVG 렌더로 둘째 그림 y=**543.2px** (native 와 동일, 결함 시 567.8) 를 확인했습니다
- [x] Native Skia 3종 (`local_validation.md` §4.3): `--features native-skia --lib` 3946/3946 · `issue_2225_missing_picture_placeholder` 2/2 · `render_p37_direct_pdf_export` 4/4 (모두 release-test, `target/pr-review`)

새 fixture 는 없습니다 (재현 문서와 오라클 PDF 는 #6576 체리픽으로 이미 저장소에 있습니다).

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 — 캡션 y 산식에서 baseline 조회 한 번을 제거했습니다.
- 재현·측정: 위 실측 표 (macOS arm64, release-test).

## 스크린샷

5쪽 캡션·표 구간. 가로선은 한/글 2020 오라클 위치(빨강 캡션 343.7pt · 파랑 표 상단 397.4pt · 초록 둘째 그림 407.9pt):

![수정 전 / 수정 후 / 한글 2020](https://raw.githubusercontent.com/jeong-sik/rhwp/assets/tac-caption-6593/p5-compare-crop.png)

쪽 전체:

![쪽 전체 비교](https://raw.githubusercontent.com/jeong-sik/rhwp/assets/tac-caption-6593/p5-compare.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
