### PR TITLE
docs(review): PR 6657 source 후속 comment 계획을 보완한다

### DIFF
--- a/mydocs/pr/archives/pr_6642_review.md
+++ b/mydocs/pr/archives/pr_6642_review.md
@@ -29,6 +29,19 @@
 - 비교 첨부: [RHWP와 기준 PDF 5쪽 비교](../assets/pr_6642_6652_jeong_sik_integration_20260903/review_6642_rhwp_oracle.png).
 - 네이티브 Skia 출력에서 셀, 표, 글자처럼 취급되는 도형의 페이지 내 배치가 기준 PDF와 같은 구조로 유지됨을 확인했다. 폰트 래스터화 차이가 있어 픽셀 동일성은 주장하지 않는다.
 
+## Merge 후 contributor PR comment 계획
+
+병합 후 [원 PR #6642](https://github.com/edwardkim/rhwp/pull/6642)에 아래 사실을 한 번 게시한다.
+
+- [통합 PR #6657](https://github.com/edwardkim/rhwp/pull/6657)이 [merge commit `56d054852d03b9737f9a159073939d6bccebac77`](https://github.com/edwardkim/rhwp/commit/56d054852d03b9737f9a159073939d6bccebac77)으로 병합됐고, 이 PR의 source 반영 commit은 `76c27710a`다.
+- PR head의 CI, Rust CodeQL worker, Canvas visual diff, Adapter inter-diff, Proptest가 성공했다. devel push의 CI 및 CodeQL aggregate도 success이고 trusted post-merge reuse 정책에 따른 heavy worker skip은 expected skip이다.
+- [Visual Sweep 가이드](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/verification/visual_sweep_guide.md#github-merge-comment)를 따르며, 실제 HWP 5쪽과 정본 PDF 5쪽의 구조 배치를 확인했다. 픽셀 동일성은 주장하지 않는다.
+- `![PR 6642 p5 visual review](https://raw.githubusercontent.com/edwardkim/rhwp/56d054852d03b9737f9a159073939d6bccebac77/mydocs/pr/assets/pr_6642_6652_jeong_sik_integration_20260903/review_6642_rhwp_oracle.png)`를 실제 comment에 포함한다.
+
+## Merge 후 issue comment 계획
+
+[Issue #6632](https://github.com/edwardkim/rhwp/issues/6632)에는 위 merge commit, 실제 PR/devel 검증, `exam_kor.hwp` 5쪽과 정본 PDF 5쪽의 증적 범위, 수동 close 사유를 body-file comment로 남긴 뒤 CLOSED 처리한다. 통합 PR 본문에 closing keyword가 없으므로 auto-close가 아닌 수동 close임을 명시한다.
+
 ## 수용 범위
 
 이 기록은 최신 head를 `upstream/devel` 위에 provenance-preserving cherry-pick한 통합 검토 결과다. 원 PR을 직접 병합하지 않고, 이후 통합 PR의 CI 및 병합 후 검증이 모두 성공할 때에만 원 PR 후속 처리 대상으로 삼는다.

--- a/mydocs/pr/archives/pr_6650_review.md
+++ b/mydocs/pr/archives/pr_6650_review.md
@@ -29,6 +29,19 @@
 - 비교 첨부: [RHWP와 기준 PDF 17쪽 비교](../assets/pr_6642_6652_jeong_sik_integration_20260903/review_6650_rhwp_oracle.png).
 - 비교 출력에서 중첩 표와 도식의 물리 배치는 확인했다. 현 Mac 네이티브 Skia 환경은 해당 한글 글꼴을 모두 제공하지 않아 RHWP 쪽 일부 글리프가 대체 문자로 보이며, 이 첨부는 문자 모양의 픽셀 동일성 증명이 아니다. 회귀 테스트의 좌표 단언이 여백 계약의 실행 증적이다.
 
+## Merge 후 contributor PR comment 계획
+
+병합 후 [원 PR #6650](https://github.com/edwardkim/rhwp/pull/6650)에 아래 사실을 한 번 게시한다.
+
+- [통합 PR #6657](https://github.com/edwardkim/rhwp/pull/6657)이 [merge commit `56d054852d03b9737f9a159073939d6bccebac77`](https://github.com/edwardkim/rhwp/commit/56d054852d03b9737f9a159073939d6bccebac77)으로 병합됐고, 이 PR의 source 반영 commit은 `018b64322`다.
+- PR head의 CI, Rust CodeQL worker, Canvas visual diff, Adapter inter-diff, Proptest가 성공했다. devel push의 CI 및 CodeQL aggregate도 success이고 trusted post-merge reuse 정책에 따른 heavy worker skip은 expected skip이다.
+- [Visual Sweep 가이드](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/verification/visual_sweep_guide.md#github-merge-comment)를 따르며, 실제 HWP 17쪽과 정본 PDF 17쪽의 물리 배치와 회귀 테스트의 여백 좌표 계약을 확인했다. 현 Mac 글꼴 대체 때문에 문자 모양의 픽셀 동일성은 주장하지 않는다.
+- `![PR 6650 p17 visual review](https://raw.githubusercontent.com/edwardkim/rhwp/56d054852d03b9737f9a159073939d6bccebac77/mydocs/pr/assets/pr_6642_6652_jeong_sik_integration_20260903/review_6650_rhwp_oracle.png)`를 실제 comment에 포함한다.
+
+## Merge 후 issue comment 계획
+
+[Issue #6648](https://github.com/edwardkim/rhwp/issues/6648)에는 위 merge commit, 실제 PR/devel 검증, `k-water-rfp.hwp` 17쪽과 정본 PDF 17쪽의 증적 범위, 수동 close 사유를 body-file comment로 남긴 뒤 CLOSED 처리한다. 통합 PR 본문에 closing keyword가 없으므로 auto-close가 아닌 수동 close임을 명시한다.
+
 ## 수용 범위
 
 이 기록은 최신 head를 `upstream/devel` 위에 provenance-preserving cherry-pick한 통합 검토 결과다. 원 PR을 직접 병합하지 않고, 이후 통합 PR의 CI 및 병합 후 검증이 모두 성공할 때에만 원 PR 후속 처리 대상으로 삼는다.

--- a/mydocs/pr/archives/pr_6652_review.md
+++ b/mydocs/pr/archives/pr_6652_review.md
@@ -29,6 +29,19 @@
 - 비교 첨부: [RHWP와 기준 PDF 2쪽 비교](../assets/pr_6642_6652_jeong_sik_integration_20260903/review_6652_rhwp_oracle.png).
 - 비교 출력에서 글상자, inline 그림, 표의 물리 배치를 확인했다. 현 Mac 네이티브 Skia 환경의 한글 글꼴 대체 때문에 문자 모양의 픽셀 동일성은 주장하지 않는다. 회귀 테스트는 그림 뒤 텍스트 시작점의 좌표 계약을 직접 단언한다.
 
+## Merge 후 contributor PR comment 계획
+
+병합 후 [원 PR #6652](https://github.com/edwardkim/rhwp/pull/6652)에 아래 사실을 한 번 게시한다.
+
+- [통합 PR #6657](https://github.com/edwardkim/rhwp/pull/6657)이 [merge commit `56d054852d03b9737f9a159073939d6bccebac77`](https://github.com/edwardkim/rhwp/commit/56d054852d03b9737f9a159073939d6bccebac77)으로 병합됐고, 이 PR의 source 반영 commit은 `e0e07783d`다.
+- PR head의 CI, Rust CodeQL worker, Canvas visual diff, Adapter inter-diff, Proptest가 성공했다. devel push의 CI 및 CodeQL aggregate도 success이고 trusted post-merge reuse 정책에 따른 heavy worker skip은 expected skip이다.
+- [Visual Sweep 가이드](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/verification/visual_sweep_guide.md#github-merge-comment)를 따르며, 실제 HWP 2쪽과 정본 PDF 2쪽의 글상자, inline 그림, 표의 물리 배치를 확인했다. 현 Mac 글꼴 대체 때문에 문자 모양의 픽셀 동일성은 주장하지 않는다.
+- `![PR 6652 p2 visual review](https://raw.githubusercontent.com/edwardkim/rhwp/56d054852d03b9737f9a159073939d6bccebac77/mydocs/pr/assets/pr_6642_6652_jeong_sik_integration_20260903/review_6652_rhwp_oracle.png)`를 실제 comment에 포함한다.
+
+## Merge 후 issue comment 계획
+
+[Issue #6651](https://github.com/edwardkim/rhwp/issues/6651)에는 위 merge commit, 실제 PR/devel 검증, `table-in-tbox.hwp` 2쪽과 정본 PDF 2쪽의 증적 범위, 수동 close 사유를 body-file comment로 남긴 뒤 CLOSED 처리한다. 통합 PR 본문에 closing keyword가 없으므로 auto-close가 아닌 수동 close임을 명시한다.
+
 ## 수용 범위
 
 이 기록은 최신 head를 `upstream/devel` 위에 provenance-preserving cherry-pick한 통합 검토 결과다. 원 PR을 직접 병합하지 않고, 이후 통합 PR의 CI 및 병합 후 검증이 모두 성공할 때에만 원 PR 후속 처리 대상으로 삼는다.


### PR DESCRIPTION
## 목적

[PR #6657](https://github.com/edwardkim/rhwp/pull/6657)의 merge 뒤 source PR 및 issue 후속 comment를 `post_merge.md`에 따라 게시하기 전에, source review 기록에 필수 comment 계획을 보완합니다.

## 범위

- `mydocs/pr/archives/pr_6642_review.md`
- `mydocs/pr/archives/pr_6650_review.md`
- `mydocs/pr/archives/pr_6652_review.md`

각 기록에 실제 merge SHA, 최신 PR/devel CI 결과, 수동 issue close 사유, devel에 이미 존재하는 direct visual asset을 기록합니다.

코드, 테스트, workflow, golden, sample, 신규 asset은 포함하지 않습니다. 이 PR이 merge되고 devel CI가 성공한 뒤에만 원 PR #6642, #6650, #6652의 comment와 close를 한 번씩 처리합니다.
