### PR TITLE
fix(layout): 문단 안 줄 전진을 저장 사다리의 vpos 차로 맞춘다 (#6656)

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -4812,8 +4812,35 @@ impl LayoutEngine {
                 .as_ref()
                 .map(|flow| flow.extra_rows)
                 .unwrap_or(0);
+            // [#6656] 문단 안 다음 줄까지의 전진은 저장 줄의 **글자 높이(th)** 다. 줄 상자
+            // 높이(lh)는 그 줄이 품은 개체까지 덮지만, 한/글은 다음 줄을 th + ls 자리에
+            // 놓고 개체가 아래 줄 공간을 침범하게 둔다. 코퍼스 전수(samples↔pdf 215문서,
+            // lh≠th 인 문단 안 연속 줄): th+ls 45건 / lh+ls 1건.
+            // 예) hwpctl_ParameterSetID_Item_v1.2 문단 0.7: ls[2] vpos=0 lh=1560 th=1000
+            // ls=600 → ls[3] vpos=1600 (= th+ls). 한/글 3쪽 둘째 줄 89.3, rhwp 는 96.8.
+            // 상자 높이(`line_height`)는 그대로 두고 전진만 줄인다.
+            // 전진값은 추정하지 않고 **저장 사다리의 다음 줄 vpos 차**를 그대로 쓴다.
+            // 세 가지를 함께 요구한다. ① 사다리를 다시 짜지 않은 문단일 것. ② 이 줄의 상자
+            // 높이가 저장 `lh` 그대로일 것 — 재조판된 상자에 저장 전진을 섞으면 사다리도
+            // 상자도 아닌 값이 된다. ③ 전진이 실제 글자(`max_fs`)를 담을 것 — HWP3 변환본
+            // 처럼 낡은 값이면 다음 줄이 글자 위로 올라온다(hwp3-empty-cell 겹침 1건).
+            let stored_line_advance = para.filter(|_| !source_metrics_reflowed).and_then(|p| {
+                let seg = p.line_segs.get(line_idx)?;
+                let next = p.line_segs.get(line_idx + 1)?;
+                if (hwpunit_to_px(seg.line_height, self.dpi) - line_height).abs() >= 0.5 {
+                    return None;
+                }
+                if seg.vertical_pos < 0 || next.vertical_pos <= seg.vertical_pos {
+                    return None;
+                }
+                let step =
+                    hwpunit_to_px(next.vertical_pos - seg.vertical_pos, self.dpi) - line_spacing_px;
+                (step > 0.0 && step < line_height && (max_fs <= 0.0 || step + 0.5 >= max_fs))
+                    .then_some(step)
+            });
+            let flow_step = stored_line_advance.unwrap_or(line_height);
             let line_flow_height =
-                line_height + equation_tac_extra_rows as f64 * (line_height + line_spacing_px);
+                flow_step + equation_tac_extra_rows as f64 * (line_height + line_spacing_px);
             let render_line_flow_height =
                 if cell_ctx.is_none() && para_index >= self.endnote_para_base.get() {
                     // 미주 lineSeg의 행 진행값이 실제 TextLine bbox보다 작으면 단일 줄 미주가

--- a/tests/cases/issue_6656_line_advance_text_height.rs
+++ b/tests/cases/issue_6656_line_advance_text_height.rs
@@ -1,0 +1,80 @@
+//! [#6656] 문단 안 줄 전진은 저장 줄의 글자 높이(th)를 따른다.
+//!
+//! 저장 줄 사다리(`ls[]`)는 문단 안에서 다음 줄을 `th + ls` 자리에 놓는다. 줄 상자 높이
+//! `lh` 는 그 줄이 품은 개체까지 덮지만 전진에는 쓰이지 않는다 — 한/글은 개체가 아래 줄
+//! 공간을 침범하게 둔다. 코퍼스 전수(samples↔pdf 215 문서, `lh != th` 인 문단 안 연속 줄):
+//! `th + ls` 45건 / `lh + ls` 1건.
+//!
+//! `samples/hwpctl_ParameterSetID_Item_v1.2.hwp` 문단 0.7 은 3쪽에서 vpos 가 0 으로 리셋된다:
+//! `ls[2] vpos=0 lh=1560 th=1000 ls=600` → `ls[3] vpos=1600`(= th+ls). 그 줄들에는 23.2px
+//! 아이콘이 있어 `lh` 가 크다. 종전 rhwp 는 `lh + ls`(2160HU=28.8px)로 전진해 둘째 줄부터
+//! 7.5px 씩 밀렸고, 3쪽 아이콘 넷이 한/글보다 15px 아래였다.
+//!
+//! 구현은 `th + ls` 를 다시 계산하지 않고 저장된 `next.vertical_pos - seg.vertical_pos` 를
+//! 그대로 읽는다. 위 45:1 은 그 값이 어떤 규칙을 따르는지 보여 주는 근거일 뿐이다.
+//!
+//! 한/글 2022 PDF(`pdf/hwpctl_ParameterSetID_Item_v1.2-2022.pdf`, 같은 쪽 크기) 실측:
+//! 위 아이콘 쌍 y=99.4, 아래 쌍 y=156.9.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+fn page_svg(rel: &str, page: u32) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {rel}: {e:?}"));
+    doc.render_page_svg(page)
+        .unwrap_or_else(|e| panic!("render {rel} p{}: {e:?}", page + 1))
+}
+
+/// 태그 조각에서 `name="…"` 숫자 속성. 첫 속성은 앞에 공백이 없고, 다른 속성 이름의 꼬리에
+/// 걸리지 않게 앞 글자가 영숫자가 아닐 때만 받는다.
+fn attr(tag: &str, name: &str) -> Option<f64> {
+    let pat = format!("{name}=\"");
+    let mut from = 0;
+    while let Some(i) = tag[from..].find(&pat) {
+        let at = from + i;
+        if at == 0 || !tag.as_bytes()[at - 1].is_ascii_alphanumeric() {
+            let s = at + pat.len();
+            let e = s + tag[s..].find('"')?;
+            return tag[s..e].parse().ok();
+        }
+        from = at + 1;
+    }
+    None
+}
+
+/// 폭이 `w`(±0.6) 인 그림 자리의 (x, y). 자른 그림은 `<svg>` 래퍼로 나오므로 둘 다 본다.
+fn images_with_width(svg: &str, w: f64) -> Vec<(f64, f64)> {
+    let mut out = Vec::new();
+    for open in ["<image ", "<svg "] {
+        for t in svg.split(open).skip(1) {
+            let t = &t[..t.find('>').expect("태그 닫힘")];
+            if (attr(t, "width").unwrap_or(0.0) - w).abs() < 0.6 {
+                if let (Some(x), Some(y)) = (attr(t, "x"), attr(t, "y")) {
+                    out.push((x, y));
+                }
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn lines_advance_by_stored_text_height_not_line_box_height() {
+    let svg = page_svg("samples/hwpctl_ParameterSetID_Item_v1.2.hwp", 2);
+    let icons = images_with_width(&svg, 23.2);
+    assert!(icons.len() >= 4, "3쪽 23.2px 아이콘 4개: {icons:?}");
+    let mut ys: Vec<f64> = icons.iter().map(|(_, y)| *y).collect();
+    ys.sort_by(f64::total_cmp);
+    ys.dedup_by(|a, b| (*a - *b).abs() < 0.5);
+    assert!(
+        ys.iter().any(|y| (y - 99.4).abs() < 0.7),
+        "위 아이콘 줄 y 99.4 (한/글 99.4, 종전 114.3): {ys:?}"
+    );
+    assert!(
+        ys.iter().any(|y| (y - 157.0).abs() < 0.7),
+        "아래 아이콘 줄 y 157.0 (한/글 156.9, 종전 171.9): {ys:?}"
+    );
+}

--- a/tests/fixtures/text_overlap_baseline.tsv
+++ b/tests/fixtures/text_overlap_baseline.tsv
@@ -1,24 +1,21 @@
 정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp	58
-정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwpx	244
-2025 행정업무운영 편람(최종).hwp	21
-2025 행정업무운영 편람(최종).hwpx	22
+정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwpx	223
+2025 행정업무운영 편람(최종).hwp	18
+2025 행정업무운영 편람(최종).hwpx	19
 3-09월_교육_통합_2023.hwp	7
 3-09월_교육_통합_2023.hwpx	7
-3-11월_실전_통합_2024-구분선위20미주사이0구분선아래20.hwpx	1
 76076_regulatory_analysis.hwp	6
 80168_regulatory_analysis.hwp	9
-86712_regulatory_analysis.hwp	4
+86712_regulatory_analysis.hwp	3
 basic/issue1994_behindtext_table_20200830.hwp	5
 basic/sungeo.hwp	23
-exam_science.hwp	2
+exam_science.hwp	3
 exam_social.hwp	4
 exam-kor-2p.hwp	1
 exam-kor-3p.hwp	23
 exam-kor-4p.hwp	14
 group-drawing-02.hwp	5
 hwp-multi-001.hwp	97
-hwp3-sample-hwp5.hwp	3
-hwp3-sample-hwpx.hwpx	3
 hwp3-sample10-hwp5.hwp	147
 hwp3-sample10-hwpx.hwpx	132
 hwp3-sample10.hwp	189
@@ -40,33 +37,32 @@ hwp5-tbl-attr-1916.hwp	5
 hwpctl_API_v2.4.hwp	5
 hwpx_sample2.hwp	35
 hwpx_sample2.hwpx	37
-hwpx/2024년 연간 해외직접투자 보도자료 _ ff.hwpx	77
+hwpx/2024년 연간 해외직접투자 보도자료 _ ff.hwpx	76
 hwpx/2024년 1분기 해외직접투자 보도자료 ff.hwp	76
 hwpx/2024년 1분기 해외직접투자 보도자료 ff.hwpx	76
 hwpx/2024년 2분기 해외직접투자 보도자료ff.hwpx	86
 hwpx/2025년 1분기 해외직접투자 보도자료f.hwpx	75
-hwpx/2025년 2분기 해외직접투자 (최종).hwpx	100
+hwpx/2025년 2분기 해외직접투자 (최종).hwpx	97
 hwpx/exam_social.hwpx	4
 hwpx/exam-kor-2p.hwpx	1
 hwpx/exam-kor-3p.hwpx	23
 hwpx/exam-kor-4p.hwpx	14
-hwpx/hancom-hwp/2024년 연간 해외직접투자 보도자료 _ ff.hwp	77
+hwpx/hancom-hwp/2024년 연간 해외직접투자 보도자료 _ ff.hwp	76
 hwpx/hancom-hwp/2024년 1분기 해외직접투자 보도자료 ff.hwp	76
 hwpx/hancom-hwp/2024년 2분기 해외직접투자 보도자료ff.hwp	86
 hwpx/hancom-hwp/2025년 1분기 해외직접투자 보도자료f.hwp	75
-hwpx/hancom-hwp/2025년 2분기 해외직접투자 (최종).hwp	100
+hwpx/hancom-hwp/2025년 2분기 해외직접투자 (최종).hwp	97
 hwpx/hancom-hwp/hang_job_01.hwp	1
 hwpx/hancom-hwp/hwpx-01.hwp	76
-hwpx/hancom-hwp/hwpx-02.hwp	77
+hwpx/hancom-hwp/hwpx-02.hwp	76
 hwpx/hancom-hwp/hwpx-h-01.hwp	76
-hwpx/hancom-hwp/hwpx-h-02.hwp	100
+hwpx/hancom-hwp/hwpx-h-02.hwp	97
 hwpx/hancom-hwp/hwpx-h-03.hwp	75
 hwpx/hancom-hwp/mel-001.hwp	1
 hwpx/hwpx-01.hwpx	76
 hwpx/hwpx-h-01.hwpx	76
-hwpx/hwpx-h-02.hwpx	100
+hwpx/hwpx-h-02.hwpx	97
 hwpx/hwpx-h-03.hwpx	75
-hwpx/k-water-rfp.hwpx	1
 hwpx/mel-001.hwpx	1
 hwpx/opengov/36382669_결재문서본문_’26년 제3차 강사선정 심의회 운영결과.hwpx	1
 hwpx/opengov/36384689_결재문서본문_화재발생종합보고서(제2026-298호).hwpx	3
@@ -81,12 +77,12 @@ issue1891_external_bindata_link.hwpx	3
 issue1891/76076_regulatory_analysis.hwpx	7
 issue1891/80168_regulatory_analysis.hwpx	9
 issue1891/80250_regulatory_analysis.hwpx	2
-issue1891/86712_regulatory_analysis.hwpx	4
-issue1921/59043_regulatory_analysis.hwp	4
+issue1891/86712_regulatory_analysis.hwpx	3
+issue1921/59043_regulatory_analysis.hwp	3
 issue1937_rowbreak_footnote_overpagination.hwp	135
 issue1949_giant_cell_nested_tables_perf.hwp	8
 issue1949_giant_cell_nested_tables_perf.hwpx	8
-issue2006/1790387_prep_final_report.hwpx	100
+issue2006/1790387_prep_final_report.hwpx	22
 issue2217/20200830.hwp	5
 issue2470/36341511_masked.hwpx	9
 issue2559/1341000_research_report_footnotes.hwp	27
@@ -95,10 +91,11 @@ issue3837/stored_vpos_rewind_form.hwp	4
 issue4090/156492236_규제샌드박스_min.hwpx	4
 issue4491/30213_1.혼합단지등 제도개선 방안.hwp	3
 issue4514/sample1-repro.hwp	1
+issue4599/36374873_night_guard_log.hwpx	10
 issue4690/30098_indent_over_stored_cs.hwp	2
 issue5169_viewtext_changetracking.hwp	17
 issue5679/10857_delegation_rules.hwp	6
-issue5699/37787_regulatory_impact.hwp	5
+issue5699/37787_regulatory_impact.hwp	3
 issue5714/1490000-200800034_vietnam_labor_report.hwp	4
 issue5724/2689441_wmf_contents_ole.hwp	1
 issue5788/tac_table_missing_anchor_line_spacing.hwp	5
@@ -114,14 +111,17 @@ issue6036/156509073_police_press_release.hwpx	1
 issue6044/156513948.hwpx	3
 issue6060/30307_local_service_reform.hwp	2
 issue6086/30098_resident_registration_reform.hwp	2
-issue6111/56345_regulatory_impact_analysis.hwp	2
+issue6111/56345_regulatory_impact_analysis.hwp	1
 issue6121/156531618_police_press_header.hwpx	1
+issue6180/156745974_tac_object_line_spacing.hwpx	2
+issue6181/156562368_inline_tac_table_line_advance.hwpx	5
 issue6269/156739836_public_sector_jobs_stats.hwpx	1
-issue6284/child_policy_top_caption_charts.hwpx	56
+issue6284/child_policy_top_caption_charts.hwpx	52
 issue6310/press_release_cell_logo.hwpx	4
 issue6465/press_release_footer_logos.hwpx	7
-k-water-rfp-2024.hwp	1
-k-water-rfp.hwp	1
+issue6524/30098_float_host_split_lineseg.hwp	2
+issue6551/113424_evaluation_guideline.hwpx	3
+issue6601/36331407_side_by_side_tac_tables.hwpx	12
 kps-ai.hwp	2
 mel-001.hwp	1
 multi-table-001.hwp	1
@@ -146,12 +146,6 @@ task2093/1192000_hydrogen_policy_research.hwp	1
 task2097/21217935_simsa_jipyo.hwp	75
 task2097/75544_pii_bunseok.hwpx	8
 task2279/36404953_gyeoljae.hwpx	1
-task2287/1342000_edu_curriculum_map.hwp	95
+task2287/1342000_edu_curriculum_map.hwp	94
 task2430/1382000_domestic_violence_survey.hwp	18
 task3307/issue3307_outline_number.hwpx	3
-issue6524/30098_float_host_split_lineseg.hwp	2
-issue6181/156562368_inline_tac_table_line_advance.hwpx	5
-issue6180/156745974_tac_object_line_spacing.hwpx	2
-issue4599/36374873_night_guard_log.hwpx	10
-issue6551/113424_evaluation_guideline.hwpx	3
-issue6601/36331407_side_by_side_tac_tables.hwpx	12


### PR DESCRIPTION
closes #6656

## 무엇을 고쳤나

문단 안에서 다음 줄로 내려가는 전진값을 **저장 사다리의 다음 줄 `vpos` 차** 로 맞췄습니다. 줄 상자 높이(`line_height`)는 그 줄이 품은 개체까지 덮지만, 한/글은 전진에 쓰지 않고 개체가 아래 줄 공간을 침범하게 둡니다. rhwp 는 `lh + ls` 로 전진해 개체가 있는 줄마다 `(lh − th)` 씩 밀렸고, 그 아래 본문·그림이 통째로 내려갔습니다.

같은 규칙이 `renderer/mod.rs` 의 `corrected_line_metrics_for_source` 에 이미 있는데, 게이트가 **문단 단위** `controls.is_empty()` 라 개체가 하나라도 있는 문단은 통째로 빠졌습니다. 이 PR 은 줄 상자 높이는 그대로 두고 **전진값만** 사다리에서 읽습니다. 값을 추정하지 않으려고 `th + ls` 를 계산하는 대신 저장된 `next.vertical_pos − seg.vertical_pos` 를 그대로 씁니다.

세 조건을 함께 요구합니다. ① 사다리를 다시 짜지 않은 문단(`source_metrics_reflowed` 아님). ② 이 줄의 상자 높이가 저장 `lh` 그대로일 것 — 재조판된 상자에 저장 전진을 섞으면 사다리도 상자도 아닌 값이 됩니다. ③ 전진이 실제 글자(`max_fs`)를 담을 것 — HWP3 변환본처럼 낡은 값이면 다음 줄이 글자 위로 올라옵니다(`hwp3-empty-cell` 에서 실제로 겹침 1건이 생겨 이 조건을 넣었습니다).

## 근거 — 저장 줄 사다리 전수

`samples/`↔`pdf/` 짝이 있는 215 문서의 `rhwp dump` 에서, **문단 안 연속 줄**의 `다음 vpos − 현재 vpos` 를 셌습니다. `lh == th` 인 줄은 두 규칙이 구별되지 않으므로 제외했습니다.

| 규칙 | 건수 |
|---|---:|
| **th + ls** | **45** |
| lh + ls | 1 |

45건은 18개 문서에 흩어져 있습니다 — `[2027] 온새미로 1 본교재`(8), `3-09월_교육_통합`(4+4), `exam_math`·`exam_math_no`·`exam_science`(각 4), `hwpctl_ParameterSetID_Item_v1.2`(3), `21_언어_기출`·`endnote-01`·`footnote-01`·`pr-1674`(각 2), 그 외 1건씩. 유일한 반례는 `issue1950_hwp3_tab_charoffset` 1건입니다.

예: `hwpctl_ParameterSetID_Item_v1.2` 문단 0.7 (3쪽에서 vpos 리셋)

```
ls[2] vpos=0     lh=1560 th=1000 ls=600
ls[3] vpos=1600  lh=1560 th=1000 ls=600   ← Δ1600 = th + ls  (lh+ls 라면 2160)
ls[4] vpos=3200  lh=1560 th=1560 ls=600   ← Δ1600 = th + ls
ls[5] vpos=5360  lh=1560 th=1560 ls=600   ← Δ2160 = th + ls (= lh+ls)
```

이 줄들은 23.2px 아이콘을 품어 `lh` 가 큽니다. 그래도 사다리는 `th + ls` 로 갑니다.

## 실측 (한/글 2022 PDF, 같은 쪽 크기)

**`hwpctl_ParameterSetID_Item_v1.2.hwp` 3쪽**

| 글줄 | 수정 전 | 수정 후 | 한/글 |
|---|---:|---:|---:|
| `- CrookedSlashFlag1(...)` | 68.0 | 68.0 | 68.0 |
| `- CounterSlashFlag(...)` | 96.8 | 89.4 | 89.3 |
| `SlashFlag는 대각선의 ...` | 132.0 | 117.0 | 117.0 |
| `CrookedSlashFlag는 ...` | 160.8 | 145.8 | 145.8 |
| 아이콘 4개 y | 114.3 / 171.9 | 99.4 / 157.0 | 99.4 / 156.9 |

**`exam_math.hwp` 3쪽 오른쪽 단**: `에서 최댓값을 갖도록 하는 ...` 215.8 → 199.4 (한/글 199.6), `순서쌍에 대하여 ...` 250.9 → 234.5 (한/글 234.7). 왼쪽 단과 4쪽은 변화 없이 종전대로 맞습니다.

**코퍼스 그림 회귀**: `samples/`↔`pdf/` 그림 955장 중 **28장이 움직여 27장이 한/글에 가까워졌습니다.** 문서별 `|dy|` 입니다.

| 문서 | 장수 | 중앙값 전 | 중앙값 후 | 최대 전 | 최대 후 |
|---|---:|---:|---:|---:|---:|
| hwpctl_ParameterSetID_Item_v1.2 | 19 | 15.0 | 0.1 | 23.6 | 0.1 |
| exam_science | 5 | 9.1 | 3.7 | 22.8 | 3.8 |
| 3-09월_교육_통합-구분선아래20 | 2 | 18.0 | 0.4 | 18.2 | 0.6 |
| 3-09월_교육_통합-미주사이20 | 2 | 18.0 | 0.4 | 18.2 | 0.6 |

`exam_science` 는 4쪽 두 장이 +22.8·+22.3 에서 −0.1·−0.5 로 맞고, 1쪽 한 장이 +9.0 에서 +3.7 로 줄지만 남습니다. 남는 두 장은 표 셀 안에 있고 셀 높이는 이 PR 이 건드리지 않는 측정 경로에서 정해집니다. #6660 으로 올렸습니다.

움직인 28장 중 1장은 `|dy|` 가 13.7 에서 28.6 으로 커졌습니다. hwpctl 3쪽의 같은 크기(75.2×20.8) 아이콘이 한 줄에 여러 개 있어 스윕이 다른 짝을 고른 것으로, 이 짝의 `dx` 는 +384.9 입니다. 표의 hwpctl 값은 `|dx| < 5` 인 17장으로 냈습니다. 그 쪽 아이콘 4개를 직접 재면 모두 한/글과 0.1px 안입니다(위 표).

## 스크린샷 (한/글 PDF | 수정 전 | 수정 후)

**hwpctl 3쪽 — 둘째 줄부터 7.5px 씩 밀리던 것이 한/글 줄 자리로**

![hwpctl 3쪽](https://raw.githubusercontent.com/jeong-sik/rhwp/30f19d796f629c9a0cebdce1843ef73d16c10229/01-hwpctl-p3.png)

**exam_math 3쪽 오른쪽 단 — 두 줄이 16.4px 아래 있던 것이 한/글 자리로**

![exam_math 3쪽](https://raw.githubusercontent.com/jeong-sik/rhwp/30f19d796f629c9a0cebdce1843ef73d16c10229/02-exam-math-p3.png)

**3-09월_교육_통합_2024 6쪽 — 그림 2장이 18px 아래 있던 것이 한/글 자리로**

![3-09월 6쪽](https://raw.githubusercontent.com/jeong-sik/rhwp/30f19d796f629c9a0cebdce1843ef73d16c10229/03-edu-2024-p6.png)

## 검증

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- 새 계약 `tests/cases/issue_6656_line_advance_text_height.rs` 1: hwpctl 3쪽 아이콘 줄 y 99.4·157.0 ± 0.7. 음성 대조: 수정 없는 트리에서 실패 (114.3 / 143.1 / 171.9 / 200.7).
- 통합 스위트 28개 전체 (`--profile release-test --target-dir target/pr-review --no-fail-fast`): 27개 통과, 실패 1건 — `regression_suite_026::redact_dry_run_marks_findings_raw_untrusted`. 단독 실행은 통과합니다(`1 passed`). JSON 출처 봉투 스위트라 이 변경과 닿는 곳이 없고, 28개를 한꺼번에 돌릴 때만 나옵니다.
- Native Skia 3종: `--features native-skia --lib` 3946 통과, `issue_2225_missing_picture_placeholder` 2 통과, `render_p37_direct_pdf_export` 4 통과. WASM: `scripts/wasm-pack-locked.sh --target web --out-dir pkg --no-opt` 통과.
- 글자 겹침 원장 `tests/fixtures/text_overlap_baseline.tsv` 갱신 — **이 변경은 겹침을 크게 줄입니다**: `1790387_prep_final_report.hwpx` 100 → 22, `정책연구용역사업 중간진도보고서.hwpx` 244 → 223, `2025 행정업무운영 편람` 21 → 18(hwpx 22 → 19), `37787_regulatory_impact` 5 → 3, `child_policy_top_caption_charts` 56 → 52, k-water 1 → 0 등. 늘어난 곳은 `exam_science.hwp` 2 → 3 하나인데, 그 자리(4쪽 오른쪽 단 수식 줄)는 **한/글 자신도 글자 상자가 8.7px 겹칩니다**(한/글 글자 상자 339.7~358.0 과 349.3~367.7). 한/글 줄 자리에 맞추면 필연적으로 생기는 겹침이라 원장에 실었습니다.
- `samples/` 372 문서 render tree 전수 대조: 38 문서가 움직였고 전부 이 규칙이 걸리는 문서입니다(개체가 있는 문단의 줄·그 아래 흐름). 한/글 PDF 가 있는 문서로 확인한 값은 위 표와 같습니다.
- `git diff --check`, `rust-unit-test-tiers --check`, `rust-test-suite-manifest --check` 통과

## 범위 밖

- 측정 경로(`height_measurer` 의 `line_height.max(text_height) + line_spacing`)는 이 PR 에서 건드리지 않았습니다. 렌더와 쪽나눔이 갈리는 사례가 스위트에서 나오면 따로 올리겠습니다.
- 유일한 반례 `issue1950_hwp3_tab_charoffset` 1건은 HWP3 변환본이라 별도 확인이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
