### PR TITLE
[renderer] 글자처럼 그림의 바깥 여백을 줄 안 배치에 반영한다 (#6603, #6595 위에 얹음)

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -11930,17 +11930,14 @@ impl LayoutEngine {
                             use crate::model::shape::CaptionDirection;
                             let caption_spacing = hwpunit_to_px(caption.spacing as i32, self.dpi);
                             let caption_h = self.calculate_caption_height(&pic.caption, styles);
-                            // [Task #864 Stage E v2] paragraph_layout 가 inline TAC image 를
-                            // baseline-aligned (y = pic_y + baseline - pic_h) 위치에 emit
-                            // 함. caption 은 image 바로 아래 (image_bottom = pic_y + baseline)
-                            // 에 위치해야 함. 기존 pic_y + pic_h 사용 시 image 영역 안에
-                            // 그려져 가려짐.
-                            let baseline_px = para
-                                .line_segs
-                                .first()
-                                .map(|ls| hwpunit_to_px(ls.baseline_distance, self.dpi))
-                                .unwrap_or(effective_pic_h);
-                            let image_bottom = effective_pic_y + baseline_px.max(effective_pic_h);
+                            // 캡션은 실제로 그려진 그림 상자 바로 아래에 붙는다.
+                            // `effective_pic_y` 는 emit 된 ImageNode 의 상단이므로 상자 바닥은
+                            // 그 높이를 더한 값이다. 종전에는 상단에 `max(baseline, 높이)` 를
+                            // 더했는데, 저장 줄이 그림+캡션을 통째로 예약해 baseline 이 그림보다
+                            // 큰 줄에서는 (baseline − 그림 높이)만큼 캡션이 내려가 줄을 넘고,
+                            // 그 아래 내용이 전부 밀렸다 (156489219 5쪽: 캡션 +25.5pt, 뒤따르는
+                            // 표·그림 +17.9pt). 보통 줄은 baseline < 그림 높이라 두 식이 같다.
+                            let image_bottom = effective_pic_y + effective_pic_h;
                             let cap_y = match caption.direction {
                                 CaptionDirection::Bottom => image_bottom + caption_spacing,
                                 CaptionDirection::Top => effective_pic_y,

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -11599,6 +11599,14 @@ impl LayoutEngine {
                 if let Control::Picture(pic) = ctrl {
                     if pic.common.treat_as_char {
                         let (pic_w, pic_h) = self.resolve_inline_picture_size(pic, col_area);
+                        // [#6603] 줄 안 폭·높이는 바깥 여백을 포함한 상자로 세고, 잉크는
+                        // 상자의 (왼쪽, 위) 여백 안쪽에 그린다 (paragraph_layout 과 같은 계약).
+                        let (margin_left, margin_right, margin_top, margin_bottom) =
+                            super::layout::paragraph_layout::tac_picture_outer_margins_px(
+                                pic, self.dpi,
+                            );
+                        let box_w = pic_w + margin_left + margin_right;
+                        let box_h = pic_h + margin_top + margin_bottom;
                         // 같은 paragraph 의 sibling wrap=TopAndBottom 개체(tac=false)가
                         // 차지하는 vertical 영역만큼 picture y 보정.
                         let sibling_reserved_hu =
@@ -11615,9 +11623,18 @@ impl LayoutEngine {
                             .iter()
                             .enumerate()
                             .filter_map(|(ci, control)| match control {
-                                Control::Picture(sibling) if sibling.common.treat_as_char => Some(
-                                    (ci, self.resolve_inline_picture_size(sibling, col_area).0),
-                                ),
+                                Control::Picture(sibling) if sibling.common.treat_as_char => {
+                                    let (ml, mr, _, _) =
+                                        super::layout::paragraph_layout::tac_picture_outer_margins_px(
+                                            sibling, self.dpi,
+                                        );
+                                    Some((
+                                        ci,
+                                        self.resolve_inline_picture_size(sibling, col_area).0
+                                            + ml
+                                            + mr,
+                                    ))
+                                }
                                 _ => None,
                             })
                             .collect();
@@ -11686,7 +11703,7 @@ impl LayoutEngine {
                         let para_margin_right =
                             para_style_ref.map(|s| s.margin_right).unwrap_or(0.0);
                         let avail_w =
-                            (col_area.width - effective_margin_left - para_margin_right).max(pic_w);
+                            (col_area.width - effective_margin_left - para_margin_right).max(box_w);
                         // [Task #1151 v9 결함 D] pic_x 결정:
                         // - 단일 picture: 기존 alignment 그대로
                         // - 시퀀스 첫 picture: total_tac_width 기반 alignment + state 초기화
@@ -11699,7 +11716,7 @@ impl LayoutEngine {
                             let line_right = col_area.x + effective_margin_left + avail_w;
                             // [Task #1151 v9 Stage 24] line wrap: cursor_x + pic_w > avail 면
                             // 다음 line 으로 wrap (cursor_x reset, line_top_y advance).
-                            if cur + pic_w > line_right + 0.5 {
+                            if cur + box_w > line_right + 0.5 {
                                 if let Some(state) = para_inline_state.get_mut(&para_index) {
                                     state.cursor_x = col_area.x + effective_margin_left;
                                     state.line_top_y += state.line_height;
@@ -11726,10 +11743,10 @@ impl LayoutEngine {
                                 Alignment::Center | Alignment::Distribute => {
                                     col_area.x
                                         + effective_margin_left
-                                        + (avail_w - pic_w).max(0.0) / 2.0
+                                        + (avail_w - box_w).max(0.0) / 2.0
                                 }
                                 Alignment::Right => {
-                                    col_area.x + effective_margin_left + (avail_w - pic_w).max(0.0)
+                                    col_area.x + effective_margin_left + (avail_w - box_w).max(0.0)
                                 }
                                 _ => col_area.x + effective_margin_left,
                             }
@@ -11792,19 +11809,19 @@ impl LayoutEngine {
                         if !is_single_pic {
                             let entry = para_inline_state.entry(para_index).or_insert(
                                 super::layout::paragraph_layout::ParaInlineState {
-                                    cursor_x: pic_x + pic_w,
+                                    cursor_x: pic_x + box_w,
                                     line_top_y: pic_y,
-                                    line_height: pic_h,
+                                    line_height: box_h,
                                 },
                             );
                             if is_subsequent_in_seq {
-                                entry.cursor_x = pic_x + pic_w;
-                                entry.line_height = entry.line_height.max(pic_h);
+                                entry.cursor_x = pic_x + box_w;
+                                entry.line_height = entry.line_height.max(box_h);
                             } else {
                                 // 첫 picture: 초기화 (기존 값 덮어쓰기)
-                                entry.cursor_x = pic_x + pic_w;
+                                entry.cursor_x = pic_x + box_w;
                                 entry.line_top_y = pic_y;
-                                entry.line_height = pic_h;
+                                entry.line_height = box_h;
                             }
                         }
 
@@ -11841,7 +11858,12 @@ impl LayoutEngine {
                                     external_path: pic.image_attr.external_path.clone(),
                                     ..ImageNode::new(bin_data_id, image_data)
                                 }),
-                                BoundingBox::new(pic_x, pic_y, pic_w, pic_h),
+                                BoundingBox::new(
+                                    pic_x + margin_left,
+                                    pic_y + margin_top,
+                                    pic_w,
+                                    pic_h,
+                                ),
                             );
                             // Task #347: 같은 문단의 InFrontOfText 표가 이미 렌더되어
                             // col_node.children에 들어있으면 그 앞에 끼워넣어 z-order 보존
@@ -11862,8 +11884,8 @@ impl LayoutEngine {
                                 para_index,
                                 control_index,
                                 None,
-                                pic_x,
-                                pic_y,
+                                pic_x + margin_left,
+                                pic_y + margin_top,
                             );
                             if !has_real_text {
                                 // [Task #462] LINE_SEG 의 lh+ls 를 advance 로 사용 — 이미지 박스

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -1318,6 +1318,26 @@ fn tac_object_box_height_px(object_h: f64, caption: &Option<Caption>, dpi: f64) 
     object_h + hwpunit_to_px(i32::from(cap.spacing), dpi) + caption_h
 }
 
+/// [#6603] 글자처럼 그림의 바깥 여백(px) — (왼쪽, 오른쪽, 위, 아래).
+///
+/// 한/글은 여백을 포함한 상자를 줄 안에 놓고 잉크를 상자의 (왼쪽 여백, 위 여백)
+/// 안쪽에 그린다. 줄 안 폭과 baseline 에 앉히는 높이는 상자로 세고, ImageNode 는
+/// 잉크 크기로 낸다. 실측(samples↔pdf 215문서): 사방 3.01mm 여백의 빈 문단 TAC
+/// 그림이 왼쪽·양쪽 정렬에서 (−11.33, −11.22)px, 가운데 정렬에서 (0, −11.22)px
+/// 어긋났다 — 가운데는 좌우 여백이 같아 x 가 상쇄된다 (hwp3-sample14-hwp5 3쪽 pi=29).
+pub(crate) fn tac_picture_outer_margins_px(
+    pic: &crate::model::image::Picture,
+    dpi: f64,
+) -> (f64, f64, f64, f64) {
+    let m = &pic.common.margin;
+    (
+        hwpunit_to_px(i32::from(m.left), dpi),
+        hwpunit_to_px(i32::from(m.right), dpi),
+        hwpunit_to_px(i32::from(m.top), dpi),
+        hwpunit_to_px(i32::from(m.bottom), dpi),
+    )
+}
+
 fn tac_picture_label_extra_for_line(
     _cell_ctx: Option<&CellContext>,
     runs_all_whitespace: bool,
@@ -3093,12 +3113,18 @@ impl LayoutEngine {
                     }
                     if let Some(ctrl) = p.controls.get(tac_ci) {
                         if let Control::Picture(pic) = ctrl {
-                            let (_, pic_h) = self.resolve_inline_picture_size(pic, col_area);
+                            let (pic_w, pic_h) = self.resolve_inline_picture_size(pic, col_area);
                             if raw_lh + 4.0 >= pic_h {
                                 *reserved_tac_picture_height = Some(pic_h);
                             }
-                            let box_h = tac_object_box_height_px(pic_h, &pic.caption, self.dpi);
-                            let img_y = (y + baseline - box_h).max(y);
+                            // [#6603] 상자(잉크 + 캡션 + 위아래 여백)를 baseline 에 앉히고
+                            // 잉크는 상자의 (왼쪽, 위) 여백 안쪽에 그린다.
+                            let (margin_left, _, margin_top, margin_bottom) =
+                                tac_picture_outer_margins_px(pic, self.dpi);
+                            let box_h = tac_object_box_height_px(pic_h, &pic.caption, self.dpi)
+                                + margin_top
+                                + margin_bottom;
+                            let img_y = (y + baseline - box_h).max(y) + margin_top;
                             let bin_data_id = pic.image_attr.bin_data_id;
                             let image_data = find_bin_data_bytes(bdc, bin_data_id);
                             let crop = {
@@ -3125,7 +3151,7 @@ impl LayoutEngine {
                                 original_size_hu,
                                 bin_data_id,
                                 image_data,
-                                BoundingBox::new(x, img_y, tac_w, pic_h),
+                                BoundingBox::new(x + margin_left, img_y, pic_w, pic_h),
                             );
                             line_node.children.push(img_node);
                             x += tac_w;
@@ -3592,7 +3618,14 @@ impl LayoutEngine {
                         .and_then(|p| p.controls.get(*ci))
                         .and_then(|ctrl| match ctrl {
                             Control::Picture(pic) => {
-                                Some(self.resolve_inline_picture_size(pic, col_area).0)
+                                // [#6603] 줄 안에서 차지하는 폭은 잉크 + 좌우 바깥 여백.
+                                let (margin_left, margin_right, _, _) =
+                                    tac_picture_outer_margins_px(pic, self.dpi);
+                                Some(
+                                    self.resolve_inline_picture_size(pic, col_area).0
+                                        + margin_left
+                                        + margin_right,
+                                )
                             }
                             _ => None,
                         })
@@ -6624,7 +6657,11 @@ impl LayoutEngine {
                     if let (Some(p), Some(bdc)) = (para, bin_data_content) {
                         if let Some(ctrl) = p.controls.get(tac_ci) {
                             if let Control::Picture(pic) = ctrl {
-                                let (_, pic_h) = self.resolve_inline_picture_size(pic, col_area);
+                                let (pic_w, pic_h) =
+                                    self.resolve_inline_picture_size(pic, col_area);
+                                // [#6603] 잉크는 바깥 여백 상자의 (왼쪽, 위) 안쪽에 그린다.
+                                let (margin_left, _, margin_top, margin_bottom) =
+                                    tac_picture_outer_margins_px(pic, self.dpi);
                                 // LINE_SEG vpos가 TopAndBottom 흐름 위치를 이미 담고 있으면
                                 // sibling 예약 높이를 다시 더하지 않는다.
                                 let sibling_reserved_px = if para_topbottom_line_vpos_base.is_some()
@@ -6662,11 +6699,14 @@ impl LayoutEngine {
                                     y + label_extra
                                 } else {
                                     // [#6575] 같은 계약의 형제 경로 — 상자 전체로 맞춘다.
+                                    // [#6603] 상자에는 위아래 바깥 여백도 들어간다.
                                     let box_h =
-                                        tac_object_box_height_px(pic_h, &pic.caption, self.dpi);
+                                        tac_object_box_height_px(pic_h, &pic.caption, self.dpi)
+                                            + margin_top
+                                            + margin_bottom;
                                     (y + baseline - box_h).max(y)
                                 };
-                                let img_y = base_img_y + sibling_reserved_px;
+                                let img_y = base_img_y + sibling_reserved_px + margin_top;
                                 let bin_data_id = pic.image_attr.bin_data_id;
                                 let image_data = find_bin_data_bytes(bdc, bin_data_id);
                                 let crop = {
@@ -6696,7 +6736,7 @@ impl LayoutEngine {
                                     original_size_hu,
                                     bin_data_id,
                                     image_data,
-                                    BoundingBox::new(x, img_y, tac_w, pic_h),
+                                    BoundingBox::new(x + margin_left, img_y, pic_w, pic_h),
                                 );
                                 line_node.children.push(img_node);
                                 // [Task #864 Stage G] inline TAC picture 의 위치 등록.
@@ -6712,7 +6752,7 @@ impl LayoutEngine {
                                     para_index,
                                     tac_ci,
                                     cell_ctx.as_ref(),
-                                    x,
+                                    x + margin_left,
                                     img_y,
                                 );
                             }
@@ -7925,7 +7965,10 @@ impl LayoutEngine {
                                 empty_line_logical_end += 1;
                                 continue;
                             }
-                            let (_, pic_h) = self.resolve_inline_picture_size(pic, col_area);
+                            let (pic_w, pic_h) = self.resolve_inline_picture_size(pic, col_area);
+                            // [#6603] 잉크는 바깥 여백 상자의 (왼쪽, 위) 안쪽에 그린다.
+                            let (margin_left, _, margin_top, margin_bottom) =
+                                tac_picture_outer_margins_px(pic, self.dpi);
                             // LINE_SEG vpos가 TopAndBottom 흐름 위치를 이미 담고 있으면
                             // sibling 예약 높이를 다시 더하지 않는다.
                             let sibling_reserved_px = if vars.has_topbottom_vpos_base {
@@ -7951,10 +7994,13 @@ impl LayoutEngine {
                                 vars.y + label_extra
                             } else {
                                 // [#6575] baseline 정렬 대상은 그림이 아니라 개체 상자 전체다.
-                                let box_h = tac_object_box_height_px(pic_h, &pic.caption, self.dpi);
+                                // [#6603] 상자에는 위아래 바깥 여백도 들어간다.
+                                let box_h = tac_object_box_height_px(pic_h, &pic.caption, self.dpi)
+                                    + margin_top
+                                    + margin_bottom;
                                 (vars.y + vars.baseline - box_h).max(vars.y)
                             };
-                            let img_y = base_img_y + sibling_reserved_px;
+                            let img_y = base_img_y + sibling_reserved_px + margin_top;
                             let bin_data_id = pic.image_attr.bin_data_id;
                             let image_data = find_bin_data_bytes(bdc, bin_data_id);
                             let crop = {
@@ -7981,7 +8027,7 @@ impl LayoutEngine {
                                 original_size_hu,
                                 bin_data_id,
                                 image_data,
-                                BoundingBox::new(img_x, img_y, tac_w, pic_h),
+                                BoundingBox::new(img_x + margin_left, img_y, pic_w, pic_h),
                             );
                             line_node.children.push(img_node);
                             // [Task #418/#376] layout_shape_item 의 Task #347 분기 (빈 문단 +
@@ -7992,7 +8038,7 @@ impl LayoutEngine {
                                 vars.para_index,
                                 tac_ci,
                                 cell_ctx.as_ref(),
-                                img_x,
+                                img_x + margin_left,
                                 img_y,
                             );
                             img_x += tac_w;

--- a/tests/cases/issue_6593_tac_caption_follows_image_bottom.rs
+++ b/tests/cases/issue_6593_tac_caption_follows_image_bottom.rs
@@ -1,0 +1,113 @@
+//! Issue #6593: 캡션 붙은 글자처럼(TAC) 그림의 아래 캡션이 그림 바닥이 아니라
+//! `그림 상단 + baseline` 에 붙어, 저장 줄을 넘고 뒤 내용을 18pt 밀던 결함의 가드.
+//!
+//! `layout_shape_item` 은 캡션 y 를 `image_bottom + spacing` 으로 잡는데, 종전에는
+//! `image_bottom = 그림 상단 + max(baseline, 그림 높이)` 였다. 저장 줄이 그림 + 캡션을
+//! 통째로 예약한 줄은 baseline 이 그림 높이보다 커서, 캡션이 `baseline − 그림 높이`
+//! 만큼 내려가 줄 바닥을 넘고 `result_y` 가 캡션 끝으로 밀린다.
+//!
+//! 재현 문서 `samples/issue6575/156489219_satellite_pm_release.hwp` 5쪽
+//! (한글 2020 PDF `pdf/156489219_satellite_pm_release-2020.pdf` 대조, px = pt × 96/72):
+//!
+//! ```text
+//! 그림 pi=43   y=233.7  h=205.7  baseline=240.7  raw_lh=283.1  caption=Bottom(spacing 850HU)
+//!
+//!                     수정 전     수정 후    한/글 2020
+//! 캡션 첫 줄          492.3       457.3      458.3
+//! 다음 표 pi=44       553.7       529.1      529.9
+//! ```
+//!
+//! 수정 전 캡션 블록 끝(551.8)이 줄 바닥(516.8)을 35px 넘겨 표가 24.6px 내려갔다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::fs;
+use std::path::Path;
+
+const SAMPLE: &str = "samples/issue6575/156489219_satellite_pm_release.hwp";
+/// 쪽 상단 제목표에도 같은 문구가 있어 꺾쇠까지 포함해 캡션만 고른다.
+const CAPTION_TEXT: &str = "< 환경위성센터 누리집 주요 화면 >";
+const TABLE_PARA_INDEX: u64 = 44;
+
+/// 한/글 2020 실측 458.3px. 결함 시 492.3px (baseline − 그림 높이 = +35.0).
+const EXPECTED_CAPTION_Y: f64 = 457.3;
+/// 한/글 2020 실측 529.9px. 결함 시 553.7px (캡션 넘침 +24.6).
+const EXPECTED_TABLE_Y: f64 = 529.1;
+const TOLERANCE_PX: f64 = 1.5;
+
+#[derive(Default)]
+struct Found {
+    caption_ys: Vec<(String, f64)>,
+    table_y: Option<f64>,
+}
+
+fn walk(node: &serde_json::Value, found: &mut Found) {
+    let ty = node.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    let y = node
+        .get("bbox")
+        .and_then(|b| b.get("y"))
+        .and_then(|v| v.as_f64());
+    match ty {
+        "TextRun" => {
+            let text = node.get("text").and_then(|t| t.as_str()).unwrap_or("");
+            if text.contains(CAPTION_TEXT) {
+                found
+                    .caption_ys
+                    .push((text.to_string(), y.unwrap_or(f64::NAN)));
+            }
+        }
+        "Table" => {
+            if node.get("pi").and_then(|v| v.as_u64()) == Some(TABLE_PARA_INDEX) {
+                assert!(
+                    found.table_y.is_none(),
+                    "표 pi={TABLE_PARA_INDEX} 가 5쪽에 두 번 나온다"
+                );
+                found.table_y = y;
+            }
+        }
+        _ => {}
+    }
+    for child in node
+        .get("children")
+        .and_then(|c| c.as_array())
+        .into_iter()
+        .flatten()
+    {
+        walk(child, found);
+    }
+}
+
+#[test]
+fn bottom_caption_of_tac_picture_starts_right_below_the_drawn_picture() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+    let document = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {SAMPLE}: {e}"));
+    let json = document
+        .get_page_render_tree(4)
+        .expect("render tree page 5");
+    let tree: serde_json::Value = serde_json::from_str(&json).expect("parse render tree json");
+
+    let mut found = Found::default();
+    walk(&tree, &mut found);
+
+    assert_eq!(
+        found.caption_ys.len(),
+        1,
+        "캡션 글줄 `{CAPTION_TEXT}` 은 5쪽에 한 번 있어야 한다: {:?}",
+        found.caption_ys
+    );
+    let caption_y = found.caption_ys[0].1;
+    assert!(
+        (caption_y - EXPECTED_CAPTION_Y).abs() < TOLERANCE_PX,
+        "캡션 첫 줄 y={caption_y:.1}px — 그림 바닥(439.4) + 간격 아래 {EXPECTED_CAPTION_Y:.1} 이어야 한다. \
+         결함 시 492.3 (그림 상단 + baseline 기준, +35.0px)"
+    );
+
+    let table_y = found.table_y.expect("5쪽에 표 pi=44 가 있어야 한다");
+    assert!(
+        (table_y - EXPECTED_TABLE_Y).abs() < TOLERANCE_PX,
+        "표 pi=44 y={table_y:.1}px — 저장 줄 바닥 + gap + outer margin 인 {EXPECTED_TABLE_Y:.1} 이어야 한다. \
+         결함 시 553.7 (넘친 캡션 끝을 따라 +24.6px)"
+    );
+}

--- a/tests/cases/issue_6603_tac_picture_outer_margin.rs
+++ b/tests/cases/issue_6603_tac_picture_outer_margin.rs
@@ -1,0 +1,104 @@
+//! Issue #6603: 글자처럼(TAC) 그림의 바깥 여백이 줄 안 잉크 위치에 반영되지 않아
+//! 여백만큼 좌·상으로 어긋나던 결함의 가드 (#6596 의 줄 안 형제).
+//!
+//! 한/글은 여백을 포함한 상자를 줄 안에 놓고 잉크를 상자의 (왼쪽 여백, 위 여백)
+//! 안쪽에 그린다. 종전 줄 안 배치 경로(`tac_offsets_px` 폭·`make_picture_image_node`
+//! 세 자리·`layout_shape_item` fallback)는 여백을 어디에도 넣지 않았다.
+//!
+//! `samples/hwp3-sample14-hwp5.hwp` (한컴 PDF `pdf/hwp3-sample14-hwp5-2022.pdf` 대조,
+//! 96DPI px). 빈 문단의 TAC 그림, 바깥 여백 3.01mm(11.36px) 사방:
+//!
+//! ```text
+//! 2쪽 pi=16  문단 양쪽 정렬   → (124.73, 143.52)   종전 (113.4, 132.3)
+//! 3쪽 pi=29  문단 가운데 정렬 → (263.22, 143.52)   종전 (263.3, 132.3)
+//! ```
+//!
+//! 가운데 정렬은 좌우 여백이 같아 x 가 그대로이고 y 만 위 여백만큼 내려간다 —
+//! 상자 폭으로 가운데를 잡지 않고 잉크 원점에만 여백을 더하면 x 가 11.36 틀어진다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::fs;
+use std::path::Path;
+
+const SAMPLE: &str = "samples/hwp3-sample14-hwp5.hwp";
+const TOLERANCE_PX: f64 = 1.5;
+
+struct Case {
+    page_index: u32,
+    para_index: u64,
+    expected: (f64, f64),
+    defect: (f64, f64),
+    note: &'static str,
+}
+
+const CASES: &[Case] = &[
+    Case {
+        page_index: 1,
+        para_index: 16,
+        expected: (124.73, 143.52),
+        defect: (113.4, 132.3),
+        note: "양쪽 정렬 빈 문단 — 잉크가 (왼쪽, 위) 여백만큼 안쪽",
+    },
+    Case {
+        page_index: 2,
+        para_index: 29,
+        expected: (263.22, 143.52),
+        defect: (263.3, 132.3),
+        note: "가운데 정렬 빈 문단 — 상자를 가운데 놓으므로 x 는 그대로, y 만 위 여백만큼",
+    },
+];
+
+fn find_image(node: &serde_json::Value, para_index: u64, out: &mut Vec<(f64, f64)>) {
+    if node.get("type").and_then(|t| t.as_str()) == Some("Image")
+        && node.get("pi").and_then(|v| v.as_u64()) == Some(para_index)
+    {
+        let bbox = &node["bbox"];
+        let get = |k: &str| bbox.get(k).and_then(|v| v.as_f64()).unwrap_or(f64::NAN);
+        out.push((get("x"), get("y")));
+    }
+    for child in node
+        .get("children")
+        .and_then(|c| c.as_array())
+        .into_iter()
+        .flatten()
+    {
+        find_image(child, para_index, out);
+    }
+}
+
+#[test]
+fn tac_picture_ink_sits_inside_its_outer_margin_box() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+    let document = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {SAMPLE}: {e}"));
+    for case in CASES {
+        let json = document
+            .get_page_render_tree(case.page_index)
+            .unwrap_or_else(|e| panic!("{}쪽 render tree: {e:?}", case.page_index + 1));
+        let tree: serde_json::Value = serde_json::from_str(&json).expect("parse render tree json");
+
+        let mut images = Vec::new();
+        find_image(&tree, case.para_index, &mut images);
+        assert_eq!(
+            images.len(),
+            1,
+            "{}쪽 pi={} 그림은 하나여야 한다: {images:?}",
+            case.page_index + 1,
+            case.para_index
+        );
+        let (x, y) = images[0];
+        let (ex, ey) = case.expected;
+        assert!(
+            (x - ex).abs() < TOLERANCE_PX && (y - ey).abs() < TOLERANCE_PX,
+            "{}쪽 pi={} 그림 ({x:.2}, {y:.2}) — 한컴 PDF 실측 ({ex}, {ey}) 이어야 한다. \
+             결함 시 ({:.2}, {:.2}). {}",
+            case.page_index + 1,
+            case.para_index,
+            case.defect.0,
+            case.defect.1,
+            case.note
+        );
+    }
+}


### PR DESCRIPTION
> **PR base: `devel`** · 작업 브랜치는 최신 `upstream/devel`(a5f3bf695)에서 생성했습니다.
> **#6595 에 의존합니다** — 그 커밋(`fix(renderer): 글자처럼 그림의 아래 캡션을 그림 상자 바닥에 붙인다 (#6593)`)을 이 브랜치에 그대로 얹었습니다. #6595 가 먼저 병합되면 이 PR 의 diff 는 두 번째 커밋만 남습니다. 이유는 아래 "왜 #6595 위에 얹었나".

## 변경 요약

글자처럼(TAC) 그림의 **바깥 여백**을 줄 안 배치에 반영합니다. #6596(#6602, 부동 그림)과 같은 상자 규칙입니다 — 한/글은 여백을 포함한 상자를 줄 안에 놓고 잉크를 상자의 (왼쪽 여백, 위 여백) 안쪽에 그리는데, rhwp 의 줄 안 경로는 여백을 어디에도 넣지 않아 그림이 여백만큼 **좌·상으로** 어긋났습니다.

- **증상** (`samples/`↔`pdf/` 한컴 PDF 쌍 215문서, 줄 안 TAC 그림, 96DPI px): 사방 3.01mm(11.36px) 여백의 빈 문단 TAC 그림이 왼쪽·양쪽 정렬에서 **(−11.33, −11.22)**, 가운데 정렬에서 **(0, −11.22)** — 가운데는 좌우 여백이 같아 x 가 상쇄됩니다. 꼬리말의 오른쪽 정렬 TAC 그림은 **+11.66**(오른쪽 여백이 반대 부호로) 입니다.
- **원인**: `paragraph_layout.rs` 의 `tac_offsets_px` 폭이 잉크 폭만이고, `make_picture_image_node` 세 자리(빈 줄·글줄 안·`place_unmatched_line_tac_pictures`)와 `layout.rs` `layout_shape_item` 의 fallback 이 모두 상자 원점에 잉크를 그립니다. baseline 에 앉히는 높이(`tac_object_box_height_px`)도 캡션만 더하고 여백은 안 더합니다.
- **수정**: 헬퍼 `tac_picture_outer_margins_px` 하나로 ① 줄 안 폭 = 잉크 + 좌우 여백(`tac_offsets_px`, `layout_shape_item` 의 가로 분배·정렬), ② baseline 에 앉히는 상자 높이 = 잉크 + 캡션 + 위아래 여백, ③ 잉크 원점 = 상자 원점 + (왼쪽 여백, 위 여백). ImageNode 는 잉크 크기 그대로 냅니다. 여백 0 인 그림은 식이 종전과 같습니다.

### 실측 (96DPI px, 한컴 PDF 이미지 bbox 대조)

| 문서 | 쪽·pi | 문단 정렬 | 한/글 | 수정 전 | 수정 후 |
|---|---|---|---:|---:|---:|
| hwp3-sample14-hwp5 | 2쪽 pi=16 | 양쪽 | (124.73, 143.52) | (113.4, 132.3) | **(124.8, 143.6)** |
| hwp3-sample14-hwp5 | 3쪽 pi=29 | 가운데 | (263.22, 143.52) | (263.3, 132.3) | **(263.3, 143.6)** |
| hwp3-sample14-hwp5 | 3쪽 pi=33 | 양쪽 | (124.73, 406.12) | (113.4, 395.1) | **(124.8, 406.5)** |
| hwp3-sample-hwp5 꼬리말 | 1~16쪽 | 오른쪽 | (588.64, 1019.37) | (600.3, 1023.1) | **(589.0, 1020.5)** |

**전수 대조** (`devel`+#6593 ↔ 이 브랜치, 1,124 그림): 움직인 행 154건 중 **개선 128 · 동일 12 · 악화 14**, **215문서 쪽수 변화 0**. |dy| 분포: `<1px` 433→460, `<4px` 119→55.

악화 14건은 두 종류이고 PR 범위 안에서 정직하게 남깁니다.
- `36388711`(결재문서) 본문 글줄 속 2.5mm 아이콘 12건: 아래 여백만 0.70mm(2.64px). 종전 잉크가 한/글보다 **+1.3~1.5 아래**, 수정 후 **−1.1~1.5 위** — 절대 오차는 같고 부호만 바뀝니다. 한/글은 두 규칙의 중간(대략 아래 여백의 절반)에 두는 것으로 보이는데, 표본이 이 문서 하나(위 여백 0·아래 여백만)라 규칙을 특정하지 못했습니다. 이슈 #6603 에 남겼습니다.
- `exam_kor` 글줄 속 인라인 그림 2건: x ±2px — 앞 글자 폭 잡음 범위입니다.

### 왜 #6595 위에 얹었나

`devel` 의 캡션 산식은 `잉크 상단 + baseline`(#6593 의 결함)이라, 잉크가 위 여백만큼 내려가면 캡션도 따라 내려가 `hwp3-sample14` 3쪽의 다음 문단(pi=30)이 6px 밀립니다. #6595 의 수정(캡션 = 잉크 바닥 기준)과 함께면 캡션은 그림 바로 아래(263.8, 한/글 261.6)에 붙고 pi=30 은 그대로(295.1)입니다. 둘을 따로 병합해도 결과는 같지만, 이 PR 만 먼저 들어가면 그 사이 sample14 3쪽 본문이 6px 밀린 상태가 됩니다.

## 관련 이슈

closes #6603

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] 새 integration test 는 원본을 `tests/cases/issue_6603_tac_picture_outer_margin.rs` 에만 추가 (`tests/generated/` 미포함). 새 fixture 없음 — 저장소의 `samples/hwp3-sample14-hwp5.hwp` 와 `pdf/hwp3-sample14-hwp5-2022.pdf` 를 그대로 씁니다.
- [x] `src/**` 의 `#[cfg(test)]` 변경 없음
- [x] `cargo test` — focused (release-test, `target/pr-review`): `regression_suite_016 issue_6603` 1/1 · `issue_6593`(캡션)·`issue_6575_tac_caption_box_baseline`·`issue_6575_tac_picture_line_top`·`issue_6122`(셀 안 TAC 그림)·`issue_6284`(위 캡션)·`issue_5789`(선 도형 baseline)·`issue_1151`(TAC 가로 분배)·`issue_5727`(빈 줄 소유 TAC) 각 초록 · `regression_suite_021 oracle_page_count_baseline` 16/16 · `--lib tac` 통과
- [x] 음성 대조 — 같은 테스트를 `upstream/devel`(a5f3bf695) 트리에 넣고 돌리면 `2쪽 pi=16 그림 (113.40, 132.30) — 한컴 PDF 실측 (124.73, 143.52) 이어야 한다` 로 실패합니다 (`regression_suite_016 issue_6603` 0/1)
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] 관련 샘플 파일로 SVG 내보내기 확인 (아래 스크린샷)
- [x] 웹(WASM) 렌더링 확인 — 호스트에 Docker 표준 WASM 경로가 없어 `local_validation.md` 안내대로 `--no-opt` 진단 경로(`CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg --no-opt`)로 빌드했고, headless Chrome 의 studio 에서 `hwp3-sample14-hwp5.hwp` 를 열어 WASM 엔진의 3쪽 SVG 렌더로 가운데 정렬 그림 (263.28, 143.63)px (native 와 동일, 한/글 263.22, 143.52) 를 확인했습니다
- [x] Native Skia 3종 (`local_validation.md` §4.3): `--features native-skia --lib` 3946/3946 · `issue_2225_missing_picture_placeholder` 2/2 · `render_p37_direct_pdf_export` 4/4 (모두 release-test, `target/pr-review`)

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 — TAC 그림 하나당 여백 4개의 단위 변환이 추가됩니다.
- 재현·측정: 위 실측 표 (macOS arm64, release-test).

## 스크린샷

`hwp3-sample14-hwp5` 3쪽. 빨간 테두리는 한/글 PDF 의 그림 bbox 두 개 ((263.22, 143.52) 와 (124.73, 406.12)):

![수정 전 / 수정 후 / 한글 (첫 그림 확대)](https://raw.githubusercontent.com/jeong-sik/rhwp/assets/tac-margin-6603/p3-compare-crop.png)

쪽 전체:

![쪽 전체 비교](https://raw.githubusercontent.com/jeong-sik/rhwp/assets/tac-margin-6603/p3-compare.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
