### PR TITLE
fix(measure): 묶음 빈칸 전진폭을 일반 공백과 같게 한다 (#6646)

### DIFF
--- a/src/renderer/layout/text_measurement.rs
+++ b/src/renderer/layout/text_measurement.rs
@@ -1048,6 +1048,18 @@ fn measure_char_width_embedded_decision<'a>(
         };
     };
     // HWP 반각 처리: space 및 한컴이 반각으로 처리하는 구두점/기호.
+    //
+    // [#6646] 묶음 빈칸(U+00A0)은 **줄바꿈만 막는 공백**이라 전진폭이 일반 공백과
+    // 같아야 하는데, 글꼴 글리프 폭을 그대로 쓰면 같은 문서 안에서도 글꼴마다
+    // 제각각이 된다 — `exam_eng.hwp` 1쪽 실측: 일반 공백은 어느 글꼴이든 7.667px
+    // 인데 묶음 빈칸은 `Times New Roman` 3.827 · `HY신명조` 5.093 ·
+    // `한양신명조` 7.747 이다. 글꼴 표 자체도 567개 중 149개에서 두 값이 다르고
+    // **50개는 0** 이라(글자가 자리를 안 차지한다는 뜻) 그대로 쓸 수 없다.
+    //
+    // 공백과 같은 갈래로 넣어 글꼴과 무관하게 같은 폭을 쓴다. 아래 갈래는 이미
+    // `hancom_pdf_space_width` 오버레이와 `em/2` 폴백을 갖고 있어, 공백에 대해
+    // 검증된 회계를 그대로 물려받는다.
+    let c = if c == '\u{00A0}' { ' ' } else { c };
     let (w, width_source) = if c == ' ' {
         if let Some(width) = hancom_pdf_space_width(primary_name, font_size) {
             (width, "metricSpaceOverlay")

--- a/tests/cases/issue_6646_nbsp_advance_matches_space.rs
+++ b/tests/cases/issue_6646_nbsp_advance_matches_space.rs
@@ -1,0 +1,107 @@
+//! [Issue #6646] 묶음 빈칸 전진폭이 글꼴마다 달라 문항 번호 뒤 본문이 당겨진다.
+//!
+//! 근인: 묶음 빈칸(HWP5 문자 컨트롤 30 → `U+00A0`)을 일반 글자처럼 글꼴 글리프
+//! 폭으로 재고 있었다. 묶음 빈칸은 **줄바꿈만 막는 공백**이라 전진폭이 일반 공백과
+//! 같아야 하는데, 글꼴 표의 두 값이 제각각이다.
+//!
+//! `exam_eng.hwp` 1쪽 실측(글꼴 15.33px): 일반 공백은 어느 글꼴이든 7.667px 인데
+//! 묶음 빈칸은 `Times New Roman` 3.827 · `HY신명조` 5.093 · `한양신명조` 7.747 이다.
+//! 글꼴 표 자체도 567개 중 149개에서 두 값이 다르고 50개는 0 이다.
+//!
+//! 수정: `measure_char_width_embedded_decision` 에서 묶음 빈칸을 일반 공백과 같은
+//! 갈래로 넣는다.
+//!
+//! 실측(`'.'` → `'대'` origin 간격): 수정 전 12.27px / 수정 후 16.27px /
+//! 한/글 2022 PDF 16.01px.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+
+const SAMPLE: &str = "samples/exam_eng.hwp";
+/// 7번 문항 줄을 고르는 표식. 번호와 본문이 한 줄에 있다.
+const LINE_PREFIX: &str = "7.";
+const LINE_CONTAINS: &str = "대화를";
+/// `'.'` → `'대'` 간격의 허용 구간. 한/글 16.01px 이고, 묶음 빈칸을 글꼴 글리프
+/// 폭으로 재면 12.27px 로 좁아진다.
+const EXPECTED_GAP: std::ops::RangeInclusive<f64> = 15.0..=17.0;
+
+/// SVG 의 한 글자짜리 `<text>` 를 baseline 으로 묶어 글줄을 만든다.
+/// 대부분의 글자는 `transform="translate(x,y)"` 로, 일부는 `x`/`y` 속성으로 놓인다.
+fn glyph_lines(svg: &str) -> Vec<Vec<(f64, char)>> {
+    let mut rows: std::collections::BTreeMap<i64, Vec<(f64, char)>> = Default::default();
+    for chunk in svg.split("<text ").skip(1) {
+        let Some(head_end) = chunk.find('>') else {
+            continue;
+        };
+        let head = &chunk[..head_end];
+        let attr = |name: &str| -> Option<f64> {
+            let key = format!("{name}=\"");
+            let s = head.find(&key)? + key.len();
+            let e = s + head[s..].find('"')?;
+            head[s..e].parse().ok()
+        };
+        let translated = head.find("translate(").map(|at| {
+            let tail = &head[at + 10..];
+            let end = tail.find(')').unwrap_or(tail.len());
+            let mut parts = tail[..end].split(',');
+            (
+                parts.next().and_then(|v| v.trim().parse::<f64>().ok()),
+                parts.next().and_then(|v| v.trim().parse::<f64>().ok()),
+            )
+        });
+        let (Some(x), Some(y)) = translated.unwrap_or((attr("x"), attr("y"))) else {
+            continue;
+        };
+        let body = &chunk[head_end + 1..];
+        let Some(end) = body.find("</text>") else {
+            continue;
+        };
+        let mut chars = body[..end].chars();
+        let (Some(c), None) = (chars.next(), chars.next()) else {
+            continue;
+        };
+        if c.is_whitespace() {
+            continue;
+        }
+        rows.entry((y * 10.0).round() as i64)
+            .or_default()
+            .push((x, c));
+    }
+    rows.into_values()
+        .map(|mut v| {
+            v.sort_by(|a, b| a.0.partial_cmp(&b.0).expect("finite x"));
+            v
+        })
+        .collect()
+}
+
+#[test]
+fn issue_6646_nbsp_advance_matches_plain_space() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let core = DocumentCore::from_bytes(&std::fs::read(path).expect("read sample")).expect("open");
+    let svg = core.render_page_svg_native(0).expect("page 1 svg");
+
+    let line = glyph_lines(&svg)
+        .into_iter()
+        .find(|v| {
+            let text: String = v.iter().map(|(_, c)| *c).collect();
+            text.starts_with(LINE_PREFIX) && text.contains(LINE_CONTAINS)
+        })
+        .unwrap_or_else(|| panic!("1쪽에서 `{LINE_PREFIX}…{LINE_CONTAINS}` 글줄을 찾아야 한다"));
+
+    let dot_x = line[1].0;
+    let first_hangul_x = line
+        .iter()
+        .find(|(_, c)| *c == '대')
+        .map(|(x, _)| *x)
+        .expect("그 글줄의 `대`");
+    let gap = first_hangul_x - dot_x;
+
+    assert!(
+        EXPECTED_GAP.contains(&gap),
+        "`'.'` → `'대'` 간격이 {gap:.2}px 이다 — 한/글 16.01px 기준 {EXPECTED_GAP:?} \
+         안이어야 한다. 묶음 빈칸을 글꼴 글리프 폭으로 재면 12.27px 로 좁아진다 (#6646)."
+    );
+}


### PR DESCRIPTION
## 무엇을 고쳤나

묶음 빈칸(HWP5 문자 컨트롤 30 → `U+00A0`)의 전진폭이 글꼴마다 달라, 문항 번호 뒤 본문이 왼쪽으로 당겨집니다.

묶음 빈칸은 **줄바꿈만 막는 공백**이라 전진폭이 일반 공백과 같아야 하는데, 일반 글자처럼 글꼴 글리프 폭으로 재고 있었습니다.

```rust
// measure_char_width_embedded_decision
let c = if c == '\u{00A0}' { ' ' } else { c };
let (w, width_source) = if c == ' ' { … };
```

공백 갈래는 이미 `hancom_pdf_space_width` 오버레이와 `em/2` 폴백을 갖고 있어, 공백에 대해 검증된 회계를 그대로 물려받습니다. 새 상수를 만들지 않았습니다.

## 왜 글꼴 표를 못 쓰나

`exam_eng.hwp` 1쪽에서 두 문자의 폭을 찍어 비교했습니다(글꼴 15.33px).

| 글꼴 | 일반 공백 | 묶음 빈칸 |
|---|---:|---:|
| Times New Roman | 7.667 | **3.827** (절반) |
| HY신명조 | 7.667 | **5.093** |
| 한양신명조 | — | 7.747 |

**같은 문서 안에서도 글꼴마다 다릅니다.** 표 자체를 전수 비교하면 이렇습니다.

| | 개수 |
|---|---:|
| `U+0020 == U+00A0` | 367 |
| 다름 | 149 |
| **`U+00A0 == 0`** | **50** |

다른 149개는 방향도 일정하지 않습니다(글꼴 6·7 은 341→512, 34·35 는 401→201). 폭 0 은 글자가 자리를 차지하지 않는다는 뜻이라 그대로 쓸 수 없습니다.

## 실측

![7번 문항](https://raw.githubusercontent.com/jeong-sik/rhwp/assets/issue-6646/gap.png)

왼쪽이 한/글, 가운데가 수정 전, 오른쪽이 수정 후입니다. 가운데만 `7.` 뒤 간격이 좁습니다.

`'.'` → `'대'` origin 간격입니다.

| | 간격 |
|---|---:|
| 수정 전 | 12.27px |
| **수정 후** | **16.27px** |
| 한/글 2022 PDF | 16.01px |

### 코퍼스 전수

215문서 1124장 중 짝지어진 924장입니다.

| 축 | 악화 | 개선 |
|---|---:|---:|
| 세로 `dy` | 1 | **11** |
| 가로 `dx` | **0** | **4** |

큰 개선들입니다.

```
issue2004_cell_image_stack  p5~8  dx  −31.46 → −3.56 (외 3장)
exam_science                p4    dy   22.75 → −0.15
3-09월_교육_통합_2024-*        p6    dy   18.18 →  0.58
hwpctl_ParameterSetID_Item  p52   dy   23.61 →  0.11
```

악화 1건은 `hwpctl_ParameterSetID_Item` 3쪽인데, **같은 쪽에서 다른 그림이 15.04 → 0.14 로 크게 개선**됩니다. 그 쪽 흐름이 바뀌며 생긴 재배치로 보입니다.

글자 폭 수정인데 **그림 위치 지표에서 개선이 나온 것**이 이 수정의 독립 증거입니다.

## 테스트

`tests/cases/issue_6646_nbsp_advance_matches_space.rs` 를 더했습니다. 1쪽 7번 문항 줄에서 `'.'` → `'대'` 간격을 봅니다.

## 로컬 검증

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] 28개 스위트 `--no-fail-fast`
- [x] Native Skia 3종
- [x] WASM 빌드
- [x] `git diff --check`, `rust-unit-test-tiers --check`, `rust-test-suite-manifest --check`
- [x] 코퍼스 전수 스윕 (924장, 세로 개선 11·악화 1 / 가로 개선 4·악화 0)

closes #6646

🤖 Generated with [Claude Code](https://claude.com/claude-code)
