### PR TITLE
fix(chart): 차트 XML 의 글꼴·선 굵기·gapWidth 를 읽고 없으면 한/글 기본 서식으로 배치한다 (#6624)

### DIFF
--- a/crates/rhwp-ooxml-chart/src/lib.rs
+++ b/crates/rhwp-ooxml-chart/src/lib.rs
@@ -58,6 +58,16 @@ pub struct OoxmlChart {
     pub categories: Vec<String>,
     /// 시리즈 중 하나라도 보조축을 쓰면 true
     pub has_secondary_axis: bool,
+    /// [#6624] `c:plotArea` 의 축 선언(`c:catAx`/`c:valAx`/`c:dateAx`/`c:serAx`) — 문서 순서.
+    /// 격자선(`c:majorGridlines`)·눈금(`c:majorTickMark`)·숨김(`c:delete`)을 렌더러가 읽는다.
+    /// 코퍼스: 값축(l)만 격자, 눈금은 전부 `out`, 주식형은 격자 없음. 선언이 없으면(축 없는
+    /// 원형, 축 요소를 안 쓴 문서) 렌더러가 코퍼스 기본(값축 격자·눈금 out)을 쓴다.
+    pub axes: Vec<OoxmlAxis>,
+    /// [#6624] `c:plotArea > c:spPr > a:ln` — 플롯 영역 테두리. 코퍼스는 전건 `a:noFill`.
+    pub plot_area_line: LineSpec,
+    /// [#6624] `c:chartSpace > c:spPr > a:ln` — 차트 바깥 테두리. 코퍼스는 전건 미지정이라
+    /// 한/글 기본(#8c8c8c 0.75px)으로 그린다.
+    pub chart_line: LineSpec,
     /// 막대(bar/bar3D) plot의 `c:grouping` (clustered/stacked/percentStacked).
     /// 막대 렌더러만 사용. line/pie 무관. (C1a #1453 막대 누적 보정)
     pub grouping: BarGrouping,
@@ -205,6 +215,61 @@ pub enum SeriesMarker {
     Auto,
     /// 명시 심볼 (diamond/square/triangle/x 등 — 코퍼스 밖, 사이클 폴백과 병행)
     Named(String),
+}
+
+/// 선 선언 (`c:spPr > a:ln`) — 플롯 영역·차트 테두리용. [#6624]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LineSpec {
+    /// `a:ln` 이 없다 — 렌더러가 기본 서식을 정한다.
+    #[default]
+    Unspecified,
+    /// `a:ln > a:noFill` — 선 없음.
+    None,
+    /// `a:ln > a:solidFill` — 색과 굵기(EMU, 없으면 None).
+    Solid { rgb: u32, width_emu: Option<u32> },
+}
+
+/// 축 종류 (`c:catAx`/`c:valAx`/`c:dateAx`/`c:serAx`). [#6624]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AxisKind {
+    #[default]
+    Category,
+    Value,
+    Date,
+    Series,
+}
+
+/// 축 위치 (`c:axPos`). [#6624]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AxisPos {
+    Left,
+    Right,
+    Top,
+    #[default]
+    Bottom,
+}
+
+/// 주 눈금 표시 (`c:majorTickMark`). 없으면 OOXML 기본 `cross` 가 아니라 코퍼스 기본 `out`
+/// 을 쓴다 — 한/글 문서는 전건 명시한다. [#6624]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TickMark {
+    #[default]
+    Out,
+    In,
+    Cross,
+    None,
+}
+
+/// 축 선언 하나. [#6624]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct OoxmlAxis {
+    pub kind: AxisKind,
+    pub pos: AxisPos,
+    /// `c:majorGridlines` 요소 존재 — 이 축의 눈금 위치에 격자선.
+    pub major_gridlines: bool,
+    pub major_tick_mark: TickMark,
+    /// `c:delete val="1"` — 축선·눈금·라벨을 그리지 않는다 (격자선은 유지).
+    pub deleted: bool,
 }
 
 /// 범례 위치 (`c:legendPos`). C1c #1882 갭③.

--- a/crates/rhwp-ooxml-chart/src/lib.rs
+++ b/crates/rhwp-ooxml-chart/src/lib.rs
@@ -46,6 +46,14 @@ pub struct OoxmlChart {
     pub has_title_elem: bool,
     /// `c:autoTitleDeleted val="1"` — 자동 제목 억제 플래그. (C1c #1882 갭①)
     pub auto_title_deleted: bool,
+    /// [#6624] `c:chartSpace > c:txPr > a:p > a:pPr > a:defRPr sz` — 차트 전체 기본 글꼴
+    /// 크기(pt). 축 라벨·범례·격자 여백 산정이 쓴다. 한컴 코퍼스 28종은 전건 `sz="1000"`.
+    /// 없으면 렌더러가 10pt 를 쓴다.
+    pub text_size_pt: Option<f64>,
+    /// [#6624] `c:title` 안의 `a:defRPr sz`/`a:rPr sz` — 제목 글꼴 크기(pt). 축 제목
+    /// (`c:plotArea` 안 `c:title`)은 제외. 코퍼스는 전건 미지정이라 한컴이 14pt 로 그린다.
+    /// 없으면 렌더러가 14pt 를 쓴다.
+    pub title_size_pt: Option<f64>,
     pub series: Vec<OoxmlSeries>,
     pub categories: Vec<String>,
     /// 시리즈 중 하나라도 보조축을 쓰면 true
@@ -320,6 +328,10 @@ pub struct OoxmlSeries {
     /// 막대·꺾은선·분산형은 자기 규칙(`line_markers`·`scatter_style`)으로 선을 정하므로
     /// 이 값을 보지 않는다.
     pub line_none: bool,
+    /// [#6624] 계열 `c:spPr > a:ln w` — 선 굵기(EMU, 12700 = 1pt). 점별(`c:dPt`)·표식
+    /// (`c:marker`) 의 spPr 은 제외. 없으면 렌더러가 Office 기본 2.25pt 를 쓴다
+    /// (한컴 꺽은선형 실측 3px = 2.25pt).
+    pub line_width_emu: Option<u32>,
 }
 
 impl OoxmlChart {

--- a/crates/rhwp-ooxml-chart/src/parser.rs
+++ b/crates/rhwp-ooxml-chart/src/parser.rs
@@ -37,6 +37,12 @@ struct ParseState {
     // c:dPt(점별 속성) 블록 내부 — 점별 explosion 을 계열로 승격하지 않기 위한
     // 문맥 게이트 (PR #2500 후속)
     in_d_pt: bool,
+    // [#6624] 글꼴 크기·선 굵기 문맥. c:chart 밖의 c:txPr 만 차트 전체 기본 글꼴이고,
+    // c:plotArea 안 c:title 은 축 제목, c:marker 안 spPr 은 표식 테두리라 제외한다.
+    in_chart_body: bool,
+    in_plot_area: bool,
+    in_tx_pr: bool,
+    in_marker: bool,
     bar_dir: Option<BarDir>,
     // 현재 파싱 중인 plot 블록 (barChart/lineChart/pieChart) 안에 있는지
     cur_plot_type: Option<OoxmlChartType>,
@@ -408,6 +414,7 @@ fn handle_start(e: &quick_xml::events::BytesStart, chart: &mut OoxmlChart, st: &
             }
         }
         b"marker" => {
+            st.in_marker = true;
             if let Some(ser) = st.cur_series.as_mut() {
                 // 계열 내부 <c:marker> 래퍼 — symbol 자식이 없으면 자동 표식
                 // (stock 종가 실측: <c:marker><c:size val="7"/> 만). symbol이 오면
@@ -492,9 +499,39 @@ fn handle_start(e: &quick_xml::events::BytesStart, chart: &mut OoxmlChart, st: &
             st.in_a_t = true;
             st.cur_text_buf.clear();
         }
+        b"chart" => st.in_chart_body = true,
+        b"plotArea" => st.in_plot_area = true,
+        b"txPr" => st.in_tx_pr = true,
+        // [#6624] 글꼴 크기(sz, 1/100pt). `c:chartSpace > c:txPr`(c:chart 밖)의 defRPr 는
+        // 차트 전체 기본, `c:title` 안의 defRPr/rPr 는 제목. 축 제목(plotArea 안)은 제외.
+        b"defRPr" | b"rPr" => {
+            if let Some(pt) = attr_val(e, "sz").and_then(|v| v.parse::<f64>().ok()) {
+                let pt = pt / 100.0;
+                if st.in_chart_title && !st.in_plot_area {
+                    if chart.title_size_pt.is_none() {
+                        chart.title_size_pt = Some(pt);
+                    }
+                } else if st.in_tx_pr && !st.in_chart_body && chart.text_size_pt.is_none() {
+                    chart.text_size_pt = Some(pt);
+                }
+            }
+        }
         b"spPr" => st.in_sp_pr = true,
         b"solidFill" => st.in_solid_fill = true,
-        b"ln" => st.in_ln = true,
+        b"ln" => {
+            st.in_ln = true;
+            // [#6624] 계열 `c:spPr > a:ln w` (EMU) — 선 굵기. 점별(dPt)·표식(marker)의
+            // spPr 은 계열 선이 아니라 제외.
+            if st.in_sp_pr && !st.in_d_pt && !st.in_marker {
+                if let Some(w) = attr_val(e, "w").and_then(|v| v.parse::<u32>().ok()) {
+                    if let Some(ser) = st.cur_series.as_mut() {
+                        if ser.line_width_emu.is_none() {
+                            ser.line_width_emu = Some(w);
+                        }
+                    }
+                }
+            }
+        }
         // [#6053] `c:spPr > a:ln > a:noFill` — 선 없음. `a:ln` 안일 때만 본다
         // (`spPr > noFill` 은 면 채움 없음이라 뜻이 다르다). 주식형 렌더러가 소비한다.
         b"noFill" => {
@@ -611,6 +648,10 @@ fn handle_end(name: &[u8], chart: &mut OoxmlChart, st: &mut ParseState) {
         b"cat" => st.in_cat = false,
         b"val" => st.in_val = false,
         b"dPt" => st.in_d_pt = false,
+        b"chart" => st.in_chart_body = false,
+        b"plotArea" => st.in_plot_area = false,
+        b"txPr" => st.in_tx_pr = false,
+        b"marker" => st.in_marker = false,
         b"xVal" => st.in_x_val = false,
         b"yVal" => st.in_y_val = false,
         b"title" => st.in_chart_title = false,

--- a/crates/rhwp-ooxml-chart/src/parser.rs
+++ b/crates/rhwp-ooxml-chart/src/parser.rs
@@ -17,6 +17,53 @@ use quick_xml::events::Event;
 use quick_xml::Reader;
 use std::collections::HashMap;
 
+use super::{AxisKind, AxisPos, LineSpec, OoxmlAxis, TickMark};
+
+/// [#6624] 계열 밖 `c:spPr > a:ln` 의 주인.
+#[derive(Clone, Copy)]
+enum LineOwner {
+    PlotArea,
+    ChartSpace,
+}
+
+/// 지금 열린 `a:ln` 이 플롯 영역/차트 바깥 것인지. 계열·축·점별·표식·제목·범례·데이터표의
+/// spPr 은 해당 없음.
+fn line_owner(st: &ParseState) -> Option<LineOwner> {
+    if !(st.in_sp_pr && st.in_ln)
+        || st.cur_series.is_some()
+        || st.cur_axis.is_some()
+        || st.in_d_pt
+        || st.in_marker
+        || st.in_chart_title
+        || st.in_d_table
+    {
+        return None;
+    }
+    if st.in_plot_area {
+        Some(LineOwner::PlotArea)
+    } else if !st.in_chart_body {
+        Some(LineOwner::ChartSpace)
+    } else {
+        None
+    }
+}
+
+fn set_line(chart: &mut OoxmlChart, owner: LineOwner, spec: LineSpec) {
+    match owner {
+        LineOwner::PlotArea => chart.plot_area_line = spec,
+        LineOwner::ChartSpace => chart.chart_line = spec,
+    }
+}
+
+/// [#6624] 축 선언 시작 — `chart.axes` 에 넣고 열린 축으로 표시한다.
+fn open_axis(chart: &mut OoxmlChart, st: &mut ParseState, kind: AxisKind) {
+    chart.axes.push(OoxmlAxis {
+        kind,
+        ..Default::default()
+    });
+    st.cur_axis = Some(chart.axes.len() - 1);
+}
+
 /// 파싱 진행 시 문맥(현재 어떤 태그 트리에 있는지) 추적
 #[derive(Default)]
 struct ParseState {
@@ -43,6 +90,11 @@ struct ParseState {
     in_plot_area: bool,
     in_tx_pr: bool,
     in_marker: bool,
+    // [#6624] 지금 열려 있는 축 선언의 `chart.axes` 색인 (catAx/valAx/dateAx/serAx 안).
+    cur_axis: Option<usize>,
+    // [#6624] 열린 `a:ln` 의 `w`(EMU) — 플롯 영역·차트 테두리 선 굵기용.
+    cur_ln_w: Option<u32>,
+    in_d_table: bool,
     bar_dir: Option<BarDir>,
     // 현재 파싱 중인 plot 블록 (barChart/lineChart/pieChart) 안에 있는지
     cur_plot_type: Option<OoxmlChartType>,
@@ -520,10 +572,11 @@ fn handle_start(e: &quick_xml::events::BytesStart, chart: &mut OoxmlChart, st: &
         b"solidFill" => st.in_solid_fill = true,
         b"ln" => {
             st.in_ln = true;
+            st.cur_ln_w = attr_val(e, "w").and_then(|v| v.parse::<u32>().ok());
             // [#6624] 계열 `c:spPr > a:ln w` (EMU) — 선 굵기. 점별(dPt)·표식(marker)의
             // spPr 은 계열 선이 아니라 제외.
             if st.in_sp_pr && !st.in_d_pt && !st.in_marker {
-                if let Some(w) = attr_val(e, "w").and_then(|v| v.parse::<u32>().ok()) {
+                if let Some(w) = st.cur_ln_w {
                     if let Some(ser) = st.cur_series.as_mut() {
                         if ser.line_width_emu.is_none() {
                             ser.line_width_emu = Some(w);
@@ -532,12 +585,15 @@ fn handle_start(e: &quick_xml::events::BytesStart, chart: &mut OoxmlChart, st: &
                 }
             }
         }
+        b"dTable" => st.in_d_table = true,
         // [#6053] `c:spPr > a:ln > a:noFill` — 선 없음. `a:ln` 안일 때만 본다
         // (`spPr > noFill` 은 면 채움 없음이라 뜻이 다르다). 주식형 렌더러가 소비한다.
         b"noFill" => {
             if st.in_sp_pr && st.in_ln {
                 if let Some(ser) = st.cur_series.as_mut() {
                     ser.line_none = true;
+                } else if let Some(owner) = line_owner(st) {
+                    set_line(chart, owner, LineSpec::None);
                 }
             }
         }
@@ -549,6 +605,15 @@ fn handle_start(e: &quick_xml::events::BytesStart, chart: &mut OoxmlChart, st: &
                             if ser.color.is_none() {
                                 ser.color = Some(rgb);
                             }
+                        } else if let Some(owner) = line_owner(st) {
+                            set_line(
+                                chart,
+                                owner,
+                                LineSpec::Solid {
+                                    rgb,
+                                    width_emu: st.cur_ln_w,
+                                },
+                            );
                         }
                     }
                 }
@@ -562,6 +627,15 @@ fn handle_start(e: &quick_xml::events::BytesStart, chart: &mut OoxmlChart, st: &
                             if ser.color.is_none() {
                                 ser.color = Some(rgb);
                             }
+                        } else if let Some(owner) = line_owner(st) {
+                            set_line(
+                                chart,
+                                owner,
+                                LineSpec::Solid {
+                                    rgb,
+                                    width_emu: st.cur_ln_w,
+                                },
+                            );
                         }
                     }
                 }
@@ -583,8 +657,16 @@ fn handle_start(e: &quick_xml::events::BytesStart, chart: &mut OoxmlChart, st: &
             }
         }
         b"axPos" => {
-            if st.in_val_ax {
-                if let Some(val) = attr_val(e, "val") {
+            if let Some(val) = attr_val(e, "val") {
+                if let Some(ax) = st.cur_axis.and_then(|i| chart.axes.get_mut(i)) {
+                    ax.pos = match val.as_str() {
+                        "l" => AxisPos::Left,
+                        "r" => AxisPos::Right,
+                        "t" => AxisPos::Top,
+                        _ => AxisPos::Bottom,
+                    };
+                }
+                if st.in_val_ax {
                     st.cur_val_ax_pos = Some(val);
                 }
             }
@@ -593,6 +675,37 @@ fn handle_start(e: &quick_xml::events::BytesStart, chart: &mut OoxmlChart, st: &
             st.in_val_ax = true;
             st.cur_val_ax_id = None;
             st.cur_val_ax_pos = None;
+            open_axis(chart, st, AxisKind::Value);
+        }
+        b"catAx" => open_axis(chart, st, AxisKind::Category),
+        b"dateAx" => open_axis(chart, st, AxisKind::Date),
+        b"serAx" => open_axis(chart, st, AxisKind::Series),
+        // [#6624] 축 선언 안의 격자·눈금·숨김. 축 밖의 동명 요소(dLbls 의 delete 등)는 무시.
+        b"majorGridlines" => {
+            if let Some(ax) = st.cur_axis.and_then(|i| chart.axes.get_mut(i)) {
+                ax.major_gridlines = true;
+            }
+        }
+        b"majorTickMark" => {
+            if let (Some(ax), Some(val)) = (
+                st.cur_axis.and_then(|i| chart.axes.get_mut(i)),
+                attr_val(e, "val"),
+            ) {
+                ax.major_tick_mark = match val.as_str() {
+                    "in" => TickMark::In,
+                    "cross" => TickMark::Cross,
+                    "none" => TickMark::None,
+                    _ => TickMark::Out,
+                };
+            }
+        }
+        b"delete" => {
+            if let (Some(ax), Some(val)) = (
+                st.cur_axis.and_then(|i| chart.axes.get_mut(i)),
+                attr_val(e, "val"),
+            ) {
+                ax.deleted = matches!(val.as_str(), "1" | "true");
+            }
         }
         _ => {}
     }
@@ -665,10 +778,16 @@ fn handle_end(name: &[u8], chart: &mut OoxmlChart, st: &mut ParseState) {
             st.in_sp_pr = false;
         }
         b"solidFill" => st.in_solid_fill = false,
-        b"ln" => st.in_ln = false,
+        b"ln" => {
+            st.in_ln = false;
+            st.cur_ln_w = None;
+        }
+        b"dTable" => st.in_d_table = false,
         b"numCache" => st.in_num_cache = false,
+        b"catAx" | b"dateAx" | b"serAx" => st.cur_axis = None,
         b"valAx" => {
             st.in_val_ax = false;
+            st.cur_axis = None;
             if let (Some(id), Some(pos)) = (st.cur_val_ax_id.take(), st.cur_val_ax_pos.take()) {
                 st.val_ax_map.insert(id, pos);
             } else if let Some(id) = st.cur_val_ax_id.take() {

--- a/crates/rhwp-ooxml-chart/src/renderer.rs
+++ b/crates/rhwp-ooxml-chart/src/renderer.rs
@@ -28,6 +28,84 @@ fn palette(i: usize) -> u32 {
     DEFAULT_PALETTE[i % DEFAULT_PALETTE.len()]
 }
 
+/// 한/글 기본 차트 서식 — 차트 XML 에 글꼴 크기(`sz`)와 수동 레이아웃(`manualLayout`)이
+/// 없을 때 한/글이 자동 배치에 쓰는 값. `pdf/chart/**` 한/글 PDF 28종(프레임 430×250px)의
+/// 래스터 실측 (#6624): 제목 잉크 y 18.0~35.5(≈14pt, 검정), 첫 격자선 y 61, 축선 y 209,
+/// 카테고리 라벨 잉크 y 226.5~239.5(≈10pt, 검정), 격자·축선 #8C8C8C 1px. 여백은 전부
+/// 글꼴 크기의 배수로 두어 차트 크기가 달라도 같은 비율을 유지한다.
+mod hancom_default {
+    /// 제목 글꼴(pt) — 차트 XML 의 `c:title` 에 `sz` 가 없을 때. 코퍼스 전건 미지정.
+    pub const TITLE_PT: f64 = 14.0;
+    /// 축 라벨·범례 글꼴(pt) — `c:chartSpace > c:txPr` 에 `sz` 가 없을 때. 코퍼스 전건 1000.
+    pub const LABEL_PT: f64 = 10.0;
+    /// 계열 선 굵기(pt) — 계열 `a:ln` 에 `w` 가 없을 때 (Office 기본 28575 EMU, 한컴 실측 3px).
+    pub const SERIES_LINE_PT: f64 = 2.25;
+    /// 제목·라벨·범례 글자색.
+    pub const TEXT_COLOR: &str = "#000000";
+    /// 프레임 상단 → 제목 baseline = 1.9 × 제목 글꼴 (실측 35.5px = 위 여백 18 + 한글 잉크 17.5).
+    pub const TITLE_BASELINE_EM: f64 = 1.9;
+    /// 제목 baseline → 플롯 상단 = 1.36 × 제목 글꼴 (실측 61 − 35.5 = 25.5px).
+    pub const TITLE_PLOT_GAP_EM: f64 = 1.36;
+    /// 제목이 없을 때 프레임 상단 → 플롯 상단 (라벨 글꼴 배수, 코퍼스에 표본 없음).
+    pub const NO_TITLE_TOP_EM: f64 = 1.0;
+    /// 플롯 하단 → 프레임 하단 = 3.1 × 라벨 글꼴 (실측 250 − 209 = 41px).
+    pub const BOTTOM_PAD_EM: f64 = 3.1;
+    /// 플롯 하단 → 카테고리 라벨 baseline = 2.3 × 라벨 글꼴 (실측 239.5 − 209 = 30.5px).
+    pub const CATEGORY_LABEL_BASELINE_EM: f64 = 2.3;
+    /// 원형: 제목 baseline → 원 상단 = 1.0 × 제목 글꼴 (실측 2차원원형 원 상단 54.5 = 35.5 + 19).
+    pub const PIE_TITLE_GAP_EM: f64 = 1.0;
+    /// 원형: 원 하단 → 프레임 하단 = 1.1 × 라벨 글꼴 (실측 252.5 − 237.5 = 15px).
+    /// 축 라벨이 없으므로 `BOTTOM_PAD_EM` 대신 쓴다. 왼쪽 여백도 0.
+    pub const PIE_BOTTOM_PAD_EM: f64 = 1.1;
+    /// 라벨 오른끝 → 플롯 왼쪽 = 1.3 × 라벨 글꼴 (실측 라인 27.5 − 8 ≈ 19, 가로막대 69.7 − 53 ≈ 17).
+    pub const LEFT_GAP_EM: f64 = 1.3;
+    /// 플롯 오른쪽 → 범례 영역 = 0.6 × 라벨 글꼴 (실측 356 → 365).
+    pub const RIGHT_GAP_EM: f64 = 0.6;
+    /// 한글 한 글자 폭 (em 비율). 숫자·라틴은 `DIGIT_EM`.
+    pub const CJK_EM: f64 = 0.9;
+    pub const DIGIT_EM: f64 = 0.55;
+    /// 격자선·축선 스타일 (실측 #8C8C8C, 1px — 3D 방 선은 `ROOM_LINE_STYLE` 별도 실측).
+    pub const GRID_STYLE: &str = "stroke=\"#8c8c8c\" stroke-width=\"1\"";
+}
+
+/// CSS px / pt (96dpi).
+const PX_PER_PT: f64 = 96.0 / 72.0;
+/// OOXML `c:gapWidth`·`c:gapDepth` 기본값(%). 요소가 없을 때.
+const OOXML_DEFAULT_GAP_PERCENT: f64 = 150.0;
+/// EMU / pt.
+const EMU_PER_PT: f64 = 12700.0;
+
+/// 축 라벨·범례 글꼴 px — 차트 XML 의 기본 글꼴(`text_size_pt`), 없으면 한컴 기본 10pt.
+fn label_font_px(chart: &OoxmlChart) -> f64 {
+    chart.text_size_pt.unwrap_or(hancom_default::LABEL_PT) * PX_PER_PT
+}
+
+/// 제목 글꼴 px — 제목 `sz`, 없으면 한컴 기본 14pt.
+fn title_font_px(chart: &OoxmlChart) -> f64 {
+    chart.title_size_pt.unwrap_or(hancom_default::TITLE_PT) * PX_PER_PT
+}
+
+/// 계열 선 굵기 px — `a:ln w`(EMU), 없으면 Office 기본 2.25pt.
+fn series_line_px(ser: &OoxmlSeries) -> f64 {
+    ser.line_width_emu
+        .map(|w| w as f64 / EMU_PER_PT)
+        .unwrap_or(hancom_default::SERIES_LINE_PT)
+        * PX_PER_PT
+}
+
+/// 라벨 문자열의 대략 폭(px) — 한글은 `CJK_EM`, 나머지는 `DIGIT_EM` 배.
+fn label_text_width(text: &str, font: f64) -> f64 {
+    text.chars()
+        .map(|c| {
+            if c.is_ascii() {
+                font * hancom_default::DIGIT_EM
+            } else {
+                font * hancom_default::CJK_EM
+            }
+        })
+        .sum()
+}
+
 fn color_hex(c: u32) -> String {
     format!("#{:06x}", c & 0xFFFFFF)
 }
@@ -210,8 +288,22 @@ pub fn render_chart_svg(chart: &OoxmlChart, x: f64, y: f64, w: f64, h: f64) -> S
         })
     });
 
-    // 영역 분할
-    let title_h = if effective_title.is_some() { 22.0 } else { 4.0 };
+    // 영역 분할 — 한/글 기본 서식(`hancom_default`, #6624): 제목 baseline 1.9T, 제목→플롯 1.36T,
+    // 플롯 아래 3.1L, 라벨 폭 + 1.3L 왼쪽 여백 (T=제목 글꼴, L=라벨 글꼴).
+    let title_font = title_font_px(chart);
+    let label_font = label_font_px(chart);
+    // 원형은 축·축 라벨이 없어 제목 아래 간격과 아래 여백이 다르다 (실측 2차원원형 지름 183 =
+    // 프레임 높이 252.5 − 위 54.5 − 아래 15).
+    let is_pie = chart.chart_type == OoxmlChartType::Pie;
+    let title_h = match (effective_title.is_some(), is_pie) {
+        (true, false) => {
+            title_font * (hancom_default::TITLE_BASELINE_EM + hancom_default::TITLE_PLOT_GAP_EM)
+        }
+        (true, true) => {
+            title_font * (hancom_default::TITLE_BASELINE_EM + hancom_default::PIE_TITLE_GAP_EM)
+        }
+        (false, _) => label_font * hancom_default::NO_TITLE_TOP_EM,
+    };
     // 파이는 카테고리 기반 범례라 시리즈 이름과 무관하게 항상 그려진다(파이 분기가
     // render_legend/render_legend_right를 무조건 호출) — 공간 예약도 그에 맞춰야 함.
     let legend_visible =
@@ -227,13 +319,12 @@ pub fn render_chart_svg(chart: &OoxmlChart, x: f64, y: f64, w: f64, h: f64) -> S
         0.0
     };
     let legend_w = if legend_right {
-        let max_chars = legend_items(chart)
+        let max_w = legend_items(chart)
             .iter()
-            .map(|(label, _, _)| label.chars().count())
-            .max()
-            .unwrap_or(0);
-        // 스와치 10 + 간격 8 + CJK ~10px/자 (플롯 최소폭은 아래 .max(10.0)이 방어)
-        (max_chars as f64 * 10.0 + 26.0).clamp(50.0, w * 0.30)
+            .map(|(label, _, _)| label_text_width(label, label_font))
+            .fold(0.0f64, f64::max);
+        // 스와치 10 + 간격 8 + 글자 폭(10pt) + 오른쪽 여백 8 (플롯 최소폭은 아래 .max(10.0)이 방어)
+        (max_w + 26.0).clamp(50.0, w * 0.30)
     } else {
         0.0
     };
@@ -241,28 +332,42 @@ pub fn render_chart_svg(chart: &OoxmlChart, x: f64, y: f64, w: f64, h: f64) -> S
     // 좌측에 오므로 카테고리 폭 기준 — 숫자 폭(2자≈32px)으로 잡으면 라벨이 잘림.
     let horizontal_bars =
         chart.chart_type == OoxmlChartType::Bar && !chart.is_combo() && !chart.has_secondary_axis;
-    let left_pad = if horizontal_bars {
+    let left_pad = if is_pie {
+        0.0
+    } else if horizontal_bars {
         estimate_category_label_width(chart, w)
     } else {
         estimate_axis_label_width(chart, 0)
     };
+    // [#6624] 가로 값축(가로 막대·분산형)은 마지막 값 라벨이 플롯 오른끝에 가운데 정렬되어
+    // 절반이 플롯 밖으로 나온다 — 그 절반 + 라벨 간격 1.3L 을 비운다 (한/글 실측: 묶은가로
+    // 21.5px, 분산형 22.5px ≈ 3.7 + 17.3). 세로 값축은 0.6L (라인 실측 9.5px).
+    let value_axis_horizontal = horizontal_bars || chart.chart_type == OoxmlChartType::Scatter;
     let right_pad = if chart.has_secondary_axis {
         estimate_axis_label_width(chart, 1)
+    } else if value_axis_horizontal {
+        value_axis_max_label_width(chart) / 2.0 + label_font * hancom_default::LEFT_GAP_EM
     } else {
-        16.0
+        label_font * hancom_default::RIGHT_GAP_EM
     };
-    let bottom_pad = 26.0;
+    let bottom_pad = if is_pie {
+        label_font * hancom_default::PIE_BOTTOM_PAD_EM
+    } else {
+        label_font * hancom_default::BOTTOM_PAD_EM
+    };
     let plot_x = x + left_pad;
-    let plot_y = y + title_h + 4.0;
+    let plot_y = y + title_h;
     let plot_w = (w - left_pad - right_pad - legend_w).max(10.0);
     let plot_h = (h - title_h - legend_h - bottom_pad).max(10.0);
 
     if let Some(ref title) = effective_title {
-        // 한컴 제목은 regular weight (정답지 PDF 실측 — C1c #1882 갭①)
+        // 한컴 제목은 regular weight (정답지 PDF 실측 — C1c #1882 갭①), 14pt 검정 (#6624)
         svg.push_str(&format!(
-            "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"13\" font-weight=\"400\" fill=\"#222\" text-anchor=\"middle\">{}</text>\n",
+            "<text class=\"hwp-chart-title\" x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"{:.2}\" font-weight=\"400\" fill=\"{}\" text-anchor=\"middle\">{}</text>\n",
             x + w / 2.0,
-            y + title_h - 4.0,
+            y + title_font * hancom_default::TITLE_BASELINE_EM,
+            title_font,
+            hancom_default::TEXT_COLOR,
             xml_escape(title)
         ));
     }
@@ -345,34 +450,53 @@ fn series_color(s: &OoxmlSeries, idx: usize) -> String {
 /// 가로 막대 좌측 카테고리 라벨용 여백: 최장 카테고리 문자 수 기반 (CJK ~10px/자).
 /// 상한은 차트 폭의 35%(플롯 최소폭은 호출부 `.max(10.0)`이 방어).
 fn estimate_category_label_width(chart: &OoxmlChart, w: f64) -> f64 {
-    let max_chars = chart
+    let font = label_font_px(chart);
+    let max_w = chart
         .categories
         .iter()
-        .map(|c| c.chars().count())
-        .max()
-        .unwrap_or(0);
-    (max_chars as f64 * 10.0 + 14.0)
-        .min((w * 0.35).max(28.0))
-        .max(28.0)
+        .map(|c| label_text_width(c, font))
+        .fold(0.0f64, f64::max);
+    let gap = font * hancom_default::LEFT_GAP_EM;
+    (max_w + gap)
+        .min((w * 0.35).max(2.0 * font))
+        .max(2.0 * font)
 }
 
 /// 지정한 axis_group의 최대 라벨 길이(문자 수) 기반으로 여백 추정
 fn estimate_axis_label_width(chart: &OoxmlChart, axis_group: u8) -> f64 {
+    let font = label_font_px(chart);
     let series: Vec<&OoxmlSeries> = chart
         .series
         .iter()
         .filter(|s| s.axis_group == axis_group)
         .collect();
     if series.is_empty() {
-        return 16.0;
+        return font * hancom_default::LEFT_GAP_EM;
     }
     let (vmin, vmax, _) = value_range_for(series.iter().cloned(), VERTICAL_AXIS_TICKS);
     let fmt = series.first().and_then(|s| s.format_code.as_deref());
     let min_label = format_num(vmin, fmt);
     let max_label = format_num(vmax, fmt);
-    let max_chars = min_label.chars().count().max(max_label.chars().count());
-    // 숫자/콤마는 ~7px, 안전 여유 18px (좌우 플롯 영역 바깥 라벨 공간 확보)
-    (max_chars as f64 * 7.0 + 18.0).max(28.0)
+    let max_w = label_text_width(&min_label, font).max(label_text_width(&max_label, font));
+    // 라벨 폭 + 라벨~축 간격 (한/글 실측: 한 자리 값축 라벨 차트의 플롯 왼쪽 27.5px)
+    (max_w + font * hancom_default::LEFT_GAP_EM).max(2.0 * font)
+}
+
+/// 기본 값축의 마지막(최대) 라벨 폭(px) — 가로 값축 오른쪽 여백 산정용. 분산형은 X 값 범위.
+fn value_axis_max_label_width(chart: &OoxmlChart) -> f64 {
+    let font = label_font_px(chart);
+    if chart.chart_type == OoxmlChartType::Scatter {
+        let (_, xmax, _) =
+            scatter_range(chart.series.iter().flat_map(|s| s.x_values.iter().copied()));
+        return label_text_width(&format_num(xmax, None), font);
+    }
+    let series: Vec<&OoxmlSeries> = chart.series.iter().filter(|s| s.axis_group == 0).collect();
+    if series.is_empty() {
+        return 0.0;
+    }
+    let (_, vmax, _) = value_range_for(series.iter().cloned(), VERTICAL_AXIS_TICKS);
+    let fmt = series.first().and_then(|s| s.format_code.as_deref());
+    label_text_width(&format_num(vmax, fmt), font)
 }
 
 /// 시리즈 부분집합의 원시 값 범위 (0-baseline clamp + 퇴화 방어, nice 반올림 전)
@@ -587,6 +711,7 @@ fn render_bars(
 
     render_value_grid(
         svg,
+        label_font_px(chart),
         px,
         py,
         pw,
@@ -601,13 +726,17 @@ fn render_bars(
         false,
     );
 
-    let (cat_span, bar_span_total) = if horizontal {
-        let span = ph / cat_count as f64;
-        (span, span * 0.7)
-    } else {
-        let span = pw / cat_count as f64;
-        (span, span * 0.7)
-    };
+    // [#6624] 밴드 안 막대 묶음 폭 = 밴드 × n/(n + gapWidth/100). gapWidth(기본 150)는
+    // 막대 하나 폭에 대한 밴드 사이 간격 비율(OOXML `c:gapWidth`). 누적은 막대 하나(n=1)라
+    // 밴드의 0.4 (한/글 실측 누적세로 31.5/82 = 0.38, 묶은세로 3×18/82 = 0.66).
+    let n_eff = if stacked { 1.0 } else { ser_count as f64 };
+    let gap = chart
+        .bar_gap_width
+        .unwrap_or(OOXML_DEFAULT_GAP_PERCENT)
+        .max(0.0)
+        / 100.0;
+    let cat_span = if horizontal { ph } else { pw } / cat_count as f64;
+    let bar_span_total = cat_span * n_eff / (n_eff + gap);
 
     // 가로 막대는 카테고리를 아래→위로 배치 (한컴 실측: 항목 1이 맨 아래).
     // 세로는 왼→오른쪽 그대로.
@@ -744,6 +873,7 @@ fn render_line(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f64, 
     ));
     render_value_grid(
         svg,
+        label_font_px(chart),
         px,
         py,
         pw,
@@ -790,9 +920,10 @@ fn render_line(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f64, 
             points.push((px + cat_span * (i as f64 + 0.5), py + ph - ph * t));
         }
         svg.push_str(&format!(
-            "<path d=\"{}\" fill=\"none\" stroke=\"{}\" stroke-width=\"2\"/>\n",
+            "<path d=\"{}\" fill=\"none\" stroke=\"{}\" stroke-width=\"{:.2}\"/>\n",
             polyline_path(&points),
-            color
+            color,
+            series_line_px(ser)
         ));
         if chart.line_markers {
             for &(mx, my) in &points {
@@ -846,6 +977,7 @@ fn render_stock(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f64,
     ));
     render_value_grid(
         svg,
+        label_font_px(chart),
         px,
         py,
         pw,
@@ -888,7 +1020,10 @@ fn render_stock(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f64,
     };
     let cat_span = pw / cat_count as f64;
     // 캔들 폭 = cat_span / (1 + gapWidth/100) — 정답지 gapWidth=150 → 슬롯의 40%
-    let gap = chart.up_down_gap_width.unwrap_or(150.0).max(0.0);
+    let gap = chart
+        .up_down_gap_width
+        .unwrap_or(OOXML_DEFAULT_GAP_PERCENT)
+        .max(0.0);
     let candle_w = cat_span / (1.0 + gap / 100.0);
 
     for ci in 0..cat_count {
@@ -943,9 +1078,10 @@ fn render_stock(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f64,
             .map(|(ci, &v)| (px + cat_span * (ci as f64 + 0.5), y_of(v)))
             .collect();
         svg.push_str(&format!(
-            "<path d=\"{}\" fill=\"none\" stroke=\"{}\" stroke-width=\"2\"/>\n",
+            "<path d=\"{}\" fill=\"none\" stroke=\"{}\" stroke-width=\"{:.2}\"/>\n",
             polyline_path(&points),
-            series_color(ser, si)
+            series_color(ser, si),
+            series_line_px(ser)
         ));
     }
 
@@ -993,11 +1129,12 @@ fn render_scatter(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f6
         px, py, pw, ph
     ));
     // X축(하단, 수직 격자선) + Y축(좌측, 수평 격자선) — 둘 다 수치축, 소수 라벨
+    let font = label_font_px(chart);
     render_value_grid(
-        svg, px, py, pw, ph, xmin, xmax, xstep, None, true, false, false, true,
+        svg, font, px, py, pw, ph, xmin, xmax, xstep, None, true, false, false, true,
     );
     render_value_grid(
-        svg, px, py, pw, ph, ymin, ymax, ystep, None, false, false, false, true,
+        svg, font, px, py, pw, ph, ymin, ymax, ystep, None, false, false, false, true,
     );
 
     let (show_line, smooth, show_markers) = chart.scatter_style.flags();
@@ -1027,8 +1164,10 @@ fn render_scatter(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f6
                 polyline_path(&points)
             };
             svg.push_str(&format!(
-                "<path d=\"{}\" fill=\"none\" stroke=\"{}\" stroke-width=\"2\"/>\n",
-                d, color
+                "<path d=\"{}\" fill=\"none\" stroke=\"{}\" stroke-width=\"{:.2}\"/>\n",
+                d,
+                color,
+                series_line_px(ser)
             ));
         }
         if show_markers {
@@ -1190,7 +1329,9 @@ fn render_pie(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f64, p
     // 벌어진 extent(r×(1+e))가 기존 fit과 같도록 반지름 축소. explosion 부재
     // (e=0) 시 기존 산식·출력 그대로. (C2b #2278 Stage 3 v3, 정답지 쪼개진원형)
     let explode = first.explosion.unwrap_or(0.0).max(0.0) / 100.0;
-    let r = (pw.min(ph) / 2.0) * 0.9 / (1.0 + explode);
+    // 원은 플롯 영역에 꽉 차게 — 여백은 `render_chart_svg` 의 영역 분할이 이미 뺐다
+    // (#6624, 실측 2차원원형 지름 183 = 플롯 높이).
+    let r = (pw.min(ph) / 2.0) / (1.0 + explode);
 
     let mut start_angle = -std::f64::consts::FRAC_PI_2;
     for (i, &v) in first.values.iter().enumerate() {
@@ -1256,11 +1397,18 @@ fn render_of_pie(
     // 레이아웃 — 정답지(원형대원형-2022 임베드 2702×1577) 픽셀 실측 캘리브레이션:
     // 주 원 중심 x≈0.23·플롯폭, 보조 중심 x≈0.80, r1≈0.38·플롯높이(가로는 캡),
     // r2/r1 실측 0.754 = secondPieSize(75)/100 ✓ (스키마 의미 그대로)
-    let cx1 = px + pw * 0.23;
+    // [#6624] 원형대가로막대형은 주 원이 더 크고(지름 0.97·플롯높이, 중심 x 0.36·플롯폭)
+    // 막대는 플롯폭 0.18 × 플롯높이 0.955 — 정답지(원형대가로막대형-2022) 실측: 플롯
+    // 0~357 × 54~235 에서 원 x 40~215, 막대 x 258~323 / y 59.5~232.5.
+    let (cx1, r1) = match of.of_pie_type {
+        OfPieType::Pie => (px + pw * 0.23, (pw * 0.46).min(ph * 0.76) / 2.0),
+        OfPieType::Bar => (px + pw * 0.36, (pw * 0.50).min(ph * 0.97) / 2.0),
+    };
     let cy = py + ph / 2.0;
-    let r1 = (pw * 0.46).min(ph * 0.76) / 2.0;
     let cx2 = px + pw * 0.80;
     let r2 = r1 * (of.second_pie_size.max(0.0) / 100.0);
+    let bar_h = ph * 0.955;
+    let bar_w = pw * 0.18;
 
     // 주 원 — 값 시퀀스 = values[..n−k] + [combined]. 결합 슬라이스 중앙이 3시(θ=0)
     let sweep_c = combined / total * TAU;
@@ -1310,8 +1458,6 @@ fn render_of_pie(
             }
             OfPieType::Bar => {
                 // 보조 누적 막대 — 첫 분할 카테고리가 맨 위, 위→아래 누적
-                let bar_h = 2.0 * r2;
-                let bar_w = bar_h * 0.45;
                 let bx = cx2 - bar_w / 2.0;
                 let top = cy - bar_h / 2.0;
                 let mut acc = 0.0;
@@ -1370,10 +1516,8 @@ fn render_of_pie(
             let ((tx, ty), (bx2, by2)) = match of.of_pie_type {
                 OfPieType::Pie => (tangent(ux, uy, true), tangent(lx, ly, false)),
                 OfPieType::Bar => {
-                    let bar_h = 2.0 * r2;
-                    let bar_w = bar_h * 0.45;
                     let bx = cx2 - bar_w / 2.0;
-                    ((bx, cy - r2), (bx, cy + r2))
+                    ((bx, cy - bar_h / 2.0), (bx, cy + bar_h / 2.0))
                 }
             };
             for ((x1, y1), (x2, y2)) in [((ux, uy), (tx, ty)), ((lx, ly), (bx2, by2))] {
@@ -1514,7 +1658,20 @@ fn render_combo(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f64,
     // 기본축 격자 (좌측)
     let pri_fmt = pri.first().and_then(|s| s.format_code.as_deref());
     render_value_grid(
-        svg, px, py, pw, ph, pri_min, pri_max, pri_step, pri_fmt, false, false, false, false,
+        svg,
+        label_font_px(chart),
+        px,
+        py,
+        pw,
+        ph,
+        pri_min,
+        pri_max,
+        pri_step,
+        pri_fmt,
+        false,
+        false,
+        false,
+        false,
     );
 
     // 보조축 격자 (우측, 눈금만) — step 기반이라 기본축과 눈금 수가 다를 수 있음
@@ -1522,7 +1679,20 @@ fn render_combo(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f64,
     if !sec.is_empty() {
         let sec_fmt = sec.first().and_then(|s| s.format_code.as_deref());
         render_value_grid(
-            svg, px, py, pw, ph, sec_min, sec_max, sec_step, sec_fmt, false, true, false, false,
+            svg,
+            label_font_px(chart),
+            px,
+            py,
+            pw,
+            ph,
+            sec_min,
+            sec_max,
+            sec_step,
+            sec_fmt,
+            false,
+            true,
+            false,
+            false,
         );
     }
 
@@ -1640,6 +1810,7 @@ fn render_combo(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f64,
 #[allow(clippy::too_many_arguments)]
 fn render_value_grid(
     svg: &mut String,
+    font: f64,
     px: f64,
     py: f64,
     pw: f64,
@@ -1669,6 +1840,29 @@ fn render_value_grid(
     let span = (vmax - vmin).max(1e-9);
     let step = if step > 0.0 { step } else { span / 5.0 };
     let grid_lines = (span / step).round().max(1.0) as usize;
+    // [#6624] 한/글은 값축 격자선과 같은 스타일로 축선(값축·카테고리축)을 그린다.
+    // 눈금 0 의 격자선이 한쪽 축선을 겸하므로 나머지 축선 하나만 더 긋는다.
+    if !secondary {
+        if horizontal {
+            svg.push_str(&format!(
+                "<line class=\"hwp-chart-axis\" x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" {}/>\n",
+                px,
+                py + ph,
+                px + pw,
+                py + ph,
+                hancom_default::GRID_STYLE
+            ));
+        } else {
+            svg.push_str(&format!(
+                "<line class=\"hwp-chart-axis\" x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" {}/>\n",
+                px,
+                py,
+                px,
+                py + ph,
+                hancom_default::GRID_STYLE
+            ));
+        }
+    }
     for i in 0..=grid_lines {
         let t = (step * i as f64) / span;
         if horizontal {
@@ -1676,32 +1870,50 @@ fn render_value_grid(
             // 보조축일 때는 격자선 중복 방지, 라벨만
             if !secondary {
                 svg.push_str(&format!(
-                    "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" stroke=\"#e8e8e8\" stroke-width=\"0.5\"/>\n",
-                    gx, py, gx, py + ph
+                    "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" {}/>\n",
+                    gx,
+                    py,
+                    gx,
+                    py + ph,
+                    hancom_default::GRID_STYLE
                 ));
             }
             let v = vmin + step * i as f64;
             svg.push_str(&format!(
-                "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"10\" fill=\"#666\" text-anchor=\"middle\">{}</text>\n",
-                gx, py + ph + 12.0, xml_escape(&label(v))
+                "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"{:.2}\" fill=\"{}\" text-anchor=\"middle\">{}</text>\n",
+                gx,
+                py + ph + font * hancom_default::CATEGORY_LABEL_BASELINE_EM,
+                font,
+                hancom_default::TEXT_COLOR,
+                xml_escape(&label(v))
             ));
         } else {
             let gy = py + ph - ph * t;
             if !secondary {
                 svg.push_str(&format!(
-                    "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" stroke=\"#e8e8e8\" stroke-width=\"0.5\"/>\n",
-                    px, gy, px + pw, gy
+                    "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" {}/>\n",
+                    px,
+                    gy,
+                    px + pw,
+                    gy,
+                    hancom_default::GRID_STYLE
                 ));
             }
             let v = vmin + step * i as f64;
+            let gap = font * hancom_default::LEFT_GAP_EM * 0.5;
             let (tx, anchor) = if secondary {
-                (px + pw + 4.0, "start")
+                (px + pw + gap, "start")
             } else {
-                (px - 4.0, "end")
+                (px - gap, "end")
             };
             svg.push_str(&format!(
-                "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"10\" fill=\"#666\" text-anchor=\"{}\">{}</text>\n",
-                tx, gy + 3.0, anchor, xml_escape(&label(v))
+                "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"{:.2}\" fill=\"{}\" text-anchor=\"{}\">{}</text>\n",
+                tx,
+                gy + font * 0.35,
+                font,
+                hancom_default::TEXT_COLOR,
+                anchor,
+                xml_escape(&label(v))
             ));
         }
     }
@@ -1725,6 +1937,7 @@ const ROOM_TICK_DOWN: f64 = 4.0;
 #[allow(clippy::too_many_arguments)]
 fn render_value_grid_3d(
     svg: &mut String,
+    font: f64,
     proj: &ShearProj,
     vmin: f64,
     vmax: f64,
@@ -1807,9 +2020,11 @@ fn render_value_grid_3d(
                 fy + fh + ROOM_TICK_DOWN
             ));
             svg.push_str(&format!(
-                "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"10\" fill=\"#666\" text-anchor=\"middle\">{}</text>\n",
+                "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"{:.2}\" fill=\"{}\" text-anchor=\"middle\">{}</text>\n",
                 gx,
-                fy + fh + 12.0,
+                fy + fh + ROOM_TICK_DOWN + font,
+                font,
+                hancom_default::TEXT_COLOR,
                 xml_escape(&label(v))
             ));
         } else {
@@ -1837,9 +2052,11 @@ fn render_value_grid_3d(
                 gy
             ));
             svg.push_str(&format!(
-                "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"10\" fill=\"#666\" text-anchor=\"end\">{}</text>\n",
+                "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"{:.2}\" fill=\"{}\" text-anchor=\"end\">{}</text>\n",
                 fx - ROOM_TICK_LEFT - 1.0,
-                gy + 3.0,
+                gy + font * 0.35,
+                font,
+                hancom_default::TEXT_COLOR,
                 xml_escape(&label(v))
             ));
         }
@@ -1895,7 +2112,10 @@ fn render_bars_3d(
     // 두께 규칙 slot/(n_eff + gapWidth/100) — Excel gapWidth 의미(슬롯 내 여백을
     // 막대 폭 %로). 코퍼스 150: 누적 1/2.5=0.4, 묶은 3계열 3/4.5≈0.667 —
     // v1~v3 눈대중 상수의 유도 원형. 2D는 0.7 휴리스틱 동결.
-    let gap_w = chart.bar_gap_width.unwrap_or(150.0).max(0.0);
+    let gap_w = chart
+        .bar_gap_width
+        .unwrap_or(OOXML_DEFAULT_GAP_PERCENT)
+        .max(0.0);
     let n_eff = if stacked { 1.0 } else { ser_count as f64 };
 
     // fit 전 좌표로 깊이 산출 (fit이 깊이에 의존 — 역방향 순환 없음).
@@ -1904,7 +2124,13 @@ fn render_bars_3d(
     let slot0 = (if horizontal { ph } else { pw }) / cat_count as f64;
     let bar_w0 = slot0 / (n_eff + gap_w / 100.0);
     let b_depth = bar_w0 * view.depth_percent.max(0.0) / 100.0;
-    let d_scene = b_depth * (1.0 + chart.gap_depth.unwrap_or(150.0).max(0.0) / 100.0);
+    let d_scene = b_depth
+        * (1.0
+            + chart
+                .gap_depth
+                .unwrap_or(OOXML_DEFAULT_GAP_PERCENT)
+                .max(0.0)
+                / 100.0);
 
     let proj = shear_proj(&view, px, py, pw, ph, d_scene);
 
@@ -1921,6 +2147,7 @@ fn render_bars_3d(
 
     render_value_grid_3d(
         svg,
+        label_font_px(chart),
         &proj,
         vmin,
         vmax,
@@ -2063,19 +2290,28 @@ fn render_category_labels_at(
         if ci >= cat_count {
             break;
         }
+        let font = label_font_px(chart);
         if horizontal {
             // 가로 막대: 카테고리 아래→위 (한컴 실측 — 막대 배치와 동일 순서)
             let row = cat_count - 1 - ci;
-            let cy = py + cat_span * row as f64 + cat_span / 2.0 + 3.0;
+            let cy = py + cat_span * row as f64 + cat_span / 2.0 + font * 0.35;
             svg.push_str(&format!(
-                "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"10\" fill=\"#333\" text-anchor=\"end\">{}</text>\n",
-                px - left_gap, cy, xml_escape(cat)
+                "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"{:.2}\" fill=\"{}\" text-anchor=\"end\">{}</text>\n",
+                px - left_gap,
+                cy,
+                font,
+                hancom_default::TEXT_COLOR,
+                xml_escape(cat)
             ));
         } else {
             let cx = px + cat_span * ci as f64 + cat_span / 2.0;
             svg.push_str(&format!(
-                "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"10\" fill=\"#333\" text-anchor=\"middle\">{}</text>\n",
-                cx, py + ph + 14.0, xml_escape(cat)
+                "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"{:.2}\" fill=\"{}\" text-anchor=\"middle\">{}</text>\n",
+                cx,
+                py + ph + font * hancom_default::CATEGORY_LABEL_BASELINE_EM,
+                font,
+                hancom_default::TEXT_COLOR,
+                xml_escape(cat)
             ));
         }
     }
@@ -2208,8 +2444,13 @@ fn legend_items(chart: &OoxmlChart) -> Vec<(String, u32, SwatchKind)> {
 fn push_legend_swatch(svg: &mut String, ix: f64, cy: f64, color: u32, kind: SwatchKind) {
     let swatch_line = |svg: &mut String| {
         svg.push_str(&format!(
-            "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" stroke=\"{}\" stroke-width=\"2\"/>\n",
-            ix, cy, ix + 14.0, cy, color_hex(color)
+            "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" stroke=\"{}\" stroke-width=\"{:.2}\"/>\n",
+            ix,
+            cy,
+            ix + 14.0,
+            cy,
+            color_hex(color),
+            hancom_default::SERIES_LINE_PT * PX_PER_PT
         ));
     };
     match kind {
@@ -2255,6 +2496,7 @@ fn render_legend(svg: &mut String, chart: &OoxmlChart, x: f64, y: f64, w: f64, _
         return;
     }
     let items = legend_items(chart);
+    let font = label_font_px(chart);
 
     svg.push_str("<g class=\"hwp-chart-legend\">\n");
     // 가운데 정렬: 항목 개수로 총 너비 계산
@@ -2265,8 +2507,12 @@ fn render_legend(svg: &mut String, chart: &OoxmlChart, x: f64, y: f64, w: f64, _
         let ix = start_x + item_w * i as f64;
         push_legend_swatch(svg, ix, y + 11.0, *color, *kind);
         svg.push_str(&format!(
-            "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"10\" fill=\"#333\">{}</text>\n",
-            ix + 18.0, y + 14.0, xml_escape(label)
+            "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"{:.2}\" fill=\"{}\">{}</text>\n",
+            ix + 18.0,
+            y + 11.0 + font * 0.35,
+            font,
+            hancom_default::TEXT_COLOR,
+            xml_escape(label)
         ));
     }
     svg.push_str("</g>\n");
@@ -2279,7 +2525,8 @@ fn render_legend_right(svg: &mut String, chart: &OoxmlChart, x: f64, y: f64, h: 
         return;
     }
     let items = legend_items(chart);
-    let row_h = 16.0;
+    let font = label_font_px(chart);
+    let row_h = font * 1.3;
     let total_h = row_h * items.len() as f64;
     let start_y = y + ((h - total_h) / 2.0).max(0.0);
 
@@ -2288,9 +2535,11 @@ fn render_legend_right(svg: &mut String, chart: &OoxmlChart, x: f64, y: f64, h: 
         let cy = start_y + row_h * i as f64 + row_h / 2.0;
         push_legend_swatch(svg, x, cy, *color, *kind);
         svg.push_str(&format!(
-            "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"10\" fill=\"#333\">{}</text>\n",
+            "<text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"{:.2}\" fill=\"{}\">{}</text>\n",
             x + 18.0,
-            cy + 3.0,
+            cy + font * 0.35,
+            font,
+            hancom_default::TEXT_COLOR,
             xml_escape(label)
         ));
     }
@@ -2557,7 +2806,7 @@ mod tests {
         for chunk in svg.split("<path ").skip(1) {
             let end = chunk.find("/>").unwrap_or(chunk.len());
             let tag = &chunk[..end];
-            if !tag.contains("fill=\"none\"") || !tag.contains("stroke-width=\"2\"") {
+            if !tag.contains("fill=\"none\"") || !tag.contains("stroke-width=\"3.00\"") {
                 continue;
             }
             if let Some(p) = tag.find("d=\"") {
@@ -3222,7 +3471,7 @@ mod tests {
             "계열별 글리프 1개"
         );
         assert_eq!(
-            legend.matches("stroke-width=\"2\"").count(),
+            legend.matches("stroke-width=\"3.00\"").count(),
             3,
             "선분 스와치 유지"
         );
@@ -3241,7 +3490,7 @@ mod tests {
         let svg = render_chart_svg(&c, 0.0, 0.0, 400.0, 300.0);
         let legend = legend_fragment(&svg);
         assert_eq!(legend.matches("hwp-legend-glyph").count(), 0);
-        assert_eq!(legend.matches("stroke-width=\"2\"").count(), 3);
+        assert_eq!(legend.matches("stroke-width=\"3.00\"").count(), 3);
     }
 
     #[test]
@@ -3257,7 +3506,7 @@ mod tests {
             "1계열 글리프"
         );
         assert_eq!(
-            legend.matches("stroke-width=\"2\"").count(),
+            legend.matches("stroke-width=\"3.00\"").count(),
             0,
             "표식만은 선분 스와치 없음"
         );
@@ -3272,7 +3521,7 @@ mod tests {
         let legend = legend_fragment(&svg);
         assert_eq!(legend.matches("hwp-legend-glyph").count(), 1);
         assert_eq!(
-            legend.matches("stroke-width=\"2\"").count(),
+            legend.matches("stroke-width=\"3.00\"").count(),
             1,
             "선분 스와치 동반"
         );
@@ -3296,7 +3545,7 @@ mod tests {
             "stock 범례에 색 사각형 스와치 없음"
         );
         assert_eq!(
-            legend.matches("stroke-width=\"2\"").count(),
+            legend.matches("stroke-width=\"3.00\"").count(),
             0,
             "stock 범례에 선분 스와치 없음"
         );
@@ -3387,9 +3636,9 @@ mod tests {
 
     // --- #1882 v2: 단일 시리즈 이름 자동 제목 fallback ---
 
-    /// 제목 텍스트(font-size 13 — 범례/축 라벨(10px)과 구분)만 추출
+    /// 제목 텍스트(`class="hwp-chart-title"`)만 추출
     fn title_text(svg: &str) -> Option<String> {
-        let chunk = svg.split("font-size=\"13\"").nth(1)?;
+        let chunk = svg.split("class=\"hwp-chart-title\"").nth(1)?;
         let s = chunk.find('>')? + 1;
         let e = s + chunk[s..].find('<')?;
         Some(chunk[s..e].to_string())
@@ -4029,14 +4278,12 @@ mod tests {
             "gapWidth 300 누적 → 0.25, 실제 {ratio_g}"
         );
 
-        // 2D 대조군: 0.7 유지 (바이트 불변 가드)
+        // 2D 도 같은 규칙 (#6624): 누적 = 1/(1+1.5) = 0.4 — 한/글 실측 누적세로 31.5/82 = 0.38.
+        // (종전 0.7 고정은 한/글보다 1.8배 두꺼웠다.)
         let svg2d = render_chart_svg(&bars_chart(BarGrouping::Stacked), 0.0, 0.0, 400.0, 300.0);
         let f2 = blue_fronts(&svg2d);
         let ratio2 = f2[0].2 / cat_span_of(&f2);
-        assert!(
-            (ratio2 - 0.7).abs() < 1e-3,
-            "2D 누적 0.7 유지, 실제 {ratio2}"
-        );
+        assert!((ratio2 - 0.4).abs() < 1e-3, "2D 누적 0.4, 실제 {ratio2}");
     }
 
     #[test]

--- a/crates/rhwp-ooxml-chart/src/renderer.rs
+++ b/crates/rhwp-ooxml-chart/src/renderer.rs
@@ -5,9 +5,11 @@
 //! - **콤보 차트** (bar + line) 및 **이중 Y축** 지원
 
 use super::{
-    BarGrouping, LegendPos, OfPieInfo, OfPieType, OoxmlChart, OoxmlChartType, OoxmlSeries,
-    SeriesMarker, View3D,
+    AxisPos, BarGrouping, LegendPos, OfPieInfo, OfPieType, OoxmlAxis, OoxmlChart, OoxmlChartType,
+    OoxmlSeries, SeriesMarker, TickMark, View3D,
 };
+
+use super::LineSpec;
 
 /// 기본 시리즈 색상 팔레트 (시리즈 색상 미지정 시 순환 사용)
 ///
@@ -66,6 +68,69 @@ mod hancom_default {
     pub const DIGIT_EM: f64 = 0.55;
     /// 격자선·축선 스타일 (실측 #8C8C8C, 1px — 3D 방 선은 `ROOM_LINE_STYLE` 별도 실측).
     pub const GRID_STYLE: &str = "stroke=\"#8c8c8c\" stroke-width=\"1\"";
+    /// 주 눈금 길이 = 0.23 × 라벨 글꼴 (실측 4배 래스터 10~12px = 2.5~3px, 축선과 같은 선).
+    pub const TICK_EM: f64 = 0.23;
+    /// 차트 바깥 테두리 — `c:chartSpace > c:spPr` 미지정일 때 (실측 4배 래스터 3px·gray 134).
+    pub const FRAME_STYLE: &str = "stroke=\"#8c8c8c\" stroke-width=\"0.75\"";
+}
+
+/// 선 선언 → SVG stroke 속성. 미지정이면 `default_attr`, `a:noFill` 이면 선 없음. [#6624]
+fn line_attr(spec: LineSpec, default_attr: &str) -> String {
+    match spec {
+        LineSpec::Unspecified => default_attr.to_string(),
+        LineSpec::None => "stroke=\"none\"".to_string(),
+        LineSpec::Solid { rgb, width_emu } => format!(
+            "stroke=\"{}\" stroke-width=\"{:.2}\"",
+            color_hex(rgb),
+            width_emu.map(|w| w as f64 / EMU_PER_PT).unwrap_or(0.75) * PX_PER_PT
+        ),
+    }
+}
+
+/// 플롯 영역 사각형 — 흰 면 + `c:plotArea > c:spPr > a:ln`. 미지정·noFill 이면 테두리 없음
+/// (코퍼스 전건 noFill, 한/글 실측 플롯 테두리 없음). [#6624]
+fn plot_rect(chart: &OoxmlChart, px: f64, py: f64, pw: f64, ph: f64) -> String {
+    format!(
+        "<rect x=\"{:.2}\" y=\"{:.2}\" width=\"{:.2}\" height=\"{:.2}\" fill=\"#ffffff\" {}/>\n",
+        px,
+        py,
+        pw,
+        ph,
+        line_attr(chart.plot_area_line, "stroke=\"none\"")
+    )
+}
+
+/// 해당 위치의 축 선언. 없으면 코퍼스 기본(격자 있음·눈금 out·표시) — 축 요소를 안 쓴
+/// 문서와 모델을 직접 만드는 테스트가 종전 격자 출력을 유지하도록. [#6624]
+fn axis_at(chart: &OoxmlChart, pos: AxisPos) -> OoxmlAxis {
+    chart
+        .axes
+        .iter()
+        .find(|a| a.pos == pos)
+        .cloned()
+        .unwrap_or(OoxmlAxis {
+            pos,
+            major_gridlines: true,
+            ..Default::default()
+        })
+}
+
+/// 눈금 하나 — `outward` 는 축 바깥쪽 단위 벡터. `TickMark::Cross` 는 양쪽. [#6624]
+fn push_tick(svg: &mut String, tick: TickMark, x: f64, y: f64, ox: f64, oy: f64, len: f64) {
+    let (a, b) = match tick {
+        TickMark::Out => (0.0, 1.0),
+        TickMark::In => (-1.0, 0.0),
+        TickMark::Cross => (-1.0, 1.0),
+        TickMark::None => return,
+    };
+    svg.push_str(&format!(
+        "<line class=\"hwp-chart-tick\" x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" {}/>\n",
+        x + ox * len * a,
+        y + oy * len * a,
+        x + ox * len * b,
+        y + oy * len * b,
+        hancom_default::GRID_STYLE
+    ));
 }
 
 /// CSS px / pt (96dpi).
@@ -272,8 +337,12 @@ pub fn render_chart_svg(chart: &OoxmlChart, x: f64, y: f64, w: f64, h: f64) -> S
 
     let mut svg = String::new();
     svg.push_str(&format!(
-        "<g class=\"hwp-ooxml-chart\"><rect x=\"{:.2}\" y=\"{:.2}\" width=\"{:.2}\" height=\"{:.2}\" fill=\"#ffffff\" stroke=\"#cccccc\" stroke-width=\"0.5\"/>\n",
-        x, y, w, h
+        "<g class=\"hwp-ooxml-chart\"><rect x=\"{:.2}\" y=\"{:.2}\" width=\"{:.2}\" height=\"{:.2}\" fill=\"#ffffff\" {}/>\n",
+        x,
+        y,
+        w,
+        h,
+        line_attr(chart.chart_line, hancom_default::FRAME_STYLE)
     ));
 
     // C1c #1882 갭①: 명시 제목이 없어도 c:title 요소가 있고 autoTitleDeleted=0이면
@@ -704,14 +773,11 @@ fn render_bars(
         return;
     }
 
-    svg.push_str(&format!(
-        "<rect x=\"{:.2}\" y=\"{:.2}\" width=\"{:.2}\" height=\"{:.2}\" fill=\"#ffffff\" stroke=\"#cccccc\" stroke-width=\"0.5\"/>\n",
-        px, py, pw, ph
-    ));
+    svg.push_str(&plot_rect(chart, px, py, pw, ph));
 
     render_value_grid(
         svg,
-        label_font_px(chart),
+        chart,
         px,
         py,
         pw,
@@ -867,13 +933,10 @@ fn render_line(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f64, 
         value_range(chart, VERTICAL_AXIS_TICKS)
     };
 
-    svg.push_str(&format!(
-        "<rect x=\"{:.2}\" y=\"{:.2}\" width=\"{:.2}\" height=\"{:.2}\" fill=\"#ffffff\" stroke=\"#cccccc\" stroke-width=\"0.5\"/>\n",
-        px, py, pw, ph
-    ));
+    svg.push_str(&plot_rect(chart, px, py, pw, ph));
     render_value_grid(
         svg,
-        label_font_px(chart),
+        chart,
         px,
         py,
         pw,
@@ -971,13 +1034,10 @@ fn render_stock(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f64,
     let (vmin, mx, vstep) = nice_axis_no_headroom(raw_min, raw_max, VERTICAL_AXIS_TICKS);
     let vmax = mx + vstep;
 
-    svg.push_str(&format!(
-        "<rect x=\"{:.2}\" y=\"{:.2}\" width=\"{:.2}\" height=\"{:.2}\" fill=\"#ffffff\" stroke=\"#cccccc\" stroke-width=\"0.5\"/>\n",
-        px, py, pw, ph
-    ));
+    svg.push_str(&plot_rect(chart, px, py, pw, ph));
     render_value_grid(
         svg,
-        label_font_px(chart),
+        chart,
         px,
         py,
         pw,
@@ -1124,17 +1184,13 @@ fn render_scatter(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f6
     let yspan = (ymax - ymin).max(1e-9);
 
     // 플롯 배경
-    svg.push_str(&format!(
-        "<rect x=\"{:.2}\" y=\"{:.2}\" width=\"{:.2}\" height=\"{:.2}\" fill=\"#ffffff\" stroke=\"#cccccc\" stroke-width=\"0.5\"/>\n",
-        px, py, pw, ph
-    ));
+    svg.push_str(&plot_rect(chart, px, py, pw, ph));
     // X축(하단, 수직 격자선) + Y축(좌측, 수평 격자선) — 둘 다 수치축, 소수 라벨
-    let font = label_font_px(chart);
     render_value_grid(
-        svg, font, px, py, pw, ph, xmin, xmax, xstep, None, true, false, false, true,
+        svg, chart, px, py, pw, ph, xmin, xmax, xstep, None, true, false, false, true,
     );
     render_value_grid(
-        svg, font, px, py, pw, ph, ymin, ymax, ystep, None, false, false, false, true,
+        svg, chart, px, py, pw, ph, ymin, ymax, ystep, None, false, false, false, true,
     );
 
     let (show_line, smooth, show_markers) = chart.scatter_style.flags();
@@ -1650,28 +1706,12 @@ fn render_combo(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f64,
         value_range_for(sec.iter().cloned(), VERTICAL_AXIS_TICKS)
     };
 
-    svg.push_str(&format!(
-        "<rect x=\"{:.2}\" y=\"{:.2}\" width=\"{:.2}\" height=\"{:.2}\" fill=\"#ffffff\" stroke=\"#cccccc\" stroke-width=\"0.5\"/>\n",
-        px, py, pw, ph
-    ));
+    svg.push_str(&plot_rect(chart, px, py, pw, ph));
 
     // 기본축 격자 (좌측)
     let pri_fmt = pri.first().and_then(|s| s.format_code.as_deref());
     render_value_grid(
-        svg,
-        label_font_px(chart),
-        px,
-        py,
-        pw,
-        ph,
-        pri_min,
-        pri_max,
-        pri_step,
-        pri_fmt,
-        false,
-        false,
-        false,
-        false,
+        svg, chart, px, py, pw, ph, pri_min, pri_max, pri_step, pri_fmt, false, false, false, false,
     );
 
     // 보조축 격자 (우측, 눈금만) — step 기반이라 기본축과 눈금 수가 다를 수 있음
@@ -1679,19 +1719,7 @@ fn render_combo(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f64,
     if !sec.is_empty() {
         let sec_fmt = sec.first().and_then(|s| s.format_code.as_deref());
         render_value_grid(
-            svg,
-            label_font_px(chart),
-            px,
-            py,
-            pw,
-            ph,
-            sec_min,
-            sec_max,
-            sec_step,
-            sec_fmt,
-            false,
-            true,
-            false,
+            svg, chart, px, py, pw, ph, sec_min, sec_max, sec_step, sec_fmt, false, true, false,
             false,
         );
     }
@@ -1810,7 +1838,7 @@ fn render_combo(svg: &mut String, chart: &OoxmlChart, px: f64, py: f64, pw: f64,
 #[allow(clippy::too_many_arguments)]
 fn render_value_grid(
     svg: &mut String,
-    font: f64,
+    chart: &OoxmlChart,
     px: f64,
     py: f64,
     pw: f64,
@@ -1840,9 +1868,21 @@ fn render_value_grid(
     let span = (vmax - vmin).max(1e-9);
     let step = if step > 0.0 { step } else { span / 5.0 };
     let grid_lines = (span / step).round().max(1.0) as usize;
-    // [#6624] 한/글은 값축 격자선과 같은 스타일로 축선(값축·카테고리축)을 그린다.
-    // 눈금 0 의 격자선이 한쪽 축선을 겸하므로 나머지 축선 하나만 더 긋는다.
-    if !secondary {
+    // [#6624] 축 선언대로: 격자선은 `c:majorGridlines` 가 있는 축만, 축선은 숨기지 않은 축,
+    // 눈금은 `c:majorTickMark` 방향으로 (한/글 실측: 값축 축선 있음, 눈금 out 약 3px,
+    // 주식형은 격자 없음). 셋 다 격자선과 같은 선 스타일.
+    let font = label_font_px(chart);
+    let axis = axis_at(
+        chart,
+        match (horizontal, secondary) {
+            (true, false) => AxisPos::Bottom,
+            (true, true) => AxisPos::Top,
+            (false, false) => AxisPos::Left,
+            (false, true) => AxisPos::Right,
+        },
+    );
+    let tick_len = font * hancom_default::TICK_EM;
+    if !secondary && !axis.deleted {
         if horizontal {
             svg.push_str(&format!(
                 "<line class=\"hwp-chart-axis\" x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" {}/>\n",
@@ -1868,7 +1908,7 @@ fn render_value_grid(
         if horizontal {
             let gx = px + pw * t;
             // 보조축일 때는 격자선 중복 방지, 라벨만
-            if !secondary {
+            if !secondary && axis.major_gridlines {
                 svg.push_str(&format!(
                     "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" {}/>\n",
                     gx,
@@ -1877,6 +1917,12 @@ fn render_value_grid(
                     py + ph,
                     hancom_default::GRID_STYLE
                 ));
+            }
+            if axis.deleted {
+                continue;
+            }
+            if !secondary {
+                push_tick(svg, axis.major_tick_mark, gx, py + ph, 0.0, 1.0, tick_len);
             }
             let v = vmin + step * i as f64;
             svg.push_str(&format!(
@@ -1889,7 +1935,7 @@ fn render_value_grid(
             ));
         } else {
             let gy = py + ph - ph * t;
-            if !secondary {
+            if !secondary && axis.major_gridlines {
                 svg.push_str(&format!(
                     "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" {}/>\n",
                     px,
@@ -1898,6 +1944,12 @@ fn render_value_grid(
                     gy,
                     hancom_default::GRID_STYLE
                 ));
+            }
+            if axis.deleted {
+                continue;
+            }
+            if !secondary {
+                push_tick(svg, axis.major_tick_mark, px, gy, -1.0, 0.0, tick_len);
             }
             let v = vmin + step * i as f64;
             let gap = font * hancom_default::LEFT_GAP_EM * 0.5;
@@ -2286,11 +2338,60 @@ fn render_category_labels_at(
     } else {
         pw / cat_count as f64
     };
+    // [#6624] 카테고리 축선 + 경계 눈금 (한/글 실측: 아래/왼쪽 축선, 카테고리 경계마다
+    // 바깥 눈금 약 3px). `c:delete` 면 축선·눈금·라벨 전부 생략.
+    let cat_axis = axis_at(
+        chart,
+        if horizontal {
+            AxisPos::Left
+        } else {
+            AxisPos::Bottom
+        },
+    );
+    if cat_axis.deleted {
+        return;
+    }
+    let font = label_font_px(chart);
+    let tick_len = font * hancom_default::TICK_EM;
+    if horizontal {
+        svg.push_str(&format!(
+            "<line class=\"hwp-chart-cat-axis\" x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" {}/>\n",
+            px,
+            py,
+            px,
+            py + ph,
+            hancom_default::GRID_STYLE
+        ));
+        for i in 0..=cat_count {
+            let y = py + cat_span * i as f64;
+            push_tick(svg, cat_axis.major_tick_mark, px, y, -1.0, 0.0, tick_len);
+        }
+    } else {
+        svg.push_str(&format!(
+            "<line class=\"hwp-chart-cat-axis\" x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" {}/>\n",
+            px,
+            py + ph,
+            px + pw,
+            py + ph,
+            hancom_default::GRID_STYLE
+        ));
+        for i in 0..=cat_count {
+            let x = px + cat_span * i as f64;
+            push_tick(
+                svg,
+                cat_axis.major_tick_mark,
+                x,
+                py + ph,
+                0.0,
+                1.0,
+                tick_len,
+            );
+        }
+    }
     for (ci, cat) in chart.categories.iter().enumerate() {
         if ci >= cat_count {
             break;
         }
-        let font = label_font_px(chart);
         if horizontal {
             // 가로 막대: 카테고리 아래→위 (한컴 실측 — 막대 배치와 동일 순서)
             let row = cat_count - 1 - ci;

--- a/tests/cases/issue_6624_chart_default_layout.rs
+++ b/tests/cases/issue_6624_chart_default_layout.rs
@@ -10,7 +10,10 @@
 use std::path::Path;
 
 use rhwp::ooxml_chart::renderer::render_chart_svg;
-use rhwp::ooxml_chart::{BarGrouping, LegendPos, OoxmlChart, OoxmlChartType, OoxmlSeries};
+use rhwp::ooxml_chart::{
+    AxisKind, AxisPos, BarGrouping, LegendPos, LineSpec, OoxmlChart, OoxmlChartType, OoxmlSeries,
+    TickMark,
+};
 
 fn page0_svg(rel: &str) -> String {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
@@ -129,6 +132,137 @@ fn pie_fills_plot_region_like_hancom() {
         (cy_ratio - 0.578).abs() < 0.02,
         "중심 y/프레임 높이 0.578: {cy_ratio:.3}"
     );
+}
+
+// ---- 축 선언대로: 격자선·축선·눈금 ----
+
+/// 차트 그룹 안의 `<line …/>` 태그들.
+fn lines(g: &str) -> Vec<&str> {
+    g.split("<line ")
+        .skip(1)
+        .map(|l| &l[..l.find("/>").expect("line 닫힘")])
+        .collect()
+}
+
+#[test]
+fn stock_has_axes_and_ticks_but_no_gridlines() {
+    // 주식형 XML 은 두 축 다 `c:majorGridlines` 없음, `c:majorTickMark val="out"`.
+    // 한/글 실측: 격자 없음, 값축(왼쪽)·카테고리축(아래) 축선, 눈금 바깥 약 3px.
+    let svg = page0_svg("samples/chart/기타/시가고가저가종가.hwp");
+    let g = chart_group(&svg);
+    let ls = lines(g);
+    let plain: Vec<&&str> = ls.iter().filter(|l| !l.contains("class=")).collect();
+    assert!(
+        plain.is_empty(),
+        "격자선이 없어야 한다: {:?}",
+        plain.first()
+    );
+    assert_eq!(
+        ls.iter().filter(|l| l.contains("hwp-chart-axis")).count(),
+        1,
+        "값축 축선"
+    );
+    assert_eq!(
+        ls.iter()
+            .filter(|l| l.contains("hwp-chart-cat-axis"))
+            .count(),
+        1,
+        "카테고리 축선"
+    );
+    // 값축 눈금 5(0·20·40·60·80) + 카테고리 경계 눈금 5(4 카테고리)
+    let ticks: Vec<&&str> = ls.iter().filter(|l| l.contains("hwp-chart-tick")).collect();
+    assert_eq!(ticks.len(), 10, "눈금 수");
+    let t = ticks[0];
+    let (x1, x2) = (num_after(t, " x1=\""), num_after(t, " x2=\""));
+    let (y1, y2) = (num_after(t, " y1=\""), num_after(t, " y2=\""));
+    assert!(
+        ((x2 - x1).abs() - 3.07).abs() < 0.05 || ((y2 - y1).abs() - 3.07).abs() < 0.05,
+        "눈금 길이 0.23L = 3.07px: {t}"
+    );
+}
+
+#[test]
+fn scatter_draws_gridlines_only_for_the_axis_that_declares_them() {
+    // 분산형 XML: valAx(b) 격자 없음, valAx(l) 격자 있음 → 가로 격자선만.
+    let svg = page0_svg("samples/chart/분산형/직선이있는분산형.hwp");
+    let g = chart_group(&svg);
+    let ls = lines(g);
+    let grid: Vec<&&str> = ls.iter().filter(|l| !l.contains("class=")).collect();
+    assert!(!grid.is_empty(), "값축(l) 격자선");
+    for l in grid {
+        let (y1, y2) = (num_after(l, " y1=\""), num_after(l, " y2=\""));
+        assert!((y1 - y2).abs() < 0.01, "세로 격자선이 그려졌다: {l}");
+    }
+}
+
+#[test]
+fn plot_area_has_no_border_and_frame_uses_hancom_default() {
+    // plotArea spPr 는 `a:noFill` + `a:ln > a:noFill` → 플롯 테두리 없음. chartSpace spPr 없음
+    // → 한/글 기본 바깥 테두리 #8c8c8c 0.75px (실측 4배 래스터 3px·gray 134).
+    let svg = page0_svg("samples/chart/기타/시가고가저가종가.hwp");
+    let g = chart_group(&svg);
+    assert!(!g.contains("#cccccc"), "옛 연회색 테두리 잔존");
+    let frame = &g[..g.find("/>").unwrap()];
+    assert!(
+        frame.contains("stroke=\"#8c8c8c\" stroke-width=\"0.75\""),
+        "바깥 테두리: {frame}"
+    );
+    let plot = g.split("<rect ").nth(2).expect("플롯 rect");
+    let plot = &plot[..plot.find("/>").unwrap()];
+    assert!(plot.contains("stroke=\"none\""), "플롯 테두리 없음: {plot}");
+}
+
+#[test]
+fn parse_plot_area_and_chart_space_lines() {
+    let xml = r#"<c:chartSpace xmlns:c="x" xmlns:a="y"><c:chart>
+<c:title><c:spPr><a:ln><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:ln></c:spPr></c:title>
+<c:plotArea><c:barChart><c:barDir val="col"/><c:ser>
+  <c:spPr><a:ln w="12700"><a:solidFill><a:srgbClr val="00FF00"/></a:solidFill></a:ln></c:spPr>
+  <c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>3</c:v></c:pt></c:numCache></c:numRef></c:val>
+</c:ser></c:barChart>
+<c:valAx><c:axPos val="l"/><c:spPr><a:ln><a:noFill/></a:ln></c:spPr></c:valAx>
+<c:spPr><a:noFill/><a:ln w="9525"><a:noFill/></a:ln></c:spPr>
+</c:plotArea>
+<c:legend><c:spPr><a:ln><a:solidFill><a:srgbClr val="0000FF"/></a:solidFill></a:ln></c:spPr></c:legend>
+</c:chart>
+<c:spPr><a:ln w="19050"><a:solidFill><a:srgbClr val="123456"/></a:solidFill></a:ln></c:spPr>
+</c:chartSpace>"#;
+    let c = OoxmlChart::parse(xml.as_bytes()).expect("parse OK");
+    assert_eq!(c.plot_area_line, LineSpec::None, "plotArea ln noFill");
+    assert_eq!(
+        c.chart_line,
+        LineSpec::Solid {
+            rgb: 0x123456,
+            width_emu: Some(19050)
+        },
+        "chartSpace ln (제목·범례·축 spPr 은 무관)"
+    );
+    assert_eq!(c.series[0].color, Some(0x00FF00));
+}
+
+#[test]
+fn parse_axes_gridlines_ticks_delete() {
+    let xml = r#"<c:chartSpace xmlns:c="x" xmlns:a="y"><c:chart><c:plotArea>
+<c:barChart><c:barDir val="col"/><c:ser>
+  <c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>3</c:v></c:pt></c:numCache></c:numRef></c:val>
+  <c:dLbls><c:delete val="1"/></c:dLbls>
+</c:ser><c:axId val="A"/><c:axId val="B"/></c:barChart>
+<c:catAx><c:axId val="A"/><c:delete val="0"/><c:axPos val="b"/><c:majorTickMark val="none"/></c:catAx>
+<c:valAx><c:axId val="B"/><c:delete val="1"/><c:axPos val="l"/><c:majorGridlines/><c:majorTickMark val="cross"/></c:valAx>
+</c:plotArea></c:chart></c:chartSpace>"#;
+    let c = OoxmlChart::parse(xml.as_bytes()).expect("parse OK");
+    assert_eq!(c.axes.len(), 2);
+    assert_eq!(c.axes[0].kind, AxisKind::Category);
+    assert_eq!(c.axes[0].pos, AxisPos::Bottom);
+    assert!(!c.axes[0].major_gridlines && !c.axes[0].deleted);
+    assert_eq!(c.axes[0].major_tick_mark, TickMark::None);
+    assert_eq!(c.axes[1].kind, AxisKind::Value);
+    assert_eq!(c.axes[1].pos, AxisPos::Left);
+    assert!(
+        c.axes[1].major_gridlines && c.axes[1].deleted,
+        "dLbls 의 delete 는 축과 무관"
+    );
+    assert_eq!(c.axes[1].major_tick_mark, TickMark::Cross);
 }
 
 // ---- 파서: 차트 XML 에서 읽는 값 ----

--- a/tests/cases/issue_6624_chart_default_layout.rs
+++ b/tests/cases/issue_6624_chart_default_layout.rs
@@ -1,0 +1,371 @@
+//! [#6624] OOXML 차트 자동 레이아웃·기본 서식 — 한/글 정답지(`pdf/chart/**`) 실측 계약.
+//!
+//! 차트 XML 에는 글꼴 크기가 `c:chartSpace/c:txPr` 의 10pt 하나뿐이고 제목 크기·계열 선
+//! 굵기·배치(`c:manualLayout`)는 없다. 한/글은 그 자리를 기본 서식으로 채운다: 제목 14pt
+//! 검정, 라벨 10pt 검정, 격자·축선 #8c8c8c 1px, 계열 선 2.25pt. 배치는 글꼴 배수(제목
+//! baseline 1.9T, 플롯 상단 3.26T, 플롯 하단 3.1L, 원형은 왼쪽 여백 0·아래 1.1L).
+//! 이 파일은 표본 문서의 1쪽 SVG 에서 그 서식이 실제로 나오는지 본다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+use rhwp::ooxml_chart::renderer::render_chart_svg;
+use rhwp::ooxml_chart::{BarGrouping, LegendPos, OoxmlChart, OoxmlChartType, OoxmlSeries};
+
+fn page0_svg(rel: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {rel}: {e:?}"));
+    doc.render_page_svg(0)
+        .unwrap_or_else(|e| panic!("render {rel}: {e:?}"))
+}
+
+fn chart_group(svg: &str) -> &str {
+    let i = svg
+        .find("<g class=\"hwp-ooxml-chart\">")
+        .expect("OOXML 차트 그룹");
+    &svg[i..]
+}
+
+/// `pat` 바로 뒤의 숫자.
+fn num_after(s: &str, pat: &str) -> f64 {
+    let i = s.find(pat).unwrap_or_else(|| panic!("{pat} 없음")) + pat.len();
+    let rest = &s[i..];
+    let end = rest
+        .find(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-'))
+        .unwrap_or(rest.len());
+    rest[..end]
+        .parse()
+        .unwrap_or_else(|_| panic!("{pat} 뒤 숫자 아님: {rest:.20}"))
+}
+
+#[test]
+fn clustered_column_uses_hancom_default_typography_and_axis() {
+    let svg = page0_svg("samples/chart/세로막대형/묶은세로막대형.hwp");
+    let g = chart_group(&svg);
+    // 차트 XML 기본 글꼴 sz=1000 → 라벨 13.33px 검정. 제목은 sz 없음 → 14pt.
+    assert!(g.contains("class=\"hwp-chart-title\""), "제목");
+    assert!(g.contains("font-size=\"18.67\""), "제목 14pt");
+    assert!(
+        g.contains("font-size=\"13.33\" fill=\"#000000\""),
+        "라벨 10pt 검정"
+    );
+    assert!(
+        !g.contains("fill=\"#666\"") && !g.contains("fill=\"#333\""),
+        "옛 회색 글자 잔존"
+    );
+    assert!(g.contains("class=\"hwp-chart-axis\""), "축선");
+    assert!(
+        g.contains("stroke=\"#8c8c8c\" stroke-width=\"1\""),
+        "격자·축선 #8c8c8c 1px"
+    );
+    assert!(!g.contains("stroke=\"#e8e8e8\""), "옛 연회색 격자 잔존");
+
+    // 배치: 제목 baseline → 플롯 상단(축선 y1) = 1.36T, 축선 → 프레임 하단 = 3.1L
+    let frame_y = num_after(g, " y=\"");
+    let frame_h = num_after(g, " height=\"");
+    let title = &g[g.find("class=\"hwp-chart-title\"").unwrap()..];
+    let title_y = num_after(title, " y=\"");
+    let axis = &g[g.find("class=\"hwp-chart-axis\"").unwrap()..];
+    let plot_top = num_after(axis, " y1=\"");
+    let plot_bottom = num_after(axis, " y2=\"");
+    let t = 14.0 * 96.0 / 72.0;
+    let l = 10.0 * 96.0 / 72.0;
+    assert!(
+        (title_y - frame_y - 1.9 * t).abs() < 0.1,
+        "제목 baseline 1.9T: {}",
+        title_y - frame_y
+    );
+    assert!(
+        (plot_top - title_y - 1.36 * t).abs() < 0.1,
+        "제목→플롯 1.36T: {}",
+        plot_top - title_y
+    );
+    assert!(
+        (frame_y + frame_h - plot_bottom - 3.1 * l).abs() < 0.1,
+        "플롯 하단 여백 3.1L: {}",
+        frame_y + frame_h - plot_bottom
+    );
+}
+
+#[test]
+fn line_series_default_width_is_office_2_25pt() {
+    // 계열 spPr 에 a:ln w 가 없다 → Office 기본 2.25pt = 3px (한/글 실측 3px).
+    let svg = page0_svg("samples/chart/라인/꺽은선형.hwp");
+    let g = chart_group(&svg);
+    let series_paths: Vec<&str> = g
+        .split("<path d=\"M")
+        .skip(1)
+        .map(|p| &p[..p.find("/>").expect("path 닫힘")])
+        .filter(|p| p.contains("fill=\"none\""))
+        .collect();
+    assert_eq!(series_paths.len(), 3, "계열 3");
+    for p in series_paths {
+        assert!(
+            p.contains("stroke-width=\"3.00\""),
+            "계열 선 3px 아님: {p:.80}"
+        );
+    }
+}
+
+#[test]
+fn pie_fills_plot_region_like_hancom() {
+    // 한/글 실측 2차원원형: 프레임 252.5 에 지름 183(0.725), 중심 y 146(0.578).
+    let svg = page0_svg("samples/chart/원형/2차원원형.hwp");
+    let g = chart_group(&svg);
+    let frame_y = num_after(g, " y=\"");
+    let frame_h = num_after(g, " height=\"");
+    let r = num_after(g, " A");
+    let first = &g[g.find("<path d=\"M").unwrap()..];
+    let cy = num_after(&first[first.find(',').unwrap()..], ",");
+    let d_ratio = 2.0 * r / frame_h;
+    let cy_ratio = (cy - frame_y) / frame_h;
+    assert!(
+        (d_ratio - 0.725).abs() < 0.02,
+        "지름/프레임 높이 0.725: {d_ratio:.3}"
+    );
+    assert!(
+        (cy_ratio - 0.578).abs() < 0.02,
+        "중심 y/프레임 높이 0.578: {cy_ratio:.3}"
+    );
+}
+
+// ---- 파서: 차트 XML 에서 읽는 값 ----
+
+#[test]
+fn parse_text_size_from_chart_space_tx_pr_only() {
+    // 차트 기본 글꼴은 c:chartSpace 직계 c:txPr 의 defRPr sz. c:chart 안의 txPr(범례 800·축
+    // 제목 900)은 그 요소 것이라 기본 글꼴도 제목 글꼴도 아니다.
+    let xml = r#"<c:chartSpace xmlns:c="x" xmlns:a="y"><c:chart>
+<c:title><c:txPr><a:p><a:pPr><a:defRPr b="0"/></a:pPr></a:p></c:txPr></c:title>
+<c:plotArea><c:barChart><c:barDir val="col"/><c:ser>
+  <c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>3</c:v></c:pt></c:numCache></c:numRef></c:val>
+</c:ser></c:barChart>
+<c:valAx><c:title><c:txPr><a:p><a:pPr><a:defRPr sz="900"/></a:pPr></a:p></c:txPr></c:title></c:valAx>
+</c:plotArea>
+<c:legend><c:txPr><a:p><a:pPr><a:defRPr sz="800"/></a:pPr></a:p></c:txPr></c:legend>
+</c:chart>
+<c:txPr><a:p><a:pPr><a:defRPr sz="1000"/></a:pPr></a:p></c:txPr>
+</c:chartSpace>"#;
+    let c = OoxmlChart::parse(xml.as_bytes()).expect("parse OK");
+    assert_eq!(c.text_size_pt, Some(10.0));
+    assert_eq!(
+        c.title_size_pt, None,
+        "제목에 sz 없음 → None (축 제목 900 은 제목이 아님)"
+    );
+}
+
+#[test]
+fn parse_title_size_from_title_run() {
+    // 제목 run 의 rPr sz 가 제목 글꼴. 차트 기본 글꼴은 없으면 None.
+    let xml = r#"<c:chartSpace xmlns:c="x" xmlns:a="y"><c:chart>
+<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:rPr sz="1600"/><a:t>제목</a:t></a:r></a:p></c:rich></c:tx></c:title>
+<c:plotArea><c:barChart><c:barDir val="col"/><c:ser>
+  <c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>3</c:v></c:pt></c:numCache></c:numRef></c:val>
+</c:ser></c:barChart></c:plotArea></c:chart></c:chartSpace>"#;
+    let c = OoxmlChart::parse(xml.as_bytes()).expect("parse OK");
+    assert_eq!(c.title_size_pt, Some(16.0));
+    assert_eq!(c.text_size_pt, None);
+}
+
+#[test]
+fn parse_series_line_width_skips_marker_and_dpt() {
+    // 계열 선 굵기는 계열 직계 spPr 의 a:ln w. 표식(marker)·점별(dPt) spPr 은 제외.
+    let xml = r#"<c:chartSpace xmlns:c="x" xmlns:a="y"><c:chart><c:plotArea>
+<c:lineChart><c:ser>
+  <c:marker><c:symbol val="circle"/><c:spPr><a:ln w="9525"/></c:spPr></c:marker>
+  <c:dPt><c:idx val="0"/><c:spPr><a:ln w="12700"/></c:spPr></c:dPt>
+  <c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>3</c:v></c:pt></c:numCache></c:numRef></c:val>
+</c:ser><c:ser>
+  <c:spPr><a:ln w="28575" cap="rnd"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:ln></c:spPr>
+  <c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>3</c:v></c:pt></c:numCache></c:numRef></c:val>
+</c:ser></c:lineChart></c:plotArea></c:chart></c:chartSpace>"#;
+    let c = OoxmlChart::parse(xml.as_bytes()).expect("parse OK");
+    assert_eq!(c.series.len(), 2);
+    assert_eq!(
+        c.series[0].line_width_emu, None,
+        "표식·점별 spPr 의 ln w 는 계열 선 굵기가 아니다"
+    );
+    assert_eq!(c.series[1].line_width_emu, Some(28575));
+}
+
+// ---- 렌더러: 합성 차트로 기하 핀 (코퍼스 프레임 430×250) ----
+
+fn bars_chart() -> OoxmlChart {
+    OoxmlChart {
+        chart_type: OoxmlChartType::Column,
+        grouping: BarGrouping::Clustered,
+        // name 비움 → 범례 미렌더
+        series: vec![
+            OoxmlSeries {
+                values: vec![4.0, 3.0],
+                ..Default::default()
+            },
+            OoxmlSeries {
+                values: vec![2.0, 1.0],
+                ..Default::default()
+            },
+            OoxmlSeries {
+                values: vec![2.0, 4.0],
+                ..Default::default()
+            },
+        ],
+        categories: vec!["a".into(), "b".into()],
+        ..Default::default()
+    }
+}
+
+fn line_chart() -> OoxmlChart {
+    OoxmlChart {
+        chart_type: OoxmlChartType::Line,
+        series: vec![
+            OoxmlSeries {
+                values: vec![4.3, 2.5, 3.5, 4.5],
+                ..Default::default()
+            },
+            OoxmlSeries {
+                values: vec![2.4, 4.4, 1.8, 2.8],
+                ..Default::default()
+            },
+            OoxmlSeries {
+                values: vec![2.0, 2.0, 3.0, 5.0],
+                ..Default::default()
+            },
+        ],
+        categories: vec!["a".into(), "b".into(), "c".into(), "d".into()],
+        ..Default::default()
+    }
+}
+
+/// `pat` 가 있는 태그의 속성 문자열(`pat` 부터 `>` 앞까지).
+fn tag_after<'a>(svg: &'a str, pat: &str) -> &'a str {
+    let i = svg.find(pat).unwrap_or_else(|| panic!("{pat} 없음"));
+    let rest = &svg[i..];
+    &rest[..rest.find('>').expect("태그 닫힘")]
+}
+
+/// 한/글 기본 서식 실측 핀 — 제목 14pt 검정 baseline 35.5, 첫 격자선 61, 축선 209,
+/// 카테고리 라벨 10pt 검정, 격자·축선 #8c8c8c 1px.
+#[test]
+fn hancom_default_layout_pins_430x250() {
+    let mut chart = bars_chart();
+    chart.title = Some("차트 제목".into());
+    let svg = render_chart_svg(&chart, 0.0, 0.0, 430.0, 250.0);
+
+    let title = tag_after(&svg, "class=\"hwp-chart-title\"");
+    assert!(title.contains("font-size=\"18.67\""), "제목 14pt: {title}");
+    assert!(title.contains("fill=\"#000000\""), "제목 검정: {title}");
+    let ty = num_after(title, " y=\"");
+    assert!((ty - 35.47).abs() < 0.05, "제목 baseline 35.5: {ty}");
+
+    let axis = tag_after(&svg, "class=\"hwp-chart-axis\"");
+    assert!(
+        axis.contains("stroke=\"#8c8c8c\"") && axis.contains("stroke-width=\"1\""),
+        "축선 스타일: {axis}"
+    );
+    let top = num_after(axis, " y1=\"");
+    let bottom = num_after(axis, " y2=\"");
+    assert!((top - 60.85).abs() < 0.05, "플롯 상단(첫 격자선) 61: {top}");
+    assert!((bottom - 208.67).abs() < 0.05, "축선 209: {bottom}");
+
+    let cat = svg
+        .split("<text ")
+        .find(|t| t.contains(">a<"))
+        .expect("카테고리 라벨");
+    assert!(
+        cat.contains("font-size=\"13.33\"") && cat.contains("fill=\"#000000\""),
+        "라벨 10pt 검정: {cat}"
+    );
+    let cy = num_after(cat, " y=\"");
+    assert!(
+        (cy - (208.67 + 13.33 * 2.3)).abs() < 0.1,
+        "라벨 baseline = 축선 + 2.3L: {cy}"
+    );
+
+    for l in svg.split("<line ").skip(1) {
+        let l = &l[..l.find("/>").expect("line 닫힘")];
+        assert!(
+            l.contains("stroke=\"#8c8c8c\"") && l.contains("stroke-width=\"1\""),
+            "격자·축선 #8c8c8c 1px: {l}"
+        );
+    }
+}
+
+#[test]
+fn explicit_text_and_title_sizes_are_honored() {
+    // 차트 XML 이 준 글꼴 크기(pt)를 쓰고, 여백은 그 배수로 따라간다.
+    let mut chart = bars_chart();
+    chart.title = Some("T".into());
+    chart.text_size_pt = Some(12.0);
+    chart.title_size_pt = Some(21.0);
+    let svg = render_chart_svg(&chart, 0.0, 0.0, 430.0, 250.0);
+    let title = tag_after(&svg, "class=\"hwp-chart-title\"");
+    assert!(title.contains("font-size=\"28.00\""), "제목 21pt: {title}");
+    let ty = num_after(title, " y=\"");
+    assert!((ty - 28.0 * 1.9).abs() < 0.05, "제목 baseline 1.9T: {ty}");
+    let cat = svg
+        .split("<text ")
+        .find(|t| t.contains(">a<"))
+        .expect("카테고리 라벨");
+    assert!(cat.contains("font-size=\"16.00\""), "라벨 12pt: {cat}");
+    let axis = tag_after(&svg, "class=\"hwp-chart-axis\"");
+    let top = num_after(axis, " y1=\"");
+    assert!((top - 28.0 * 3.26).abs() < 0.05, "플롯 상단 3.26T: {top}");
+}
+
+#[test]
+fn pie_fills_plot_region_430x250() {
+    // 원형: 왼쪽 여백 0, 제목 baseline + 1.0T 아래부터 프레임 하단 1.1L 위까지가 플롯이고
+    // 원은 거기에 꽉 찬다 (한/글 실측 2차원원형 지름 183, 중심 y 146).
+    let chart = OoxmlChart {
+        chart_type: OoxmlChartType::Pie,
+        title: Some("판매".into()),
+        legend_pos: LegendPos::Right,
+        series: vec![OoxmlSeries {
+            name: "판매".into(),
+            values: vec![8.0, 3.0, 1.0, 1.0],
+            series_type: OoxmlChartType::Pie,
+            ..Default::default()
+        }],
+        categories: vec![
+            "1 분기".into(),
+            "2 분기".into(),
+            "3 분기".into(),
+            "4 분기".into(),
+        ],
+        ..Default::default()
+    };
+    let svg = render_chart_svg(&chart, 0.0, 0.0, 430.0, 250.0);
+    let r = num_after(&svg, " A");
+    let top = 18.6667 * 2.9;
+    let ph = 250.0 - top - 13.3333 * 1.1;
+    assert!(
+        (r - ph / 2.0).abs() < 0.1,
+        "반지름 = 플롯 높이/2: r={r} ph={ph}"
+    );
+    let first = &svg[svg.find("<path d=\"M").unwrap()..];
+    let cy = num_after(&first[first.find(',').unwrap()..], ",");
+    assert!(
+        (cy - (top + ph / 2.0)).abs() < 0.1,
+        "중심 y = 플롯 세로 중앙: {cy}"
+    );
+}
+
+#[test]
+fn series_line_width_default_and_explicit() {
+    // a:ln w 없음 → Office 기본 2.25pt(3px); 12700 EMU(1pt) → 1.33px.
+    let mut chart = line_chart();
+    chart.series[1].line_width_emu = Some(12700);
+    let svg = render_chart_svg(&chart, 0.0, 0.0, 430.0, 250.0);
+    let widths: Vec<&str> = svg
+        .split("<path d=\"M")
+        .skip(1)
+        .filter(|p| p.contains("fill=\"none\""))
+        .map(|p| {
+            let i = p.find("stroke-width=\"").expect("stroke-width") + 14;
+            &p[i..i + 4]
+        })
+        .collect();
+    assert_eq!(widths, vec!["3.00", "1.33", "3.00"]);
+}

--- a/tests/issue_2277_stock.rs
+++ b/tests/issue_2277_stock.rs
@@ -156,8 +156,9 @@ fn stock_five_series_keeps_candles_and_hilow() {
         // 나머지 4계열은 코퍼스의 `a:ln > a:noFill` 을 지킨다. 그래서 계열 선은 추가계열
         // 하나뿐이다 — 한컴 편집기가 더한 계열이 선+마커로 보이는 것과 같은 모양이다.
         // (위치 기반 시절의 산출은 전건 noFill 상속이라 선 0 이었다 — 원장 재판정 대기.)
+        // 기본 계열 선은 Office 기본 2.25pt = 3px (#6624 — `a:ln w` 없을 때).
         assert_eq!(
-            svg.matches(r#"stroke-width="2""#).count(),
+            svg.matches(r#"stroke-width="3.00""#).count(),
             1,
             "{rel}: 기본 스타일은 추가계열 하나 — 계열 선 1",
         );


### PR DESCRIPTION
closes #6624

## 무엇을 고쳤나

OOXML 차트(한/글 2022 형식)를 그릴 때 글꼴 크기·선 굵기·배치를 상수로 박아 두어 한/글 렌더와 달랐습니다. 차트 XML 에 있는 값은 읽고, 없는 값만 한/글 기본 서식으로 채우도록 바꿨습니다.

**차트 XML 에서 읽는 값 (새 파서 필드)**
- `c:chartSpace > c:txPr > a:defRPr sz` → `text_size_pt` (차트 기본 글꼴, 코퍼스 28종 전건 10pt)
- `c:title` 안 `a:defRPr`/`a:rPr sz` → `title_size_pt` (`c:plotArea` 안 축 제목은 제외)
- 계열 `c:spPr > a:ln w` → `line_width_emu` (`c:marker`·`c:dPt` 의 spPr 은 제외)
- `c:gapWidth` 는 이미 읽고 있었지만 2D 막대가 안 쓰고 있었습니다.
- 축 선언 `c:catAx`/`c:valAx`(/`dateAx`/`serAx`) → `axes`: `c:majorGridlines` 유무, `c:majorTickMark`, `c:delete`, `c:axPos`. 격자선은 선언한 축만(코퍼스: 값축만, 주식형은 없음), 축선은 값축·카테고리축 둘 다, 눈금은 선언 방향으로 약 3px(0.23L). 종전엔 격자를 무조건 그리고 축선·눈금은 없었습니다 — 주식형이 IoU 0.06 이었던 이유입니다.
- `c:plotArea`/`c:chartSpace` 의 `c:spPr > a:ln` → `plot_area_line`/`chart_line`. 플롯 테두리는 코퍼스 전건 `noFill`(종전엔 `#cccccc` 0.5px 를 그렸음), 바깥 테두리는 미지정이라 한/글 기본 #8c8c8c 0.75px(실측 4배 래스터 3px·gray 134).

**없을 때 쓰는 한/글 기본 서식 (`hancom_default`, 정답지 PDF 28종 실측)**

| 항목 | 종전 | 이번 | 한/글 실측 |
|---|---|---|---|
| 제목 | 13px `#222` | 14pt(18.67px) `#000` | 잉크 y 18~35.5 |
| 축 라벨·범례 | 10px `#666`/`#333` | 10pt(13.33px) `#000` | 잉크 높이 13 |
| 격자선 | `#e8e8e8` 0.5px | `#8c8c8c` 1px | `#8c8c8c` 1px |
| 축선 | 없음 | 값축·카테고리축 (격자와 같은 선) | 둘 다 있음 |
| 눈금 | 없음 | `majorTickMark` 방향 0.23L | out, 약 3px |
| 격자선 유무 | 항상 | `majorGridlines` 선언한 축만 | 값축만, 주식형 없음 |
| 플롯 테두리 | `#cccccc` 0.5px | `plotArea spPr ln` (noFill → 없음) | 없음 |
| 바깥 테두리 | `#cccccc` 0.5px | `chartSpace spPr ln`, 없으면 `#8c8c8c` 0.75px | gray 134, 0.75px |
| 계열 선 | 2px | 2.25pt(3px) | 3px |
| 막대 묶음 폭 | 밴드×0.7 고정 | 밴드×n/(n+gapWidth/100) | 누적 0.38, 묶은 0.66 |

**배치 (글꼴 크기 배수 — 차트 크기가 달라도 같은 비율)**
- 제목 baseline 1.9T, 제목→플롯 1.36T, 플롯 하단 여백 3.1L, 라벨→축 1.3L, 우측 0.6L (T=제목 글꼴, L=라벨 글꼴)
- 가로 값축(가로 막대·분산형)은 마지막 값 라벨이 플롯 밖으로 절반 나오므로 그 절반 + 1.3L 을 비웁니다.
- 원형은 축 라벨이 없어 왼쪽 여백 0, 제목→원 1.0T, 아래 1.1L 이고 원은 그 영역에 꽉 찹니다. (종전엔 반지름 0.9 배 + 축 라벨 여백까지 빼서 작았습니다.)
- 원형대가로막대형은 주 원 0.97H·중심 0.36W, 막대 0.18W×0.955H (원형대원형과 다른 기하).

## 실측

`pdf/chart/**` 한/글 PDF 28종의 차트 영역과 rhwp SVG(Chrome 래스터)를 잉크 마스크로 대조했습니다 (IoU, 세로 잉크 프로파일 상관, 색 분포 거리).

평균 (28쌍): IoU 0.246→0.443 (28/28 개선), 세로 프로파일 상관 0.249→0.565 (28/28), 가로 프로파일 상관 0.404→0.571 (22/28), 색 분포 거리 0.398→0.338 (18/28).

<details><summary>차트별 전→후 (IoU · 세로 상관 · 가로 상관 · 색 거리)</summary>

| 유형 | 차트 | IoU 전→후 | 세로 상관 전→후 | 가로 상관 전→후 | 색 거리 전→후 |
|---|---|---|---|---|---|
| 가로막대형 | 3차원누적가로막대형 | 0.18→0.45 | -0.05→0.65 | 0.62→0.66 | 0.41→0.34 |
| 가로막대형 | 3차원묶은가로막대형 | 0.26→0.50 | 0.04→0.69 | 0.70→0.73 | 0.54→0.44 |
| 가로막대형 | 누적가로막대형 | 0.28→0.34 | 0.14→0.40 | 0.67→0.63 | 0.57→0.38 |
| 가로막대형 | 묶은가로막대형 | 0.29→0.37 | 0.12→0.47 | 0.75→0.71 | 0.43→0.43 |
| 가로막대형 | 백프로기준누적가로막대형 | 0.30→0.37 | 0.21→0.45 | 0.66→0.63 | 0.81→0.48 |
| 기타 | 고가저가종가 | 0.01→0.13 | -0.06→0.14 | 0.01→0.35 | 0.09→0.10 |
| 기타 | 시가고가저가종가 | 0.08→0.18 | 0.07→0.21 | 0.10→0.39 | 0.12→0.12 |
| 라인 | 꺽은선형 | 0.04→0.25 | 0.06→0.31 | 0.03→0.39 | 0.20→0.19 |
| 라인 | 누적꺽은선형 | 0.03→0.20 | 0.01→0.23 | 0.03→0.37 | 0.19→0.19 |
| 라인 | 백프로기준누적꺽은선형 | 0.03→0.18 | -0.03→0.35 | 0.03→0.35 | 0.19→0.20 |
| 라인 | 표식이있는꺽은선형 | 0.04→0.25 | 0.08→0.32 | 0.04→0.40 | 0.21→0.20 |
| 라인 | 표식이있는누적꺽은선형 | 0.04→0.20 | 0.03→0.24 | 0.03→0.37 | 0.20→0.19 |
| 분산형 | 곡선및표식이있는분산형 | 0.03→0.43 | -0.01→0.60 | 0.06→0.41 | 0.17→0.17 |
| 분산형 | 곡선이있는분산형 | 0.03→0.43 | -0.01→0.60 | 0.06→0.41 | 0.17→0.17 |
| 분산형 | 직선및표식이있는분산형 | 0.03→0.43 | -0.00→0.60 | 0.06→0.41 | 0.17→0.17 |
| 분산형 | 직선이있는분산형 | 0.03→0.43 | -0.01→0.60 | 0.04→0.41 | 0.17→0.17 |
| 분산형 | 표식만있는분산형 | 0.01→0.35 | -0.03→0.57 | 0.03→0.39 | 0.15→0.15 |
| 세로막대형 | 3차원누적세로막대형 | 0.33→0.37 | 0.45→0.61 | 0.53→0.50 | 0.29→0.30 |
| 세로막대형 | 3차원묶은세로막대형 | 0.34→0.39 | 0.54→0.78 | 0.36→0.32 | 0.59→0.48 |
| 세로막대형 | 누적세로막대형 | 0.36→0.51 | 0.50→0.59 | 0.53→0.72 | 0.58→0.36 |
| 세로막대형 | 묶은세로막대형 | 0.45→0.63 | 0.58→0.75 | 0.62→0.78 | 0.48→0.46 |
| 세로막대형 | 백프로기준누적세로막대형 | 0.29→0.35 | 0.30→0.62 | 0.31→0.36 | 0.88→0.51 |
| 원형 | 2차원원형 | 0.68→0.86 | 0.68→0.80 | 0.94→0.97 | 0.55→0.55 |
| 원형 | 3차원원형 | 0.69→0.86 | 0.78→0.92 | 0.93→0.95 | 0.71→0.69 |
| 원형 | 원형대가로막대형 | 0.54→0.80 | 0.76→0.86 | 0.78→0.92 | 0.65→0.68 |
| 원형 | 원형대원형 | 0.60→0.77 | 0.79→0.91 | 0.85→0.91 | 0.54→0.54 |
| 원형 | 쪼개진원형 | 0.47→0.77 | 0.59→0.71 | 0.85→0.92 | 0.41→0.40 |
| 특이케이스 | 가로막대형_하나만있을떄_단일시리즈제목 | 0.41→0.61 | 0.45→0.81 | 0.69→0.63 | 0.67→0.42 |

</details>

하네스: `pdf/chart/**` 1쪽 이미지 bbox 를 차트 영역으로 96dpi×2 래스터, rhwp 는 `export-svg` 1쪽을 Chrome 으로 같은 배율 래스터 후 RawSvg bbox 크롭. 잉크 마스크(밝기<235) IoU·행/열 잉크 프로파일 상관·상위 8색 분포 L1.

## 스크린샷 (한/글 PDF | 수정 전 | 수정 후)

**묶은세로막대형 — 배치·글꼴·축선·눈금·바깥 테두리**

![묶은세로막대형 — 배치·글꼴·축선·눈금·바깥 테두리](https://raw.githubusercontent.com/jeong-sik/rhwp/b2ca9ae31a54f3f2cc921884fc98ad9cf9ad7da0/01-clustered-column.png)

**누적세로막대형 — 막대 폭 밴드×0.4 (gapWidth 150)**

![누적세로막대형 — 막대 폭 밴드×0.4 (gapWidth 150)](https://raw.githubusercontent.com/jeong-sik/rhwp/b2ca9ae31a54f3f2cc921884fc98ad9cf9ad7da0/02-stacked-column.png)

**3차원묶은세로막대형**

![3차원묶은세로막대형](https://raw.githubusercontent.com/jeong-sik/rhwp/b2ca9ae31a54f3f2cc921884fc98ad9cf9ad7da0/03-clustered-column-3d.png)

**묶은가로막대형 — 가로 값축 오른쪽 여백**

![묶은가로막대형 — 가로 값축 오른쪽 여백](https://raw.githubusercontent.com/jeong-sik/rhwp/b2ca9ae31a54f3f2cc921884fc98ad9cf9ad7da0/04-clustered-bar.png)

**꺽은선형 — 계열 선 2.25pt**

![꺽은선형 — 계열 선 2.25pt](https://raw.githubusercontent.com/jeong-sik/rhwp/b2ca9ae31a54f3f2cc921884fc98ad9cf9ad7da0/05-line.png)

**직선이있는분산형 — 격자는 선언한 값축(l)만**

![직선이있는분산형 — 격자는 선언한 값축(l)만](https://raw.githubusercontent.com/jeong-sik/rhwp/b2ca9ae31a54f3f2cc921884fc98ad9cf9ad7da0/06-scatter-line.png)

**2차원원형 — 원이 플롯에 꽉 참**

![2차원원형 — 원이 플롯에 꽉 참](https://raw.githubusercontent.com/jeong-sik/rhwp/b2ca9ae31a54f3f2cc921884fc98ad9cf9ad7da0/07-pie.png)

**원형대가로막대형 — 주 원·막대 기하**

![원형대가로막대형 — 주 원·막대 기하](https://raw.githubusercontent.com/jeong-sik/rhwp/b2ca9ae31a54f3f2cc921884fc98ad9cf9ad7da0/08-bar-of-pie.png)

**시가고가저가종가 — 격자 없음·축선·눈금·플롯 테두리 없음**

![시가고가저가종가 — 격자 없음·축선·눈금·플롯 테두리 없음](https://raw.githubusercontent.com/jeong-sik/rhwp/b2ca9ae31a54f3f2cc921884fc98ad9cf9ad7da0/09-stock-ohlc.png)

**고가저가종가**

![고가저가종가](https://raw.githubusercontent.com/jeong-sik/rhwp/b2ca9ae31a54f3f2cc921884fc98ad9cf9ad7da0/10-stock-hlc.png)

## 검증

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p rhwp-ooxml-chart` 165 (3D 두께 테스트의 "2D 는 0.7 유지" 대조군을 0.4 로 갱신 — 한/글 실측 0.38)
- 새 계약 `tests/cases/issue_6624_chart_default_layout.rs` 15: 표본 6(묶은세로막대형 배치·서식, 꺽은선형 선 굵기, 2차원원형 원 크기·중심, 주식형 격자 0·축선 2·눈금 10, 분산형 가로 격자만, 주식형 플롯 테두리 없음·바깥 #8c8c8c) + 파서 5(chartSpace txPr sz만 기본 글꼴, 제목 run sz, marker·dPt 의 ln w 제외, 축 격자·눈금·delete, plotArea/chartSpace 선) + 합성 차트 기하 핀 4(430×250 배치, 명시 글꼴 크기 반영, 원형 영역, 선 굵기 기본/명시). 소스 안 단위 테스트 총량 상한(4225) 때문에 `tests/cases` 에 둡니다.
- 음성 대조: 첫 커밋 시점의 계약 파일(표본 3건)을 수정 전 devel 트리에서 돌리면 전부 실패(제목 class 없음, 선 2px, 원 중심 0.508). 축·테두리 계약은 옛 모델에 `axes`/`plot_area_line` 필드가 없어 수정 전 트리에선 컴파일 자체가 되지 않습니다.
- 차트 통합 스위트(1882·1431·2277·2129·2278·1453·4098·3546·4100·4099·ooxml_chart_structure_contract·6053 를 담은 8개) 필터 `chart ooxml scatter stock issue_6624`, `--profile release-test --target-dir target/pr-review`. `issue_2277_stock` 의 "계열 선 = `stroke-width="2"` 1개" 단정을 기본 선 굵기 3px 에 맞춰 갱신했습니다.
- Native Skia 3종: `--locked --profile release-test --target-dir target/pr-review --features native-skia --lib` 3946 통과, `issue_2225_missing_picture_placeholder` 2 통과, `render_p37_direct_pdf_export` 4 통과
- WASM: `CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg --no-opt` 통과 (Docker 없어 wasm-opt 는 생략)
- `git diff --check`, `rust-unit-test-tiers --check`(4221/4225), `rust-test-suite-manifest --check` 통과

## 범위 밖 (같은 하네스로 보이는 남은 편차)

- 3D 원형 타원 반지름 계수(0.9, 실측 0.857), 표식 크기(`c:marker > c:size`), 주식형 캔들 폭.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
