### PR TITLE
fix(layout): 글상자 문단의 글자처럼 개체 폭을 첫 줄 글자 오프셋으로 겹쳐 주지 않는다 (#6651)

### DIFF
--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -3106,20 +3106,12 @@ impl LayoutEngine {
                     + textbox_vpos_px(first_ls.vertical_pos, textbox_vpos_origin_hu, self.dpi);
                 para_y = vpos_y.max(para_y);
             }
-            // 인라인(treat_as_char) 컨트롤의 총 폭 계산
-            let tb_inline_width: f64 = para
-                .controls
-                .iter()
-                .map(|ctrl| match ctrl {
-                    Control::Picture(pic) if pic.common.treat_as_char => {
-                        hwpunit_to_px(pic.common.width as i32, self.dpi)
-                    }
-                    Control::Shape(shape) if shape.common().treat_as_char => {
-                        hwpunit_to_px(shape.common().width as i32, self.dpi)
-                    }
-                    _ => 0.0,
-                })
-                .sum();
+            // [#6651] 글자처럼 개체 폭 합을 첫 줄 글자 오프셋(`first_line_x_offset`)으로
+            // 넘기지 않는다. 그 오프셋은 "개체를 문단 시작에 놓고 글자를 뒤에" 두던 옛
+            // 모델의 것이고, 지금은 `layout_composed_paragraph` 의 `run_tacs` 분기가 개체의
+            // 글자 위치에서 `tac_w` 를 전진시키며 아래 인라인 개체 렌더러가 개체를 그 자리에
+            // 놓는다. 오프셋을 겹쳐 주면 글자만 개체 폭만큼 두 번 밀린다 — table-in-tbox
+            // 2쪽 "␣[그림]␣서비스 기간" 의 '서' 가 134.3 (한/글 116.8, 그림 17.5).
             let para_col_area = LayoutRect {
                 y: para_y,
                 ..inner_area
@@ -3153,7 +3145,7 @@ impl LayoutEngine {
                 Some(cell_ctx),
                 true,
                 is_last_para,
-                tb_inline_width,
+                0.0,
                 None,
                 Some(para),
                 None,

--- a/tests/cases/issue_6651_textbox_tac_text_offset.rs
+++ b/tests/cases/issue_6651_textbox_tac_text_offset.rs
@@ -1,0 +1,107 @@
+//! [#6651] 글상자 문단에서 글자처럼 그림 뒤의 글자가 그림 폭만큼 두 번 밀리지 않는 계약.
+//!
+//! `samples/table-in-tbox.hwp` 2쪽 글상자 문단 p[7] "␣[그림 17.5×15]␣서비스 기간 : 2025년 …"
+//! (왼쪽 정렬, 안쪽 왼끝 79.4). 한/글 2022 PDF 실측: 그림 x 89.3, '서' origin x 116.8
+//! = 79.4 + 빈칸 10 + 그림 17.5 + 빈칸 10. 종전 rhwp 는 첫 run 이 79.4 + 17.4 에서 시작해
+//! '서' 가 134.3 이었다(그림은 89.4 로 맞았음).
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+fn page_svg(rel: &str, page: u32) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {rel}: {e:?}"));
+    doc.render_page_svg(page)
+        .unwrap_or_else(|e| panic!("render {rel} p{}: {e:?}", page + 1))
+}
+
+/// 태그 조각에서 `name="…"` 숫자 속성. 첫 속성은 앞에 공백이 없고, 다른 속성 이름의 꼬리에
+/// 걸리지 않게 앞 글자가 영숫자가 아닐 때만 받는다.
+fn attr(tag: &str, name: &str) -> Option<f64> {
+    let pat = format!("{name}=\"");
+    let mut from = 0;
+    while let Some(i) = tag[from..].find(&pat) {
+        let at = from + i;
+        if at == 0 || !tag.as_bytes()[at - 1].is_ascii_alphanumeric() {
+            let s = at + pat.len();
+            let e = s + tag[s..].find('"')?;
+            return tag[s..e].parse().ok();
+        }
+        from = at + 1;
+    }
+    None
+}
+
+/// 글자 하나짜리 `<text>` 의 (x, y, 글자). 원점은 `x="…" y="…"` 또는 `translate(x,y)`.
+fn glyphs(svg: &str) -> Vec<(f64, f64, char)> {
+    let mut out = Vec::new();
+    for t in svg.split("<text ").skip(1) {
+        let Some(close) = t.find('>') else { continue };
+        let (head, rest) = t.split_at(close);
+        let body = &rest[1..rest.find("</text>").unwrap_or(1)];
+        let mut cs = body.chars();
+        let (Some(c), None) = (cs.next(), cs.next()) else {
+            continue;
+        };
+        let origin = if let Some(tr) = head.find("translate(") {
+            let nums = &head[tr + "translate(".len()..];
+            nums.find(')').and_then(|end| {
+                let mut it = nums[..end].split(',');
+                let x = it.next()?.trim().parse().ok()?;
+                let y = it.next()?.trim().parse().ok()?;
+                Some((x, y))
+            })
+        } else {
+            attr(head, "x").zip(attr(head, "y"))
+        };
+        if let Some((x, y)) = origin {
+            out.push((x, y, c));
+        }
+    }
+    out
+}
+
+/// 폭·높이가 (w, h)(±0.6) 인 `<image>` 자리의 (x, y) 목록.
+fn images_sized(svg: &str, w: f64, h: f64) -> Vec<(f64, f64)> {
+    let mut out = Vec::new();
+    for t in svg.split("<image ").skip(1) {
+        let t = &t[..t.find('>').expect("태그 닫힘")];
+        if (attr(t, "width").unwrap_or(0.0) - w).abs() < 0.6
+            && (attr(t, "height").unwrap_or(0.0) - h).abs() < 0.6
+        {
+            if let (Some(x), Some(y)) = (attr(t, "x"), attr(t, "y")) {
+                out.push((x, y));
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn text_after_an_inline_picture_in_a_textbox_advances_once() {
+    let svg = page_svg("samples/table-in-tbox.hwp", 1);
+    // 그림 4장(17.5×15.0)은 제자리(x 89.4)다.
+    let pics = images_sized(&svg, 17.5, 15.0);
+    assert!(pics.len() >= 4, "글상자 안 17.5×15 그림 4장: {pics:?}");
+    for (x, y) in &pics {
+        assert!(
+            (x - 89.4).abs() < 0.7,
+            "그림 x 89.4 (한/글 89.3): ({x:.1}, {y:.1})"
+        );
+    }
+    // 그림 줄의 첫 글자 '서'(y≈510.8 기준선) — 79.4 + 빈칸 + 그림 + 빈칸 = 116.9.
+    let seo: Vec<(f64, f64)> = glyphs(&svg)
+        .into_iter()
+        .filter(|(_, y, c)| *c == '서' && (y - 510.8).abs() < 1.5)
+        .map(|(x, y, _)| (x, y))
+        .collect();
+    assert!(!seo.is_empty(), "'서비스 기간' 줄의 '서' 글리프");
+    for (x, y) in &seo {
+        assert!(
+            (x - 116.9).abs() < 0.7,
+            "'서' x = 79.4 + 10 + 17.5 + 10 = 116.9 (한/글 116.8, 종전 134.3): ({x:.1}, {y:.1})"
+        );
+    }
+}


### PR DESCRIPTION
closes #6651

## 무엇을 고쳤나

글상자(사각형 안 텍스트) 문단 루프(`shape_layout.rs`)가 그 문단의 글자처럼 그림·도형 폭 합 `tb_inline_width` 를 `layout_composed_paragraph` 의 `first_line_x_offset` 으로 넘기고 있었습니다. 이 오프셋은 "글자처럼 개체를 문단 시작에 놓고 글자를 그 뒤에" 두던 옛 모델의 것입니다. 지금은

- 문단 배치의 `run_tacs` 분기가 개체의 **글자 위치**에서 `tac_w` 만큼 전진시키고,
- 글상자 전용 인라인 개체 렌더러(같은 파일 3164~)가 개체를 앞 글자 폭 뒤에 놓습니다.

그래서 오프셋이 겹치면 **글자만** 개체 폭만큼 두 번 밀립니다(개체는 제자리). 표 셀·본문 경로에는 이 오프셋이 없어 exam_kor 5쪽 셀의 "㉠[그림]" 줄은 맞았고, 글상자 다른 호출자(2843)도 이미 0.0 을 넘깁니다. 가운데·오른쪽 정렬에서는 `available_width` 가 이 오프셋만큼 줄어드는데 폭 추정에는 TAC 폭이 이미 들어 있어(`included_tac_width`) 정렬 오프셋에도 같은 이중 계산이 있었습니다.

`tb_inline_width` 를 지우고 0.0 을 넘깁니다.

## 실측

`samples/table-in-tbox.hwp` 2쪽 글상자 문단 p[7]~p[10] "␣[그림 17.5×15]␣서비스 기간 : …" (왼쪽 정렬, 글상자 안쪽 왼끝 79.4, 빈칸 10px). 한/글 2022 PDF 는 같은 쪽 크기.

| 항목 (96DPI px) | 수정 전 | 수정 후 | 한/글 2022 |
|---|---:|---:|---:|
| 그림 x | 89.4 | 89.4 | 89.3 |
| 첫 run(빈칸) x | 96.8 | 79.4 | — |
| '서' origin x | 134.3 | 116.9 | 116.8 |
| 구성 | 79.4 + **17.4** + 10 + 17.5 + 10 | 79.4 + 10 + 17.5 + 10 | 79.4 + 10 + 17.5 + 10 |

**코퍼스 회귀**: `samples/` 372 문서 render tree 전수 대조(순수 devel vs 수정)에서 13 문서가 움직였고 전부 `TextBox/TextLine/TextRun` 폭·x 만 바뀝니다(개체·표·줄 노드 변화 0). 보이는 글자가 움직인 문서는 둘뿐이고 둘 다 한/글 쪽으로 갑니다:

| 문서 | 자리 | 수정 전 | 수정 후 | 한/글 |
|---|---|---:|---:|---:|
| table-in-tbox 2쪽 | 글상자 "␣[그림]␣서비스" '서' x | 134.3 | 116.9 | 116.8 (2022) |
| 2025 행정업무운영 편람 11쪽 (hwp·hwpx) | 표지 글상자 "2025 행정…" '2' x | 311.4 | 301.3 | 296.3 (2024) |
| 같은 문서 29쪽 | 같은 글상자 | 315.4 | 305.3 | 300.3 |

편람에 남는 +5.0 은 글꼴 폭 차이(숫자 전진 rhwp 6.0 vs 한/글 6.6)라 별건입니다. 나머지 11 문서(hongbo·hwpspec·hwp-3.0-HWPML·tac-img-02·rowbreak-problem-pages·issue5543·156636617)는 로고 줄의 **빈칸 run** 폭만 바뀌고 보이는 글자는 전후 동일함을 글리프 좌표로 확인했습니다(가운데·오른쪽 정렬 폭 계산에서 이중 계산이 사라진 결과).

## 스크린샷 (한/글 PDF | 수정 전 | 수정 후)

**table-in-tbox 2쪽 글상자 — 그림 뒤 글자가 한/글 자리로 (그림·세로는 그대로)**

![table-in-tbox 2쪽](https://raw.githubusercontent.com/jeong-sik/rhwp/c5421eb363f7d827b27720ec77e183aa77af701d/01-table-in-tbox-p2-lines.png)

## 검증

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- 새 계약 `tests/cases/issue_6651_textbox_tac_text_offset.rs` 1: 그림 4장 x 89.4 유지 + '서' x 116.9 ± 0.7. 음성 대조: 수정 없는 트리에서 실패 ('서' 134.3).
- 통합 스위트 28개 전체 (`--profile release-test --target-dir target/pr-review --no-fail-fast`): 28개 전부 실행. 실패 4건은 이 변경과 무관한 동시 실행 간섭입니다 — `csv_to_chart_structure_contract` 2건, `issue_3885_json_provenance_envelope` 2건 모두 같은 트리에서 단독 실행하면 통과합니다(두 스위트가 같은 임시 산출 경로를 씁니다). 렌더러·레이아웃 스위트는 전부 통과.
- Native Skia 3종·WASM: `--locked --profile release-test --target-dir target/pr-review --features native-skia --lib` 3946 통과, `issue_2225_missing_picture_placeholder` 2 통과, `render_p37_direct_pdf_export` 4 통과, `CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg --no-opt` 통과 (Docker 없어 wasm-opt 생략)
- `git diff --check`, `rust-unit-test-tiers --check`, `rust-test-suite-manifest --check` 통과

## 범위 밖

- 같은 글상자 그림 4장의 세로 자리(rhwp 줄 위 493.8, 한/글 498.1 — 글자처럼 그림을 기준선에 맞추는 규칙)는 별건입니다.
- 같은 문서 글상자 안 **표** 안의 그림 dx −12~−44 도 별건입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
