### PR TITLE
fix(wmf): 창 축이 뒤집힌 WMF 의 블릿을 장치 좌표에서 정규화한다 — 그림이 안 보이거나 거울상이던 결함 (#6617)

### DIFF
--- a/src/wmf/converter/svg/device_context.rs
+++ b/src/wmf/converter/svg/device_context.rs
@@ -174,19 +174,49 @@ impl DeviceContext {
     }
 
     pub fn point_s_to_absolute_point(&self, point: &PointS) -> PointS {
-        let x = (f32::from((point.x - self.window.origin_x).abs()) / self.window.scale_x) as i16;
-        let y = (f32::from((point.y - self.window.origin_y).abs()) / self.window.scale_y) as i16;
+        let (x, y) = self
+            .window
+            .to_device(f32::from(point.x), f32::from(point.y));
 
-        PointS { x, y }
+        PointS {
+            x: x as i16,
+            y: y as i16,
+        }
     }
 
     pub fn point_s_to_relative_point(&self, point: &PointS) -> PointS {
-        let x = (f32::from((point.x - self.window.origin_x).abs()) / self.window.scale_x) as i16
-            + self.drawing_position.x;
-        let y = (f32::from((point.y - self.window.origin_y).abs()) / self.window.scale_y) as i16
-            + self.drawing_position.y;
+        let (x, y) = self
+            .window
+            .to_device(f32::from(point.x), f32::from(point.y));
 
-        PointS { x, y }
+        PointS {
+            x: x as i16 + self.drawing_position.x,
+            y: y as i16 + self.drawing_position.y,
+        }
+    }
+
+    /// [#6617] 블릿(BitBlt·StretchBlt·DIB 계열) 목적 사각형을 장치 좌표로 옮긴다.
+    ///
+    /// 두 모서리 `(x, y)`·`(x + width, y + height)` 를 각각 창 매핑으로 보내고 작은 쪽을
+    /// 원점으로 삼는다. GDI 의 뒤집기는 논리 폭/높이 부호와 창 축 방향의 **곱**으로
+    /// 정해지므로, 장치 좌표에서 두 번째 모서리가 첫 모서리보다 앞이면 그 축을 뒤집는다.
+    /// y-up 창(SetWindowExt y<0)의 음수 높이 DIB 는 두 부호가 상쇄돼 바로 선 그림이다
+    /// (bitmap.hwp OLE 표현, 156462405 7쪽 인물 사진).
+    pub fn blit_dest_rect(&self, x: i16, y: i16, width: i16, height: i16) -> BlitDestRect {
+        let (x0, y0) = self.window.to_device(f32::from(x), f32::from(y));
+        let (x1, y1) = self.window.to_device(
+            f32::from(x) + f32::from(width),
+            f32::from(y) + f32::from(height),
+        );
+        let (ix0, iy0, ix1, iy1) = (x0 as i32, y0 as i32, x1 as i32, y1 as i32);
+        BlitDestRect {
+            x: ix0.min(ix1),
+            y: iy0.min(iy1),
+            width: (ix1 - ix0).abs(),
+            height: (iy1 - iy0).abs(),
+            flip_x: ix1 < ix0,
+            flip_y: iy1 < iy0,
+        }
     }
 
     pub fn poly_fill_rule(&self) -> String {
@@ -202,6 +232,18 @@ impl DeviceContext {
     }
 }
 
+/// [#6617] 장치(viewBox) 좌표로 정규화한 블릿 목적 사각형. 폭·높이는 0 이상이고
+/// 뒤집힘은 `flip_x`/`flip_y` 로 따로 든다.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BlitDestRect {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+    pub flip_x: bool,
+    pub flip_y: bool,
+}
+
 #[derive(Clone, Debug)]
 pub struct Window {
     pub x: i16,
@@ -212,8 +254,10 @@ pub struct Window {
     pub scale_y: f32,
     /// SetWindowExt가 명시적으로 호출되었는지 여부
     pub ext_explicitly_set: bool,
-    /// [Task #860 Stage D] WMF 의 SetWindowExt y < 0 (Cartesian, bottom-up) 인 경우 true.
-    /// SVG renderer 는 top-down (y 아래 증가). y < 0 처리를 위해 element y 좌표 flip 필요.
+    /// SetWindowExt x < 0 — 논리 x 가 커질수록 장치에서는 왼쪽으로 간다.
+    pub x_inverted: bool,
+    /// SetWindowExt y < 0 (Cartesian, bottom-up) — 논리 y 가 커질수록 장치에서는 위로 간다.
+    /// SVG 는 top-down 이라 `to_device` 가 y 축을 뒤집는다.
     pub y_inverted: bool,
 }
 
@@ -227,6 +271,7 @@ impl Default for Window {
             scale_x: 1.0,
             scale_y: 1.0,
             ext_explicitly_set: false,
+            x_inverted: false,
             y_inverted: false,
         }
     }
@@ -241,13 +286,24 @@ impl Window {
         self.x = x.abs();
         self.y = y.abs();
         self.ext_explicitly_set = true;
-        // [Task #860 Stage D] y < 0 = Cartesian 좌표계 (bottom-up) — 일부 application
-        // 이 WMF 에 SetWindowExt(width, -height) 로 bottom-up 설정. SVG 변환 시
-        // y-flip transform 필요. 현재 sample 들에서는 미발견.
-        if y < 0 {
-            self.y_inverted = true;
-        }
+        self.x_inverted = x < 0;
+        self.y_inverted = y < 0;
         self
+    }
+
+    /// [#6617] 논리 좌표를 창 원점 기준 장치(viewBox) 좌표로 옮긴다.
+    ///
+    /// viewBox 는 `(0, 0, |ext_x|, |ext_y|)` 이고(`as_view_box`), 창 범위 안의 논리 점은
+    /// 여기서 `[0, |ext|]` 로 들어온다. 축이 뒤집힌 창(SetWindowExt 음수)은 그 축의 부호를
+    /// 바꿔서 옮긴다 — y-up 창에서 논리 `origin_y` 가 장치 0(위), `origin_y + ext_y`
+    /// (ext_y<0) 가 장치 `|ext_y|`(아래) 다. 창 밖의 점은 음수 또는 범위 밖 좌표가 되고,
+    /// `generate` 의 viewBox 자동 확장이 그 점을 포함시킨다.
+    pub fn to_device(&self, x: f32, y: f32) -> (f32, f32) {
+        let dx = x - f32::from(self.origin_x);
+        let dy = y - f32::from(self.origin_y);
+        let dx = if self.x_inverted { -dx } else { dx };
+        let dy = if self.y_inverted { -dy } else { dy };
+        (dx / self.scale_x, dy / self.scale_y)
     }
 
     pub fn origin(mut self, origin_x: i16, origin_y: i16) -> Self {

--- a/src/wmf/converter/svg/mod.rs
+++ b/src/wmf/converter/svg/mod.rs
@@ -80,39 +80,27 @@ impl crate::wmf::converter::Player for SVGPlayer {
         // (예: HWP3 sample14 의 WMF 가 1189 인데 image y+height=2304) viewBox 가 element
         // 를 cover 못 해 rsvg-convert 렌더 시 잘림. element 들의 max x+width / y+height
         // 까지 viewBox 확장 (한컴 SVG 변환의 자동 확장 시멘틱 정합).
+        // [#6617] 창 앞쪽(음수 장치 좌표)으로 넘친 요소는 GDI 처럼 잘린다. 예전의
+        // "min x/y 로 viewBox 앞쪽 확장"([Task #860 Stage D])은 viewBox 원점이 창 원점이던
+        // 때의 보정이라 [Task #864] 이후 원점 상대 좌표에서는 걸릴 일이 없었고, y-up 창의
+        // 음수 높이 DIB 를 논리 부호로 정규화해 생긴 가짜 음수 y 에만 걸려 viewBox 를 세로
+        // 두 배로 만들었다(bitmap.hwp, 156462405). 장치 좌표에서는 그 음수가 생기지 않는다.
         let (raw_vb_x, raw_vb_y, mut vb_w, mut vb_h) = context_current.window.as_view_box();
-        let mut vb_x = i32::from(raw_vb_x);
-        let mut vb_y = i32::from(raw_vb_y);
+        let vb_x = i32::from(raw_vb_x);
+        let vb_y = i32::from(raw_vb_y);
         let mut vb_w_i32 = i32::from(vb_w);
         let mut vb_h_i32 = i32::from(vb_h);
         let mut vb_right = vb_x + vb_w_i32;
         let mut vb_bottom = vb_y + vb_h_i32;
         for elem in elements.iter() {
-            let max_x = element_max_x(elem);
-            let max_y = element_max_y(elem);
-            let min_x = element_min_x(elem);
-            let min_y = element_min_y(elem);
-            if let Some(mx) = max_x {
+            if let Some(mx) = element_max_x(elem) {
                 if mx > vb_right {
                     vb_right = mx;
                 }
             }
-            if let Some(my) = max_y {
+            if let Some(my) = element_max_y(elem) {
                 if my > vb_bottom {
                     vb_bottom = my;
-                }
-            }
-            // [Task #860 Stage D] element 의 min y 가 viewBox y 보다 작으면 viewBox 위쪽
-            // 확장 (HWP3 sample14 의 WMF: BoundingBox origin (329, 1536) 인데 element
-            // y=1008 — Placeable header 의 BoundingBox 와 element 좌표 mismatch 보정).
-            if let Some(nx) = min_x {
-                if nx < vb_x {
-                    vb_x = nx;
-                }
-            }
-            if let Some(ny) = min_y {
-                if ny < vb_y {
-                    vb_y = ny;
                 }
             }
         }
@@ -134,24 +122,12 @@ impl crate::wmf::converter::Player for SVGPlayer {
             document = document.add(defs);
         }
 
-        // [Task #860 Stage D] WMF SetWindowExt y < 0 (Cartesian, bottom-up) 인 경우
-        // SVG (top-down) 정합 위해 y-flip transform 적용:
-        //   transform="translate(0, vb_h) scale(1, -1)"
-        // 이는 viewBox 안 element 의 y 좌표를 flip 하여 한컴 정합.
-        // HWP3 sample14 의 WMF 가 bottom-up 좌표계 사용 (캡션 outline 위, BMP 박스 아래
-        // 의 시각이 한컴과 반대로 나타나는 결함 정정).
-        if context_current.window.y_inverted {
-            let group =
-                Node::new("g").set("transform", format!("translate(0,{vb_h_i32}) scale(1,-1)"));
-            let mut group = group;
-            for v in elements {
-                group = group.add(v);
-            }
-            document = document.add(group);
-        } else {
-            for v in elements {
-                document = document.add(v);
-            }
+        // [#6617] y-up 창(SetWindowExt y < 0)의 축 뒤집기는 요소 좌표를 만들 때
+        // `Window::to_device` 가 이미 끝냈다(장치 좌표 = viewBox 좌표). 예전의
+        // `translate(0, vb_h) scale(1,-1)` 그룹은 창 바닥이 논리 0 일 때만 맞는 특수식이라,
+        // 원점이 0 인 y-up 창(bitmap.hwp OLE 표현, 156462405)의 그림을 viewBox 밖으로 보냈다.
+        for v in elements {
+            document = document.add(v);
         }
 
         Ok(document.to_string().into_bytes())
@@ -178,12 +154,10 @@ impl crate::wmf::converter::Player for SVGPlayer {
                 target,
                 ..
             } => {
-                let pt = self.context_current.point_s_to_absolute_point(&PointS {
-                    x: x_dest,
-                    y: y_dest,
-                });
-                let mut operator =
-                    TernaryRasterOperator::new(raster_operation, pt.x, pt.y, height, width);
+                let rect = self
+                    .context_current
+                    .blit_dest_rect(x_dest, y_dest, width, height);
+                let mut operator = TernaryRasterOperator::new(raster_operation, rect);
 
                 if raster_operation.use_selected_brush() {
                     operator = operator.brush(self.selected_brush().clone());
@@ -203,12 +177,10 @@ impl crate::wmf::converter::Player for SVGPlayer {
                 x_dest,
                 ..
             } => {
-                let pt = self.context_current.point_s_to_absolute_point(&PointS {
-                    x: x_dest,
-                    y: y_dest,
-                });
-                let mut operator =
-                    TernaryRasterOperator::new(raster_operation, pt.x, pt.y, height, width);
+                let rect = self
+                    .context_current
+                    .blit_dest_rect(x_dest, y_dest, width, height);
+                let mut operator = TernaryRasterOperator::new(raster_operation, rect);
 
                 if raster_operation.use_selected_brush() {
                     operator = operator.brush(self.selected_brush().clone());
@@ -256,12 +228,10 @@ impl crate::wmf::converter::Player for SVGPlayer {
                 target,
                 ..
             } => {
-                let pt = self.context_current.point_s_to_absolute_point(&PointS {
-                    x: x_dest,
-                    y: y_dest,
-                });
-                let mut operator =
-                    TernaryRasterOperator::new(raster_operation, pt.x, pt.y, height, width);
+                let rect = self
+                    .context_current
+                    .blit_dest_rect(x_dest, y_dest, width, height);
+                let mut operator = TernaryRasterOperator::new(raster_operation, rect);
 
                 if raster_operation.use_selected_brush() {
                     operator = operator.brush(self.selected_brush().clone());
@@ -281,12 +251,10 @@ impl crate::wmf::converter::Player for SVGPlayer {
                 x_dest,
                 ..
             } => {
-                let pt = self.context_current.point_s_to_absolute_point(&PointS {
-                    x: x_dest,
-                    y: y_dest,
-                });
-                let mut operator =
-                    TernaryRasterOperator::new(raster_operation, pt.x, pt.y, height, width);
+                let rect = self
+                    .context_current
+                    .blit_dest_rect(x_dest, y_dest, width, height);
+                let mut operator = TernaryRasterOperator::new(raster_operation, rect);
 
                 if raster_operation.use_selected_brush() {
                     operator = operator.brush(self.selected_brush().clone());
@@ -334,17 +302,10 @@ impl crate::wmf::converter::Player for SVGPlayer {
                 target,
                 ..
             } => {
-                let pt = self.context_current.point_s_to_absolute_point(&PointS {
-                    x: x_dest,
-                    y: y_dest,
-                });
-                let mut operator = TernaryRasterOperator::new(
-                    raster_operation,
-                    pt.x,
-                    pt.y,
-                    dest_height,
-                    dest_width,
-                );
+                let rect =
+                    self.context_current
+                        .blit_dest_rect(x_dest, y_dest, dest_width, dest_height);
+                let mut operator = TernaryRasterOperator::new(raster_operation, rect);
 
                 if raster_operation.use_selected_brush() {
                     operator = operator.brush(self.selected_brush().clone());
@@ -364,17 +325,10 @@ impl crate::wmf::converter::Player for SVGPlayer {
                 x_dest,
                 ..
             } => {
-                let pt = self.context_current.point_s_to_absolute_point(&PointS {
-                    x: x_dest,
-                    y: y_dest,
-                });
-                let mut operator = TernaryRasterOperator::new(
-                    raster_operation,
-                    pt.x,
-                    pt.y,
-                    dest_height,
-                    dest_width,
-                );
+                let rect =
+                    self.context_current
+                        .blit_dest_rect(x_dest, y_dest, dest_width, dest_height);
+                let mut operator = TernaryRasterOperator::new(raster_operation, rect);
 
                 if raster_operation.use_selected_brush() {
                     operator = operator.brush(self.selected_brush().clone());
@@ -436,17 +390,10 @@ impl crate::wmf::converter::Player for SVGPlayer {
                 target,
                 ..
             } => {
-                let pt = self.context_current.point_s_to_absolute_point(&PointS {
-                    x: x_dest,
-                    y: y_dest,
-                });
-                let mut operator = TernaryRasterOperator::new(
-                    raster_operation,
-                    pt.x,
-                    pt.y,
-                    dest_height,
-                    dest_width,
-                );
+                let rect =
+                    self.context_current
+                        .blit_dest_rect(x_dest, y_dest, dest_width, dest_height);
+                let mut operator = TernaryRasterOperator::new(raster_operation, rect);
 
                 if raster_operation.use_selected_brush() {
                     operator = operator.brush(self.selected_brush().clone());
@@ -466,17 +413,10 @@ impl crate::wmf::converter::Player for SVGPlayer {
                 x_dest,
                 ..
             } => {
-                let pt = self.context_current.point_s_to_absolute_point(&PointS {
-                    x: x_dest,
-                    y: y_dest,
-                });
-                let mut operator = TernaryRasterOperator::new(
-                    raster_operation,
-                    pt.x,
-                    pt.y,
-                    dest_height,
-                    dest_width,
-                );
+                let rect =
+                    self.context_current
+                        .blit_dest_rect(x_dest, y_dest, dest_width, dest_height);
+                let mut operator = TernaryRasterOperator::new(raster_operation, rect);
 
                 if raster_operation.use_selected_brush() {
                     operator = operator.brush(self.selected_brush().clone());
@@ -524,11 +464,10 @@ impl crate::wmf::converter::Player for SVGPlayer {
             ..
         } = record;
 
-        let pt = self
+        let rect = self
             .context_current
-            .point_s_to_absolute_point(&PointS { x: x_dst, y: y_dst });
-        let mut operator =
-            TernaryRasterOperator::new(raster_operation, pt.x, pt.y, dest_height, dest_width);
+            .blit_dest_rect(x_dst, y_dst, dest_width, dest_height);
+        let mut operator = TernaryRasterOperator::new(raster_operation, rect);
 
         if raster_operation.use_selected_brush() {
             operator = operator.brush(self.selected_brush().clone());
@@ -2374,18 +2313,6 @@ fn element_max_y(elem: &Node) -> Option<i32> {
         }
     }
     None
-}
-
-/// [Task #860 Stage D] Node 의 x attribute (viewBox 위쪽 확장 용).
-fn element_min_x(elem: &Node) -> Option<i32> {
-    let s = elem.to_string();
-    parse_attr_i32(&s, "x")
-}
-
-/// [Task #860 Stage D] Node 의 y attribute (viewBox 위쪽 확장 용).
-fn element_min_y(elem: &Node) -> Option<i32> {
-    let s = elem.to_string();
-    parse_attr_i32(&s, "y")
 }
 
 /// 단순 SVG attribute 값 parse (i32). 미존재 또는 parse 실패 시 None.

--- a/src/wmf/converter/svg/ternary_raster_operator.rs
+++ b/src/wmf/converter/svg/ternary_raster_operator.rs
@@ -1,5 +1,5 @@
 use crate::wmf::converter::{
-    svg::{node::Node, util::url_string, Fill},
+    svg::{device_context::BlitDestRect, node::Node, util::url_string, Fill},
     *,
 };
 
@@ -11,7 +11,7 @@ pub enum TernaryRasterOperationError {
     NoSource { cause: String },
 }
 
-type BrushOnlyRopKey = (i16, i16, i16, i16, String);
+type BrushOnlyRopKey = (i32, i32, i32, i32, String);
 
 #[derive(Default)]
 pub struct BrushOnlyRopSequence {
@@ -83,10 +83,8 @@ impl BrushOnlyRopSequence {
 
 pub struct TernaryRasterOperator {
     operation: TernaryRasterOperation,
-    x: i16,
-    y: i16,
-    height: i16,
-    width: i16,
+    /// [#6617] 장치 좌표로 정규화한 목적 사각형(`DeviceContext::blit_dest_rect`).
+    rect: BlitDestRect,
     brush: Option<Brush>,
     source: Option<Source>,
 }
@@ -97,42 +95,39 @@ enum Source {
 }
 
 impl TernaryRasterOperator {
-    pub fn new(operation: TernaryRasterOperation, x: i16, y: i16, height: i16, width: i16) -> Self {
+    pub fn new(operation: TernaryRasterOperation, rect: BlitDestRect) -> Self {
         Self {
             operation,
-            x,
-            y,
-            height,
-            width,
+            rect,
             brush: None,
             source: None,
         }
     }
 
-    /// [#6140] 목적 사각형이 음수 폭/높이로 온 경우의 SVG 정규화.
+    /// 목적 사각형과, 뒤집힌 축이 있으면 그 축을 되돌리는 `transform`.
     ///
-    /// GDI 는 `dest_height`/`dest_width` 가 음수면 그 축으로 뒤집어 blit 한다.
-    /// SVG 의 `width`/`height` 는 **음수를 오류로 규정**하므로 그대로 내보내면
-    /// 브라우저가 그 속성을 무시하고(=절대값·비반전) 그린다 — bottom-up WMF 가
-    /// 이미 y-flip 그룹 안에 있으면 그 결과가 상하 반전이 된다(156462405 7쪽
-    /// 인물 사진). 원점·크기를 양수로 정규화하고, 뒤집힘은 요소 자신의
-    /// `transform` 으로 표현한다.
+    /// [#6140] SVG 의 `width`/`height` 는 음수를 오류로 규정하므로 사각형은 항상 양수 크기로
+    /// 두고 뒤집힘을 요소 자신의 `transform` 으로 표현한다. [#6617] 어느 축이 뒤집히는지는
+    /// 논리 폭/높이 부호가 아니라 장치 좌표에서 정한다(`DeviceContext::blit_dest_rect`) —
+    /// y-up 창의 음수 높이 DIB 는 뒤집히지 않는다.
     fn normalized_rect(&self) -> (i32, i32, i32, i32, Option<String>) {
-        let (x, y) = (i32::from(self.x), i32::from(self.y));
-        let (w, h) = (i32::from(self.width), i32::from(self.height));
-        let x_norm = if w < 0 { x + w } else { x };
-        let y_norm = if h < 0 { y + h } else { y };
-        let w_abs = w.abs();
-        let h_abs = h.abs();
+        let BlitDestRect {
+            x,
+            y,
+            width,
+            height,
+            flip_x,
+            flip_y,
+        } = self.rect;
         let mut parts = Vec::new();
-        if w < 0 {
-            parts.push(format!("translate({},0) scale(-1,1)", 2 * x_norm + w_abs));
+        if flip_x {
+            parts.push(format!("translate({},0) scale(-1,1)", 2 * x + width));
         }
-        if h < 0 {
-            parts.push(format!("translate(0,{}) scale(1,-1)", 2 * y_norm + h_abs));
+        if flip_y {
+            parts.push(format!("translate(0,{}) scale(1,-1)", 2 * y + height));
         }
         let transform = (!parts.is_empty()).then(|| parts.join(" "));
-        (x_norm, y_norm, w_abs, h_abs, transform)
+        (x, y, width, height, transform)
     }
 
     pub fn brush(mut self, brush: Brush) -> Self {
@@ -178,10 +173,10 @@ impl TernaryRasterOperator {
 
         let result: Node = match self.operation {
             TernaryRasterOperation::BLACKNESS => Node::new("rect")
-                .set("x", self.x)
-                .set("y", self.y)
-                .set("width", self.width)
-                .set("height", self.height)
+                .set("x", self.rect.x)
+                .set("y", self.rect.y)
+                .set("width", self.rect.width)
+                .set("height", self.rect.height)
                 .set("stroke", "none")
                 .set("fill", "black"),
             TernaryRasterOperation::SRCCOPY => {
@@ -216,17 +211,17 @@ impl TernaryRasterOperator {
                 };
 
                 Node::new("rect")
-                    .set("x", self.x)
-                    .set("y", self.y)
-                    .set("width", self.width)
-                    .set("height", self.height)
+                    .set("x", self.rect.x)
+                    .set("y", self.rect.y)
+                    .set("width", self.rect.width)
+                    .set("height", self.rect.height)
                     .set("fill", fill.as_str())
             }
             TernaryRasterOperation::WHITENESS => Node::new("rect")
-                .set("x", self.x)
-                .set("y", self.y)
-                .set("width", self.width)
-                .set("height", self.height)
+                .set("x", self.rect.x)
+                .set("y", self.rect.y)
+                .set("width", self.rect.width)
+                .set("height", self.rect.height)
                 .set("stroke", "none")
                 .set("fill", "white"),
             // [#6469] 미구현 ROP 을 **통째로 버리지 않는다.**
@@ -273,16 +268,22 @@ impl TernaryRasterOperator {
                 // 그림(흰 원)을 덮는다. 다만 전역 이력에서 같은 키를 찾으면 독립된
                 // 후속 draw까지 지워질 수 있으므로, 출력 요소 순서상 연속한
                 // PATINVERT → DPA → PATINVERT만 상쇄한다.
-                let key = (self.x, self.y, self.width, self.height, fill.clone());
+                let key = (
+                    self.rect.x,
+                    self.rect.y,
+                    self.rect.width,
+                    self.rect.height,
+                    fill.clone(),
+                );
                 if brush_only_rop_sequence.observe(operation, key, element_count) {
                     return Ok(None);
                 }
 
                 Node::new("rect")
-                    .set("x", self.x)
-                    .set("y", self.y)
-                    .set("width", self.width)
-                    .set("height", self.height)
+                    .set("x", self.rect.x)
+                    .set("y", self.rect.y)
+                    .set("width", self.rect.width)
+                    .set("height", self.rect.height)
                     .set("fill", fill.as_str())
             }
             operation if operation.use_source() => {

--- a/tests/cases/issue_6140_wmf_bitmap_negative_height.rs
+++ b/tests/cases/issue_6140_wmf_bitmap_negative_height.rs
@@ -3,13 +3,16 @@
 //!
 //! 근인: WMF 의 목적 사각형이 음수 높이(`dest_height < 0`)로 오는데 그 값을 SVG
 //! `height` 에 그대로 냈다. SVG 는 음수 `width`/`height` 를 **오류로 규정**하므로
-//! 브라우저는 그 속성을 무시하고(=절대값·비반전) 그린다. 이 WMF 는 이미 bottom-up
-//! y-flip 그룹(`translate(0,H) scale(1,-1)`) 안에 있어, 비트맵 자신의 되돌림이
-//! 사라지면 그룹의 flip 만 남아 사진이 뒤집힌다.
+//! 브라우저는 그 속성을 무시하고(=절대값·비반전) 그린다.
 //!
-//! 수정: 원점·크기를 양수로 정규화하고 뒤집힘은 요소 자신의 `transform` 으로
-//! 표현한다. 이 테스트는 그 계약을 SVG 산출로 고정한다 — CLI PNG 는 PyMuPDF 가
-//! 내장 SVG 를 건너뛰어("ignoring external image") 이 결함을 못 잡는다.
+//! [#6617] 이 WMF 는 y-up 창(`SetWindowExt` y<0)이다. GDI 에서 y-up 창의 음수 높이
+//! 블릿은 두 부호가 상쇄돼 **바로 선** 그림이고, 창 매핑(`Window::to_device`)이 y 축을
+//! 이미 뒤집으므로 SVG 에는 어떤 뒤집기 `transform` 도 남지 않아야 한다. 예전의
+//! "y-flip 그룹 + 요소 자체 역변환" 조합은 창 바닥이 논리 0 일 때만 맞았고, 원점 0 인
+//! 이 문서에서는 그림을 viewBox 밖으로 보냈다.
+//!
+//! 이 테스트는 그 계약을 SVG 산출로 고정한다 — CLI PNG 는 PyMuPDF 가 내장 SVG 를
+//! 건너뛰어("ignoring external image") 이 결함을 못 잡는다.
 #![cfg(not(target_arch = "wasm32"))]
 
 use std::path::Path;
@@ -21,8 +24,11 @@ const SAMPLE: &str = "samples/issue6140/156462405_smart_expo.hwp";
 /// 사진이 있는 쪽(0-based).
 const PAGE: u32 = 6;
 
+/// 사진 WMF: `SetWindowExt(281, -285)`, `SetWindowOrg(0, 0)`, `DIBStretchBlt dest (0, 0, 281, -285)`.
+const PHOTO_VIEW_BOX: &str = "viewBox=\"0 0 281 285\"";
+
 #[test]
-fn issue_6140_wmf_bitmap_keeps_positive_extent_and_own_flip() {
+fn issue_6140_wmf_bitmap_keeps_positive_extent_without_any_flip() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
     let core = DocumentCore::from_bytes(&std::fs::read(path).expect("read sample")).expect("open");
     let svg = core.render_page_svg_native(PAGE).expect("page 7 svg");
@@ -30,30 +36,32 @@ fn issue_6140_wmf_bitmap_keeps_positive_extent_and_own_flip() {
     let inner = embedded_svgs(&svg);
     assert!(!inner.is_empty(), "7쪽에 내장 WMF SVG 가 있어야 한다");
 
-    let mut checked = 0usize;
-    for doc in &inner {
-        // bottom-up WMF 만 대상 — y-flip 그룹이 있는 산출.
-        if !doc.contains("scale(1,-1)") {
-            continue;
-        }
-        for image in image_elements(doc) {
-            assert!(
-                !image.contains("height=\"-") && !image.contains("width=\"-"),
-                "SVG 는 음수 width/height 를 오류로 규정한다 — 브라우저가 무시해 비트맵이 \
-                 뒤집힌다: {image}"
-            );
-            // 목적 사각형이 뒤집힌 비트맵은 자기 transform 으로 되돌아와야 한다.
-            assert!(
-                image.contains("transform=\"") && image.contains("scale(1,-1)"),
-                "y-flip 그룹 안 비트맵은 자체 역변환을 가져야 한다: {image}"
-            );
-            checked += 1;
-        }
-    }
+    let photo = inner
+        .iter()
+        .find(|doc| doc.contains(PHOTO_VIEW_BOX))
+        .unwrap_or_else(|| panic!("y-up 창 사진 WMF({PHOTO_VIEW_BOX})를 찾지 못했다"));
     assert!(
-        checked > 0,
-        "bottom-up WMF 의 비트맵 <image> 를 찾지 못했다"
+        !photo.contains("scale(1,-1)") && !photo.contains("scale(-1,1)"),
+        "y-up 창의 뒤집기는 창 매핑이 끝내므로 SVG 에 뒤집기 transform 이 남으면 안 된다: {}",
+        image_elements(photo).join(" | ")
     );
+    let images = image_elements(photo);
+    assert_eq!(
+        images.len(),
+        1,
+        "사진 비트맵 <image> 는 하나여야 한다: {images:?}"
+    );
+    let image = &images[0];
+    assert!(
+        !image.contains("height=\"-") && !image.contains("width=\"-"),
+        "SVG 는 음수 width/height 를 오류로 규정한다: {image}"
+    );
+    for attr in ["x=\"0\"", "y=\"0\"", "width=\"281\"", "height=\"285\""] {
+        assert!(
+            image.contains(attr),
+            "사진은 창 전체 (0, 0, 281, 285) 를 채워야 한다 — {attr} 없음: {image}"
+        );
+    }
 }
 
 /// 페이지 SVG 안에 data URI 로 박힌 WMF 산출 SVG 들.

--- a/tests/cases/issue_6617_wmf_yup_window_mapping.rs
+++ b/tests/cases/issue_6617_wmf_yup_window_mapping.rs
@@ -1,0 +1,115 @@
+//! [#6617] y-up 창 WMF 의 음수 높이 DIB 가 두 번 뒤집혀 viewBox 밖으로 나간다
+//! (bitmap.hwp OLE 표현 메타파일 — 모든 표면에서 그림이 안 보임).
+//!
+//! WMF: `SetMapMode(8)`, `SetWindowExt(1152, -648)`, `SetWindowOrg(0, 0)`,
+//! `DIBStretchBlt dest (x=0, y=0, w=1152, h=-648)`. 수정 전 산출은
+//! `<svg viewBox="0 -648 1152 1296"><g transform="translate(0,1296) scale(1,-1)">
+//! <image y="-648" … transform="translate(0,-648) scale(1,-1)"/></g></svg>` 로, 그림이
+//! y ∈ [1296, 1944] 에 놓여 viewBox 밖이었다.
+//!
+//! 창 매핑(`Window::to_device`)이 y-up 축을 한 번 뒤집고, 블릿 목적 사각형은 두 모서리를
+//! 장치 좌표로 옮겨 정규화한다(`DeviceContext::blit_dest_rect`). 그 결과 그림은 창 전체
+//! `(0, 0, 1152, 648)` 을 뒤집기 없이 채운다. 한/글 2022 PDF 1쪽 잉크 bbox (322, 178)–(484, 281)
+//! 과 rhwp SVG 래스터가 같은 자리다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+use base64::Engine;
+use rhwp::document_core::DocumentCore;
+
+const SAMPLE: &str = "samples/bitmap.hwp";
+const PAGE: u32 = 0;
+
+#[test]
+fn issue_6617_yup_window_bitmap_fills_view_box_upright() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let core = DocumentCore::from_bytes(&std::fs::read(path).expect("read sample")).expect("open");
+    let svg = core.render_page_svg_native(PAGE).expect("page 1 svg");
+
+    // 페이지 SVG 는 같은 OLE 표현 WMF 를 두 자리(본문 그림, 겹침 레이어)에 심는다 — 전부 같은 계약.
+    let inner = embedded_svgs(&svg);
+    assert!(
+        !inner.is_empty(),
+        "1쪽에 OLE 표현 WMF 하위 SVG 가 있어야 한다"
+    );
+    for doc in &inner {
+        assert!(
+            doc.contains("viewBox=\"0 0 1152 648\""),
+            "viewBox 는 창 범위 (0, 0, |ext_x|, |ext_y|) 여야 한다: {}",
+            root_tag(doc)
+        );
+        assert!(
+            !doc.contains("<g transform=") && !doc.contains("scale(1,-1)"),
+            "y-up 창의 뒤집기는 창 매핑이 끝내므로 뒤집기 그룹·transform 이 남으면 안 된다"
+        );
+        let images = image_elements(doc);
+        assert_eq!(
+            images.len(),
+            1,
+            "비트맵 <image> 는 하나여야 한다: {images:?}"
+        );
+        let image = &images[0];
+        for attr in ["x=\"0\"", "y=\"0\"", "width=\"1152\"", "height=\"648\""] {
+            assert!(
+                image.contains(attr),
+                "비트맵은 창 전체를 채워야 한다 — {attr} 없음: {image}"
+            );
+        }
+        assert!(
+            !image.contains("transform="),
+            "y-up 창의 음수 높이 DIB 는 바로 선 그림이라 자체 뒤집기가 없어야 한다: {image}"
+        );
+    }
+}
+
+fn root_tag(doc: &str) -> &str {
+    let start = doc.find("<svg").unwrap_or(0);
+    let end = doc[start..]
+        .find('>')
+        .map(|e| start + e + 1)
+        .unwrap_or(doc.len());
+    &doc[start..end]
+}
+
+/// 페이지 SVG 안에 data URI 로 박힌 WMF 산출 SVG 들.
+fn embedded_svgs(svg: &str) -> Vec<String> {
+    let marker = "data:image/svg+xml;base64,";
+    let mut out = Vec::new();
+    let mut rest = svg;
+    while let Some(idx) = rest.find(marker) {
+        let tail = &rest[idx + marker.len()..];
+        let end = tail
+            .find(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '+' || ch == '/' || ch == '='))
+            .unwrap_or(tail.len());
+        if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(&tail[..end]) {
+            if let Ok(text) = String::from_utf8(bytes) {
+                out.push(text);
+            }
+        }
+        rest = &tail[end..];
+    }
+    out
+}
+
+fn image_elements(doc: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = doc;
+    while let Some(idx) = rest.find("<image") {
+        let tail = &rest[idx..];
+        let end = tail.find('>').map(|e| e + 1).unwrap_or(tail.len());
+        let element = &tail[..end];
+        let trimmed = match element.find("href=\"") {
+            Some(h) => {
+                let head = &element[..h];
+                let after = &element[h..];
+                let close = after[6..].find('"').map(|e| e + 7).unwrap_or(after.len());
+                format!("{head}href=\"…\"{}", &after[close..])
+            }
+            None => element.to_string(),
+        };
+        out.push(trimmed);
+        rest = &tail[end..];
+    }
+    out
+}


### PR DESCRIPTION
closes #6617

## 무엇을 고쳤나

WMF 창(`SetWindowExt`)의 축이 뒤집힌 문서에서 그림이 **보이지 않거나 거울상**으로 나오던 결함을 고쳤다. 창 매핑을 부호 있는 한 식으로 통일하고, 블릿(BitBlt·StretchBlt·DIB 계열) 목적 사각형을 장치 좌표에서 정규화한다.

| 문서 | 창 | 수정 전 | 수정 후 |
|---|---|---|---|
| `samples/bitmap.hwp` 1쪽 (OLE 표현 WMF) | `SetWindowExt(1152, -648)`, `DIBStretchBlt dest h=-648` | 그림 없음 (viewBox 밖 y 1296~1944) | 잉크 bbox (322, 178)–(484, 281) = 한/글 2022 PDF 래스터와 동일 |
| `samples/issue6140/156462405_smart_expo.hwp` 7쪽 사진 | `SetWindowExt(281, -285)`, dest h=-285 | viewBox `0 -285 281 570` + 뒤집기 두 겹 | `viewBox="0 0 281 285"`, 뒤집기 없음, 사진 바로 섬 |
| `samples/issue5714/1490000-200800034_vietnam_labor_report.hwp` 60쪽 차트 | `SetWindowExt` x<0 | **좌우 거울상**, 폭 절반 (viewBox `-24895 0 49790 22461`) | `viewBox="0 0 24895 22461"`, 정상 |

## 원인

WMF→SVG 변환기에 y 뒤집기가 세 겹 있었다.

1. `point_s_to_absolute_point` 가 `(p − origin).abs()` 로 점을 옮긴다 — y-up 창(`ext_y<0`)에서 창 안의 점은 origin 아래(음수)라 abs 가 우연히 뒤집기 구실을 했다.
2. Stage D(#860)가 y-up 창 요소 전체를 `<g transform="translate(0, vb_h) scale(1,-1)">` 로 다시 뒤집었다 — 창 바닥이 논리 0 일 때(origin_y = |ext_y|)만 맞는 특수식.
3. #6140 이 음수 높이 DIB 를 논리 부호로 정규화해 `y=-648` + 요소 자체 뒤집기를 냈고, Stage D 의 "min y 로 viewBox 위쪽 확장"이 그 가짜 음수를 받아 viewBox 를 세로 두 배로 만들었다.

`bitmap.hwp` 처럼 origin 이 0 인 y-up 창에서는 1+2+3 이 겹쳐 그림이 y ∈ [1296, 1944] 로 밀려 viewBox 밖이 됐고, x 축이 뒤집힌 창에는 2 가 없어 abs 로 접힌 좌표에 요소 뒤집기만 남아 거울상이 됐다.

## 수정

- `Window::to_device`: 논리 좌표 → 창 원점 기준 장치 좌표. 축이 뒤집힌 창(`SetWindowExt` 음수)은 그 축의 부호를 바꾼다. viewBox 는 `(0, 0, |ext_x|, |ext_y|)` 그대로. `point_s_to_absolute_point`/`point_s_to_relative_point` 가 이것을 쓴다(abs 제거).
- `DeviceContext::blit_dest_rect`: 목적 사각형의 두 모서리를 각각 옮겨 작은 쪽을 원점으로 삼고, 장치 좌표에서 두 번째 모서리가 앞이면 그 축을 뒤집는다. GDI 의 뒤집기는 논리 폭/높이 부호와 창 축 방향의 곱이라, y-up 창의 음수 높이 DIB 는 두 부호가 상쇄돼 바로 선 그림이다. 블릿 호출부 9곳이 모두 이 함수를 지난다. `TernaryRasterOperator` 는 정규화된 `BlitDestRect` 만 받는다.
- `generate`: y-up `g` 뒤집기 그룹과 Stage D 의 min x/y viewBox 앞쪽 확장을 제거한다. 앞쪽 확장은 viewBox 원점이 창 원점이던 때의 보정이라 #864 이후 원점 상대 좌표에서는 걸릴 일이 없었고, 3 의 가짜 음수에만 걸리고 있었다. 창 앞쪽(음수 장치 좌표)으로 넘친 요소는 GDI 처럼 잘린다. 뒤쪽(max) 확장은 sample14 실측이 있어 그대로 둔다.

## 실측 스크린샷

bitmap.hwp 1쪽 — 수정 전 rhwp SVG(Chrome 래스터, 잉크 없음) / 수정 후 / 한/글 2022 PDF. 잉크 bbox 가 (322, 178)–(484, 281) 로 같다.

![bitmap p1](https://raw.githubusercontent.com/jeong-sik/rhwp/4dd85e3403205f2e42c93f8cf1fb7ac4c934da8a/bitmap-p1-before-after-oracle.png)

156462405 7쪽 사진(3배 확대) — 수정 전은 빈 틀, 수정 후 바로 선 사진. (#6140 의 계약 테스트는 SVG 구조만 봐서 이 빈 틀을 못 잡았다.)

![expo p7](https://raw.githubusercontent.com/jeong-sik/rhwp/4dd85e3403205f2e42c93f8cf1fb7ac4c934da8a/expo-p7-photo-before-after.png)

vietnam 보고서 60쪽 차트(하위 SVG 래스터) — 수정 전 좌우 거울상·반 폭, 수정 후 정상.

![vietnam p60](https://raw.githubusercontent.com/jeong-sik/rhwp/4dd85e3403205f2e42c93f8cf1fb7ac4c934da8a/vietnam-p60-chart-before-after.png)

## 코퍼스 대조

WMF·EMF·OLE 표현 메타파일이 든 샘플 104문서 전수에서 페이지 SVG 안 하위 SVG(WMF 변환 결과)를 수정 전(`devel` a5f3bf695)/후로 뽑아 문자열 대조했다.

| | 값 |
|---|---:|
| 대조한 문서 / 하위 SVG | 104 / 85 |
| 바뀐 하위 SVG | 22 |
| 그중 viewBox·`<image>` 가 바뀐 것 | 6 |

바뀐 6건: bitmap.hwp 1쪽 ×2(같은 WMF 를 두 자리에 심음), 156462405 7쪽, vietnam 보고서 60쪽 ×2 — 모두 위 표의 수정 대상. 나머지 하나는 `hwp3-sample4-hwp5` 35쪽의 DIB 가 창 위로 1 단위 넘친 경우로, 예전엔 abs 가 `y=1` 로 접고 viewBox 를 213 으로 늘렸고 지금은 `y=-1` 로 두고 창 높이 212 에서 GDI 처럼 자른다(그림 세로 0.5%).

나머지 16건은 viewBox·`<image>` 가 그대로이고, 흰 배경 폴리곤의 모서리가 `(1,1)`→`(-1,-1)` 로 바뀐 것뿐이다(창 밖 1 단위를 abs 가 안쪽으로 접던 것 — 시각 변화 없음). hwp3-sample14 13장을 포함한 나머지 문서는 바이트 단위로 같다.

PDF 표면은 #6612(PR #6618)가 하위 SVG 의 비트맵을 살린 뒤에야 이 그림이 나온다 — 두 PR 은 독립이고 순서는 상관없다.

## 테스트

- `tests/cases/issue_6617_wmf_yup_window_mapping.rs` — bitmap.hwp 1쪽 하위 SVG: `viewBox="0 0 1152 648"`, `<image x=0 y=0 width=1152 height=648>` 하나, 뒤집기 그룹·transform 없음.
- `tests/cases/issue_6140_wmf_bitmap_negative_height.rs` — #6140 계약을 새 모델로 고쳤다: 156462405 7쪽 사진 WMF(`viewBox="0 0 281 285"`)는 뒤집기 transform 없이 창 전체 (0, 0, 281, 285) 를 채운다. 옛 계약("y-flip 그룹 안 비트맵은 자체 역변환을 가진다")은 그 그룹 자체가 원인이었다.

음성 대조: 두 테스트를 `devel`(a5f3bf695) 트리에서 돌리면 둘 다 실패한다 — #6617 은 viewBox 단정(`0 -648 1152 1296`), #6140 은 `viewBox="0 0 281 285"` 인 사진 WMF 를 찾지 못함.

## 로컬 검증

- [x] **`cargo fmt --all -- --check` 통과**
- [x] 새 integration test 는 `tests/cases/*.rs` 원본만 추가·수정, `tests/generated/`·manifest 커밋 없음
- [x] `src/**` `#[cfg(test)]` 변경 없음
- [x] `cargo test` — focused `issue_6617_yup_window_bitmap_fills_view_box_upright` · `issue_6140_wmf_bitmap_keeps_positive_extent_without_any_flip` 2/2 통과(스위트는 manifest 가 배정), 이름에 `wmf` 가 든 통합 테스트 14/14 통과 (release-test 전체는 GitHub 전체 CI)
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] 관련 샘플 SVG 내보내기 확인 — 위 스크린샷(Chrome 래스터)
- [x] Native Skia 3종(공식 명령, release-test · pr-review): `--features native-skia --lib` 3946/3946, `issue_2225_missing_picture_placeholder` 2/2, `render_p37_direct_pdf_export` 4/4
- [x] WASM: Docker 부재라 `CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg --no-opt` 진단 경로 exit 0 (WMF 변환기는 wasm 에서도 쓰이므로 빌드 확인)
- [x] `git diff --check`

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 — 블릿마다 점 변환 한 번이 두 번이 되고 viewBox 앞쪽 확장 계산이 빠진다.
- 재현·측정: 미측정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
