### PR TITLE
fix(layout): 셀 안에서 글자와 글자처럼 도형이 한 줄인 문단의 줄 높이를 접지 않는다 (#6632)

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -4242,7 +4242,12 @@ impl LayoutEngine {
                 (font_lh, ensure_min_baseline(font_bl, max_fs))
             } else if has_tac_shape
                 && !empty_tac_guide_has_explicit_shape_height
-                && (cell_ctx.is_none() || max_fs > 0.0)
+                // [#6632] 셀 안에서는 접지 않는다. 접힌 높이를 되돌리는 바닥값
+                // (`layout_column_item` 의 `para_start + max(seg_lh, shape_max_h)`)은 본문
+                // 문단에만 있어서, 셀에서 접으면 다음 문단이 도형 높이만큼 위로 올라온다
+                // (exam_kor 5쪽 셀: 글자+글상자 줄 lh 26.5 → 18.4, 뒤 그림 줄 8.1px 위).
+                // 행 높이 측정은 저장 lh 를 믿으므로 배치도 같은 값을 써야 맞는다.
+                && cell_ctx.is_none()
                 && raw_lh > max_fs * 1.5
             {
                 // Shape와 텍스트가 같은 줄에 있으면 Shape 높이가 line_height에 포함된다.

--- a/tests/cases/issue_6632_cell_tac_shape_line_height.rs
+++ b/tests/cases/issue_6632_cell_tac_shape_line_height.rs
@@ -1,0 +1,109 @@
+//! [#6632] 셀 안에서 글자와 글자처럼 도형이 한 줄인 문단의 줄 높이 계약.
+//!
+//! `samples/exam_kor.hwp` 5쪽 pi=145 셀[5]: p1 "(가) ⇨ [A 단계] ⇨ (나)" 는 글자와 글자처럼
+//! 글상자(높이 26.5px)가 한 줄이고 저장 줄 원장 lh=1984HU(26.5px). 다음 문단 p2(그림 3장,
+//! 79.4px)의 저장 vpos=11024HU(147.0px) = p1 시작 104.7 + 26.5 + 줄간격 9.2 + 문단 뒤 여백 6.7.
+//! 종전 rhwp 는 글자+도형 줄을 글꼴 높이(18.4)로 접어 p2 가 138.9(8.1px 위)였다. 본문은
+//! `layout_column_item` 바닥값이 되돌리지만 셀엔 그 바닥값이 없다. 한/글 2022 PDF(4절→A3
+//! 균일 배율 0.9385, 왼쪽 위 기준) 실측: 그림 상단 451.2 (셀 내용 상단 304.3 + 147.0).
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+fn page_svg(rel: &str, page: u32) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {rel}: {e:?}"));
+    doc.render_page_svg(page)
+        .unwrap_or_else(|e| panic!("render {rel} p{}: {e:?}", page + 1))
+}
+
+/// 태그 조각에서 `name="…"` 숫자 속성. 첫 속성은 앞에 공백이 없고(`<image x="…`), 다른
+/// 속성 이름의 꼬리에 걸리지 않게 앞 글자가 영숫자가 아닐 때만 받는다.
+fn attr(tag: &str, name: &str) -> Option<f64> {
+    let pat = format!("{name}=\"");
+    let mut from = 0;
+    while let Some(i) = tag[from..].find(&pat) {
+        let at = from + i;
+        if at == 0 || !tag.as_bytes()[at - 1].is_ascii_alphanumeric() {
+            let s = at + pat.len();
+            let e = s + tag[s..].find('"')?;
+            return tag[s..e].parse().ok();
+        }
+        from = at + 1;
+    }
+    None
+}
+
+/// 폭이 `w`(±0.6) 인 그림 자리의 (x, y) 목록. 자른 그림은 `<svg x y width height viewBox>`
+/// 래퍼 안에 원본 픽셀 크기의 `<image>` 로 들어가므로 래퍼도 본다.
+fn images_with_width(svg: &str, w: f64) -> Vec<(f64, f64)> {
+    let mut out = Vec::new();
+    for open in ["<image ", "<svg "] {
+        for t in svg.split(open).skip(1) {
+            let t = &t[..t.find('>').expect("태그 닫힘")];
+            if (attr(t, "width").unwrap_or(0.0) - w).abs() < 0.6 {
+                if let (Some(x), Some(y)) = (attr(t, "x"), attr(t, "y")) {
+                    out.push((x, y));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// 글자 `ch` 하나짜리 `<text>` 의 (x, 기준선 y) 목록.
+fn glyphs(svg: &str, ch: &str) -> Vec<(f64, f64)> {
+    let mut out = Vec::new();
+    for t in svg.split("<text ").skip(1) {
+        let Some(close) = t.find('>') else { continue };
+        let (head, rest) = t.split_at(close);
+        let body = &rest[1..rest.find("</text>").unwrap_or(1)];
+        if body.trim() != ch {
+            continue;
+        }
+        if let (Some(x), Some(y)) = (attr(head, "x"), attr(head, "y")) {
+            out.push((x, y));
+        }
+    }
+    out
+}
+
+/// 같은 결함의 글자 판: `samples/hwpspec.hwp` 106쪽 셀 안 그림 라벨 "(x1, y1)" 줄은 글자와
+/// 글자처럼 곡선 도형(저장 lh 152.9px) 한 줄. 종전엔 16.0 으로 접혀 다음 문단 "(x2, y2)",
+/// "(x3, y3)" 가 도형 위에 겹쳤다(기준선 422.1·446.1). 한/글 2024 PDF 실측 글리프 상자
+/// 아래 543.7·585.9 (기준선 ≈ 541.0·583.2), 수정 후 540.7·582.9.
+#[test]
+fn text_after_a_text_and_shape_line_in_a_cell_follows_the_stored_line_height() {
+    let svg = page_svg("samples/hwpspec.hwp", 105);
+    let two: Vec<_> = glyphs(&svg, "2")
+        .into_iter()
+        .filter(|(x, _)| (x - 505.2).abs() < 0.7)
+        .collect();
+    let three: Vec<_> = glyphs(&svg, "3")
+        .into_iter()
+        .filter(|(x, _)| (x - 261.5).abs() < 0.7)
+        .collect();
+    assert!(
+        two.iter().any(|(_, y)| (y - 540.7).abs() < 0.7),
+        "(x2, y2) 의 '2' 기준선 540.7 (종전 422.1): {two:?}"
+    );
+    assert!(
+        three.iter().any(|(_, y)| (y - 582.9).abs() < 0.7),
+        "(x3, y3) 의 '3' 기준선 582.9 (종전 446.1): {three:?}"
+    );
+}
+
+#[test]
+fn pictures_after_a_text_and_shape_line_follow_the_stored_line_height() {
+    let svg = page_svg("samples/exam_kor.hwp", 4);
+    let imgs = images_with_width(&svg, 79.4);
+    assert_eq!(imgs.len(), 3, "㉠㉡㉢ 그림 3장: {imgs:?}");
+    for (x, y) in &imgs {
+        assert!(
+            (y - 451.3).abs() < 0.7,
+            "그림 y = 셀 내용 상단 304.3 + 저장 vpos 147.0 (종전 443.2): ({x:.1}, {y:.1})"
+        );
+    }
+}


### PR DESCRIPTION
closes #6632

## 무엇을 고쳤나

셀 안에서 글자와 "글자처럼 취급" 도형이 한 줄에 있는 문단은 줄 높이가 글꼴 높이로 접혀, 뒤따르는 문단(그림 줄)이 도형 높이만큼 위로 올라왔습니다.

- `layout_composed_paragraph` 의 `has_tac_shape` 분기는 저장 줄 높이(`raw_lh`)가 글꼴 높이의 1.5배를 넘으면 줄 높이를 `max_fs × 1.2` 로 접습니다. 본문에서는 `layout_column_item` 이 `para_start + max(seg_lh, shape_max_h)` 를 바닥값으로 되돌려 주지만, 셀 배치 경로(`layout_horizontal_cell_paragraphs`)에는 그 바닥값이 없습니다.
- 셀 행 높이 측정은 저장 줄 원장(LINE_SEG)의 `lh` 를 그대로 믿습니다. 배치만 접으니 측정과 배치가 어긋나고, 다음 문단이 저장 `vpos` 보다 위에 놓입니다.

셀에서는 접지 않고 저장 줄 높이를 그대로 씁니다(`&& cell_ctx.is_none()`). 도형만 있는 줄(`max_fs=0`)은 [#1842] 가 이미 셀에서 같은 처리를 했고, 이 PR 은 글자가 함께 있는 줄까지 같은 규칙으로 맞춥니다. 본문 문단 경로는 바뀌지 않습니다.

## 실측

`samples/exam_kor.hwp` 5쪽 pi=145 표의 셀[5]. 문단 p1 "(가) ⇨ [A 단계] ⇨ (나)" 는 글자 + 글자처럼 글상자(높이 26.5px) 한 줄, p2 는 그림 3장(79.4px). 한/글 2022 PDF 는 4절→A3 맞춤 인쇄라 높이 기준 균일 배율 0.9385, 왼쪽 위 기준으로 되돌렸습니다.

| 항목 (96DPI px, 셀 내용 상단 기준) | 저장 원장 | 수정 전 | 수정 후 | 한/글 2022 PDF |
|---|---:|---:|---:|---:|
| p1 줄 높이 `lh` | 1984HU = 26.5 | 18.4 (접힘) | 26.5 | — |
| p2 그림 줄 `vpos` | 11024HU = 147.0 | 138.9 | 147.0 | 146.9 |
| 그림 상단 쪽 절대 y | — | 443.2 | 451.3 | 451.2 |

**코퍼스 회귀 (그림)**: `samples/`↔`pdf/` 215 쌍 중 그림이 있는 71 문서 1124 자리, PDF 그림과 짝지어진 955 장의 위치를 수정 전(upstream/devel)·후로 전수 재면 움직인 그림은 exam_kor 5쪽 3장뿐이고 전부 개선입니다(|dx|+|dy| 10.4/13.7/9.1 → 2.6/5.8/1.3, 남은 값은 가로 간격 문제로 별건). 악화 0.

**코퍼스 회귀 (글자까지)**: `cell_ctx` 는 표 셀뿐 아니라 글상자 안 문단에도 있어서, `samples/` 372 문서 전체의 render tree(모든 노드 bbox)를 전후 대조했습니다. 바뀐 문서는 7개뿐이고 모두 같은 결함(셀 안 글자+글자처럼 도형 줄이 접혀 다음 문단이 도형 위로 올라옴)의 다른 판입니다.

| 문서 | 바뀐 것 | 수정 전 | 수정 후 | 한/글 |
|---|---|---:|---:|---:|
| exam_kor 5쪽 | 그림 3장 y | 443.2 | 451.3 | 451.2 |
| hwpspec 106쪽 (hwp-3.0-HWPML 49쪽 동일) | 셀 안 그림 라벨 "(x2, y2)"·"(x3, y3)" 기준선 | 422.1 / 446.1 (곡선 위에 겹침) | 540.7 / 582.9 | ≈541.0 / 583.2 |
| 2025 행정업무운영 편람 140쪽 (hwp·hwpx) | 셀 안 화면 캡처(425px) 뒤 문단 2줄 | 캡처 위에 겹침 | 캡처 아래 | 캡처 아래 |
| synam-001 31쪽 | 셀 안 점선 상자 옆 "년·월·일" 글자 | 상자 위쪽에 떠 있음 | 상자 바닥에 맞춤 | 상자 바닥에 맞춤 |
| table_giant_cell_overfill 23쪽 | 접지 기호 옆 글줄 기준선 | 기호 바닥보다 5.2 위 | 기호 바닥 (한/글 +0.8 안) | — |

## 스크린샷 (한/글 PDF | 수정 전 | 수정 후)

**exam_kor 5쪽 셀[5] — 글상자 줄 아래 그림 3장이 8.1px 내려와 한/글과 같은 자리**

![exam_kor 5쪽 셀](https://raw.githubusercontent.com/jeong-sik/rhwp/bd3dc35c3fc33e0214d04cfbef11e1ea4cc46c85/kor-p5-cell-3way.png)

**hwpspec 106쪽 — 곡선 도형 옆 "(x1, y1)" 줄이 접혀 "(x2, y2)"·"(x3, y3)" 가 도형 위로 올라왔던 것**

![hwpspec 106쪽](https://raw.githubusercontent.com/jeong-sik/rhwp/98fa23e1c48bd288007c4ff9f35ee517234af64d/tac-hwpspec-p106.png)

**행정업무운영 편람 140쪽 — 셀 안 화면 캡처 뒤 문단이 캡처 위에 겹치던 것 (rhwp 는 이 셀이 전체적으로 위에 있는 별건 편차가 있음)**

![편람 140쪽](https://raw.githubusercontent.com/jeong-sik/rhwp/98fa23e1c48bd288007c4ff9f35ee517234af64d/tac-pyeonram-p140.png)

**synam-001 31쪽 — 점선 상자 옆 "년 월 일" 이 상자 바닥에 맞춰짐**

![synam 31쪽](https://raw.githubusercontent.com/jeong-sik/rhwp/98fa23e1c48bd288007c4ff9f35ee517234af64d/tac-synam-p31b.png)

## 검증

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- 새 계약 `tests/cases/issue_6632_cell_tac_shape_line_height.rs` 2: exam_kor 5쪽 그림 3장 y = 451.3 ± 0.7 (그림 판), hwpspec 106쪽 "(x2, y2)"·"(x3, y3)" 글리프 기준선 540.7·582.9 (글자 판). 음성 대조: 수정 전 트리에서 2건 모두 실패 (443.2 / 422.1·446.1 — 종전 값).
- 통합 스위트 28개 전체 (`--profile release-test --target-dir target/pr-review --no-fail-fast`): 28개 전부 실행·전부 통과, 실패 0. 골든 갱신 없음 (`exam-kor-page5` 골든은 6쪽 대상).
- Native Skia 3종·WASM: `--locked --profile release-test --target-dir target/pr-review --features native-skia --lib` 3946 통과, `issue_2225_missing_picture_placeholder` 2 통과, `render_p37_direct_pdf_export` 4 통과, `CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg --no-opt` 통과 (Docker 없어 wasm-opt 생략)
- `git diff --check`, `rust-unit-test-tiers --check`, `rust-test-suite-manifest --check` 통과

## 범위 밖

- 같은 셀 그림 3장의 가로 간격(+3.4px/장)은 인라인 그림 사이 간격 문제라 별건입니다.
- 쪽 나눔으로 이어지는 셀 조각(`table_partial.rs`)은 저장 흐름을 그대로 쓰므로 이 분기를 타지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
