### PR TITLE
fix(pdf): 하위 SVG 그림의 비트맵을 PDF 에 유지한다 — WMF·EMF·AI 그림이 export-pdf 에서 빈칸이 되던 결함 (#6612)

### DIFF
--- a/src/renderer/pdf.rs
+++ b/src/renderer/pdf.rs
@@ -972,6 +972,33 @@ pub fn svgs_to_pdf_with_options(
     svgs_to_pdf_with_to_chunk(svg_pages, export_options, svg2pdf_to_chunk)
 }
 
+/// [#6612] 페이지 SVG 안의 `data:image/svg+xml` 그림을 이미지째 읽는 usvg 리졸버.
+///
+/// rhwp 는 WMF·EMF·AI 그림을 SVG 로 바꿔 `<image href="data:image/svg+xml;base64,…">` 로
+/// 심는다. usvg 의 기본 데이터 리졸버는 이런 하위 SVG 를 `load_sub_svg` 로 읽는데, 그 함수는
+/// SVG 규격("`<image>` 가 참조한 SVG 는 자기 안에 `<image>` 를 둘 수 없다")대로 하위 SVG 의
+/// `<image>` 를 전부 버린다. 비트맵을 품은 WMF(`<svg viewBox><image href="data:image/png"/></svg>`)
+/// 는 그래서 PDF 에서 빈칸이 됐다(hwp3-sample14 그림 13장 전부). 페이지 SVG 와 하위 SVG 를
+/// 모두 rhwp 가 만들므로 하위 SVG 를 같은 옵션으로 파싱해 이미지를 유지한다. 다른 mime 은
+/// usvg 기본 리졸버가 처리한다.
+#[cfg(not(target_arch = "wasm32"))]
+fn pdf_image_href_resolver() -> usvg::ImageHrefResolver<'static> {
+    let default_data = usvg::ImageHrefResolver::default_data_resolver();
+    usvg::ImageHrefResolver {
+        resolve_data: Box::new(move |mime, data, opts| match mime {
+            "image/svg+xml" => match usvg::Tree::from_data(&data, opts) {
+                Ok(tree) => Some(usvg::ImageKind::SVG(tree)),
+                Err(e) => {
+                    eprintln!("경고: PDF 변환 중 하위 SVG 그림을 파싱하지 못해 건너뜁니다: {e}");
+                    None
+                }
+            },
+            _ => default_data(mime, data, opts),
+        }),
+        resolve_string: usvg::ImageHrefResolver::default_string_resolver(),
+    }
+}
+
 /// 페이지별 `to_chunk` 를 주입할 수 있는 PDF 변환.
 ///
 /// #3773: `SubsetError` 는 경고로 강등하고 나머지 페이지를 계속한다.
@@ -996,6 +1023,7 @@ where
     let fontdb = create_fontdb(export_options);
     let mut options = usvg::Options::default();
     options.fontdb = std::sync::Arc::new(fontdb);
+    options.image_href_resolver = pdf_image_href_resolver();
 
     let mut alloc = Ref::new(1);
     let catalog_ref = alloc.bump();

--- a/tests/cases/issue_6612_pdf_keeps_sub_svg_images.rs
+++ b/tests/cases/issue_6612_pdf_keeps_sub_svg_images.rs
@@ -1,0 +1,71 @@
+//! #6612: `data:image/svg+xml` 로 심긴 그림(WMF·EMF·AI 변환 결과) 안의 비트맵이 PDF 에 남아야 한다.
+//!
+//! usvg 의 기본 하위 SVG 로더는 SVG 규격대로 참조된 SVG 안의 `<image>` 를 전부 버린다.
+//! rhwp 의 WMF 변환은 비트맵을 `<svg viewBox><image href="data:image/png"/></svg>` 로 감싸므로
+//! 그대로 두면 그림 자리가 빈칸이 된다. PDF 경계에서 하위 SVG 를 이미지 유지한 채 파싱한다.
+
+use base64::Engine;
+use rhwp::renderer::pdf::{svgs_to_pdf, PdfExportOptions};
+use rhwp::DocumentCore;
+
+/// 2×1 PNG(왼쪽 빨강, 오른쪽 파랑).
+const PNG_2X1_BASE64: &str =
+    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAIAAAB7QOjdAAAAD0lEQVR4nGP4z8DAwPAfAAcAAf9+CLHQAAAAAElFTkSuQmCC";
+
+/// svg2pdf 가 래스터 그림마다 쓰는 XObject 사전 항목.
+const IMAGE_XOBJECT_MARKER: &str = "/Subtype /Image";
+
+fn count_image_xobjects(pdf: &[u8]) -> usize {
+    String::from_utf8_lossy(pdf)
+        .matches(IMAGE_XOBJECT_MARKER)
+        .count()
+}
+
+/// rhwp 의 WMF→SVG 래퍼와 같은 꼴: viewBox 만 있는 하위 SVG 안에 비트맵 `<image>` 하나.
+fn page_with_sub_svg_bitmap() -> String {
+    let sub_svg = format!(
+        concat!(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 4 2">"#,
+            r#"<image href="data:image/png;base64,{png}" width="4" height="2" x="0" y="0"/>"#,
+            r#"</svg>"#,
+        ),
+        png = PNG_2X1_BASE64
+    );
+    let sub_svg_b64 = base64::engine::general_purpose::STANDARD.encode(sub_svg.as_bytes());
+    format!(
+        concat!(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">"#,
+            r#"<image href="data:image/svg+xml;base64,{sub}" x="20" y="10" width="120" height="60" preserveAspectRatio="none"/>"#,
+            r#"</svg>"#,
+        ),
+        sub = sub_svg_b64
+    )
+}
+
+#[test]
+fn issue_6612_sub_svg_bitmap_reaches_pdf() {
+    let pdf = svgs_to_pdf(&[page_with_sub_svg_bitmap()]).expect("PDF 변환이 실패했다");
+    assert!(pdf.starts_with(b"%PDF-"), "PDF 헤더가 없다");
+    assert_eq!(
+        count_image_xobjects(&pdf),
+        1,
+        "하위 SVG 안의 비트맵이 이미지 XObject 로 남아야 한다"
+    );
+}
+
+#[test]
+fn issue_6612_sample14_wmf_pictures_reach_pdf() {
+    // hwp3-sample14-hwp5: 그림 13장이 전부 비트맵 WMF 이고, 몇 장은 비트맵 타일을 여러 개 품어
+    // 이미지 XObject 는 21개다(PyMuPDF `get_image_info` 배치 수와 같다). 수정 전에는 0개였다.
+    let core = DocumentCore::from_bytes(include_bytes!("../../samples/hwp3-sample14-hwp5.hwp"))
+        .expect("샘플 문서를 열지 못했다");
+    let pages: Vec<u32> = (0..core.page_count()).collect();
+    let pdf = core
+        .render_pages_pdf_native_with_options(&pages, &PdfExportOptions::default())
+        .expect("PDF 변환이 실패했다");
+    assert_eq!(
+        count_image_xobjects(&pdf),
+        21,
+        "WMF 그림 13장의 비트맵 타일 21개가 모두 이미지 XObject 로 남아야 한다"
+    );
+}


### PR DESCRIPTION
closes #6612

## 무엇을 고쳤나

WMF·EMF·AI 그림이 든 문서를 `export-pdf` 로 내보내면 그림 자리가 **빈칸**이 되던 결함을 고쳤다. `export-svg`·`export-png`·studio 캔버스는 원래 정상이었고, PDF 표면만 그림이 사라졌다.

`samples/hwp3-sample14-hwp5.hwp` (그림 13장 전부 비트맵 WMF) 의 PDF 이미지 XObject:

| | 이미지 XObject | 3쪽 첫 그림 bbox (96DPI px) |
|---|---:|---|
| 수정 전 rhwp PDF (devel) | **0** | 없음 |
| 수정 후 rhwp PDF | 21 (WMF 13장, 몇 장은 타일 여러 개) | (263.3, 132.3)–(530.5, 241.0) |
| 한/글 2022 PDF | 13 | (263.2, 143.5)–(530.3, 252.2) |

남은 y 11px 차이는 이 브랜치(devel)에 아직 없는 글자처럼 취급 그림의 바깥 여백 수정(#6603, PR #6605)의 알려진 편차이고, 이 PR 범위 밖이다.

## 원인

rhwp 는 WMF 를 SVG 로 변환해 페이지 SVG 에 `<image href="data:image/svg+xml;base64,…">` 로 심는다(`image_resolver.rs` `convert_wmf_to_svg`, EMF·AI 도 같은 mime). 비트맵 하나짜리 WMF 는 하위 SVG 가 `<svg viewBox="0 0 1997 816"><image href="data:image/png;base64,…"/></svg>` 다.

PDF 경로 `pdf.rs` `svgs_to_pdf_with_to_chunk` 는 `usvg::Options::default()` 로 페이지 SVG 를 파싱한다. usvg 0.45 의 기본 데이터 리졸버는 `image/svg+xml` 을 `load_sub_svg` 로 읽는데, 이 함수는 SVG 규격("`<image>` 가 참조한 SVG 는 자기 안에 `<image>` 를 둘 수 없다")대로 **하위 SVG 의 `<image>` 를 전부 제거**한다(`usvg-0.45.1/src/parser/image.rs:330`). 비트맵을 품은 WMF 는 빈 트리가 되어 svg2pdf 가 그릴 것이 없었다.

## 수정

PDF 변환의 `usvg::Options.image_href_resolver` 를 rhwp 가 소유한다(`pdf_image_href_resolver`). `image/svg+xml` 데이터 URI 는 usvg 의 하위 로더 대신 **같은 옵션으로 `Tree::from_data` 해 `ImageKind::SVG`** 로 돌려주어 안의 `<image>` 를 유지하고, 나머지 mime 은 usvg 기본 리졸버에 그대로 넘긴다. 페이지 SVG 와 하위 SVG 를 모두 rhwp 가 만들므로 규격의 제한을 따를 이유가 없다. 파싱에 실패한 하위 SVG 는 경고를 찍고 건너뛴다(수정 전 usvg 도 같은 동작).

SVG·PNG(native-skia)·캔버스 경로는 건드리지 않았다. `gpu` feature 의 `gpu.rs` `parse_svg` 는 별도 크레이트 인스턴스(`resvg-gpu` 0.46 의 usvg)를 쓰고 이 호스트에서 빌드·검증하지 못해 범위 밖으로 두었다 — 같은 결함이 있을 수 있어 이슈에 기록했다.

## 실측 스크린샷 (수정 전 / 수정 후 / 한/글 2022 PDF, 빨간 테두리 = 이미지 XObject bbox)

hwp3-sample14 3쪽:

![s14 p3](https://raw.githubusercontent.com/jeong-sik/rhwp/1b3769ec0abddd2fef567ade431a6b876c99b76a/s14-p3-before-after-oracle.png)

hwp3-sample14 2쪽:

![s14 p2](https://raw.githubusercontent.com/jeong-sik/rhwp/1b3769ec0abddd2fef567ade431a6b876c99b76a/s14-p2-before-after-oracle.png)

한/글은 WMF 한 장을 비트맵 하나로 굽고(화살표·설명 글자까지 포함), rhwp 는 WMF 안의 비트맵 타일만 이미지로 두고 벡터는 벡터로 그린다. 그래서 개수는 다르지만 자리와 내용은 같다.

## 코퍼스 대조 (PDF 표면)

`samples/` ↔ `pdf/` 한컴 PDF 쌍 전수에서 rhwp `export-pdf` 와 한컴 PDF 의 이미지 XObject 를 PyMuPDF 로 쪽별 대조했다(수정 전 = `devel`, 수정 후 = 이 브랜치).

| | 문서 | rhwp 이미지 XObject 합계 | 한컴과 짝지어진 수 |
|---|---:|---:|---:|
| 수정 전 (devel) | 194 | 886 | 710 |
| 수정 후 | 194 | 966 | 740 |

이미지가 늘어난 문서 7개(rhwp 수정 전 → 후, 한컴):

| 문서 | 전 → 후 | 한컴 PDF |
|---|---:|---:|
| hwp3-sample14-hwp5 | 0 → 21 | 13 |
| hwp3-sample4 · hwp3-sample4-hwp5 | 0 → 13 (각) | 169 |
| nested_group_vectors | 3 → 25 | 27 |
| memo_field_hwp5 | 128 → 137 | 69 |
| bitmap | 0 → 1 | 1 |
| 한셀OLE | 0 → 1 | 1 |

나머지 187문서는 이미지 수·위치·크기 행이 하나도 바뀌지 않았고, 쪽수 변화도 0이다. 한컴 PDF 는 그림 하나를 비트맵 하나로 굽고 rhwp 는 WMF 안의 타일·벡터를 그대로 두므로 개수는 같을 필요가 없다.

`bitmap` 은 예외다. OLE 표현 WMF 가 y-up 창인데 음수 높이 DIB 가 두 번 뒤집혀 viewBox 밖으로 나가는 별도 결함(#6617)이라 SVG·PDF 모든 표면에서 원래부터 그림이 안 보인다. 이 PR 뒤에는 이미지 XObject 가 놓이긴 하지만 비어 있고 자리도 어긋난다(수정 전에도 빈칸, 눈에 보이는 변화 없음). #6617 에서 WMF 창 매핑을 고치면 이 PR 의 리졸버를 그대로 타고 PDF 에도 나온다.

## 테스트

`tests/cases/issue_6612_pdf_keeps_sub_svg_images.rs`
- `issue_6612_sub_svg_bitmap_reaches_pdf` — rhwp 래퍼와 같은 꼴(viewBox 만 있는 하위 SVG + 비트맵 `<image>`)의 합성 페이지 → 이미지 XObject 1개.
- `issue_6612_sample14_wmf_pictures_reach_pdf` — hwp3-sample14 11쪽 → 이미지 XObject 21개.

음성 대조: 같은 테스트를 `devel`(a5f3bf695) 트리에서 돌리면 둘 다 0개로 실패한다.

## 로컬 검증

- [x] **`cargo fmt --all -- --check` 통과** (push 직전 재실행)
- [x] 새 integration test 는 `tests/cases/issue_6612_pdf_keeps_sub_svg_images.rs` 원본만 추가했고 `tests/generated/`·`tests/suites/manifest.json`·Cargo target 은 커밋하지 않음
- [x] `src/**` 의 `#[cfg(test)]` 변경 없음 (`node scripts/rust-unit-test-tiers.mjs --check` 통과)
- [x] `cargo test` — focused `cargo test --profile release-test --target-dir target/pr-review --test regression_suite_017 -- issue_6612` 2/2 통과 (release-test 전체는 GitHub 전체 CI 로 대신)
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] 관련 샘플 SVG 내보내기 확인 — SVG 경로는 변경 없음, `export-svg` 결과 동일. PDF 는 위 스크린샷
- [x] Native Skia 3종(공식 명령, release-test · pr-review): `--features native-skia --lib` 3946/3946, `issue_2225_missing_picture_placeholder` 2/2, `render_p37_direct_pdf_export` 4/4
- [x] WASM: Docker 부재라 `CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg --no-opt` 진단 경로 exit 0 (변경 함수는 `cfg(not(target_arch = "wasm32"))` 라 WASM 표면 영향 없음)
- [x] `git diff --check`
- [ ] rhwp-studio 변경 없음
- [ ] 작업 증빙 캡슐 — 문서 편집 작업이 아니라 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: 변환 시간 영향 없음. usvg 는 수정 전에도 하위 SVG 를 파싱했고(`load_sub_svg`) 결과에서 `<image>` 만 버렸다. 이제 그 비트맵이 PDF 에 들어가므로 파일 크기는 그림만큼 커진다.
- 재현·측정: `rhwp export-pdf samples/hwp3-sample14-hwp5.hwp` — 수정 전 651KB, 수정 후 701KB (11쪽, 이미지 XObject 0 → 21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
