### PR TITLE
fix(measure): 글자 없이 개체만 담은 칸 마지막 줄은 꼬리 줄간격을 더하지 않는다 (#6681)

### DIFF
--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -1850,8 +1850,21 @@ impl HeightMeasurer {
                                         // 측정)을 낳았다. TAC(글자처럼) 표의 다문단 셀은
                                         // [Task #874/#1086] 보존 핀(KTX TOC 등)을 위해
                                         // 기존 포함 회계를 유지한다.
+                                        //
+                                        // [#6681] 그 예외에서 **글자 없이 개체만 담은
+                                        // 줄**은 뺀다. 그런 줄의 높이는 개체가 차지한
+                                        // 자리이고 뒤에 붙일 줄이 없다 — exam_science
+                                        // 4쪽 `자료` 칸의 마지막 문단이 그렇다
+                                        // (`text_len=0`, `lh=3037` = 안쪽 표 두 행
+                                        // 1424+1613, `ls=460`). 그 6.1px 이 칸 높이에
+                                        // 들어가 아래 흐름이 통째로 6px 밀렸다.
+                                        // 보존 핀의 마지막 문단은 글자가 있어 종전대로다.
+                                        let last_line_is_object_only =
+                                            p.text.trim().is_empty() && !p.controls.is_empty();
                                         let include_trailing_ls = !is_cell_last_line
-                                            || (cell_para_count > 1 && table.common.treat_as_char);
+                                            || (cell_para_count > 1
+                                                && table.common.treat_as_char
+                                                && !last_line_is_object_only);
                                         if include_trailing_ls {
                                             let trailing =
                                                 hwpunit_to_px(line.line_spacing, self.dpi);
@@ -2716,8 +2729,21 @@ impl HeightMeasurer {
                                         // 측정)을 낳았다. TAC(글자처럼) 표의 다문단 셀은
                                         // [Task #874/#1086] 보존 핀(KTX TOC 등)을 위해
                                         // 기존 포함 회계를 유지한다.
+                                        //
+                                        // [#6681] 그 예외에서 **글자 없이 개체만 담은
+                                        // 줄**은 뺀다. 그런 줄의 높이는 개체가 차지한
+                                        // 자리이고 뒤에 붙일 줄이 없다 — exam_science
+                                        // 4쪽 `자료` 칸의 마지막 문단이 그렇다
+                                        // (`text_len=0`, `lh=3037` = 안쪽 표 두 행
+                                        // 1424+1613, `ls=460`). 그 6.1px 이 칸 높이에
+                                        // 들어가 아래 흐름이 통째로 6px 밀렸다.
+                                        // 보존 핀의 마지막 문단은 글자가 있어 종전대로다.
+                                        let last_line_is_object_only =
+                                            p.text.trim().is_empty() && !p.controls.is_empty();
                                         let include_trailing_ls = !is_cell_last_line
-                                            || (cell_para_count > 1 && table.common.treat_as_char);
+                                            || (cell_para_count > 1
+                                                && table.common.treat_as_char
+                                                && !last_line_is_object_only);
                                         if include_trailing_ls {
                                             let trailing =
                                                 hwpunit_to_px(line.line_spacing, self.dpi);

--- a/tests/cases/issue_6681_cell_last_object_line_drops_trailing_ls.rs
+++ b/tests/cases/issue_6681_cell_last_object_line_drops_trailing_ls.rs
@@ -1,0 +1,116 @@
+//! [Issue #6681] 칸을 닫고 다음 요소로 가는 전진량이 6px 과다하다.
+//!
+//! 근인: `#5923` 이 "칸 마지막 줄의 꼬리 줄간격은 제외" 를 세우면서, 글자처럼
+//! 취급 표의 다문단 칸만 예외로 남겼다. 그 예외는 원리가 아니라 당시 보존 핀
+//! (KTX TOC 등)에 맞춘 조건이다.
+//!
+//! `exam_science.hwp` 4쪽 `자료` 칸의 마지막 문단은 **글자 없이 안쪽 표만 담은
+//! 줄**이다.
+//!
+//! ```text
+//! p[15] ctrls=1 text_len=0  ls[0] vpos=29580 lh=3037 ls=460
+//! p[15] 내부표: 2행×3열   (칸 h=1424 + 1613 = 3037HU)
+//! ```
+//!
+//! `lh` 가 안쪽 표 높이와 같고 `ls=460`(6.1px)이 그 예외로 칸 높이에 들어가,
+//! 그 아래 흐름이 통째로 6px 밀렸다.
+//!
+//! 실측(왼쪽 단 글줄을 한/글과 짝지은 편차):
+//!   수정 전  644.3 (+0.6) → 704.4 (**−5.4**) → 736.3 (−5.3) → 903.4 (−4.4)
+//!   수정 후  644.3 (+0.6) → 698.3 (**+0.7**) → 730.2 (+0.8) → 897.3 (+1.7)
+//!
+//! 그런 줄의 높이는 개체가 차지한 자리이고 뒤에 붙일 줄이 없다. 보존 핀의
+//! 마지막 문단은 글자가 있어 종전 회계를 그대로 쓴다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+
+const SAMPLE: &str = "samples/exam_science.hwp";
+/// 4쪽 왼쪽 단 x 대역. 단 경계는 렌더 트리 기준 70.7~493.3 이다.
+const LEFT_COLUMN_X: std::ops::Range<f64> = 68.0..495.0;
+/// 문제의 표 아래 첫 본문 글줄에 들어 있는 글자들. 이 줄이 6px 밀렸다.
+const ANCHOR_TEXT: &str = "일정하고";
+/// 그 글줄 baseline 의 허용 구간. 한/글 699.0px, 수정 전에는 704.4px 였다.
+const EXPECTED_BASELINE: std::ops::RangeInclusive<f64> = 696.0..=701.0;
+
+/// SVG 의 한 글자짜리 `<text>` 를 baseline 으로 묶어 글줄을 만든다.
+fn glyph_lines(svg: &str) -> Vec<(f64, f64, String)> {
+    let mut rows: std::collections::BTreeMap<i64, Vec<(f64, char)>> = Default::default();
+    for chunk in svg.split("<text ").skip(1) {
+        let Some(head_end) = chunk.find('>') else {
+            continue;
+        };
+        let head = &chunk[..head_end];
+        let attr = |name: &str| -> Option<f64> {
+            let key = format!("{name}=\"");
+            let s = head.find(&key)? + key.len();
+            let e = s + head[s..].find('"')?;
+            head[s..e].parse().ok()
+        };
+        // 대부분의 글자는 `transform="translate(x,y) …"` 로 놓인다. `x`/`y` 속성을
+        // 쓰는 글자도 섞여 있어 둘 다 받는다.
+        let translated = head.find("translate(").map(|at| {
+            let tail = &head[at + 10..];
+            let end = tail.find(')').unwrap_or(tail.len());
+            let mut parts = tail[..end].split(',');
+            (
+                parts.next().and_then(|v| v.trim().parse::<f64>().ok()),
+                parts.next().and_then(|v| v.trim().parse::<f64>().ok()),
+            )
+        });
+        let (Some(x), Some(y)) = translated
+            .map(|(a, b)| (a, b))
+            .unwrap_or((attr("x"), attr("y")))
+        else {
+            continue;
+        };
+        let body = &chunk[head_end + 1..];
+        let Some(end) = body.find("</text>") else {
+            continue;
+        };
+        let mut chars = body[..end].chars();
+        let (Some(c), None) = (chars.next(), chars.next()) else {
+            continue;
+        };
+        if c.is_whitespace() {
+            continue;
+        }
+        rows.entry((y * 10.0).round() as i64)
+            .or_default()
+            .push((x, c));
+    }
+    rows.into_iter()
+        .map(|(key, mut v)| {
+            v.sort_by(|a, b| a.0.partial_cmp(&b.0).expect("finite x"));
+            let min_x = v[0].0;
+            (
+                key as f64 / 10.0,
+                min_x,
+                v.into_iter().map(|(_, c)| c).collect(),
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn issue_6681_object_only_last_line_does_not_add_trailing_line_spacing() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let core = DocumentCore::from_bytes(&std::fs::read(path).expect("read sample")).expect("open");
+    let svg = core.render_page_svg_native(3).expect("page 4 svg");
+
+    let line = glyph_lines(&svg)
+        .into_iter()
+        .find(|(_, x, text)| LEFT_COLUMN_X.contains(x) && text.contains(ANCHOR_TEXT))
+        .unwrap_or_else(|| panic!("4쪽 왼쪽 단에서 `{ANCHOR_TEXT}` 글줄을 찾아야 한다"));
+
+    assert!(
+        EXPECTED_BASELINE.contains(&line.0),
+        "표 아래 첫 본문 글줄 baseline 이 {:.1} 이다 — 한/글 699.0px 기준 \
+         {EXPECTED_BASELINE:?} 안이어야 한다. 글자 없이 개체만 담은 칸 마지막 줄의 \
+         꼬리 줄간격(6.1px)을 칸 높이에 넣으면 704.4 로 밀린다 (#6681). 글줄: {}",
+        line.0,
+        line.2,
+    );
+}

--- a/tests/cases/issue_6681_cell_last_object_line_drops_trailing_ls.rs
+++ b/tests/cases/issue_6681_cell_last_object_line_drops_trailing_ls.rs
@@ -60,10 +60,7 @@ fn glyph_lines(svg: &str) -> Vec<(f64, f64, String)> {
                 parts.next().and_then(|v| v.trim().parse::<f64>().ok()),
             )
         });
-        let (Some(x), Some(y)) = translated
-            .map(|(a, b)| (a, b))
-            .unwrap_or((attr("x"), attr("y")))
-        else {
+        let (Some(x), Some(y)) = translated.unwrap_or((attr("x"), attr("y"))) else {
             continue;
         };
         let body = &chunk[head_end + 1..];


### PR DESCRIPTION
## 무엇을 고쳤나

칸을 닫고 다음 요소로 가는 전진량이 6px 큽니다.

`#5923` 이 "칸 마지막 줄의 꼬리 줄간격은 제외" 를 세우면서 글자처럼 취급 표의 다문단 칸만 예외로 남겼는데, 그 예외에서 **글자 없이 개체만 담은 줄**을 뺍니다. 그런 줄의 높이는 개체가 차지한 자리이고 뒤에 붙일 줄이 없습니다.

```rust
let last_line_is_object_only = p.text.trim().is_empty() && !p.controls.is_empty();
let include_trailing_ls = !is_cell_last_line
    || (cell_para_count > 1 && table.common.treat_as_char && !last_line_is_object_only);
```

예외를 넓히는 것이 아니라 **좁히는** 방향입니다. 보존 핀(KTX TOC 등)의 마지막 문단은 글자가 있어 종전 회계를 그대로 씁니다.

## 어디서 6px 이 들어가나

`samples/exam_science.hwp` 4쪽 `자료` 칸의 마지막 문단입니다.

```
p[15] ctrls=1 text_len=0  ls[0] vpos=29580 lh=3037 ls=460
p[15] 내부표: 2행×3열   (칸 h=1424 + 1613 = 3037HU)
```

`lh=3037` 이 안쪽 표 두 행 높이와 **정확히 같습니다** — 그 줄이 표를 담습니다. 그리고 `ls=460` = **6.1px** 이 그 예외로 칸 높이에 들어갑니다.

## 실측

![표 아래 전진량 비교](https://raw.githubusercontent.com/jeong-sik/rhwp/assets/issue-6681/gap.png)

왼쪽이 한/글, 가운데가 수정 전, 오른쪽이 수정 후입니다. 가운데만 표 아래 본문이 내려가 마지막 `① 6w` 줄이 잘렸습니다.

### 왼쪽 단 글줄 편차 (한/글 − rhwp)

| 글줄 y | 수정 전 | 수정 후 |
|---|---:|---:|
| 644.3 (표 안) | +0.60 | +0.60 |
| 표 아래 첫 줄 | **−5.40** | **+0.70** |
| 그 다음 줄 | −5.30 | +0.80 |
| 아래쪽 표 위 | −4.40 | +1.70 |

`644.3` 까지는 맞다가 표 아래에서 6px 뛰고 그 아래로 누적됐습니다. 수정 후에는 그 점프가 사라집니다.

### 그 표 자체는 원래 정상입니다

```
rhwp : 610.5, 629.5, 651.0     간격 19.0 / 21.5
한/글: 611.0, 630.0, 651.5     간격 19.0 / 21.5
```

두 행이 선언값(1424·1613HU)과 일치합니다. 어긋난 것은 표를 닫는 전진량 하나입니다.

### 코퍼스 전수

215문서 1124장 중 짝지어진 930장에서 **악화 0, 개선 3** 입니다.

| 문서·쪽 | 수정 전 | 수정 후 |
|---|---:|---:|
| `21_언어_기출_편집가능본` p12 | 6.60 | **2.50** |
| `exam_science` p4 | 3.30 | **−2.90** |
| `exam_science` p4 | 3.20 | **−2.90** |

다른 문서에서도 같은 결함이 있었습니다.

## 테스트

`tests/cases/issue_6681_cell_last_object_line_drops_trailing_ls.rs` 를 더했습니다. 표 아래 첫 본문 글줄의 baseline 을 봅니다.

수정을 빼면 이렇게 실패합니다.

```
표 아래 첫 본문 글줄 baseline 이 704.4 이다 — 한/글 699.0px 기준 696.0..=701.0 안이어야 한다.
글자 없이 개체만 담은 칸 마지막 줄의 꼬리 줄간격(6.1px)을 칸 높이에 넣으면 704.4 로 밀린다 (#6681).
```

## 로컬 검증

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] 28개 스위트 `--no-fail-fast` — `issue_3885_json_provenance_envelope` 1건만 실패하며 devel 기준선에서도 빨간 건입니다
- [x] Native Skia 3종
- [x] WASM 빌드
- [x] `git diff --check`, `rust-unit-test-tiers --check`, `rust-test-suite-manifest --check`
- [x] 코퍼스 전수 그림 위치 스윕 (930장, 악화 0 · 개선 3)

closes #6681

🤖 Generated with [Claude Code](https://claude.com/claude-code)
