### PR TITLE
떠 있는 그림이 앞 쪽에서 이어진 문단에 붙으면 85.6px 아래에 놓인다

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -12223,12 +12223,16 @@ impl LayoutEngine {
                             // `PartialParagraph { start_line > 0 }` 분기: "이어지는 partial
                             // paragraph 는 이전 쪽/단에서 시작한 문단의 나머지다"). 여기서는
                             // 그 규칙을 개체 앵커에 연결한다.
-                            let anchor_starts_on_earlier_page =
-                                ctx.page_content.column_contents.iter()
-                                    .flat_map(|cc| cc.items.iter())
-                                    .any(|it| matches!(it,
+                            let anchor_starts_on_earlier_page = ctx
+                                .page_content
+                                .column_contents
+                                .iter()
+                                .flat_map(|cc| cc.items.iter())
+                                .any(|it| {
+                                    matches!(it,
                                         PageItem::PartialParagraph { para_index: q, start_line, .. }
-                                            if *q == para_index && *start_line > 0));
+                                            if *q == para_index && *start_line > 0)
+                                });
                             let para_base_y = if anchor_starts_on_earlier_page {
                                 ctx.col_area.y
                             } else {

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -12212,8 +12212,28 @@ impl LayoutEngine {
                                         control_index,
                                     )
                                 });
-                            let para_base_y =
-                                para_start_y.get(&para_index).copied().unwrap_or(y_offset);
+                            // [#6704] 앵커 문단이 앞 쪽/단에서 이어진 조각이면
+                            // `para_start_y` 는 그 문단의 시작이 아니라 이 쪽에서 흐름이
+                            // 도달한 자리다. Para 기준 개체는 흐름에서 빠져 있으므로 그
+                            // 자리를 쓰면 앞 항목이 흘린 만큼 그대로 내려간다 —
+                            // hwp3-sample 7쪽 그림이 +85.6px. 한/글은 넘어온 쪽의 본문
+                            // 맨 위를 기준으로 삼는다.
+                            //
+                            // 본문 흐름은 같은 규칙을 이미 지킨다(layout.rs 의
+                            // `PartialParagraph { start_line > 0 }` 분기: "이어지는 partial
+                            // paragraph 는 이전 쪽/단에서 시작한 문단의 나머지다"). 여기서는
+                            // 그 규칙을 개체 앵커에 연결한다.
+                            let anchor_starts_on_earlier_page =
+                                ctx.page_content.column_contents.iter()
+                                    .flat_map(|cc| cc.items.iter())
+                                    .any(|it| matches!(it,
+                                        PageItem::PartialParagraph { para_index: q, start_line, .. }
+                                            if *q == para_index && *start_line > 0));
+                            let para_base_y = if anchor_starts_on_earlier_page {
+                                ctx.col_area.y
+                            } else {
+                                para_start_y.get(&para_index).copied().unwrap_or(y_offset)
+                            };
                             if std::env::var("RHWP_5715_DBG").is_ok() {
                                 eprintln!(
                                     "[5715] pi={para_index} ci={control_index} base={para_base_y:.1} from_map={} y_off={y_offset:.1}",

--- a/tests/cases/issue_6704_floating_picture_anchor_on_continued_para.rs
+++ b/tests/cases/issue_6704_floating_picture_anchor_on_continued_para.rs
@@ -1,0 +1,94 @@
+//! [#6704] 앵커 문단이 앞 쪽에서 이어진 조각이면 떠 있는 그림은 그 쪽 본문 맨 위를 기준으로 놓는다.
+//!
+//! `vert=Para` 개체는 앵커 문단의 시작 y 에 저장 offset 을 더해 놓인다. 그런데 앵커
+//! 문단이 앞 쪽에서 시작해 이 쪽으로 이어진 조각이면, `para_start_y` 에 담긴 값은 그
+//! 문단의 시작이 아니라 이 쪽에서 흐름이 도달한 자리다. 개체는 흐름에서 빠져 있으므로
+//! 그 자리를 쓰면 앞 항목이 흘린 만큼 그대로 내려간다.
+//!
+//! `samples/hwp3-sample.hwp` 문단 0.76(저장 `vpos=51520` = 686.9px, 6쪽)에 붙은
+//! `bin_id=3` 그림(`tac=false`, `wrap=TopAndBottom`, `vert=Para(off=8400)`)은 7쪽에
+//! 그려진다. 7쪽 본문 시작은 132.27px 인데 종전 rhwp 는 흐름이 도달한 217.60px 을 앵커로
+//! 써서 그림이 85.6px 아래에 놓였다.
+//!
+//! 한/글 2022 PDF(`pdf/hwp3-sample-2022.pdf`, 16쪽/16쪽·A4 동일) 실측: 그 그림 y=255.4,
+//! x=143.1. 가로는 종전에도 맞았다(dx −0.02).
+//!
+//! 같은 쪽 다른 그림들은 앵커가 이 쪽에서 시작하므로 규칙 밖이다 — 그 값이 함께 바뀌지
+//! 않는지도 같이 고정한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+fn page_svg(rel: &str, page: u32) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {rel}: {e:?}"));
+    doc.render_page_svg(page)
+        .unwrap_or_else(|e| panic!("render {rel} p{}: {e:?}", page + 1))
+}
+
+/// SVG 안 `<image>` 의 (x, y, width) 를 모은다.
+fn image_boxes(svg: &str) -> Vec<(f64, f64, f64)> {
+    let mut out = Vec::new();
+    for chunk in svg.split("<image").skip(1) {
+        let head = &chunk[..chunk.find('>').unwrap_or(chunk.len())];
+        let attr = |k: &str| -> Option<f64> {
+            let pat = format!(" {k}=\"");
+            let i = head.find(&pat)? + pat.len();
+            let rest = &head[i..];
+            rest[..rest.find('"')?].parse().ok()
+        };
+        if let (Some(x), Some(y), Some(w)) = (attr("x"), attr("y"), attr("width")) {
+            out.push((x, y, w));
+        }
+    }
+    out
+}
+
+#[test]
+fn floating_picture_anchored_to_continued_paragraph_starts_at_body_top() {
+    let svg = page_svg("samples/hwp3-sample.hwp", 6); // 0-based → 7쪽
+
+    // 폭 519px(38940 HU) 인 그림이 문제의 개체다. 같은 쪽 바닥글 그림(80px)과 구분된다.
+    let big: Vec<(f64, f64, f64)> = image_boxes(&svg)
+        .into_iter()
+        .filter(|(_, _, w)| (515.0..=525.0).contains(w))
+        .collect();
+
+    assert_eq!(big.len(), 1, "7쪽 519px 그림이 하나여야 한다: {big:?}");
+    let (x, y, _) = big[0];
+
+    // 한/글 실측 (255.4, 143.1). 오라클 추출 오차 ±3px.
+    assert!(
+        (252.0..=259.0).contains(&y),
+        "그림 y 가 한/글(255.4) 근처여야 한다. 종전 값은 341.0 이었다. 실제: {y}"
+    );
+    assert!(
+        (140.0..=146.0).contains(&x),
+        "그림 x 는 종전에도 맞았다(한/글 143.1). 실제: {x}"
+    );
+}
+
+#[test]
+fn same_page_pictures_with_local_anchor_are_untouched() {
+    let svg = page_svg("samples/hwp3-sample.hwp", 6);
+
+    // 바닥글 그림(80px). 앵커가 이 쪽에서 시작하므로 이 규칙의 대상이 아니다.
+    let footer: Vec<(f64, f64, f64)> = image_boxes(&svg)
+        .into_iter()
+        .filter(|(_, _, w)| (75.0..=85.0).contains(w))
+        .collect();
+
+    assert!(
+        !footer.is_empty(),
+        "7쪽 바닥글 그림을 찾지 못했다 — 표본이 바뀌었는지 확인할 것"
+    );
+    // 한/글 실측 y=1019.4 (dy +1.13 은 이 수정 전후로 같다).
+    for (_, y, _) in &footer {
+        assert!(
+            (1016.0..=1024.0).contains(y),
+            "바닥글 그림 y 가 움직이면 안 된다(한/글 1019.4). 실제: {y}"
+        );
+    }
+}


### PR DESCRIPTION
## 무엇을 고쳤나

앞 쪽에서 이어진 문단에 붙은 떠 있는 그림이 85.6px 아래에 놓이던 것을 고칩니다.

`vert=Para` 개체는 앵커 문단의 시작 자리에 저장 오프셋을 더해 놓입니다. 그런데 앵커 문단이 **앞 쪽에서 시작해 이 쪽으로 이어진 조각**이면, `para_start_y` 에 담긴 값은 그 문단의 시작이 아니라 이 쪽에서 글이 흘러 내려온 자리입니다. 개체는 글 흐름에서 빠져 있으니 그 자리를 쓰면 앞 항목이 차지한 만큼 그대로 밀려납니다.

한/글은 넘어온 쪽의 본문 맨 위를 기준으로 삼습니다.

## 실측

`samples/hwp3-sample.hwp` 7쪽. 왼쪽이 한/글, 가운데가 수정 전, 오른쪽이 수정 후입니다.

![한/글 · 수정 전 · 수정 후](https://raw.githubusercontent.com/jeong-sik/rhwp/assets/6704/shot6704.png)

그림과 캡션이 상자 단위로 함께 제자리로 옵니다.

| | 수정 전 | 수정 후 | 한/글 |
|---|---|---|---|
| 그림 y | 341.0 | **255.6** | 255.4 |
| 그림 x | 143.1 | 143.1 | 143.1 |
| dy | **+85.60** | **+0.20** | — |

가로는 원래 맞았고 세로만 어긋나 있었습니다.

## 코퍼스 검증

`samples` ↔ `pdf` 215 문서, 이미지 1124장(짝지음 1016, 오라클에서 짝을 못 찾은 108장은 판정에서 제외). 기준선은 이 PR 의 base 인 `b6b9384ed` 를 같은 하네스로 다시 측정했습니다.

```
짝지음 1016  개선 4  회귀 0  변화없음 1012

  -85.40  hwp3-sample        p7 pi76   85.60 -> 0.20
  -85.40  hwp3-sample-hwp5   p7 pi76   85.60 -> 0.20
  -85.40  hwp3-sample-hwpx   p7 pi76   85.60 -> 0.20
  -85.40  issue_265          p7 pi76   85.60 -> 0.20
```

`hwp3`·`hwp5`·`hwpx` 세 포맷이 같은 값으로 움직입니다. 공통 IR 이후의 배치 문제라는 뜻입니다. `issue_265` 는 이 작업에서 겨누지 않은 문서인데 같은 조건이라 함께 고쳐졌습니다.

## 왜 이 조건인가

글 본문은 같은 규칙을 이미 지킵니다. `layout.rs` 의 `PartialParagraph { start_line > 0 }` 분기에 이렇게 적혀 있습니다.

> 이어지는 partial paragraph는 이전 쪽/단에서 시작한 문단의 나머지다. 다음 항목과의 간격은 원본 절대 vpos 차이가 아니라 현재 쪽의 순차 y를 따라야 한다.

이 PR 은 새 규칙을 만들지 않고, 그 규칙을 개체 앵커 자리에 연결합니다. 판정에 쓰는 `PageItem::PartialParagraph { start_line }` 는 `pagination.rs:562` 에 이미 있는 값입니다.

바로 아래 `deferred_page_start_square` 분기는 건드리지 않았습니다. 그쪽은 `vpos=0` narrow band 라는 다른 상황을 다루고, 두 조건을 섞으면 어느 쪽이 무엇을 고치는지 알 수 없게 됩니다.

### 감싸기 종류로 조건을 넓히지 않은 이유

`deferred_page_start_square` 의 `Square` 제한을 푸는 방법도 있었지만, 그러면 감싸기 종류를 하나씩 끼워 넣는 모양이 됩니다. 실제 조건은 감싸기가 아니라 "앵커 문단이 앞 쪽에서 이어졌는가" 입니다.

## 조건을 어떻게 확정했나

같은 쪽 그림 넷 중 하나만 결함입니다. 후보 조건을 계측으로 걸렀습니다.

```
pi=41  base=132.3  col_top=132.3  first_on_page=true   cont=false   정상
pi=76  base=217.6  col_top=132.3  first_on_page=false  cont=true    결함 (+85.60)
pi=78  base=153.6  col_top=132.3  first_on_page=false  cont=false   정상
pi=97  base=418.1  col_top=132.3  first_on_page=false  cont=false   정상
```

처음에 세운 `base != col_area.y`(= `first_on_page=false`)는 정상인 pi=78·97 까지 걸립니다. `start_line > 0` 만 결함 하나를 정확히 가릅니다.

## 테스트

`tests/cases/issue_6704_floating_picture_anchor_on_continued_para.rs` 2건.

1. 7쪽 519px 그림의 y 가 한/글(255.4) 근처인지
2. 같은 쪽 바닥글 그림(앵커가 이 쪽에서 시작 — 규칙 밖)이 움직이지 않는지

수정을 빼고 돌리면 1번이 `실제: 340.96` 으로 실패하고 2번은 통과합니다. 두 테스트가 각각 다른 것을 잡습니다.

## 로컬 검증

- `node scripts/rust-test-suite-manifest.mjs --prepare`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo clippy -p rhwp --lib --target wasm32-unknown-unknown -- -D warnings`
- `cargo build --workspace` + `cargo clippy --workspace --all-targets -- -D warnings`
- `node scripts/run-rust-test.mjs issue_6704_floating_picture_anchor_on_continued_para` — 2 passed
- `cargo nextest run --no-fail-fast` — 8989건 중 8988 통과
- `git diff --check`, `rust-unit-test-tiers --check`, `rust-test-suite-manifest --check`
- 코퍼스 스윕 215 문서 (위 표)

전체 스위트에서 `cli_exit_codes corrupt_input_does_not_panic_in_renderer` 1건이 실패하는데, base 인 `b6b9384ed` 에서도 같은 메시지로 실패합니다(`종료 코드 0 를 기대했다`). 이 PR 과 무관한 기존 실패입니다.

closes #6704

🤖 Generated with [Claude Code](https://claude.com/claude-code)
