### PR TITLE
docs: PR #6691 contributor 후속 계획 보완

### DIFF
--- a/mydocs/pr/archives/pr_6659_review.md
+++ b/mydocs/pr/archives/pr_6659_review.md
@@ -72,3 +72,13 @@ mergeability를 다시 확인한 뒤에만 병합한다.
 - `hwpctl_ParameterSetID_Item_v1.2.hwp` p3: [rhwp/PDF/overlay 합성](../assets/pr_6659_6664_jeong_sik_integration_20260903/review_6659_hwpctl_p3.png)
 - `exam_math.hwp` p3: [rhwp/PDF/overlay 합성](../assets/pr_6659_6664_jeong_sik_integration_20260903/review_6659_exam_math_p3.png)
 - 사람 검토에서 코드 블록·푸터 및 양단 문제 구획이 페이지 안에 유지됨을 확인했다. 픽셀 수치는 글꼴 차이를 포함한 참고값이며 구조 판정을 대체하지 않는다.
+
+## Merge 후 contributor PR comment 계획
+
+- 이 기록 보완 PR이 merge되고 그 merge SHA의 devel CI가 성공한 뒤에만 원 PR #6659에 한 번 게시한다.
+- 수용 사실: PR #6691 merge commit 573059ee7bd4b74626143723d31d0b74ab0320b8로 provenance-preserving cherry-pick aafc00e7a를 통합했다.
+- 실제 CI: PR CI 33747890105와 CodeQL 33747890268, devel CI 33749587952와 CodeQL 33749587899, Adapter 33749587901, Proptest 33749587881이 success다.
+- 시각 판정: hwpctl p3와 exam_math p3은 각각 flagged 0/1이다. pixel match는 95.22274%, 97.99917%이고, 사람 검토에서 코드 블록·푸터 및 양단 문제 구획의 페이지 내 수용을 확인했다.
+- 자동 ink/proxy 수치는 글꼴 폭·줄바꿈·raster 차이를 포함하는 보조값임을 명시한다. 시각 비교 방법 정본은 https://github.com/edwardkim/rhwp/blob/573059ee7bd4b74626143723d31d0b74ab0320b8/mydocs/manual/verification/visual_sweep_guide.md#github-merge-comment 이다.
+- devel 안정 asset: ![PR 6659 hwpctl p3 visual review](https://raw.githubusercontent.com/edwardkim/rhwp/573059ee7bd4b74626143723d31d0b74ab0320b8/mydocs/pr/assets/pr_6659_6664_jeong_sik_integration_20260903/review_6659_hwpctl_p3.png)
+- #6656은 height_measurer 측정 경로와의 정합 DoD가 남아 있으므로 원 PR close와 별개로 OPEN을 유지한다.

--- a/mydocs/pr/archives/pr_6661_review.md
+++ b/mydocs/pr/archives/pr_6661_review.md
@@ -72,3 +72,13 @@ mergeability를 다시 확인한 뒤에만 수용하며, #6655 후속 처리는 
 - p6: [후속 본문 합성](../assets/pr_6659_6664_jeong_sik_integration_20260903/review_6661_issue2004_p6.png)
 - p4-p8: [contact sheet](../assets/pr_6659_6664_jeong_sik_integration_20260903/review_6661_issue2004_p4_p8_contact_sheet.png)
 - 사람 검토에서 p4 그림 적층·본문 회피와 p5-p8 페이지 흐름이 유지됨을 확인했다. 현재 보정은 synthetic 재분류 stack에만 가로 오프셋을 적용한다.
+
+## Merge 후 contributor PR comment 계획
+
+- 이 기록 보완 PR이 merge되고 그 merge SHA의 devel CI가 성공한 뒤에만 원 PR #6661에 한 번 게시한다.
+- 수용 사실: PR #6691 merge commit 573059ee7bd4b74626143723d31d0b74ab0320b8로 cherry-pick e33b0e324를 통합했고, 메인터너 보정 c89a7bf56이 synthetic 재분류 stack에만 가로 오프셋을 제한했다.
+- 실제 CI: PR CI 33747890105와 CodeQL 33747890268, devel CI 33749587952와 CodeQL 33749587899, Adapter 33749587901, Proptest 33749587881이 success다.
+- 시각 판정: issue2004 p4-p8은 5쪽 모두 flagged 0/5이며 pixel match 78.82516-83.19475%, ink/proxy 19.16494-30.48460%다. p4 배너·인물 적층과 본문 회피, p5-p8 페이지 흐름을 사람이 확인했다.
+- 자동 ink/proxy 수치는 글꼴 폭·줄바꿈·raster 차이를 포함하는 보조값임을 명시한다. 시각 비교 방법 정본은 https://github.com/edwardkim/rhwp/blob/573059ee7bd4b74626143723d31d0b74ab0320b8/mydocs/manual/verification/visual_sweep_guide.md#github-merge-comment 이다.
+- devel 안정 asset: ![PR 6661 issue2004 p4 visual review](https://raw.githubusercontent.com/edwardkim/rhwp/573059ee7bd4b74626143723d31d0b74ab0320b8/mydocs/pr/assets/pr_6659_6664_jeong_sik_integration_20260903/review_6661_issue2004_p4.png)
+- #6655는 devel 반영과 push CI 성공 뒤 자동 CLOSED 상태를 확인한다.

--- a/mydocs/pr/archives/pr_6663_review.md
+++ b/mydocs/pr/archives/pr_6663_review.md
@@ -51,3 +51,11 @@ mergeability를 확인한 뒤에만 수용한다. #6662의 상태 변경은 통�
 
 - 이 PR은 working 문서만 변경하므로 별도 시각 fixture 검증 대상이 아니다.
 - 함께 검토한 renderer 변경의 시각 결과는 [PR #6659, #6661, #6664 시각 스윕](pr_6659_6664_jeong_sik_visual_sweep.md)에 분리해 기록했다.
+
+## Merge 후 contributor PR comment 계획
+
+- 이 기록 보완 PR이 merge되고 그 merge SHA의 devel CI가 성공한 뒤에만 원 PR #6663에 한 번 게시한다.
+- 수용 사실: PR #6691 merge commit 573059ee7bd4b74626143723d31d0b74ab0320b8로 cherry-pick bc466368c를 통합하고, 메인터너 보정 c89a7bf56으로 #6655의 미래 종료 표현을 현재 OPEN 상태에 맞게 고쳤다.
+- 실제 CI: PR CI 33747890105와 CodeQL 33747890268, devel CI 33749587952와 CodeQL 33749587899, Adapter 33749587901, Proptest 33749587881이 success다.
+- 이 PR은 working 문서 전용이므로 자체 visual fixture나 PNG를 주장하지 않는다. 관련 renderer 시각 증적의 정본은 pr_6659_6664_jeong_sik_visual_sweep.md다.
+- #6662는 남은 원인 현황 원장이므로 OPEN을 유지한다.

--- a/mydocs/pr/archives/pr_6664_review.md
+++ b/mydocs/pr/archives/pr_6664_review.md
@@ -64,3 +64,13 @@ mergeability를 다시 확인한 뒤에만 병합한다.
 - 통합 기록: [PR #6659, #6661, #6664 시각 스윕](pr_6659_6664_jeong_sik_visual_sweep.md)
 - `hwpx_sample2.hwp` p9: [rhwp/PDF/overlay 합성](../assets/pr_6659_6664_jeong_sik_integration_20260903/review_6664_hwpx_sample2_p9.png)
 - 사람 검토에서 상단 표, 안내 문단, 신청방법 상자와 하단 단계 도식이 페이지 경계 안에서 기준 순서를 유지함을 확인했다.
+
+## Merge 후 contributor PR comment 계획
+
+- 이 기록 보완 PR이 merge되고 그 merge SHA의 devel CI가 성공한 뒤에만 원 PR #6664에 한 번 게시한다.
+- 수용 사실: PR #6691 merge commit 573059ee7bd4b74626143723d31d0b74ab0320b8로 cherry-pick f3f9e25b9를 통합했다.
+- 실제 CI: PR CI 33747890105와 CodeQL 33747890268, devel CI 33749587952와 CodeQL 33749587899, Adapter 33749587901, Proptest 33749587881이 success다.
+- 시각 판정: hwpx_sample2 p9는 flagged 0/1, pixel match 79.09768%, ink/proxy 12.49530%다. 사람 검토에서 표·안내 문단·절차 도식의 순서와 페이지 내 수용을 확인했다.
+- 자동 ink/proxy 수치는 글꼴 폭·줄바꿈·raster 차이를 포함하는 보조값임을 명시한다. 시각 비교 방법 정본은 https://github.com/edwardkim/rhwp/blob/573059ee7bd4b74626143723d31d0b74ab0320b8/mydocs/manual/verification/visual_sweep_guide.md#github-merge-comment 이다.
+- devel 안정 asset: ![PR 6664 hwpx sample2 p9 visual review](https://raw.githubusercontent.com/edwardkim/rhwp/573059ee7bd4b74626143723d31d0b74ab0320b8/mydocs/pr/assets/pr_6659_6664_jeong_sik_integration_20260903/review_6664_hwpx_sample2_p9.png)
+- #6653은 p9 continuation-page 빈 띠만 해결됐고 8쪽 첫 문단과 누적 편차가 남아 있으므로 OPEN을 유지한다.


### PR DESCRIPTION
## 목적

PR #6691이 이미 devel에 병합된 뒤 확인된 post-merge 절차 누락을 문서로 보완합니다.

각 원 PR archive review에 실제 merge SHA, 실제 PR/devel CI, 시각 증적의 페이지·지표·사람 판정, devel의 raw PNG URL 및 issue 종료 경계를 추가합니다.

## 범위

- mydocs/pr/archives/pr_6659_review.md
- mydocs/pr/archives/pr_6661_review.md
- mydocs/pr/archives/pr_6663_review.md
- mydocs/pr/archives/pr_6664_review.md

source, test, workflow, golden/baseline, sample, LFS 변경은 포함하지 않습니다.

## 후속 처리 조건

이 PR의 최신 head CI 및 merge 가능 상태를 확인해 병합한 뒤, 그 merge SHA의 devel CI가 성공할 때만 원 PR #6659, #6661, #6663, #6664에 계획된 comment를 한 번 게시하고 close 처리합니다.

#6655는 CLOSED를 유지합니다. #6653과 #6656은 review 범위 밖 DoD가 남아 OPEN을 유지하며, #6662는 현황 원장으로 OPEN을 유지합니다.
