### PR TITLE
fix(layout): 1×1 상자 표를 풀어 그릴 때 상자 셀의 안 여백을 안쪽 표와 테두리에 준다 (#6621)

### DIFF
--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -2526,17 +2526,27 @@ impl LayoutEngine {
                             inline_x_override,
                             paper_w,
                         );
+                        // 안쪽 표의 바깥 여백도 셀 안 여백 안쪽에 그대로 남는다. 아래
+                        // `layout_table` 호출은 상자와 같은 depth(본문이면 0)·inline 위치로 안쪽
+                        // 표를 놓아 `compute_table_y_position` 의 중첩 표 분기(om_top)와 반환값의
+                        // om 포함 높이를 타지 않으므로 여기서 더한다. k-water 17쪽 실측: 셀 pad
+                        // (510,510,141,141) + 안쪽 표 om 141 → 한/글 점선은 실선에서 (8.7, 3.8) 안쪽,
+                        // exam_social 4번 상자: 안쪽 표 om_bottom 283 → 상자 바닥 +3.8px.
+                        let om_l = hwpunit_to_px(nested.outer_margin_left as i32, self.dpi);
+                        let om_r = hwpunit_to_px(nested.outer_margin_right as i32, self.dpi);
+                        let om_t = hwpunit_to_px(nested.outer_margin_top as i32, self.dpi);
+                        let om_b = hwpunit_to_px(nested.outer_margin_bottom as i32, self.dpi);
                         // 안쪽 표가 여백을 뺀 내용 상자보다 조금 넓게 저장된 문서(exam_social:
                         // 1.4px)는 한/글처럼 오른쪽 여백으로 흘러넘기고 축소하지 않는다.
                         let inner_area = LayoutRect {
-                            x: col_area.x + pad_l,
+                            x: col_area.x + pad_l + om_l,
                             y: col_area.y,
-                            width: (col_area.width - pad_l - pad_r).max(nested_w),
+                            width: (col_area.width - pad_l - pad_r - om_l - om_r).max(nested_w),
                             height: col_area.height,
                         };
-                        let inner_y_start = y_start + pad_t;
+                        let inner_y_start = y_start + pad_t + om_t;
                         // 글자처럼 상자는 x 를 줄 배치가 준 inline_x_override 로 받으므로 그 값도 옮긴다.
-                        let inner_inline_x = inline_x_override.map(|x| x + pad_l);
+                        let inner_inline_x = inline_x_override.map(|x| x + pad_l + om_l);
 
                         let y_end = self.layout_table(
                             tree,
@@ -2564,7 +2574,7 @@ impl LayoutEngine {
                             false,
                         );
 
-                        let y_end = y_end + pad_b;
+                        let y_end = y_end + om_b + pad_b;
                         if let Some(bs_borders) = outer_border_meta {
                             let outer_h_actual = (y_end - outer_y).max(0.0);
                             if outer_h_actual > 0.0 {

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -2496,15 +2496,28 @@ impl LayoutEngine {
                             None
                         };
 
+                        // [#6621] 상자를 unwrap 해도 상자 셀의 안 여백은 남는다. 한/글은 안쪽 표를
+                        // 여백만큼 안쪽(+pad_l, +pad_t)에 놓고, 상자 테두리는 바깥 표 선언 폭과
+                        // "안쪽 표 높이 + 상하 여백"으로 그리며, 뒤 흐름도 아래 여백만큼 더 내려간다.
+                        // exam_social 1쪽 pi=15 실측: 여백 850HU=11.3px, 안쪽 표·그림 5장이
+                        // (+11.3, +11.3), 상자 높이 +22.7px. 여백 0 이면 종전과 같다.
+                        let (pad_l, pad_r, pad_t, pad_b) =
+                            self.resolve_cell_padding_for_context(cell, table);
                         // nested 표 위치/size 미리 결정 (nested layout 의 위치 결정 logic 동일)
                         let pw_now = self.current_paper_width.get();
                         let paper_w = if pw_now > 0.0 { Some(pw_now) } else { None };
                         let nested_w = hwpunit_to_px(nested.common.width as i32, self.dpi)
                             * self.render_table_width_scale(nested);
-                        let outer_w_for_box = nested_w;
+                        let outer_w_declared = hwpunit_to_px(table.common.width as i32, self.dpi)
+                            * self.render_table_width_scale(table);
+                        let outer_w_for_box = if outer_w_declared > 0.5 {
+                            outer_w_declared
+                        } else {
+                            nested_w + pad_l + pad_r
+                        };
                         let outer_x_for_box = self.compute_table_x_position(
-                            nested,
-                            nested_w,
+                            table,
+                            outer_w_for_box,
                             col_area,
                             depth,
                             host_alignment,
@@ -2513,6 +2526,17 @@ impl LayoutEngine {
                             inline_x_override,
                             paper_w,
                         );
+                        // 안쪽 표가 여백을 뺀 내용 상자보다 조금 넓게 저장된 문서(exam_social:
+                        // 1.4px)는 한/글처럼 오른쪽 여백으로 흘러넘기고 축소하지 않는다.
+                        let inner_area = LayoutRect {
+                            x: col_area.x + pad_l,
+                            y: col_area.y,
+                            width: (col_area.width - pad_l - pad_r).max(nested_w),
+                            height: col_area.height,
+                        };
+                        let inner_y_start = y_start + pad_t;
+                        // 글자처럼 상자는 x 를 줄 배치가 준 inline_x_override 로 받으므로 그 값도 옮긴다.
+                        let inner_inline_x = inline_x_override.map(|x| x + pad_l);
 
                         let y_end = self.layout_table(
                             tree,
@@ -2521,8 +2545,8 @@ impl LayoutEngine {
                             section_index,
                             styles,
                             outline_numbering_id,
-                            col_area,
-                            y_start,
+                            &inner_area,
+                            inner_y_start,
                             bin_data_content,
                             None,
                             depth,
@@ -2531,7 +2555,7 @@ impl LayoutEngine {
                             enclosing_cell_ctx,
                             host_margin_left,
                             host_margin_right,
-                            inline_x_override,
+                            inner_inline_x,
                             nested_split,
                             para_y,
                             None,
@@ -2540,6 +2564,7 @@ impl LayoutEngine {
                             false,
                         );
 
+                        let y_end = y_end + pad_b;
                         if let Some(bs_borders) = outer_border_meta {
                             let outer_h_actual = (y_end - outer_y).max(0.0);
                             if outer_h_actual > 0.0 {

--- a/tests/cases/issue_6621_wrapper_cell_padding.rs
+++ b/tests/cases/issue_6621_wrapper_cell_padding.rs
@@ -1,0 +1,97 @@
+//! [#6621] 1×1 상자 표(안 여백 850HU)를 unwrap 할 때 안쪽 표와 테두리가 상자 셀의 안 여백을
+//! 잃던 결함의 계약.
+//!
+//! `samples/exam_social.hwp` 1쪽 pi=15: 바깥 1×1 표(셀 pad 850HU=11.33px, bf=6 테두리) 안에
+//! 6×3 대화체 표가 들어 있고 첫 열 셀마다 41.5px 정사각형 그림이 글자처럼 놓인다. 한/글 2022
+//! PDF(4절→A3 균일 배율 0.9385, 왼쪽 위 기준) 실측: 상자 왼쪽 선 x=549.9, 위 선 y=325.0,
+//! 첫 그림 (561.2, 343.3) = 상자 원점 + 여백 11.33 + 첫 행 5.1 + 셀 여백 1.9. 종전 rhwp 는
+//! 안쪽 표를 상자 원점(549.9, 324.9)에 그려 그림 5장이 (−11.3, −11.5), 상자 높이가 22.7px
+//! 짧았다(저장 줄 원장은 그림 줄 lh = 그림 높이라 줄 높이 문제가 아니다).
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+fn page0_svg() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/exam_social.hwp");
+    let bytes = std::fs::read(&path).expect("read exam_social.hwp");
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse exam_social.hwp");
+    doc.render_page_svg(0).expect("render page 1")
+}
+
+/// 태그 조각에서 `name="…"` 숫자 속성. 첫 속성은 앞에 공백이 없고(`<image x="…`), 다른
+/// 속성 이름의 꼬리(`x1=` 의 `1=` 등)에 걸리지 않게 앞 글자가 영숫자가 아닐 때만 받는다.
+fn attr(tag: &str, name: &str) -> Option<f64> {
+    let pat = format!("{name}=\"");
+    let mut from = 0;
+    while let Some(i) = tag[from..].find(&pat) {
+        let at = from + i;
+        if at == 0 || !tag.as_bytes()[at - 1].is_ascii_alphanumeric() {
+            let s = at + pat.len();
+            let e = s + tag[s..].find('"')?;
+            return tag[s..e].parse().ok();
+        }
+        from = at + 1;
+    }
+    None
+}
+
+/// 41.5px 정사각형 `<image>` 들 (x, y) — 문서 순서.
+fn small_square_images(svg: &str) -> Vec<(f64, f64)> {
+    svg.split("<image ")
+        .skip(1)
+        .map(|t| &t[..t.find('>').expect("image 닫힘")])
+        .filter(|t| {
+            let (w, h) = (
+                attr(t, "width").unwrap_or(0.0),
+                attr(t, "height").unwrap_or(0.0),
+            );
+            (w - 41.5).abs() < 0.6 && (h - 41.5).abs() < 0.6
+        })
+        .filter_map(|t| Some((attr(t, "x")?, attr(t, "y")?)))
+        .collect()
+}
+
+#[test]
+fn nested_table_pictures_sit_inside_the_wrapper_cell_padding() {
+    let svg = page0_svg();
+    let imgs = small_square_images(&svg);
+    assert!(imgs.len() >= 4, "41.5px 그림이 4장 이상: {imgs:?}");
+    // 첫 열(x≈561.2) 과 셋째 열(x≈906.6) 두 자리에만 있고, 첫 그림 y 는 343.3
+    for (x, y) in &imgs {
+        assert!(
+            (x - 561.2).abs() < 0.7 || (x - 906.6).abs() < 0.7,
+            "그림 x 가 상자 안 여백(549.9+11.33) 기준이 아니다: ({x:.1}, {y:.1})"
+        );
+    }
+    let (x0, y0) = imgs[0];
+    assert!((x0 - 561.2).abs() < 0.7, "첫 그림 x 561.2: {x0:.1}");
+    assert!((y0 - 343.3).abs() < 0.7, "첫 그림 y 343.3: {y0:.1}");
+}
+
+#[test]
+fn wrapper_border_box_includes_top_and_bottom_padding() {
+    let svg = page0_svg();
+    // 상자 왼쪽 세로 테두리: x≈549.9 인 <line> 중 가장 긴 것. 높이 = 안쪽 표 343.9 + 여백 22.7.
+    let mut best: Option<(f64, f64)> = None;
+    for t in svg.split("<line ").skip(1) {
+        let t = &t[..t.find("/>").expect("line 닫힘")];
+        let (Some(x1), Some(x2), Some(y1), Some(y2)) =
+            (attr(t, "x1"), attr(t, "x2"), attr(t, "y1"), attr(t, "y2"))
+        else {
+            continue;
+        };
+        if (x1 - x2).abs() < 0.01 && (x1 - 549.9).abs() < 0.7 {
+            let (top, bottom) = (y1.min(y2), y1.max(y2));
+            if best.is_none_or(|(a, b)| bottom - top > b - a) {
+                best = Some((top, bottom));
+            }
+        }
+    }
+    let (top, bottom) = best.expect("상자 왼쪽 테두리");
+    assert!((top - 325.0).abs() < 0.7, "상자 위 325.0: {top:.1}");
+    assert!(
+        (bottom - top - (343.9 + 22.7)).abs() < 1.0,
+        "상자 높이 = 안쪽 표 343.9 + 여백 22.7: {:.1}",
+        bottom - top
+    );
+}

--- a/tests/cases/issue_6621_wrapper_cell_padding.rs
+++ b/tests/cases/issue_6621_wrapper_cell_padding.rs
@@ -4,9 +4,10 @@
 //! `samples/exam_social.hwp` 1쪽 pi=15: 바깥 1×1 표(셀 pad 850HU=11.33px, bf=6 테두리) 안에
 //! 6×3 대화체 표가 들어 있고 첫 열 셀마다 41.5px 정사각형 그림이 글자처럼 놓인다. 한/글 2022
 //! PDF(4절→A3 균일 배율 0.9385, 왼쪽 위 기준) 실측: 상자 왼쪽 선 x=549.9, 위 선 y=325.0,
-//! 첫 그림 (561.2, 343.3) = 상자 원점 + 여백 11.33 + 첫 행 5.1 + 셀 여백 1.9. 종전 rhwp 는
-//! 안쪽 표를 상자 원점(549.9, 324.9)에 그려 그림 5장이 (−11.3, −11.5), 상자 높이가 22.7px
-//! 짧았다(저장 줄 원장은 그림 줄 lh = 그림 높이라 줄 높이 문제가 아니다).
+//! 첫 그림 (561.2, 343.3) = 상자 원점 + 여백 11.33 + 첫 행 5.1 + 셀 여백 1.9, 상자 아래 선
+//! y=695.5 (높이 370.4 = 안쪽 표 343.9 + 여백 22.7 + 안쪽 표 바깥 여백 아래 283HU=3.8).
+//! 종전 rhwp 는 안쪽 표를 상자 원점(549.9, 324.9)에 그려 그림 5장이 (−11.3, −11.5), 상자
+//! 높이가 26.5px 짧았다(저장 줄 원장은 그림 줄 lh = 그림 높이라 줄 높이 문제가 아니다).
 #![cfg(not(target_arch = "wasm32"))]
 
 use std::path::Path;
@@ -71,7 +72,8 @@ fn nested_table_pictures_sit_inside_the_wrapper_cell_padding() {
 #[test]
 fn wrapper_border_box_includes_top_and_bottom_padding() {
     let svg = page0_svg();
-    // 상자 왼쪽 세로 테두리: x≈549.9 인 <line> 중 가장 긴 것. 높이 = 안쪽 표 343.9 + 여백 22.7.
+    // 상자 왼쪽 세로 테두리: x≈549.9 인 <line> 중 가장 긴 것.
+    // 높이 = 안쪽 표 343.9 + 셀 여백 22.7 + 안쪽 표 바깥 여백 아래 3.8 (한/글 370.4).
     let mut best: Option<(f64, f64)> = None;
     for t in svg.split("<line ").skip(1) {
         let t = &t[..t.find("/>").expect("line 닫힘")];
@@ -90,8 +92,8 @@ fn wrapper_border_box_includes_top_and_bottom_padding() {
     let (top, bottom) = best.expect("상자 왼쪽 테두리");
     assert!((top - 325.0).abs() < 0.7, "상자 위 325.0: {top:.1}");
     assert!(
-        (bottom - top - (343.9 + 22.7)).abs() < 1.0,
-        "상자 높이 = 안쪽 표 343.9 + 여백 22.7: {:.1}",
+        (bottom - top - (343.9 + 22.7 + 3.8)).abs() < 1.0,
+        "상자 높이 = 안쪽 표 343.9 + 셀 여백 22.7 + 안쪽 표 om_bottom 3.8: {:.1}",
         bottom - top
     );
 }

--- a/tests/issue_nested_table_border.rs
+++ b/tests/issue_nested_table_border.rs
@@ -10,6 +10,11 @@
 //!
 //! 권위 자료: pi=15 4번 자료 박스 (외부 1x1 padding=850 + 내부 6x3 대화체).
 //! 한컴2022 PDF (`pdf/exam_social-2022.pdf`) p1 우측 4번 영역 외곽 박스 시각 정합.
+//!
+//! [#6621] 상자 기하는 한/글 PDF 실측(4절→A3 높이 기준 균일 배율 0.9385, 왼쪽 위 기준)
+//! 으로 못 박는다: 상자 실선 x 549.9~961.8 (= 상자 표 선언 폭 30894HU=411.9px),
+//! y 325.1~695.5 (높이 370.4 = 안쪽 표 + 셀 안 여백 850HU×2 + 안쪽 표 om_bottom 283).
+//! 종전 rhwp 는 안쪽 표 폭(390.65)으로 상자를 그려 오른쪽 선이 940.5 였다.
 
 use std::fs;
 use std::path::Path;
@@ -28,12 +33,11 @@ fn nested_table_border_exam_social_p1_q4_outline_present() {
     let svg = doc.render_page_svg(0).expect("render_page_svg");
 
     // 4번 자료 박스 외곽 4개 라인이 SVG 에 존재해야 한다.
-    // 박스 width: nested 6x3 표 측정 결과 — 390.65 (nested.common.width).
-    // x 좌표: 549.88 (좌) ~ 940.53 (우) — body left margin + nested 표 위치.
-    // y 좌표: 다른 PR 영역의 페이지네이션 변경에 따라 시프트 가능 영역으로 영역
-    // 좌표 hardcoded 영역 회피 영역 영역 — x 좌표 영역과 stroke 영역 본질 영역만 영역 검증 영역.
+    // x 좌표: 549.88 (좌) ~ 961.8 (우) — body left margin + 상자 표 선언 폭 411.9px.
+    // 한/글 PDF 실측 549.9 / 961.8. y 는 앞 내용의 페이지네이션에 따라 움직일 수 있어
+    // 절대값 대신 상자 높이(아래)로 검증한다.
     let lx = "549.8800000000001";
-    let rx = "940.5333333333334";
+    let rx = "961.8000000000002";
 
     // 좌측선: x1==x2==lx (수직선)
     let has_left_line = svg.contains(&format!("<line x1=\"{lx}\" y1="))
@@ -57,12 +61,23 @@ fn nested_table_border_exam_social_p1_q4_outline_present() {
         "4번 박스 수평 외곽선 누락 (x={lx}~{rx})"
     );
 
-    // 외곽선 stroke=#000000 width=0.75 (3 조건 AND 가드 영역 발동 영역의 본 PR 영역의 본질 영역)
+    // 좌측 세로선 + 상·하 수평선이 모두 lx 에서 시작하므로 lx 좌표는 3건 이상이다.
     let outline_pattern = format!("x1=\"{lx}\"");
     let outline_count = svg.matches(&outline_pattern).count();
     assert!(
-        outline_count >= 2,
-        "4번 박스 좌측+상단 라인 영역의 lx 좌표 ≥ 2건 영역 필요 영역 (실제: {outline_count})"
+        outline_count >= 3,
+        "4번 박스 좌측·상단·하단 라인의 lx 좌표 ≥ 3건 필요 (실제: {outline_count})"
+    );
+
+    // 상자 높이: 좌측 세로선(x=lx) 중 가장 긴 것. 한/글 370.4 (325.1~695.5).
+    let box_height = parse_lines(&svg)
+        .into_iter()
+        .filter(|(x1, _, x2, _, _)| (x1 - x2).abs() < 0.01 && (x1 - 549.88).abs() < 0.01)
+        .map(|(_, y1, _, y2, _)| (y2 - y1).abs())
+        .fold(0.0, f64::max);
+    assert!(
+        (box_height - 370.4).abs() < 1.0,
+        "4번 박스 높이 370.4 (안쪽 표 + 셀 여백 850HU×2 + 안쪽 표 om_bottom 283): {box_height:.1}"
     );
 }
 
@@ -95,10 +110,14 @@ fn parse_lines(svg: &str) -> Vec<(f64, f64, f64, f64, bool)> {
 /// 외곽 borderFill 을 한 칸 어긋나게 읽어(NONE) 실선 외곽선이 통째로 누락되고 내부 표
 /// 점선만 남았다. 정정 후에는 점선 외곽과 같은 y 에 실선 외곽선이 존재해야 한다.
 ///
-/// 가드: 전폭(>500px) 수평선 중 **점선과 y 가 일치하는 실선**이 ≥1 존재하는지 확인한다.
-/// 좌표를 hardcode 하지 않고 "외곽 박스 = 내부 표 외곽" 관계로 판정하므로, 무관한
-/// 다른 표의 실선(겹치는 점선 없음)이나 페이지네이션 시프트에 영향받지 않는다.
-/// (버그: 일치 0건 → 실패 / 정정: 상·하 2건 일치 → 통과)
+/// 가드: 전폭(>500px) 수평선 중 **점선 바깥쪽에 여백만큼 떨어진 실선**이 위·아래로 존재하는지
+/// 확인한다. 좌표를 hardcode 하지 않고 "외곽 박스 = 내부 표 외곽 + 여백" 관계로 판정하므로,
+/// 무관한 다른 표의 실선이나 페이지네이션 시프트에 영향받지 않는다.
+///
+/// [#6621] 여백은 저장값 그대로다: wrapper 셀 안 여백 위/아래 141HU + 안쪽 표 바깥 여백
+/// 위/아래 141HU = 3.8px. 한/글 2022 PDF 17쪽 실측: 실선 583.2/1001.4, 점선 587.0/997.5.
+/// 종전 rhwp 는 두 여백을 모두 버려 실선과 점선이 같은 y 였고(583.3/993.9), 상자가 7.5px
+/// 짧았다. (버그: 실선 누락 또는 점선과 같은 y → 실패 / 정정: 위·아래 3.8px 바깥 → 통과)
 #[test]
 fn nested_table_border_kwater_rfp_outer_outline_present() {
     let repo_root = env!("CARGO_MANIFEST_DIR");
@@ -106,6 +125,8 @@ fn nested_table_border_kwater_rfp_outer_outline_present() {
     let bytes = fs::read(&path).expect("read k-water-rfp.hwp");
     let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse k-water-rfp.hwp");
 
+    // 셀 안 여백 141HU + 안쪽 표 바깥 여백 141HU (96DPI px).
+    let inset = 2.0 * 141.0 * 96.0 / 7200.0;
     let mut matched_pages = Vec::new();
     for page_idx in 0..doc.page_count() {
         let svg = doc
@@ -120,19 +141,31 @@ fn nested_table_border_kwater_rfp_outer_outline_present() {
             .filter(|(x1, y1, x2, y2, dashed)| *dashed && is_wide_horiz(*x1, *y1, *x2, *y2))
             .map(|(_, y1, ..)| *y1)
             .collect();
-        // 점선(내부 표 외곽 격자)과 y 가 일치(±1px)하는 실선(wrapper 외곽 테두리) 개수.
-        let outer_solid_on_inner = lines
+        let (Some(dashed_top), Some(dashed_bottom)) = (
+            dashed_ys.iter().cloned().reduce(f64::min),
+            dashed_ys.iter().cloned().reduce(f64::max),
+        ) else {
+            continue;
+        };
+        let solid_ys: Vec<f64> = lines
             .iter()
             .filter(|(x1, y1, x2, y2, dashed)| !*dashed && is_wide_horiz(*x1, *y1, *x2, *y2))
-            .filter(|(_, y1, ..)| dashed_ys.iter().any(|dy| (dy - *y1).abs() < 1.0))
-            .count();
-        if outer_solid_on_inner >= 1 {
-            matched_pages.push((page_idx + 1, outer_solid_on_inner));
+            .map(|(_, y1, ..)| *y1)
+            .collect();
+        // 점선 맨 위에서 여백만큼 위, 맨 아래에서 여백만큼 아래에 실선(wrapper 외곽)이 있다.
+        let has_top = solid_ys
+            .iter()
+            .any(|sy| (dashed_top - sy - inset).abs() < 0.5);
+        let has_bottom = solid_ys
+            .iter()
+            .any(|sy| (sy - dashed_bottom - inset).abs() < 0.5);
+        if has_top && has_bottom {
+            matched_pages.push(page_idx + 1);
         }
     }
 
     assert!(
         !matched_pages.is_empty(),
-        "wrapper 외곽 실선 테두리 누락 (내부 표 점선 외곽과 겹치는 전폭 실선 0건)"
+        "wrapper 외곽 실선 테두리 누락 (내부 표 점선 위·아래 {inset:.1}px 바깥의 전폭 실선 0쪽)"
     );
 }


### PR DESCRIPTION
closes #6621

## 무엇을 고쳤나

글자 없는 셀 하나에 표 하나가 든 1×1 상자 표는 `layout_table` 이 "unwrap" 해서 안쪽 표를 직접 그리고 상자 테두리 네 선을 따로 덧그립니다. 이 경로가 두 가지 여백을 버렸습니다.

1. **상자 셀의 안 여백(`padding`)** — 안쪽 표(와 그 안의 글자처럼 그림)가 상자 원점에 붙고, 상자 높이가 상하 여백만큼 짧고, 뒤따르는 본문도 그만큼 위로 올라왔습니다. (첫 커밋)
2. **안쪽 표의 바깥 여백(`outer_margin_*`)** — unwrap 경로는 안쪽 표를 상자와 같은 depth(본문이면 0)·inline 위치로 `layout_table` 에 넘겨서, 중첩 표 분기(`compute_table_y_position` 의 om_top, 반환 높이의 om_top+om_bottom)를 타지 않습니다. 그래서 안쪽 표 원점과 상자 바닥에서 바깥 여백이 통째로 빠졌습니다. (둘째 커밋 — CI 가 잡은 `issue_nested_table_border` 실패를 좇다가 찾았습니다)

한/글은 둘 다 둡니다: 안쪽 표 원점 = 상자 원점 + 셀 안 여백 + 안쪽 표 바깥 여백, 상자 바닥 = 안쪽 표 바닥 + 안쪽 표 바깥 여백 아래 + 셀 안 여백 아래, 상자 폭 = 바깥 표 선언 폭. 이번 수정은 그대로 따르고, 여백이 모두 0 인 상자는 종전과 같습니다. 글자처럼 상자는 x 를 줄 배치가 준 `inline_x_override` 로 받으므로 그 값도 같이 옮깁니다.

`#6621` 본문의 "그림 줄 높이가 자란다"는 추정은 틀렸습니다. 저장 줄 원장(`rhwp dump`)은 그림 셀의 그림 줄이 `lh = 그림 높이`, 다음 문단 `vpos = lh + ls` 로 여유가 없고, 행 높이 합(25791HU = 343.9px)도 rhwp 와 같습니다. 이슈에 정정 코멘트를 달았습니다.

## 실측

한/글 PDF 는 exam_social 이 4절→A3 맞춤 인쇄라 높이 기준 균일 배율 0.9385, 왼쪽 위 기준으로 되돌렸습니다(1쪽 잉크 왼끝 PDF 71 = rhwp 71). k-water-rfp 는 같은 쪽 크기(배율 1.001)입니다.

**exam_social 1쪽 pi=15 4번 상자** (셀 pad 850HU = 11.33px, 안쪽 6×3 표 om = (0, 283, 0, 283))

| 항목 (96DPI px) | 수정 전 | 수정 후 | 한/글 2022 |
|---|---:|---:|---:|
| 상자 왼쪽/오른쪽 선 x | 549.9 / 940.5 | 549.9 / 961.8 | 549.9 / 961.8 |
| 상자 위/아래 선 y | 324.9 / 668.7 | 324.9 / 695.2 | 325.1 / 695.5 |
| 첫 행 그림 (x, y) | (549.9, 331.9) | (561.2, 343.2) | (561.2, 343.3) |
| 셋째 열 그림 x | 895.3 | 906.6 | 906.6 |
| 글자처럼 그림 5장 편차 | (−11.3, −11.5) | ±0.35 | — |

**k-water-rfp 17쪽 상자** (셀 pad (510, 510, 141, 141), 안쪽 3×2 표 om = 141 네 방향 → 한/글은 점선을 실선에서 가로 8.7·세로 3.8 안쪽에 둡니다)

| 항목 (96DPI px) | 수정 전 | 수정 후 | 한/글 2022 |
|---|---:|---:|---:|
| 상자 실선 위/아래 y | 583.3 / 993.9 | 583.3 / 1001.4 | 583.2 / 1001.4 |
| 안쪽 표 점선 위/아래 y | 583.3 / 993.9 (실선과 같음) | 587.1 / 997.7 | 587.0 / 997.5 |
| 상자 실선 왼쪽/오른쪽 x | 81.9 / 703.0 | 81.9 / 716.9 | 82.0 / 717.2 |
| 안쪽 표 점선 왼쪽/오른쪽 x | 81.9 / 703.0 | 90.6 / 711.7 | 90.6 / 712.0 |

**코퍼스 회귀**: `samples/` 372 문서 전체의 render tree(모든 노드 bbox)를 수정 전(upstream/devel)·후로 전수 대조하면 바뀐 문서는 11개이고 전부 이 경로(1×1 상자 unwrap)의 문서입니다 — exam_social(+p1 복제)·k-water-rfp(+2024 복제)·2025 행정업무운영 편람(hwp·hwpx)·76076/80168/80250/86712_regulatory_analysis·issue1891_external_bindata_link. 한/글 PDF 가 있는 문서로 확인한 값:

| 문서 | 안쪽 표 모서리 | 수정 전 | 수정 후 | 한/글 2022 |
|---|---|---:|---:|---:|
| exam_social 1쪽 4번 상자 | 첫 그림 | (549.9, 331.9) | (561.2, 343.2) | (561.2, 343.3) |
| k-water-rfp 17쪽 | 점선 왼쪽 위 | (81.9, 583.3) | (90.6, 587.1) | (90.6, 587.0) |
| 80168_regulatory_analysis 6쪽 (자리차지 상자, 셀 pad (0,0,141,141) + 안쪽 om 141) | 왼쪽 위 | (75.6, 878.0) | (77.5, 881.8) | (79.4, 883.6) |

80168 에 남은 (−1.9, −1.8) 은 **자리차지 상자 표 자체의 바깥 여백**(om 141)이 depth 0 unwrap 에서 빠지는 별건이라 #6643 으로 뺐습니다(글자처럼 상자는 줄 배치가 그 여백을 주므로 k-water 는 정확히 맞습니다). 악화 0.

## 스크린샷 (한/글 PDF | 수정 전 | 수정 후)

**exam_social 1쪽 상자 위쪽 — 그림·글자가 여백 안으로**

![exam_social 상자 위](https://raw.githubusercontent.com/jeong-sik/rhwp/9908064a3bebfed377f33497bc5c1d194e03ad82/01-exam-social-p1-box-top.png)

**exam_social 1쪽 상자 아래쪽 — 상자 바닥 선이 한/글 자리(695.5)로, 뒤따르는 <보 기> 도 같이**

![exam_social 상자 아래](https://raw.githubusercontent.com/jeong-sik/rhwp/5c1f3ad628d052563a35ff0e5981bd078d83d55d/03-social-p1-boxbottom-3way.png)

**k-water-rfp 17쪽 상자 위 — 실선 아래 3.8px 에 점선(수정 전엔 겹침), 오른쪽 선이 717 까지**

![k-water 상자 위](https://raw.githubusercontent.com/jeong-sik/rhwp/5c1f3ad628d052563a35ff0e5981bd078d83d55d/03-kwater-p17-boxtop-3way.png)

**k-water-rfp 17쪽 상자 아래 — 점선 아래 3.8px 에 실선**

![k-water 상자 아래](https://raw.githubusercontent.com/jeong-sik/rhwp/5c1f3ad628d052563a35ff0e5981bd078d83d55d/03-kwater-p17-boxbottom-3way.png)

## 검증

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- 새 계약 `tests/cases/issue_6621_wrapper_cell_padding.rs` 2: 그림 5장이 (561.2, 343.3) 기준 열에 놓이는지, 상자 왼쪽 테두리 높이 = 343.9 + 22.7 + 3.8 인지.
- 기존 계약 `tests/issue_nested_table_border.rs` 2 갱신: 옛 기하(상자 폭 = 안쪽 표 폭 → 오른쪽 선 940.5, 실선 = 점선 y)를 못 박고 있어 한/글 실측으로 바꿨습니다 — 오른쪽 선 x 961.8·상자 높이 370.4, k-water 는 "점선 맨 위·아래에서 3.8px(셀 pad 141 + om 141) 바깥의 전폭 실선". 이 2건이 첫 push 의 CI 실패(Archive B)였습니다.
- 음성 대조: 위 4건을 수정 전 트리에서 돌리면 모두 실패 (그림 (549.9, 331.9), 상자 높이 343.9, 오른쪽 선 없음, 실선=점선).
- 통합 스위트 28개 전체 (`--profile release-test --target-dir target/pr-review --no-fail-fast`): 28개 전부 실행·전부 통과, 실패 0. (첫 push 는 12개만 돌려 `issue_nested_table_border` 를 놓쳤습니다.)
- Native Skia 3종·WASM: `--locked --profile release-test --target-dir target/pr-review --features native-skia --lib` 3946 통과, `issue_2225_missing_picture_placeholder` 2 통과, `render_p37_direct_pdf_export` 4 통과, `CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg --no-opt` 통과 (Docker 없어 wasm-opt 생략)
- `git diff --check`, `rust-unit-test-tiers --check`, `rust-test-suite-manifest --check` 통과

## 범위 밖

- 자리차지(TopAndBottom) 상자 표 자체의 바깥 여백이 depth 0 unwrap 에서 빠지는 것: #6643 (80168 6쪽 (−1.9, −1.8)).
- 같은 문서 2쪽 pi=21 처럼 1×1 상자 안에 글자와 그림이 함께 있어 unwrap 되지 않는 경우의 그림 (−15.0, −7.4) 는 다른 경로입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
