### PR TITLE
fix(layout): 인라인으로 재분류된 부동 그림이 자기 가로 오프셋을 잃지 않게 한다 (#6655)

### DIFF
--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -22,9 +22,29 @@ use super::{
 use crate::model::bin_data::BinDataContent;
 use crate::model::control::Control;
 use crate::model::paragraph::Paragraph;
-use crate::model::shape::CaptionDirection;
+use crate::model::shape::{CaptionDirection, CommonObjAttr, HorzRelTo};
 use crate::model::style::{Alignment, BorderLine};
 use crate::renderer::float_placement::native_multirow_internal_reset_rowbreak_anchor_advance_hu;
+
+/// 인라인으로 재분류된 부동 그림이 유지해야 할 문단 기준 가로 오프셋(px).
+///
+/// `[#2004]` 정규화(`reclassify_cell_floating_stacks`)는 같은 자리에 겹친 전면급
+/// 부동 그림 더미를 **그림 1장짜리 인라인 문단 N개**로 쪼갠다. 한글이 이런 더미를
+/// 쪽당 1장씩 놓는 것을 재현하려면 필요한 변환이다(끄면 그림이 아예 안 그려진다).
+/// 다만 그 변환은 `treat_as_char` 만 바꾸고 개체의 `horzOffset` 은 그대로 두는데,
+/// 인라인 배치는 그 값을 보지 않아 쪼갠 그림이 전부 셀 왼끝에 겹친다
+/// (issue2004 5~8쪽: 한글 대비 −19~−28px).
+///
+/// 저장 글자처럼 그림은 위치값을 쓰지 않는다 — samples/ 의 `treat_as_char` 그림
+/// 360장 중 354장이 `horzOffset = 0` 이고, 0 이 아닌 6장은 전부 `horz_rel_to`
+/// 가 `Column` 이다. 문단 기준 오프셋을 가진 인라인 그림은 이 재분류가 만든
+/// 것뿐이므로, 이 보정은 그 그림에만 실제로 작동한다.
+fn inline_para_horizontal_offset_px(common: &CommonObjAttr, dpi: f64) -> f64 {
+    if !matches!(common.horz_rel_to, HorzRelTo::Para) {
+        return 0.0;
+    }
+    hwpunit_to_px(common.horizontal_offset as i32, dpi)
+}
 
 /// `layout_partial_table_resolved`가 표 자체와 분리해 사용하는 host 문맥.
 ///
@@ -2099,7 +2119,11 @@ impl LayoutEngine {
                                             );
                                         }
                                         let pic_area = LayoutRect {
-                                            x: inline_x,
+                                            x: inline_x
+                                                + inline_para_horizontal_offset_px(
+                                                    &pic.common,
+                                                    self.dpi,
+                                                ),
                                             y: inline_tac_y,
                                             width: clamped_w,
                                             height: clamped_h,

--- a/tests/cases/issue_6655_inline_stack_horz_offset.rs
+++ b/tests/cases/issue_6655_inline_stack_horz_offset.rs
@@ -1,0 +1,87 @@
+//! [#6655] 인라인으로 재분류된 부동 그림 스택은 각자의 가로 오프셋을 유지한다.
+//!
+//! `[#2004]` 정규화는 같은 자리에 겹친 전면급 부동 그림 더미를 그림 1장짜리 인라인
+//! 문단 N개로 쪼갠다. 한글이 이런 더미를 쪽당 1장씩 놓는 것을 재현하는 변환이라
+//! 되돌릴 수 없다 — 끄면 그 그림들이 아예 렌더되지 않는다. 다만 변환이 개체의
+//! `horzOffset` 을 배치에 넘기지 않아, 종전에는 5장이 모두 셀 왼끝 82.4 에 겹쳤다.
+//!
+//! `samples/issue2004_cell_image_stack.hwpx` 문단 42 의 1×1 표 셀에 그림 5장이
+//! 있고, 전부 `treatAsChar=0 / wrap=Square / horzRelTo=Para / horzAlign=Left` 로
+//! `horzOffset` 만 다르다(0 / 1580 / 2092 / 1550 / 1432 HWPUNIT).
+//!
+//! 한글 2022 PDF(`pdf/issue2004_cell_image_stack-2022.pdf`) 실측 x 는 각각
+//! 86.0 / 107.1 / 113.9 / 106.7 / 105.1 이다. 여기서 공통으로 빠지는 3.6px 은
+//! 표 자체의 바깥 여백 283HWPUNIT 이고 #6643 의 몫이라 이 계약에서는 뺀다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+fn page_svg(rel: &str, page: u32) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {rel}: {e:?}"));
+    doc.render_page_svg(page)
+        .unwrap_or_else(|e| panic!("render {rel} p{}: {e:?}", page + 1))
+}
+
+/// 태그 조각에서 `name="…"` 숫자 속성. 첫 속성은 앞에 공백이 없고, 다른 속성 이름의
+/// 꼬리에 걸리지 않게 앞 글자가 영숫자가 아닐 때만 받는다.
+fn attr(tag: &str, name: &str) -> Option<f64> {
+    let pat = format!("{name}=\"");
+    let mut from = 0;
+    while let Some(i) = tag[from..].find(&pat) {
+        let at = from + i;
+        if at == 0 || !tag.as_bytes()[at - 1].is_ascii_alphanumeric() {
+            let s = at + pat.len();
+            let e = s + tag[s..].find('"')?;
+            return tag[s..e].parse().ok();
+        }
+        from = at + 1;
+    }
+    None
+}
+
+/// 폭이 `w`(±0.6) 인 그림 자리의 x. 자른 그림은 `<svg>` 래퍼로 나오므로 둘 다 본다.
+fn image_x_with_width(svg: &str, w: f64) -> Option<f64> {
+    for open in ["<image ", "<svg "] {
+        for t in svg.split(open).skip(1) {
+            let t = &t[..t.find('>').expect("태그 닫힘")];
+            if (attr(t, "width").unwrap_or(0.0) - w).abs() < 0.6 {
+                if let Some(x) = attr(t, "x") {
+                    return Some(x);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn reclassified_stack_pictures_keep_their_paragraph_horizontal_offset() {
+    // (0-기준 쪽, 그림 폭 px, 기대 x px, 한글 x px)
+    let cases = [
+        (3u32, 601.5, 82.4, 86.0),
+        (4, 579.3, 103.5, 107.1),
+        (5, 592.1, 110.3, 113.9),
+        (6, 580.1, 103.1, 106.7),
+        (7, 604.9, 101.5, 105.1),
+    ];
+    let mut seen = Vec::new();
+    for (page, width, expected_x, hancom_x) in cases {
+        let svg = page_svg("samples/issue2004_cell_image_stack.hwpx", page);
+        let x = image_x_with_width(&svg, width)
+            .unwrap_or_else(|| panic!("{}쪽 폭 {width}px 그림", page + 1));
+        assert!(
+            (x - expected_x).abs() < 0.5,
+            "{}쪽 그림 x {expected_x} (한글 {hancom_x} − 표 바깥 여백 3.6): {x}",
+            page + 1
+        );
+        seen.push(x);
+    }
+    // 종전에는 5장이 모두 셀 왼끝 82.4 에 겹쳤다. 오프셋이 살아 있으면 자리가 갈린다.
+    assert!(
+        seen.iter().any(|x| (x - seen[0]).abs() > 1.0),
+        "그림 5장이 서로 다른 x 에 놓여야 한다: {seen:?}"
+    );
+}


### PR DESCRIPTION
closes #6655

## 무엇을 고쳤나

`[#2004]` 정규화(`document_core/queries/rendering.rs` 의 `reclassify_cell_floating_stacks`)는 같은 자리에 겹친 전면급 부동 그림 더미를 **그림 1장짜리 인라인 문단 N개**로 쪼갭니다. 한/글이 이런 더미를 쪽당 1장씩 놓는 것을 재현하는 변환입니다.

그 변환은 `treat_as_char` 만 바꾸고 개체의 `horzOffset` 은 값을 그대로 둡니다. 그런데 셀 인라인 배치는 그 값을 보지 않습니다. 그래서 `issue2004_cell_image_stack` 5~8쪽에서 그림 4장이 **전부 셀 왼끝 82.4 에 겹쳤습니다**(한/글 대비 −19~−28px).

이 PR 은 셀 안 단독 인라인 그림을 놓을 때 그림의 **문단 기준 가로 오프셋을 더합니다**.

## 되돌리는 방향은 답이 아님을 먼저 확인했습니다

`reclassify_floating_pictures_inline` 호출을 env 스위치로 끄고 렌더해 봤습니다. 4~8쪽 그림 5장이 **하나도 그려지지 않습니다**(2쪽의 무관한 그림만 남음) — 비-TAC 갈래가 `cut_units` 조각에서 이 그림들을 건너뜁니다. 인라인 전환은 꼭 필요한 조치이고, 잃은 것은 x 하나뿐입니다.

## 왜 진짜 인라인 그림은 안 움직이나 — 코퍼스 전수

한/글은 글자처럼 개체에 위치값을 쓰지 않습니다. `samples/` 전체를 셌습니다.

| 항목 | 수 |
|---|---:|
| `treat_as_char` 그림 | 360 |
| 그중 `horzOffset = 0` | **354** |
| `horzOffset ≠ 0` | 6 — **전부 `horz_rel_to = Column`** |

**문단 기준(`horz_rel_to = Para`) 인라인 그림 중 오프셋이 0 이 아닌 것은 코퍼스에 한 장도 없습니다.** 그래서 이 보정은 재분류가 만든 그림에만 실제로 작동합니다.

## 실측 (한/글 2022 PDF `pdf/issue2004_cell_image_stack-2022.pdf`)

| 쪽 | `horzOffset` | 수정 전 x | 수정 후 x | 한/글 x |
|---|---:|---:|---:|---:|
| 4 | 0 | 82.4 | 82.4 | 86.0 |
| 5 | 1580 (21.1px) | 82.4 | 103.5 | 107.1 |
| 6 | 2092 (27.9px) | 82.4 | 110.3 | 113.9 |
| 7 | 1550 (20.7px) | 82.4 | 103.1 | 106.7 |
| 8 | 1432 (19.1px) | 82.4 | 101.5 | 105.1 |

그림마다 달랐던 −19~−28px 편차가 사라지고 **상수 −3.6px 하나만 남습니다**. 그 3.6px 은 표 자체의 바깥 여백 283HWPUNIT 이고 #6643 의 몫이라 이 PR 범위 밖입니다.

## 스크린샷 (한/글 PDF | 수정 전 | 수정 후)

**6쪽 — 오프셋 2092(27.9px), 그림 왼쪽 가장자리 확대**

![6쪽](https://raw.githubusercontent.com/jeong-sik/rhwp/c5d2dfbdd6beedbc5aa3d63838f67a6a01ea343d/01-p6-offset-2092.png)

**4쪽 — 오프셋 0, 대조군. 수정 전후가 같습니다**

![4쪽](https://raw.githubusercontent.com/jeong-sik/rhwp/c5d2dfbdd6beedbc5aa3d63838f67a6a01ea343d/02-p4-offset-0.png)

## 검증

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- 새 계약 `tests/cases/issue_6655_inline_stack_horz_offset.rs` 1: 4~8쪽 그림 x 82.4/103.5/110.3/103.1/101.5 ± 0.5 + 5장이 서로 다른 x 에 놓일 것. 음성 대조: 수정 없는 트리에서 실패(전부 82.4).
- 통합 스위트 28개 전체 (`--profile release-test --target-dir target/pr-review --no-fail-fast`): **32개 전부 통과, 실패 0**
- Native Skia 3종: `--features native-skia --lib` 3946 통과, `issue_2225_missing_picture_placeholder` 2 통과, `render_p37_direct_pdf_export` 4 통과. WASM: `scripts/wasm-pack-locked.sh --target web --out-dir pkg --no-opt` 통과.
- `samples/` 372 문서 render tree 전수 대조: **2 문서만 움직임**(`issue2004_cell_image_stack` 의 hwp·hwpx), Image 노드 8개. 글자·줄 변화 0.
- `git diff --check`, `rust-unit-test-tiers --check`, `rust-test-suite-manifest --check` 통과

## 범위 밖

- 본문 스택 경로(`reclassify_floating_pictures_inline` 를 문단 통째로 부르는 쪽)는 건드리지 않았습니다. 같은 손실이 있을 수 있지만 **코퍼스에 그 모양의 표본이 없어 실측으로 확인할 수 없습니다** — `samples/` 전체에서 비-TAC Square 그림이 2장 이상인 문서는 `issue2004_cell_image_stack` 하나뿐이고 그 더미는 셀 안에 있습니다. 표본이 생기면 같은 규칙(`inline_para_horizontal_offset_px`)을 그대로 적용하면 됩니다.
- 남는 −3.6px(표 바깥 여백)은 #6643 입니다.
- 쪼갠 문단에 붙는 합성 `LineSeg` 의 tag 에 `TAG_IMPLEMENTATION_PROPERTY` 가 빠져 있습니다. 이 저장소는 합성 seg 를 그 비트로 표시하는 계약을 갖고 있어(`authoritative_stored_line_start_px` 가 그 비트를 봅니다) 어긋나 보이지만, 지금 동작에 영향이 없어 이 PR 에서는 손대지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
