### PR TITLE
fix(layout): 중첩 표를 자기 줄 상자 자리에 그린다 (#6653)

### DIFF
--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -1749,6 +1749,22 @@ impl LayoutEngine {
                     line_widths
                 };
 
+                // [#6653] 중첩 표를 품은 줄은 저장 사다리에 그 표 높이로 적혀 있다
+                // (hwpx_sample2 p[21] `ls[1] vpos=0 lh=12080` = 161.07px, 표 157.3px).
+                // 글자와 표를 함께 가진 문단은 아래 텍스트 갈래를 타는데, 그 갈래가 표
+                // 전용 줄까지 지나 `para_y` 를 밀고 나서 표를 그린다 — 같은 높이를 두 번
+                // 쓴다. 8쪽에는 글자 줄이 있어 드러나지 않지만, 표 줄만 넘어온 9쪽 조각은
+                // 표가 161px 아래로 내려가 위에 빈 띠가 남는다(한/글 52.1 vs rhwp 210.6).
+                // 이 조각이 그리는 줄에 보이는 글자가 없으면 표 전용 줄이므로, 표는 그
+                // 줄이 시작한 자리에 놓는다.
+                let table_host_line_only_fragment = has_table_ctrl
+                    && composed
+                        .lines
+                        .iter()
+                        .skip(start_line)
+                        .take(end_line.saturating_sub(start_line))
+                        .all(|line| line.runs.iter().all(|run| run.text.trim().is_empty()));
+                let para_y_before_lines = para_y;
                 // 표 컨트롤이 없는 문단: 텍스트 먼저, 컨트롤 나중 (기존 동작)
                 // 표 컨트롤이 있는 문단: 문단 앞 간격 적용 → 표 먼저 배치 → 텍스트(엔터 등) 나중
                 if !has_table_ctrl
@@ -2543,7 +2559,11 @@ impl LayoutEngine {
                                 {
                                     // 중첩 표가 셀 가용 공간을 초과하면 행 범위 필터 적용
                                     let nested_y = if has_preceding_text {
-                                        para_y
+                                        if table_host_line_only_fragment {
+                                            para_y_before_lines
+                                        } else {
+                                            para_y
+                                        }
                                     } else {
                                         inner_area.y
                                     };

--- a/tests/cases/issue_6653_nested_table_host_line.rs
+++ b/tests/cases/issue_6653_nested_table_host_line.rs
@@ -1,0 +1,79 @@
+//! [#6653] 중첩 표는 자기 줄 상자 자리에 그려진다 — 그 줄만큼 밀고 나서 그리지 않는다.
+//!
+//! 저장 사다리는 중첩 표를 품은 줄을 그 표 높이로 적어 둔다.
+//! `samples/hwpx_sample2.hwp` 의 큰 셀 문단 `p[21]` 이 그렇다.
+//!
+//! ```text
+//! p[21] ctrls=1 text_len=102
+//!       ls[0] vpos=61628 lh=1100  ls=660   ← 8쪽: 글자 줄
+//!       ls[1] vpos=0     lh=12080 ls=600   ← 9쪽: 표를 품는 줄 (161.07px)
+//! ```
+//!
+//! 안쪽 표 높이가 157.3px 이므로 그 줄 상자가 곧 표 자리다. 글자와 표를 함께 가진 문단은
+//! 텍스트 갈래를 타는데, 그 갈래가 표 전용 줄까지 지나 흐름을 밀고 나서 표를 그렸다 —
+//! 같은 높이를 두 번 쓴 셈이다. 8쪽에는 글자 줄이 있어 드러나지 않지만, 표 줄만 넘어온
+//! 9쪽 조각은 표가 161px 아래로 내려가 위에 빈 띠가 남았다.
+//!
+//! 한/글 2024 PDF(`pdf/hwpx_sample2-2024.pdf`) 9쪽 실측: 바깥 표 조각 37.72~568.98,
+//! 안쪽 표 가로선 52.1 / 76.72 / 161.74 / 209.21.
+//!
+//! 이 계약은 표가 조각 위쪽(줄 상자 자리)에 오는 것을 고정한다. 한/글 52.1 과 남는
+//! 10.6px 은 셀 `valign=Center` 몫으로 보이며 아직 확정하지 못했다 — 이 시험은 그 값을
+//! 박지 않고, 표가 161px 아래로 내려가지 않는 것만 단언한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+fn page_svg(rel: &str, page: u32) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {rel}: {e:?}"));
+    doc.render_page_svg(page)
+        .unwrap_or_else(|e| panic!("render {rel} p{}: {e:?}", page + 1))
+}
+
+/// `<line>` 조각의 (x1, y1, x2, y2).
+fn lines(svg: &str) -> Vec<(f64, f64, f64, f64)> {
+    let mut out = Vec::new();
+    for seg in svg.split("<line ").skip(1) {
+        let head = &seg[..seg.find('>').unwrap_or(seg.len())];
+        let get = |k: &str| -> Option<f64> {
+            let p = head.find(&format!("{k}=\""))? + k.len() + 2;
+            let rest = &head[p..];
+            rest[..rest.find('"')?].parse().ok()
+        };
+        if let (Some(x1), Some(y1), Some(x2), Some(y2)) =
+            (get("x1"), get("y1"), get("x2"), get("y2"))
+        {
+            out.push((x1, y1, x2, y2));
+        }
+    }
+    out
+}
+
+#[test]
+fn nested_table_paints_at_its_own_host_line_on_a_continuation_page() {
+    let svg = page_svg("samples/hwpx_sample2.hwp", 8);
+    // 안쪽 표(구 분/조회방법)의 가로선은 폭 600px 대이고, 바깥 표 조각 테두리(718px)와
+    // 구분된다. 조각 상단(37.8) 아래 첫 가로선이 안쪽 표 윗선이다.
+    let mut inner: Vec<f64> = lines(&svg)
+        .into_iter()
+        .filter(|(x1, y1, x2, y2)| {
+            (y1 - y2).abs() < 0.01 && (500.0..700.0).contains(&(x2 - x1).abs()) && *y1 > 38.0
+        })
+        .map(|(_, y, ..)| y)
+        .collect();
+    inner.sort_by(f64::total_cmp);
+    let top = *inner
+        .first()
+        .unwrap_or_else(|| panic!("9쪽 안쪽 표 가로선: {inner:?}"));
+    assert!(
+        top < 60.0,
+        "9쪽 안쪽 표 윗선은 조각 상단 가까이 있어야 한다 (한/글 52.1, 수정 전 210.6): {top}"
+    );
+    assert!(
+        inner.len() >= 4,
+        "안쪽 표 가로선 4개(윗선·행 경계 2개·아랫선): {inner:?}"
+    );
+}


### PR DESCRIPTION
## 무엇을 고쳤나

저장 사다리는 **중첩 표를 품은 줄**을 그 표 높이로 적어 둡니다. `samples/hwpx_sample2.hwp` 의 큰 셀 문단 `p[21]` 이 그렇습니다.

```
p[21] ctrls=1 text_len=102
      ls[0] vpos=61628 lh=1100  ls=660   ← 8쪽: 글자 줄
      ls[1] vpos=0     lh=12080 ls=600   ← 9쪽: 표를 품는 줄 (161.07px)
```

안쪽 표 높이가 157.3px 이니 **그 줄 상자가 곧 표 자리**이고, 빈 줄은 흐름에서 그 자리를 예약하는 몫입니다.

그런데 글자와 표를 함께 가진 문단은 텍스트 갈래를 타는데, 그 갈래가 표 전용 줄까지 지나 `para_y` 를 밀고 **그 다음에** 표를 그렸습니다. 같은 높이를 두 번 쓴 셈입니다. 8쪽에는 글자 줄이 있어 드러나지 않지만, 표 줄만 넘어온 9쪽 조각은 표가 161px 아래로 내려가 위에 빈 띠가 남습니다.

이 조각이 그리는 줄에 보이는 글자가 없으면 표 전용 줄이므로, 표를 **그 줄이 시작한 자리**에 놓습니다. 흐름(`para_y`)은 그대로 둬서 뒤따르는 내용 위치는 바뀌지 않습니다(9쪽 다음 문단 200.8 → 198.8).

## 실측 (한/글 2024 PDF `pdf/hwpx_sample2-2024.pdf`)

| 9쪽 안쪽 표 윗선 | 값 |
|---|---:|
| 수정 전 | 210.6 |
| **수정 후** | **41.5** |
| 한/글 | 52.1 |

한/글 9쪽 가로선 실측: 바깥 표 조각 37.72~568.98, 안쪽 표 52.1 / 76.72 / 161.74 / 209.21.

## 스크린샷 (한/글 PDF | 수정 전 | 수정 후)

가운데 판의 빈 띠가 사라지고 표가 한/글처럼 조각 위쪽에 붙습니다.

![hwpx_sample2 9쪽](https://raw.githubusercontent.com/jeong-sik/rhwp/37fdc3bc458e3b8b5c6fcaad1b48d340a35695c4/01-hwpx-sample2-p9.png)

## 검증

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- 새 계약 `tests/cases/issue_6653_nested_table_host_line.rs` 1: 9쪽 안쪽 표 윗선이 60 미만 + 가로선 4개. 음성 대조: 수정 없는 트리에서 210.6 으로 실패.
- 통합 스위트 28개 전체: 31개 통과, 실패 1건 — `issue_3885_json_provenance_envelope::redact_dry_run_marks_findings_raw_untrusted`. 단독 실행은 통과합니다(`1 passed`). JSON 출처 봉투 스위트라 이 변경과 닿는 곳이 없고, 28개를 한꺼번에 돌릴 때만 나옵니다.
- Native Skia 3종 통과(`--features native-skia --lib` 3946 / `issue_2225` 2 / `render_p37` 4), WASM 통과.
- `samples/` 372 문서 render tree 전수: **2 문서만 움직임**(`hwpx_sample2` 의 hwp·hwpx).
- `git diff --check`, `rust-unit-test-tiers --check`, `rust-test-suite-manifest --check` 통과.

## 범위 밖 — #6653 은 닫지 않습니다

- **이 문서의 그림 24장은 안 움직입니다.** 그 그림들은 **8쪽**에 있고(dy −26.8), 8쪽 안에서 쌓인 흐름 어긋남이 원인입니다. 이 PR 은 9쪽 표 자리만 고칩니다.
- 남는 **10.6px**(한/글 52.1 vs 41.5)은 셀 `valign=Center` 몫으로 보이지만 확정하지 못했습니다. 상수로 끼워 맞추지 않고, 계약에도 그 값을 박지 않았습니다 — 표가 161px 아래로 내려가지 않는 것만 단언합니다.
- 처음 만든 조건이 `!has_preceding_text` 경우까지 덮어 `issue_5908_collapsed_page_stays_inside_the_paper` 가 깨졌습니다(39쪽 글자가 종이 밖 1545.8). 조건을 글자가 앞선 경우로 좁혀 해결했고, 지금은 통과합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
