### PR TITLE
[renderer] 머리말·꼬리말 직접 부동 그림의 기준 영역을 그 틀로 맞춘다 (#6608)

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -3894,8 +3894,6 @@ impl LayoutEngine {
                                     area_node,
                                     pic,
                                     area,
-                                    body_area,
-                                    paper_area,
                                     y_offset,
                                     bin_data_content,
                                     outer_section_index,
@@ -4869,14 +4867,20 @@ impl LayoutEngine {
     }
 
     #[allow(clippy::too_many_arguments)]
+    /// 머리말·꼬리말에 직접 놓인 부동 그림.
+    ///
+    /// [#6608] 머리말·꼬리말 안 개체는 그 틀(`area`)이 배치 기준이다 — 용지(`Paper`)·
+    /// 쪽(`Page`) 기준도 물리 용지나 본문 영역이 아니라 틀 원점에서 오프셋을 잰다.
+    /// `pic-in-head-02.hwp` 머리말 그림(`PAPER`, 오프셋 (245, 1066)HU)을 한/글은
+    /// 틀 원점 (왼쪽 여백 75.6, 위 여백 37.8)px 에서 재 (78.68, 51.94)px 에 그리는데,
+    /// 종전엔 용지 (0, 0) 에서 재 (3.3, 14.2)px 였다 — 6쪽 전부 쪽 여백만큼 어긋났다.
+    /// 실측은 `PAPER` 만 있고 `Page` 는 같은 틀로 푼다(본문 영역은 머리말 안에서 뜻이 없다).
     fn layout_header_footer_picture(
         &self,
         tree: &mut PageLayoutContext,
         area_node: &mut RenderNode,
         pic: &crate::model::image::Picture,
         area: &LayoutRect,
-        body_area: &LayoutRect,
-        paper_area: &LayoutRect,
         para_y: f64,
         bin_data_content: &[BinDataContent],
         outer_section_index: Option<usize>,
@@ -4917,8 +4921,8 @@ impl LayoutEngine {
             frame_height,
             area,
             area,
-            body_area,
-            paper_area,
+            area,
+            area,
             para_y,
             Alignment::Left,
         );

--- a/src/renderer/layout/tests.rs
+++ b/src/renderer/layout/tests.rs
@@ -2727,8 +2727,13 @@ fn header_paper_relative_shape_uses_page_origin() {
     assert!((bbox.y - hwpunit_to_px(2_250, DEFAULT_DPI)).abs() < 0.01);
 }
 
+/// [#6608] 머리말 안 용지 기준 그림은 물리 용지가 아니라 **머리말 틀 원점**에서
+/// 오프셋을 잰다. PR #1682 는 바탕쪽의 용지 원점 규칙을 머리말에도 유추해
+/// 이 테스트를 용지 원점으로 적었지만, 실문서 `pic-in-head-02.hwp` 를 한/글 2020·2022
+/// PDF 와 대조하면 머리말 그림(`PAPER`, 오프셋 (245, 1066)HU)이 틀 원점
+/// (왼쪽 여백, 위 여백) + 오프셋 = (78.68, 51.94)px 에 있다 — 6쪽 전부.
 #[test]
-fn header_paper_relative_picture_uses_page_origin() {
+fn header_paper_relative_picture_uses_header_frame_origin() {
     let tree =
         render_tree_with_header_control(Control::Picture(Box::new(crate::model::image::Picture {
             common: CommonObjAttr {
@@ -2752,8 +2757,14 @@ fn header_paper_relative_picture_uses_page_origin() {
             RenderNodeType::Image(_) | RenderNodeType::Placeholder(_)
         )
     });
-    assert!((bbox.x - hwpunit_to_px(1_500, DEFAULT_DPI)).abs() < 0.01);
-    assert!((bbox.y - hwpunit_to_px(2_250, DEFAULT_DPI)).abs() < 0.01);
+    let header_area =
+        PageLayoutInfo::from_page_def_default(&a4_page_def(), &ColumnDef::default()).header_area;
+    assert!(
+        header_area.x > 0.0 && header_area.y > 0.0,
+        "픽스처 머리말 틀은 용지 원점과 달라야 한다"
+    );
+    assert!((bbox.x - (header_area.x + hwpunit_to_px(1_500, DEFAULT_DPI))).abs() < 0.01);
+    assert!((bbox.y - (header_area.y + hwpunit_to_px(2_250, DEFAULT_DPI))).abs() < 0.01);
 }
 
 // [Task #2102] 쪽 배경 이미지 채우기는 구역 첫 쪽에만 적용된다.

--- a/tests/cases/issue_6608_header_picture_frame_origin.rs
+++ b/tests/cases/issue_6608_header_picture_frame_origin.rs
@@ -1,0 +1,76 @@
+//! Issue #6608: 머리말에 직접 놓인 용지 기준(`PAPER`) 부동 그림이 물리 용지 (0, 0) 에서
+//! 오프셋을 재 쪽 여백만큼 좌·상으로 어긋나던 결함의 가드.
+//!
+//! 한/글은 머리말·꼬리말 안 개체의 오프셋을 그 틀(머리말 영역)의 원점에서 잰다.
+//! `samples/pic-in-head-02.hwp` (여백 좌 20mm·상 10mm) 머리말 그림
+//! `horzRelTo=PAPER vertRelTo=PAPER offset=(245, 1066)HU`:
+//!
+//! ```text
+//! 한컴 PDF (pdf/pic-in-head-02-2022.pdf) 6쪽 전부   (78.68, 51.94)   = 여백 (75.6, 37.8) + 오프셋
+//! 종전 rhwp                                       (3.3, 14.2)      = 용지 (0, 0) + 오프셋
+//! ```
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::fs;
+use std::path::Path;
+
+const SAMPLE: &str = "samples/pic-in-head-02.hwp";
+const TOLERANCE_PX: f64 = 1.5;
+/// 한컴 PDF 실측 (96DPI px). 결함 시 (3.3, 14.2).
+const EXPECTED: (f64, f64) = (78.68, 51.94);
+const HEADER_PICTURE_WIDTH: f64 = 635.2;
+
+fn collect_header_images(
+    node: &serde_json::Value,
+    in_header: bool,
+    out: &mut Vec<(f64, f64, f64)>,
+) {
+    let ty = node.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    if ty == "Image" && in_header {
+        let bbox = &node["bbox"];
+        let get = |k: &str| bbox.get(k).and_then(|v| v.as_f64()).unwrap_or(f64::NAN);
+        out.push((get("x"), get("y"), get("w")));
+    }
+    for child in node
+        .get("children")
+        .and_then(|c| c.as_array())
+        .into_iter()
+        .flatten()
+    {
+        collect_header_images(child, in_header || ty == "Header", out);
+    }
+}
+
+#[test]
+fn header_paper_relative_picture_measures_its_offset_from_the_header_frame() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+    let document = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {SAMPLE}: {e}"));
+    for page_index in [0u32, 1, 2] {
+        let json = document
+            .get_page_render_tree(page_index)
+            .unwrap_or_else(|e| panic!("{}쪽 render tree: {e:?}", page_index + 1));
+        let tree: serde_json::Value = serde_json::from_str(&json).expect("parse render tree json");
+
+        let mut images = Vec::new();
+        collect_header_images(&tree, false, &mut images);
+        let (x, y, _) = images
+            .iter()
+            .copied()
+            .find(|(_, _, w)| (w - HEADER_PICTURE_WIDTH).abs() < 1.0)
+            .unwrap_or_else(|| {
+                panic!(
+                    "{}쪽 머리말에 폭 {HEADER_PICTURE_WIDTH}px 그림: {images:?}",
+                    page_index + 1
+                )
+            });
+        assert!(
+            (x - EXPECTED.0).abs() < TOLERANCE_PX && (y - EXPECTED.1).abs() < TOLERANCE_PX,
+            "{}쪽 머리말 그림 ({x:.2}, {y:.2}) — 한컴 PDF 실측 {EXPECTED:?} 이어야 한다. \
+             결함 시 (3.3, 14.2): 용지 (0, 0) 기준 오프셋",
+            page_index + 1
+        );
+    }
+}


### PR DESCRIPTION
> **PR base: `devel`** · 작업 브랜치는 최신 `upstream/devel`(51043f5f8)에서 생성했습니다. 다른 열린 PR 과 독립입니다.

## 변경 요약

머리말·꼬리말에 **직접** 놓인 부동 그림의 배치 기준을 그 틀(머리말/꼬리말 영역)로 맞춥니다. 한/글은 머리말 안 개체의 오프셋을 머리말 틀 원점(왼쪽 여백, 위 여백)에서 재는데, rhwp 는 용지 기준(`PAPER`) 그림을 물리 용지 (0, 0) 에서 재서 **쪽 여백만큼 좌·상으로** 어긋났습니다.

- **증상** (`samples/pic-in-head-02.hwp`, 여백 좌 20mm·상 10mm): 머리말 그림 `horzRelTo=PAPER vertRelTo=PAPER offset=(245, 1066)HU`, 바깥 여백 0. 한컴 PDF 6쪽 전부 (78.68, 51.94)px, rhwp (3.3, 14.2)px — 차이 (−75.38, −37.74) = (왼쪽 여백 75.59, 위 여백 37.80)px.
- **원인**: `layout.rs` `layout_header_footer_picture` 가 `compute_object_position` 에 `Paper` 기준으로 물리 용지, `Page` 기준으로 본문 영역을 넘깁니다. 단(`Column`)·문단(`Para`)만 틀(`area`)을 받습니다. 바탕쪽 도형 경로(`layout.rs` 4694~4710)가 같은 종류의 보정("바탕쪽에는 단·문단 흐름이 없다 … 본문 텍스트 영역을 기준으로")을 이미 합니다.
- **수정**: 네 기준 모두 틀(`area`)로 풉니다. 쓰이지 않게 된 `body_area`·`paper_area` 파라미터를 제거합니다. 실측은 `PAPER` 만 있고 `Page` 는 같은 틀로 풉니다 — 머리말 안에서 본문 영역은 뜻이 없습니다.

### 실측 (96DPI px, 한컴 PDF `pdf/pic-in-head-02-2022.pdf` 이미지 bbox 대조)

| 항목 | 한/글 | 수정 전 | 수정 후 |
|---|---:|---:|---:|
| 머리말 그림 (1~6쪽 동일) | (78.68, 51.94) | (3.3, 14.2) | **(78.9, 52.0)** |
| 같은 문서 머리말 표 안 그림 | (79.64, 127.86) | (79.7, 126.4) | (79.7, 126.4) 불변 |
| 같은 문서 꼬리말 TAC 그림 2장 | (75.48, 1027.04) 외 | (75.6, 1028.0) 외 | 불변 |

**전수 대조** (`devel` ↔ 이 브랜치, `samples/`↔`pdf/` 215문서 1,124 그림): 움직인 행은 `pic-in-head-02` 머리말 그림 6건뿐, 다른 문서 변화 0, **215문서 쪽수 변화 0**. 머리말 표 안 그림이 있는 `pic-in-head-01`·`3-09월_교육_통합` 은 경로가 달라 변화 없습니다.

### PR #1682 의 단위 계약을 바꿉니다

`src/renderer/layout/tests.rs` 의 `header_paper_relative_picture_uses_page_origin` 은 PR #1682("[부분 Ghidra 근거] master-page 장식 요소를 plane별 리플레이")가 바탕쪽의 용지 원점 규칙을 머리말에도 **유추**해 적은 합성 테스트입니다 — 당시 검토 기록(`mydocs/pr/archives/pr_1682_review.md` §5.1)도 "synthetic/unit render tree contract" 라고 적었고, 머리말 실문서 대조는 없었습니다. 실문서 `pic-in-head-02.hwp` 를 한/글 **2020·2022 PDF 둘 다** 로 대조하면 머리말 그림은 틀 원점 기준입니다. 그래서 그 테스트를 `header_paper_relative_picture_uses_header_frame_origin` 으로 바꾸고 기대값을 픽스처의 `header_area` 원점 + 오프셋으로 적었습니다. 형제 테스트 `header_paper_relative_shape_uses_page_origin`(도형)은 코퍼스에 머리말 직접 도형 표본이 없어 **그대로 둡니다** — 이슈 #6608 에 후속으로 남겼습니다. 바탕쪽(master page) 경로는 건드리지 않습니다.

## 관련 이슈

closes #6608

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] 새 integration test 는 원본을 `tests/cases/issue_6608_header_picture_frame_origin.rs` 에만 추가 (`tests/generated/` 미포함). 새 fixture 없음 — 저장소의 `samples/pic-in-head-02.hwp` 와 `pdf/pic-in-head-02-2022.pdf` 를 그대로 씁니다.
- [x] `src/**` 의 `#[cfg(test)]` 변경: `src/renderer/layout/tests.rs` 의 머리말 그림 단위 테스트 1개를 새 계약으로 고쳤습니다 (위 설명)
- [x] `cargo test` — focused (release-test, `target/pr-review`): `regression_suite_027 issue_6608` 1/1 · `set_hf_picture_contract`·`issue_6284_picture_top_caption_rendered` 초록 · `header`·`footer` 이름을 가진 통합 테스트 전부 초록 · `regression_suite_021 oracle_page_count_baseline` 16/16 · `--lib header` 188/188 (고친 단위 테스트 `header_paper_relative_picture_uses_header_frame_origin` 포함)
- [x] 음성 대조 — 같은 테스트를 `upstream/devel` 트리에 넣고 돌리면 `1쪽 머리말 그림 (3.30, 14.20) — 한컴 PDF 실측 (78.68, 51.94) 이어야 한다` 로 실패합니다 (`regression_suite_008 issue_6608` 0/1)
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] 관련 샘플 파일로 SVG 내보내기 확인 (아래 스크린샷)
- [x] 웹(WASM) 렌더링 확인 — 호스트에 Docker 표준 WASM 경로가 없어 `local_validation.md` 안내대로 `--no-opt` 진단 경로(`CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg --no-opt`)로 빌드했고, headless Chrome 의 studio 에서 `pic-in-head-02.hwp` 를 열어 WASM 엔진의 1쪽 그림 연산(`getPageFlowImageOps`)으로 머리말 그림 bbox (78.85, 52.00)px (native 와 동일, 한/글 78.68, 51.94) 를 확인했습니다
- [x] Native Skia 3종 (`local_validation.md` §4.3): `--features native-skia --lib` 통과(고친 단위 테스트 반영해 재실행) · `issue_2225_missing_picture_placeholder` 2/2 · `render_p37_direct_pdf_export` 4/4 (모두 release-test, `target/pr-review`)

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 — 인자 두 개를 바꿨을 뿐입니다.
- 재현·측정: 위 실측 표 (macOS arm64, release-test).

## 스크린샷

`pic-in-head-02.hwp` 1쪽 상단. 빨간 테두리는 한/글 PDF 의 머리말 그림 bbox (78.68, 51.94, 634.9×64.7px):

![수정 전 / 수정 후 / 한글 (상단 확대)](https://raw.githubusercontent.com/jeong-sik/rhwp/assets/header-pic-6608/p1-compare-crop.png)

쪽 전체:

![쪽 전체 비교](https://raw.githubusercontent.com/jeong-sik/rhwp/assets/header-pic-6608/p1-compare.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
