### PR TITLE
fix(layout): 상자를 풀 때 안쪽 표의 바깥 여백을 셀 안 여백 안쪽에 남긴다 (#6648)

### DIFF
--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -2527,17 +2527,27 @@ impl LayoutEngine {
                             inline_x_override,
                             paper_w,
                         );
+                        // [#6648] 안쪽 표의 바깥 여백도 셀 안 여백 안쪽에 그대로 남는다. 아래
+                        // `layout_table` 호출은 상자와 같은 depth(본문이면 0)·inline 위치로 안쪽
+                        // 표를 놓아 `compute_table_y_position` 의 중첩 표 분기(om_top)와
+                        // `physical_outer_box_paint_inset`(om_left)을 타지 않으므로 여기서 더한다.
+                        // k-water 17쪽 실측: 셀 pad (510,510,141,141) + 안쪽 표 om 141 → 한/글 점선은
+                        // 실선에서 (8.7, 3.8) 안쪽 (90.6, 587.0); om 없이는 (88.7, 585.2).
+                        let om_l = hwpunit_to_px(nested.outer_margin_left as i32, self.dpi);
+                        let om_r = hwpunit_to_px(nested.outer_margin_right as i32, self.dpi);
+                        let om_t = hwpunit_to_px(nested.outer_margin_top as i32, self.dpi);
+                        let om_b = hwpunit_to_px(nested.outer_margin_bottom as i32, self.dpi);
                         // 안쪽 표가 여백을 뺀 내용 상자보다 조금 넓게 저장된 문서(exam_social:
                         // 1.4px)는 한/글처럼 오른쪽 여백으로 흘러넘기고 축소하지 않는다.
                         let inner_area = LayoutRect {
-                            x: col_area.x + pad_l,
+                            x: col_area.x + pad_l + om_l,
                             y: col_area.y,
-                            width: (col_area.width - pad_l - pad_r).max(nested_w),
+                            width: (col_area.width - pad_l - pad_r - om_l - om_r).max(nested_w),
                             height: col_area.height,
                         };
-                        let inner_y_start = y_start + pad_t;
+                        let inner_y_start = y_start + pad_t + om_t;
                         // 글자처럼 상자는 x 를 줄 배치가 준 inline_x_override 로 받으므로 그 값도 옮긴다.
-                        let inner_inline_x = inline_x_override.map(|x| x + pad_l);
+                        let inner_inline_x = inline_x_override.map(|x| x + pad_l + om_l);
 
                         let y_end = self.layout_table(
                             tree,
@@ -2569,7 +2579,7 @@ impl LayoutEngine {
                         // must not erase a larger declared wrapper height.  The host 1x1 table is
                         // still the observable box: downstream flow and its bottom border use the
                         // larger of the padded child and the stored outer rectangle (#6621).
-                        let padded_child_y_end = y_end + pad_b;
+                        let padded_child_y_end = y_end + om_b + pad_b;
                         let y_end = if self.profile.get().hwp5_stored_pagination_layout() {
                             let declared_outer_height = hwpunit_to_px(
                                 crate::renderer::float_placement::signed_hwpunit(

--- a/tests/cases/issue_6648_unwrap_nested_outer_margin.rs
+++ b/tests/cases/issue_6648_unwrap_nested_outer_margin.rs
@@ -1,0 +1,95 @@
+//! [#6648] 1×1 상자 표를 풀어 그릴 때 안쪽 표의 바깥 여백(outer_margin)이 원점에 남는 계약.
+//!
+//! `samples/k-water-rfp.hwp` 17쪽 상자: 상자 셀 pad (510,510,141,141)HU, 안쪽 3×2 표 om 141HU
+//! 네 방향. 한/글 2022 PDF(같은 쪽 크기) 실측: 상자 실선 x 82.0/717.2 · y 583.2/1001.4, 안쪽 표
+//! 점선 x 90.6/712.0 · y 587.0/997.5 — 점선은 실선에서 (pad + om) = (8.7, 3.8) 안쪽이다.
+//! om 이 빠지면 점선이 (88.7, 585.2) 로 (−1.9, −1.8) 어긋난다(#6621/#6645 직후 상태).
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+fn page_svg(rel: &str, page: u32) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {rel}: {e:?}"));
+    doc.render_page_svg(page)
+        .unwrap_or_else(|e| panic!("render {rel} p{}: {e:?}", page + 1))
+}
+
+/// `<line>` 요소의 (x1, y1, x2, y2, 점선 여부).
+fn lines(svg: &str) -> Vec<(f64, f64, f64, f64, bool)> {
+    let mut out = Vec::new();
+    for seg in svg.split("<line ").skip(1) {
+        let head = &seg[..seg.find('>').unwrap_or(seg.len())];
+        let get = |k: &str| -> Option<f64> {
+            let p = head.find(&format!("{k}=\""))? + k.len() + 2;
+            let rest = &head[p..];
+            rest[..rest.find('"')?].parse().ok()
+        };
+        if let (Some(x1), Some(y1), Some(x2), Some(y2)) =
+            (get("x1"), get("y1"), get("x2"), get("y2"))
+        {
+            out.push((x1, y1, x2, y2, head.contains("stroke-dasharray")));
+        }
+    }
+    out
+}
+
+#[test]
+fn unwrapped_nested_table_keeps_its_outer_margin_inside_the_cell_padding() {
+    let svg = page_svg("samples/k-water-rfp.hwp", 16);
+    let ls = lines(&svg);
+    let wide = |x1: f64, x2: f64| (x2 - x1).abs() > 500.0;
+    let tall = |y1: f64, y2: f64| (y2 - y1).abs() > 300.0;
+
+    // 상자 실선(전폭 수평·세로) — 한/글 583.2/1001.4, 82.0/717.2.
+    let solid_h: Vec<f64> = ls
+        .iter()
+        .filter(|(x1, y1, x2, y2, d)| !*d && (y1 - y2).abs() < 0.01 && wide(*x1, *x2))
+        .map(|(_, y, ..)| *y)
+        .collect();
+    let solid_v: Vec<f64> = ls
+        .iter()
+        .filter(|(x1, y1, x2, y2, d)| {
+            !*d && (x1 - x2).abs() < 0.01 && tall(*y1, *y2) && *y1 > 560.0
+        })
+        .map(|(x, ..)| *x)
+        .collect();
+    assert!(
+        solid_h.iter().any(|y| (y - 583.3).abs() < 0.5),
+        "상자 위 실선 583.3: {solid_h:?}"
+    );
+    assert!(
+        solid_h.iter().any(|y| (y - 1001.4).abs() < 0.5),
+        "상자 아래 실선 1001.4: {solid_h:?}"
+    );
+    assert!(
+        solid_v.iter().any(|x| (x - 81.9).abs() < 0.5),
+        "상자 왼쪽 실선 81.9: {solid_v:?}"
+    );
+
+    // 안쪽 표 점선(전폭 수평·세로) — 한/글 587.0/997.5, 90.6/712.0. 종전 585.2/995.8, 88.7/709.8.
+    let dashed_h: Vec<f64> = ls
+        .iter()
+        .filter(|(x1, y1, x2, y2, d)| *d && (y1 - y2).abs() < 0.01 && wide(*x1, *x2))
+        .map(|(_, y, ..)| *y)
+        .collect();
+    let dashed_v: Vec<f64> = ls
+        .iter()
+        .filter(|(x1, y1, x2, y2, d)| *d && (x1 - x2).abs() < 0.01 && tall(*y1, *y2))
+        .map(|(x, ..)| *x)
+        .collect();
+    assert!(
+        dashed_h.iter().any(|y| (y - 587.1).abs() < 0.4),
+        "안쪽 표 위 점선 = 상자 583.3 + pad 1.9 + om 1.9 = 587.1 (한/글 587.0, 종전 585.2): {dashed_h:?}"
+    );
+    assert!(
+        dashed_h.iter().any(|y| (y - 997.7).abs() < 0.4),
+        "안쪽 표 아래 점선 997.7 (한/글 997.5, 종전 995.8): {dashed_h:?}"
+    );
+    assert!(
+        dashed_v.iter().any(|x| (x - 90.6).abs() < 0.4),
+        "안쪽 표 왼쪽 점선 = 상자 81.9 + pad 6.8 + om 1.9 = 90.6 (한/글 90.6, 종전 88.7): {dashed_v:?}"
+    );
+}


### PR DESCRIPTION
closes #6648

## 무엇을 고쳤나

1×1 상자 표를 풀어 그리는 unwrap 경로(`table_layout.rs`)는 안쪽 표를 상자와 같은 depth(본문이면 0)·inline 위치로 `layout_table` 에 넘깁니다. 그래서 중첩 표 분기(`compute_table_y_position` 의 om_top, `physical_outer_box_paint_inset` 의 om_left)를 타지 않고, **안쪽 표 자체의 바깥 여백(`outer_margin_*`)** 이 원점에서 빠졌습니다. #6621(#6645 로 통합)은 상자 셀의 안 여백을 되살렸고 상자 바닥은 메인테이너 보정(선언 높이 하한)으로 맞았지만, 안쪽 표 원점은 om 만큼 위·왼쪽에 남아 있었습니다.

안쪽 표 원점에 (om_l, om_t) 를, `inline_x_override` 에 om_l 을, 흐름 끝(`padded_child_y_end`)에 om_b 를 더합니다. 선언 높이 하한(`max`)은 그대로라 상자 바닥·뒤 흐름은 바뀌지 않습니다. om 이 0 인 안쪽 표는 종전과 같습니다.

## 실측

`samples/k-water-rfp.hwp` 17쪽 상자 — 상자 셀 pad (510,510,141,141)HU, 안쪽 3×2 표 om 141HU 네 방향. 한/글 2022 PDF 는 같은 쪽 크기(배율 1.001).

| 항목 (96DPI px) | devel (#6645) | 수정 후 | 한/글 2022 |
|---|---:|---:|---:|
| 상자 실선 왼쪽/위 (x, y) | (81.9, 583.3) | (81.9, 583.3) | (82.0, 583.2) |
| 안쪽 표 점선 왼쪽/위 (x, y) | (88.7, 585.2) | (90.6, 587.1) | (90.6, 587.0) |
| 안쪽 표 점선 오른쪽/아래 (x, y) | (709.8, 995.8) | (711.7, 997.7) | (712.0, 997.5) |
| 상자 실선 아래 y | 1001.4 | 1001.4 | 1001.4 |

`samples/exam_social.hwp` 1쪽 4번 상자는 안쪽 표 om 이 (0, 283, 0, 283) 이라 원점은 그대로(첫 그림 (561.2, 343.2) 유지)이고, 바닥 +3.8(om_bottom) 은 선언 높이 하한 370.3 이 이미 덮습니다.

## 스크린샷 (한/글 PDF | devel | 수정 후)

**k-water 17쪽 상자 왼쪽 위 — 점선이 실선에서 (8.7, 3.8) 안쪽으로**

![k-water 왼쪽 위](https://raw.githubusercontent.com/jeong-sik/rhwp/5f2e2189a46864ed1fd7253d525859b3edc46756/01-kwater-p17-topleft.png)

**k-water 17쪽 상자 왼쪽 아래**

![k-water 왼쪽 아래](https://raw.githubusercontent.com/jeong-sik/rhwp/5f2e2189a46864ed1fd7253d525859b3edc46756/02-kwater-p17-bottomleft.png)

## 검증

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- 새 계약 `tests/cases/issue_6648_unwrap_nested_outer_margin.rs` 1: k-water 17쪽 실선 583.3/1001.4/81.9 유지 + 점선 587.1/997.7/90.6. 음성 대조: om 을 더하지 않은 devel 계열 트리에서 실패 (점선 585.2/995.8/88.7).
- 기존 계약 유지: `issue_6621_wrapper_cell_padding` 2, `issue_nested_table_border` 2 (메인테이너 갱신판) 통과.
- 통합 스위트 28개 전체 (`--profile release-test --target-dir target/pr-review --no-fail-fast`): 28개 전부 실행·전부 통과, 실패 0 (FAILED 줄 전수 확인).
- Native Skia 3종·WASM: `--locked --profile release-test --target-dir target/pr-review --features native-skia --lib` 3946 통과, `issue_2225_missing_picture_placeholder` 2 통과, `render_p37_direct_pdf_export` 4 통과, `CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg --no-opt` 통과 (Docker 없어 wasm-opt 생략)
- `git diff --check`, `rust-unit-test-tiers --check`, `rust-test-suite-manifest --check` 통과

## 범위 밖

- 자리차지(TopAndBottom) 상자 표 자체의 바깥 여백이 depth 0 에서 빠지는 것: #6643 (80168 6쪽 (−1.9, −1.8)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
