### PR TITLE
fix(measure): 글자 없는 문단의 줄을 개체 높이와 함께 세지 않는다 (#6660)

### DIFF
--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -2006,13 +2006,25 @@ impl HeightMeasurer {
                     // 하지만 `줄 높이 >= 개체 높이` 를 요구해(13.3 < 56.3) 여기서는
                     // 불발한다. 가르는 것은 줄 크기가 아니라 그 문단에 **글자가 있는가** 다.
                     //
-                    // 문단이 하나뿐인 셀에만 적용한다. 뒤에 문단이 더 있으면 그 앵커
-                    // 줄은 뒤 내용을 개체 아래로 밀어 내리는 몫을 하므로 높이에서
-                    // 빼면 안 된다(#6312: 앵커 줄 전진량 27pt 계약).
+                    // 개체가 **선언된 칸보다 클 때만** 적용한다. 칸 안에 들어가는
+                    // 개체는 그 줄과 나란히 쌓이므로 둘 다 세는 것이 맞다 —
+                    // `issue6312` 의 기관명 칸(선언 39.9px, 그림 36.1px)이 그렇고,
+                    // 거기서 빼면 뒤 문단이 한/글(360.1px)에서 6.8px 더 멀어진다.
+                    // 개체가 칸을 넘으면 행이 개체에 맞춰 커지고 그 줄은 개체가
+                    // 차지한 자리 안에 든다 — exam_science 4쪽(선언 37.9px,
+                    // 그림 56.3px)이 그 경우다.
+                    //
+                    // 문단이 하나뿐인 셀에만 적용한다. 뒤에 문단이 더 있으면 그 줄은
+                    // 뒤 내용을 개체 아래로 밀어 내리는 몫을 한다.
+                    let declared_cell_h = if cell.height < 0x8000_0000 {
+                        hwpunit_to_px(cell.height as i32, self.dpi)
+                    } else {
+                        f64::INFINITY
+                    };
                     let empty_para_line_height: f64 = cell
                         .paragraphs
                         .iter()
-                        .filter(|_| cell.paragraphs.len() == 1)
+                        .filter(|_| cell.paragraphs.len() == 1 && non_inline_h > declared_cell_h)
                         .filter(|pp| {
                             pp.text.trim().is_empty() && pp.controls.iter().any(|c| {
                                 matches!(c, Control::Picture(pic) if !pic.common.treat_as_char)

--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -1996,7 +1996,37 @@ impl HeightMeasurer {
                     } else {
                         0.0
                     };
-                    let additive = text_height + non_inline_h;
+                    // [#6660] 글자가 하나도 없는 문단의 줄은 그 개체를 담는 자리이지
+                    // 개체 아래에 따로 놓이는 글줄이 아니다. `text_height` 에 그 줄을
+                    // 넣고 `non_inline_h` 에 개체를 또 넣으면 같은 자리를 두 번 센다 —
+                    // exam_science 4쪽 r=4: `13.3 + 57.6 = 70.9` 로 재어 행이 65.9px,
+                    // 한/글은 61.0px(그림 57.6 + 여백 1.88×2).
+                    //
+                    // 바로 아래 `ladder_line_covers_object` 증인이 같은 것을 잡으려
+                    // 하지만 `줄 높이 >= 개체 높이` 를 요구해(13.3 < 56.3) 여기서는
+                    // 불발한다. 가르는 것은 줄 크기가 아니라 그 문단에 **글자가 있는가** 다.
+                    //
+                    // 문단이 하나뿐인 셀에만 적용한다. 뒤에 문단이 더 있으면 그 앵커
+                    // 줄은 뒤 내용을 개체 아래로 밀어 내리는 몫을 하므로 높이에서
+                    // 빼면 안 된다(#6312: 앵커 줄 전진량 27pt 계약).
+                    let empty_para_line_height: f64 = cell
+                        .paragraphs
+                        .iter()
+                        .filter(|_| cell.paragraphs.len() == 1)
+                        .filter(|pp| {
+                            pp.text.trim().is_empty() && pp.controls.iter().any(|c| {
+                                matches!(c, Control::Picture(pic) if !pic.common.treat_as_char)
+                                    || matches!(c, Control::Shape(sh) if !sh.common().treat_as_char)
+                            })
+                        })
+                        .map(|pp| {
+                            pp.line_segs
+                                .iter()
+                                .map(|seg| hwpunit_to_px(seg.line_height.max(0), self.dpi))
+                                .sum::<f64>()
+                        })
+                        .sum();
+                    let additive = (text_height - empty_para_line_height).max(0.0) + non_inline_h;
                     // trust 는 "저장 ladder 가 개체 밀림을 이미 반영한" 셀에만 —
                     // 증거: 텍스트-빈 문단의 첫 seg vpos > 0 (줄이 개체 아래로 밀림).
                     // 반례 캘리브: KTX TOC(개체 없음 — additive 가 한컴 쪽),

--- a/tests/cases/issue_6660_empty_para_line_not_added_to_object_height.rs
+++ b/tests/cases/issue_6660_empty_para_line_not_added_to_object_height.rs
@@ -1,0 +1,73 @@
+//! [Issue #6660] 개체만 든 셀의 행이 한/글보다 커진다.
+//!
+//! 근인: 셀 높이 회계가 `text_height + non_inline_h` 인데, **글자가 하나도 없는
+//! 문단**의 줄 높이까지 `text_height` 에 들어간다. 그 줄은 개체를 담는 자리이지
+//! 개체 아래에 따로 놓이는 글줄이 아니므로 두 번 세는 셈이다.
+//!
+//! 실측(`exam_science.hwp` 4쪽 아래 표, r=4): 그림 57.6px 인 칸에서
+//! `text=13.3 + nonInline=57.6 = 70.9` 로 재어 행이 65.9px 이 됐다.
+//! 한/글은 61.0px — 그림 57.6 에 위아래 여백 1.88×2 를 더한 값이다.
+//!
+//! 같은 표 다섯 행 높이 (래스터로 괘선 픽셀 행을 찾아 실측):
+//!   수정 전  20.5 / 23.5 / 24.0 / 23.0 / 66.0
+//!   수정 후  21.5 / 24.5 / 25.0 / 25.0 / 61.0
+//!   한/글    21.5 / 24.5 / 25.0 / 25.0 / 61.0
+//!
+//! 표가 놓이는 y 자체는 여전히 한/글보다 5.5px 아래다 — 그 축은 #6681 이다.
+//! 그래서 이 시험은 절대 위치가 아니라 **행 높이**를 본다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+const SAMPLE: &str = "samples/exam_science.hwp";
+/// 4쪽 아래 표가 놓인 x 대역. 위쪽 표·본문과 겹치지 않는다.
+const TABLE_X: std::ops::Range<f64> = 250.0..500.0;
+/// 그 표가 놓인 y 대역. 표 시작이 5.5px 어긋나 있어(#6681) 넉넉히 잡는다.
+const TABLE_Y: std::ops::Range<f64> = 900.0..1120.0;
+/// 그림이 든 행의 높이. 한/글 61.0px, 그림 57.6px + 여백 1.88×2 = 61.4px.
+/// 빈 문단 줄(13.3px)을 함께 세면 65.9px 로 벗어난다.
+const PICTURE_ROW_HEIGHT: std::ops::RangeInclusive<f64> = 59.5..=62.5;
+
+/// 렌더 트리에서 표 칸 노드의 (x, y, 높이) 를 모은다.
+fn cell_boxes(node: &RenderNode, out: &mut Vec<(f64, f64, f64)>) {
+    if matches!(node.node_type, RenderNodeType::TableCell(_)) {
+        out.push((node.bbox.x, node.bbox.y, node.bbox.height));
+    }
+    for c in &node.children {
+        cell_boxes(c, out);
+    }
+}
+
+#[test]
+fn issue_6660_object_only_cell_row_matches_hancom_height() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let core = DocumentCore::from_bytes(&std::fs::read(path).expect("read sample")).expect("open");
+    let tree = core.build_page_render_tree(3).expect("page 4 render tree");
+
+    let mut boxes = Vec::new();
+    cell_boxes(&tree.root, &mut boxes);
+    let mut rows: Vec<(f64, f64)> = boxes
+        .into_iter()
+        .filter(|(x, y, _)| TABLE_X.contains(x) && TABLE_Y.contains(y))
+        .map(|(_, y, h)| (y, h))
+        .collect();
+    rows.sort_by(|a, b| a.0.partial_cmp(&b.0).expect("finite y"));
+    assert!(
+        !rows.is_empty(),
+        "4쪽 {TABLE_X:?} × {TABLE_Y:?} 구간에서 셀을 찾아야 한다"
+    );
+
+    let tallest = rows
+        .iter()
+        .map(|(_, h)| *h)
+        .fold(f64::NEG_INFINITY, f64::max);
+    assert!(
+        PICTURE_ROW_HEIGHT.contains(&tallest),
+        "그림이 든 행의 높이가 {tallest:.1}px 이다 — 한/글 61.0px 기준 \
+         {PICTURE_ROW_HEIGHT:?} 안이어야 한다. 글자 없는 문단의 줄 높이를 개체 \
+         높이에 함께 세면 65.9px 로 커진다 (#6660). 행 목록: {rows:?}"
+    );
+}


### PR DESCRIPTION
## 무엇을 고쳤나

개체만 든 셀의 행이 한/글보다 커집니다.

셀 높이 회계가 `text_height + non_inline_h` 인데, **글자가 하나도 없는 문단**의 줄 높이까지 `text_height` 에 들어갑니다. 그 줄은 개체를 담는 자리이지 개체 아래에 따로 놓이는 글줄이 아니라, 같은 자리를 두 번 세는 셈입니다.

```rust
let empty_para_line_height: f64 = cell.paragraphs.iter()
    .filter(|pp| pp.text.trim().is_empty()
        && pp.controls.iter().any(|c| /* 비-TAC 그림·도형 */))
    .map(|pp| pp.line_segs.iter()
        .map(|seg| hwpunit_to_px(seg.line_height.max(0), self.dpi)).sum::<f64>())
    .sum();
let additive = (text_height - empty_para_line_height).max(0.0) + non_inline_h;
```

바로 아래 `ladder_line_covers_object` 증인이 같은 것을 잡으려 하지만 `줄 높이 >= 개체 높이` 를 요구합니다. 이 문서는 `13.3 < 56.3` 이라 불발합니다. 가르는 것은 줄 크기가 아니라 그 문단에 **글자가 있는가** 입니다.

## 실측

`samples/exam_science.hwp` 4쪽 아래 표를 한/글 PDF 와 같은 배율로 래스터화해, 가로 괘선의 픽셀 행을 찾아 잰 값입니다. 벡터 괘선 추출은 양쪽에서 개수가 달라 쓰지 않았습니다.

![행 높이 비교](https://raw.githubusercontent.com/jeong-sik/rhwp/assets/issue-6660/rowh.png)

### 행 높이 (px)

| | 1행 | 2행 | 3행 | 4행 | 그림 행 |
|---|---:|---:|---:|---:|---:|
| 수정 전 | 20.5 | 23.5 | 24.0 | 23.0 | **66.0** |
| 수정 후 | 21.5 | 24.5 | 25.0 | 25.0 | **61.0** |
| 한/글 | 21.5 | 24.5 | 25.0 | 25.0 | **61.0** |

**다섯 행 모두 한/글과 일치합니다.** 수정 전에는 다섯 개 전부 달랐습니다.

한/글 61.0px 은 그 행 최대 그림 57.6px 에 위아래 여백 1.88px 씩을 더한 값입니다.

### 셀 안 배치

`#2071` 계약식(`CENTER = content_top + (content_h − img_h + vertOffset)/2`)은 손대지 않았습니다. 콘텐츠 높이가 맞으니 배치도 따라 맞습니다.

| | 수정 전 | 수정 후 | 한/글 |
|---|---:|---:|---:|
| 괘선→그림 (57x56) | 2.2 | **2.8** | 2.6 |
| 괘선→그림 (60x58) | 2.2 | **2.1** | 2.0 |

### 코퍼스 전수

215문서 1124장 중 짝지어진 930장에서 **이 문서 밖 그림은 한 장도 움직이지 않습니다.**

## 절대 편차(dy)는 왜 커지나

이 문서에는 축이 둘 있습니다.

| 축 | 상태 |
|---|---|
| 행 높이 | 이 PR 로 한/글과 일치 |
| 표가 놓이는 y | 919.0 vs 한/글 913.5 — **5.5px, 이 PR 범위 밖** (#6681) |

수정 전에는 행이 큰 오차와 표 시작 오차가 서로 상쇄돼 그림 편차가 `+3.3px` 로 작아 보였습니다. 행을 맞추면 상쇄가 풀려 `+5.6px` 이 됩니다.

즉 `dy` 숫자만 보면 악화로 보이지만, 그건 두 오차가 우연히 겹쳐 있던 값이 풀린 것입니다. 행 높이 다섯 개가 한/글과 정확히 맞는 쪽이 옳은 상태입니다. 표 시작 축은 #6681 로 따로 냈습니다.

## 테스트

`tests/cases/issue_6660_empty_para_line_not_added_to_object_height.rs` 를 더했습니다. 표 시작 오차가 남아 있으므로 **절대 위치가 아니라 행 높이**를 봅니다.

수정을 빼면 이렇게 실패합니다.

```
그림이 든 행의 높이가 65.9px 이다 — 한/글 61.0px 기준 59.5..=62.5 안이어야 한다.
글자 없는 문단의 줄 높이를 개체 높이에 함께 세면 65.9px 로 커진다 (#6660).
```

## 개체가 칸을 넘을 때만 적용합니다

같은 모양으로 보이는 두 칸이 서로 다른 답을 요구합니다.

| | 선언 칸 높이 | 개체 높이 | 관계 | 옳은 회계 |
|---|---:|---:|---|---|
| `exam_science` 셀[18] | 37.9px | **56.3px** | 개체가 칸보다 크다 | 개체만 |
| `issue6312` 기관명 칸 | 39.9px | **36.1px** | 개체가 칸 안에 든다 | 줄 + 개체 |

개체가 칸 안에 들어가면 그 줄과 나란히 쌓이므로 둘 다 세는 것이 맞습니다. 개체가 칸을 넘으면 행이 개체에 맞춰 커지고 그 줄은 개체가 차지한 자리 안에 듭니다.

```rust
.filter(|_| cell.paragraphs.len() == 1 && non_inline_h > declared_cell_h)
```

특정 문서를 비켜가는 조건이 아니라 **개체가 칸을 넘느냐**라는 기하 관계입니다.

`issue6312` 의 한/글 값은 그 시험 주석에 있습니다 — 문단 첫 줄 360.1px, 표 아래 괘선 320.4px. 이 조건 없이 적용하면 문단이 340.0px 이 되어 한/글에서 6.8px 더 멀어집니다.

## 로컬 검증

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] 28개 스위트 `--no-fail-fast` — 실패 0
- [x] Native Skia 3종
- [x] 코퍼스 전수 그림 위치 스윕 — 930장 중 **이 두 장만** 변화

closes #6660

🤖 Generated with [Claude Code](https://claude.com/claude-code)
