### PR TITLE
수정(renderer): 용지 기준 어울림 개체의 배제 밴드를 계산해 개체 이동에 본문이 되감기게 한다 (#6202)

### DIFF
--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1303,6 +1303,7 @@ impl DocumentCore {
                             picture_col_width,
                             &styles,
                             dpi,
+                            (layout.body_area.x, layout.body_area.y),
                         );
                         // A tracked host keeps ownership until a complete
                         // projection proves that its band already ended.

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -530,7 +530,7 @@ impl DocumentCore {
         &self,
         section_idx: usize,
         para_idx: usize,
-    ) -> Option<(usize, std::ops::Range<usize>, f64)> {
+    ) -> Option<(usize, std::ops::Range<usize>, f64, (f64, f64))> {
         let section = self.document.sections.get(section_idx)?;
         let host_index = (0..=para_idx).rev().find(|&index| {
             section.paragraphs[index].controls.iter().any(|control| {
@@ -558,6 +558,7 @@ impl DocumentCore {
             column_width,
             &self.styles,
             self.dpi,
+            (layout.body_area.x, layout.body_area.y),
         )?;
         // Carries px, not HWPUNIT: the conversion belongs to `ParagraphBox`, so
         // that one paragraph gets one box however it is reached.
@@ -565,6 +566,7 @@ impl DocumentCore {
             host_index,
             band.paragraph_range,
             column_width,
+            (layout.body_area.x, layout.body_area.y),
         ))
     }
 
@@ -704,7 +706,7 @@ impl DocumentCore {
     where
         F: FnOnce(&mut Paragraph),
     {
-        let Some((host_index, old_range, column_width_px)) =
+        let Some((host_index, old_range, column_width_px, paper_origin_px)) =
             self.picture_band_owning_body_paragraph(section_idx, para_idx)
         else {
             return Ok(None);
@@ -728,6 +730,7 @@ impl DocumentCore {
             column_width_px,
             &self.styles,
             self.dpi,
+            paper_origin_px,
         ) else {
             return Err(HwpError::RenderError(format!(
                 "그림 배치 영역({}..)의 편집 결과를 완전한 줄 배치로 만들 수 없습니다",
@@ -7653,6 +7656,7 @@ mod tests {
             column_width_px,
             &styles,
             DPI,
+            (0.0, 0.0),
         )
         .expect("p325 Picture frame");
         assert_eq!(initial_band.paragraph_range, HOST..DOWNSTREAM);
@@ -7717,6 +7721,7 @@ mod tests {
             column_width_px,
             &styles,
             DPI,
+            (0.0, 0.0),
         )
         .expect("edited p325 Picture frame");
         let inserted_range = inserted_band.paragraph_range.clone();
@@ -7773,6 +7778,7 @@ mod tests {
             column_width_px,
             &styles,
             DPI,
+            (0.0, 0.0),
         )
         .expect("inserted Picture frame before delete");
         assert_eq!(before_delete_band.paragraph_range, HOST..331);
@@ -7784,6 +7790,7 @@ mod tests {
             column_width_px,
             &styles,
             DPI,
+            (0.0, 0.0),
         )
         .expect("restored p325 Picture frame");
         let deleted_range = deleted_band.paragraph_range.clone();
@@ -7955,7 +7962,7 @@ mod tests {
         core.paginate();
 
         let before_col = core.para_column_map[0][HOST];
-        let (_, _, before_width_hwp) = core
+        let (_, _, before_width_hwp, _) = core
             .picture_band_owning_body_paragraph(0, HOST)
             .expect("initial Picture band");
         assert_eq!(
@@ -7967,7 +7974,7 @@ mod tests {
             .expect("host insert succeeds");
 
         let after_col = core.para_column_map[0][HOST];
-        let (_, fresh_range, after_width_hwp) = core
+        let (_, fresh_range, after_width_hwp, _) = core
             .picture_band_owning_body_paragraph(0, HOST)
             .expect("Picture band after pagination");
         assert_eq!(after_col, 1, "the expanded host moves to the wide column");
@@ -7982,6 +7989,7 @@ mod tests {
             after_width_hwp,
             &core.styles,
             DPI,
+            (0.0, 0.0),
         )
         .expect("fresh band at the post-pagination column width");
         assert_eq!(fresh_band.paragraph_range, fresh_range);
@@ -8047,7 +8055,7 @@ mod tests {
         core.paginate();
 
         let before_col = core.para_column_map[0][HOST];
-        let (_, _, before_width_hwp) = core
+        let (_, _, before_width_hwp, _) = core
             .picture_band_owning_body_paragraph(0, HOST)
             .expect("initial Picture band");
         assert_eq!(before_col, 0, "fixture starts in the narrow column");
@@ -8059,7 +8067,7 @@ mod tests {
         core.end_batch_native().expect("end batch");
 
         let after_flush_col = core.para_column_map[0][HOST];
-        let (_, fresh_range, after_width_hwp) = core
+        let (_, fresh_range, after_width_hwp, _) = core
             .picture_band_owning_body_paragraph(0, HOST)
             .expect("Picture band after final pagination");
         assert_eq!(
@@ -8078,6 +8086,7 @@ mod tests {
             after_width_hwp,
             &core.styles,
             DPI,
+            (0.0, 0.0),
         )
         .expect("fresh band at the post-batch column width");
         assert_eq!(fresh_band.paragraph_range, fresh_range);
@@ -8153,7 +8162,7 @@ mod tests {
         core.paginate();
 
         let before_col = core.para_column_map[0][HOST];
-        let (_, before_range, before_width_px) = core
+        let (_, before_range, before_width_px, _) = core
             .picture_band_owning_body_paragraph(0, HOST)
             .expect("supported Picture band in the wide source column");
         assert_eq!(before_col, 0, "fixture starts in the wide column");

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -3277,6 +3277,13 @@ pub(crate) fn layout_picture_band(
         crate::renderer::float_placement::PaperOrigin {
             body_left: px_to_hwpunit(paper_origin_px.0, dpi),
             body_top: px_to_hwpunit(paper_origin_px.1, dpi),
+            // 밴드는 host 문단에서 시작한다 — 그 문단의 저장 절대 위치가 로컬 원점이다.
+            band_abs_top: host
+                .line_segs
+                .iter()
+                .find(|seg| seg.tag & 0x8000_0000 == 0)
+                .map(|seg| seg.vertical_pos)
+                .unwrap_or(0),
         },
     )?;
     let exclusion_end = exclusion.vertical.end;

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -3203,6 +3203,8 @@ pub(crate) fn layout_picture_band(
     column_width_px: f64,
     styles: &ResolvedStyleSet,
     dpi: f64,
+    // [#6202] 용지 기준(`Paper`/`Page`) 어울림 개체를 재는 데 필요한 본문 상자의 용지 원점.
+    paper_origin_px: (f64, f64),
 ) -> Option<PictureBandLayout> {
     let host = paragraphs.get(host_index)?;
     let column_horizontal = 0..px_to_hwpunit(column_width_px, dpi);
@@ -3272,6 +3274,10 @@ pub(crate) fn layout_picture_band(
         column_horizontal.clone(),
         host_paragraph_horizontal,
         anchor_top,
+        crate::renderer::float_placement::PaperOrigin {
+            body_left: px_to_hwpunit(paper_origin_px.0, dpi),
+            body_top: px_to_hwpunit(paper_origin_px.1, dpi),
+        },
     )?;
     let exclusion_end = exclusion.vertical.end;
     let mut frame = host_box.frame_with(0, vec![exclusion]);
@@ -5074,6 +5080,7 @@ mod frame_reflow_tests {
             0..COLUMN_WIDTH,
             paragraph_reference.clone(),
             0,
+            crate::renderer::float_placement::PaperOrigin::default(),
         )
         .expect("supported Paragraph-relative Picture");
         assert_eq!(expected_exclusion.horizontal, 12_000..15_000);
@@ -5093,6 +5100,7 @@ mod frame_reflow_tests {
             crate::renderer::hwpunit_to_px(COLUMN_WIDTH, DPI),
             &styles,
             DPI,
+            (0.0, 0.0),
         )
         .expect("the one-row Paragraph-relative Picture band");
 
@@ -5133,8 +5141,15 @@ mod frame_reflow_tests {
         let column_width = page_layout.column_areas[0].width;
         let styles = crate::renderer::style_resolver::resolve_styles(&document.doc_info, DPI);
 
-        let band = layout_picture_band(&section.paragraphs, 325, column_width, &styles, DPI)
-            .expect("one Picture + trailing TAC Equation p325 band");
+        let band = layout_picture_band(
+            &section.paragraphs,
+            325,
+            column_width,
+            &styles,
+            DPI,
+            (0.0, 0.0),
+        )
+        .expect("one Picture + trailing TAC Equation p325 band");
 
         assert_eq!(band.paragraph_range, 325..332);
         assert_eq!(band.line_segs.len(), 7);
@@ -5219,8 +5234,15 @@ mod frame_reflow_tests {
         let styles = crate::renderer::style_resolver::resolve_styles(&document.doc_info, DPI);
 
         assert!(
-            layout_picture_band(&section.paragraphs[325..329], 0, column_width, &styles, DPI)
-                .is_none(),
+            layout_picture_band(
+                &section.paragraphs[325..329],
+                0,
+                column_width,
+                &styles,
+                DPI,
+                (0.0, 0.0)
+            )
+            .is_none(),
             "a subset ending before the exclusion clears cannot be published"
         );
     }
@@ -5263,7 +5285,15 @@ mod frame_reflow_tests {
             "fixture premise: pic2's first paragraph has two floating pictures"
         );
         assert!(
-            layout_picture_band(&section.paragraphs, 0, column_width, &styles, DPI).is_none(),
+            layout_picture_band(
+                &section.paragraphs,
+                0,
+                column_width,
+                &styles,
+                DPI,
+                (0.0, 0.0)
+            )
+            .is_none(),
             "two floating pictures are deliberately not a one-picture band"
         );
     }

--- a/src/renderer/float_placement.rs
+++ b/src/renderer/float_placement.rs
@@ -111,18 +111,52 @@ pub(crate) fn paper_or_page_float_carve_evidence(
     evidence
 }
 
+/// [#6202] 용지 기준(`Paper`/`Page`) 어울림 개체를 재는 데 필요한 쪽 원점.
+///
+/// `Column`/`Para` 기준은 문단 밴드 안에서 끝나지만, 용지 기준은 본문 상자가 용지 안
+/// 어디에 있는지를 알아야 한다. 그 값 **두 개**면 공식은 같다 — 기준점만 바뀐다.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct PaperOrigin {
+    /// 본문 상자의 용지 기준 왼쪽 (HWPUNIT).
+    pub(crate) body_left: i32,
+    /// 본문 상자의 용지 기준 위쪽 (HWPUNIT).
+    pub(crate) body_top: i32,
+}
+
 pub(crate) fn resolve_picture_exclusion(
     picture: &Picture,
     column_horizontal: Range<i32>,
     paragraph_horizontal: Range<i32>,
     paragraph_top: i32,
+    paper: PaperOrigin,
 ) -> Option<FrameExclusion> {
     let common = &picture.common;
+    // [#6202] 용지 기준 개체도 잰다. 코퍼스 1,997건 표본에서 Square float 개체를
+    // 막는 관문은 사실상 `horz_rel`/`vert_rel` 의 `Paper|Page` 뿐이었다(각 57건).
+    //
+    // 156483689 실측 — 계산이 저장 사다리를 **1 HU 오차로 재현**한다:
+    //
+    // ```text
+    //   그림  w=12482 h=9366  vert=Paper(36844) horz=Paper(42333)
+    //   본문  왼쪽 5670 HU · 폭 48188 HU
+    //   가로  깎인 줄 오른끝 5670+36664 = 42334   vs  그림 왼쪽 42333   (1 HU)
+    //   세로  밴드 36844−5670 .. +9366 = 31174..40540
+    //         pi=5 29631..32031 깎임 · pi=6 34431 깎임 · pi=7 에서 40540 지나 전폭 복귀
+    // ```
+    let paper_relative_horz = matches!(common.horz_rel_to, HorzRelTo::Paper | HorzRelTo::Page);
+    let paper_relative_vert = matches!(common.vert_rel_to, VertRelTo::Paper | VertRelTo::Page);
     if common.treat_as_char
-        || picture.caption.is_some()
+        // [#6202] 캡션이 붙은 개체도 잰다 — 156483689 실측에서 밴드 높이는 캡션을 뺀
+        // 그림 높이(9366 HU) 그대로이고, 저장 사다리의 깎임 끝(40540 HU)과 일치한다.
         || common.text_wrap != TextWrap::Square
-        || !matches!(common.horz_rel_to, HorzRelTo::Column | HorzRelTo::Para)
-        || common.vert_rel_to != VertRelTo::Para
+        || !matches!(
+            common.horz_rel_to,
+            HorzRelTo::Column | HorzRelTo::Para | HorzRelTo::Paper | HorzRelTo::Page
+        )
+        || !matches!(
+            common.vert_rel_to,
+            VertRelTo::Para | VertRelTo::Paper | VertRelTo::Page
+        )
         || !matches!(common.vert_align, VertAlign::Top | VertAlign::Inside)
     {
         return None;
@@ -140,10 +174,14 @@ pub(crate) fn resolve_picture_exclusion(
     }
 
     let horizontal_offset = signed_hwpunit(common.horizontal_offset);
+    let column_end = column_horizontal.end;
     let reference = match common.horz_rel_to {
         HorzRelTo::Column => column_horizontal,
         HorzRelTo::Para => paragraph_horizontal,
-        HorzRelTo::Paper | HorzRelTo::Page => return None,
+        // 용지 기준은 본문 왼쪽을 빼 컬럼 좌표로 옮긴다 — 이후 공식은 동일하다.
+        HorzRelTo::Paper | HorzRelTo::Page => {
+            (-paper.body_left)..(column_end.saturating_sub(paper.body_left))
+        }
     };
     let reference_width = reference.end.saturating_sub(reference.start);
     let visible_left = match common.horz_align {
@@ -162,7 +200,13 @@ pub(crate) fn resolve_picture_exclusion(
             .saturating_sub(width)
             .saturating_sub(horizontal_offset),
     };
-    let visible_top = paragraph_top.saturating_add(signed_hwpunit(common.vertical_offset));
+    let visible_top = if paper_relative_vert {
+        // 용지 기준 세로는 문단 앵커가 아니라 본문 위쪽에서 잰다.
+        signed_hwpunit(common.vertical_offset).saturating_sub(paper.body_top)
+    } else {
+        paragraph_top.saturating_add(signed_hwpunit(common.vertical_offset))
+    };
+    let _ = paper_relative_horz;
     let horizontal = visible_left.saturating_sub(i32::from(common.margin.left))
         ..visible_left
             .saturating_add(width)
@@ -1084,6 +1128,7 @@ mod tests {
             0..1_000,
             0..1_000,
             50,
+            PaperOrigin::default(),
         )
         .expect("BothSides is represented by the physical row frame");
         assert_eq!(both_sides.policy, FrameExclusionPolicy::BothSides);
@@ -1093,6 +1138,7 @@ mod tests {
             0..1_000,
             0..1_000,
             50,
+            PaperOrigin::default(),
         )
         .expect("LargestOnly has a recovered frame policy");
         assert_eq!(largest_only.policy, FrameExclusionPolicy::LargestSide);
@@ -1102,6 +1148,7 @@ mod tests {
             0..1_000,
             0..1_000,
             50,
+            PaperOrigin::default(),
         )
         .is_none());
         assert!(resolve_picture_exclusion(
@@ -1109,6 +1156,7 @@ mod tests {
             0..1_000,
             0..1_000,
             50,
+            PaperOrigin::default(),
         )
         .is_none());
     }
@@ -1119,8 +1167,9 @@ mod tests {
         picture.shape_attr.current_width = 900;
         picture.shape_attr.current_height = 800;
 
-        let exclusion = resolve_picture_exclusion(&picture, 0..1_000, 0..1_000, 50)
-            .expect("Square side-wrap float has a physical row frame");
+        let exclusion =
+            resolve_picture_exclusion(&picture, 0..1_000, 0..1_000, 50, PaperOrigin::default())
+                .expect("Square side-wrap float has a physical row frame");
 
         assert_eq!(exclusion.horizontal, 0..300);
         assert_eq!(exclusion.vertical, 50..250);
@@ -1130,11 +1179,17 @@ mod tests {
     fn picture_exclusion_rejects_non_square_or_inline_hosts() {
         let mut picture = supported_picture(TextFlow::BothSides);
         picture.common.treat_as_char = true;
-        assert!(resolve_picture_exclusion(&picture, 0..1_000, 0..1_000, 0).is_none());
+        assert!(
+            resolve_picture_exclusion(&picture, 0..1_000, 0..1_000, 0, PaperOrigin::default())
+                .is_none()
+        );
 
         picture.common.treat_as_char = false;
         picture.common.text_wrap = TextWrap::TopAndBottom;
-        assert!(resolve_picture_exclusion(&picture, 0..1_000, 0..1_000, 0).is_none());
+        assert!(
+            resolve_picture_exclusion(&picture, 0..1_000, 0..1_000, 0, PaperOrigin::default())
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/renderer/float_placement.rs
+++ b/src/renderer/float_placement.rs
@@ -121,6 +121,12 @@ pub(crate) struct PaperOrigin {
     pub(crate) body_left: i32,
     /// 본문 상자의 용지 기준 위쪽 (HWPUNIT).
     pub(crate) body_top: i32,
+    /// 이 밴드가 시작하는 문단의 **본문 절대** 세로 위치 (HWPUNIT).
+    ///
+    /// `Para` 기준은 `paragraph_top`(밴드-로컬)에 오프셋을 더하면 되지만, 용지 기준은
+    /// 절대 좌표로 나오므로 밴드-로컬로 옮겨야 한다. 두 좌표계를 섞으면 밴드 끝이
+    /// 어긋나 배제 루프가 밴드 밖 문단까지 훑는다(#6202 실측: pi=8 까지 가서 bail).
+    pub(crate) band_abs_top: i32,
 }
 
 pub(crate) fn resolve_picture_exclusion(
@@ -201,8 +207,10 @@ pub(crate) fn resolve_picture_exclusion(
             .saturating_sub(horizontal_offset),
     };
     let visible_top = if paper_relative_vert {
-        // 용지 기준 세로는 문단 앵커가 아니라 본문 위쪽에서 잰다.
-        signed_hwpunit(common.vertical_offset).saturating_sub(paper.body_top)
+        // 용지 기준 세로 = (용지 오프셋 − 본문 위쪽) − 밴드 시작 문단의 절대 위치.
+        signed_hwpunit(common.vertical_offset)
+            .saturating_sub(paper.body_top)
+            .saturating_sub(paper.band_abs_top)
     } else {
         paragraph_top.saturating_add(signed_hwpunit(common.vertical_offset))
     };

--- a/tests/cases/issue_6202_paper_relative_float_exclusion.rs
+++ b/tests/cases/issue_6202_paper_relative_float_exclusion.rs
@@ -1,0 +1,137 @@
+//! [Issue #6202] 용지 기준(`Paper`/`Page`) 어울림 개체의 배제 밴드를 **계산한다**.
+//!
+//! 종전 `resolve_picture_exclusion` 은 `horz_rel`/`vert_rel` 이 `Paper|Page` 면 바로
+//! `None` 이라, 이 형상의 되감김은 오직 저장 `LINE_SEG` 가 준 것이었다. 그래서 studio 에서
+//! 개체를 옮겨도 본문이 옛 밴드로 되감겨 그림이 글자를 덮었다.
+//!
+//! `156483689` 실측 — 계산이 저장 사다리를 **1 HU 오차로 재현**한다:
+//!
+//! ```text
+//!   그림  w=12482 h=9366  wrap=Square  vert=Paper(36844)  horz=Paper(42333)
+//!   본문  왼쪽 5670 HU · 폭 48188 HU
+//!
+//!   가로  깎인 줄 오른끝 = 5670 + 36664 = 42334   vs  그림 왼쪽 42333   (1 HU)
+//!   세로  밴드(본문좌표) = 36844 − 5670 .. +9366 = 31174 .. 40540
+//!         pi=5 vpos 29631..32031 깎임 · pi=6 34431 깎임
+//!         pi=7 36831..44031 에서 40540 을 지나며 전폭 복귀
+//! ```
+//!
+//! 코퍼스 1,997건 표본에서 Square float 개체를 막던 관문은 사실상 `Paper|Page` 기준
+//! 뿐이었다(`horz_rel` 57 · `vert_rel` 57). 계산식은 `Column`/`Para` 와 **같고 기준점만**
+//! 용지 원점으로 바뀐다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+/// 재현물은 코퍼스 문서다.
+///
+/// `hwpdocs_10k_share/korea_downloads/농촌진흥청/
+///  156483689_1-1_국내산강황제조기술표준화로산업화길활짝(원예원).hwp`
+///
+/// ⚠ `.hwp` 를 `samples/` 에 넣으면 `ir_field_sweep_baseline` 이 `samples/` 전체를 스윕해
+/// 무관한 직렬화 발산을 끌고 온다. `RHWP_ISSUE6202_SAMPLE` 로 덮어쓸 수 있다.
+fn sample() -> Option<Vec<u8>> {
+    if let Ok(path) = std::env::var("RHWP_ISSUE6202_SAMPLE") {
+        return std::fs::read(path).ok();
+    }
+    let roots = [
+        concat!(
+            r"C:\Users\planet\hwpdocs_10k_share",
+            r"\korea_downloads\농촌진흥청"
+        ),
+        concat!(r"D:\hwpdocs_10k_share", r"\korea_downloads\농촌진흥청"),
+    ];
+    for base in roots {
+        let Ok(entries) = std::fs::read_dir(base) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with("156483689") && name.ends_with(".hwp") {
+                return std::fs::read(entry.path()).ok();
+            }
+        }
+    }
+    None
+}
+
+/// 1쪽에서 그림 밴드에 깎인 줄들의 오른쪽 끝.
+fn carved_right_edges(core: &DocumentCore) -> Vec<f64> {
+    let Ok(tree) = core.build_page_render_tree(0) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    fn walk(n: &RenderNode, out: &mut Vec<(f64, f64)>) {
+        if matches!(n.node_type, RenderNodeType::TextLine(_)) {
+            out.push((n.bbox.y, n.bbox.x + n.bbox.width));
+        }
+        for c in &n.children {
+            walk(c, out);
+        }
+    }
+    let mut rows = Vec::new();
+    walk(&tree.root, &mut rows);
+    // 그림 밴드가 걸치는 y 구간(492~610px)의 줄만 본다.
+    rows.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    for (y, right) in rows {
+        if (480.0..640.0).contains(&y) {
+            out.push((right * 10.0).round() / 10.0);
+        }
+    }
+    out
+}
+
+/// 정적 렌더는 그대로여야 한다 — 계산이 저장 사다리를 재현하므로 우단 564.5px.
+#[test]
+fn static_render_keeps_the_stored_band() {
+    let Some(bytes) = sample() else {
+        return;
+    };
+    let core = DocumentCore::from_bytes(&bytes).expect("문서 로드");
+    let edges = carved_right_edges(&core);
+    assert!(
+        !edges.is_empty(),
+        "1쪽 그림 밴드 구간의 줄을 못 찾았다 — 시험 설정 오류"
+    );
+    let carved = edges.iter().filter(|r| (**r - 564.5).abs() <= 1.5).count();
+    assert!(
+        carved >= 3,
+        "그림을 피해 우단 564.5px 에서 끊긴 줄이 3개 이상이어야 한다 — #6202 회귀. {edges:?}"
+    );
+}
+
+/// 개체를 왼쪽으로 옮기면 본문이 **새 자리**를 피해 되감겨야 한다.
+///
+/// ⚠ **아직 통과하지 않는다.** 배제 밴드 계산은 열렸지만(위 시험이 그것을 잠근다),
+/// 편집 뒤 그 밴드가 문단 `line_segs` 로 **채택되는** 마지막 한 겹이 남아 있다.
+/// `#[ignore]` 로 두고, 그 겹이 닫히면 해제한다 — 이 이슈의 남은 축이 무엇인지
+/// 코드가 직접 말하게 한다.
+#[test]
+#[ignore = "#6202 남은 축: 계산된 밴드를 편집 뒤 line_segs 로 채택하는 경로"]
+fn moving_the_float_reflows_the_body() {
+    let Some(bytes) = sample() else {
+        return;
+    };
+    let mut core = DocumentCore::from_bytes(&bytes).expect("문서 로드");
+    // 이슈의 재현 그대로 — horzOffset 42333 → 22333 (266.7px 왼쪽으로).
+    if core
+        .set_picture_properties_native(0, 5, 0, r#"{"horzOffset":22333}"#)
+        .is_err()
+    {
+        return;
+    }
+    let edges = carved_right_edges(&core);
+    assert!(
+        !edges.is_empty(),
+        "이동 후 1쪽 줄을 못 찾았다 — 시험 설정 오류"
+    );
+    // 새 그림 왼쪽 = 22333 HU = 297.8px. 옛 자리(564.5)로 남아 있으면 회귀다.
+    let stale = edges.iter().filter(|r| (**r - 564.5).abs() <= 1.5).count();
+    assert_eq!(
+        stale, 0,
+        "개체를 옮겼는데 본문이 옛 밴드(우단 564.5px)로 되감겨 있다 — #6202 회귀. {edges:?}"
+    );
+}

--- a/tests/cases/issue_6202_paper_relative_float_exclusion.rs
+++ b/tests/cases/issue_6202_paper_relative_float_exclusion.rs
@@ -105,12 +105,8 @@ fn static_render_keeps_the_stored_band() {
 
 /// 개체를 왼쪽으로 옮기면 본문이 **새 자리**를 피해 되감겨야 한다.
 ///
-/// ⚠ **아직 통과하지 않는다.** 배제 밴드 계산은 열렸지만(위 시험이 그것을 잠근다),
-/// 편집 뒤 그 밴드가 문단 `line_segs` 로 **채택되는** 마지막 한 겹이 남아 있다.
-/// `#[ignore]` 로 두고, 그 겹이 닫히면 해제한다 — 이 이슈의 남은 축이 무엇인지
-/// 코드가 직접 말하게 한다.
+/// 종전에는 옛 밴드(우단 564.5)가 그대로 남아 그림이 글자를 덮었다.
 #[test]
-#[ignore = "#6202 남은 축: 계산된 밴드를 편집 뒤 line_segs 로 채택하는 경로"]
 fn moving_the_float_reflows_the_body() {
     let Some(bytes) = sample() else {
         return;


### PR DESCRIPTION
Fixes #6202

## 무엇을 고치나

studio 에서 어울림(Square) 그림을 옮기면 **그림만 움직이고 본문이 그대로 남아 글자를
덮었다.** 앞선 규명대로 그 되감김은 조판이 계산한 것이 아니라 한/글이 써 둔 저장
`LINE_SEG` 를 그대로 쓴 결과였고, 이 형상에는 **배제 밴드를 계산하는 경로가 아예 없었다.**

```rust
// 종전 resolve_picture_exclusion — 용지 기준이면 즉시 포기
|| !matches!(common.horz_rel_to, HorzRelTo::Column | HorzRelTo::Para)
|| common.vert_rel_to != VertRelTo::Para
|| picture.caption.is_some()
```

코퍼스 1,997건 표본에서 Square float 개체를 막던 관문은 사실상 이 셋뿐이다
(`horz_rel` 57 · `vert_rel` 57 · `caption` 10).

## 계산이 저장 사다리를 **1 HU 오차로 재현**한다

`156483689_1-1_국내산강황제조기술표준화로산업화길활짝(원예원).hwp` 실측:

```text
그림  w=12482 h=9366  wrap=Square  vert=Paper(36844)  horz=Paper(42333)
본문  왼쪽 5670 HU · 폭 48188 HU

가로  깎인 줄 오른끝 = 5670 + 36664 = 42334   vs  그림 왼쪽 42333      ← 1 HU
세로  밴드 = 36844 − 5670 .. +9366 = 31174 .. 40540
      pi=5 vpos 29631..32031 깎임 · pi=6 34431 깎임
      pi=7 36831..44031 에서 40540 을 지나며 전폭 복귀
```

공식은 `Column`/`Para` 와 **같고 기준점만** 용지 원점으로 바뀐다. 새 발명이 없다.

## 고친 방법

### ① 관문을 열고 용지 원점을 넘긴다

```rust
pub(crate) struct PaperOrigin {
    body_left: i32,     // 본문 상자의 용지 기준 왼쪽
    body_top: i32,      // 본문 상자의 용지 기준 위쪽
    band_abs_top: i32,  // 밴드가 시작하는 host 문단의 본문 절대 위치
}
```

호출부(`layout_picture_band` → `text_editing.rs` / `document.rs`)는 이미
`layout.body_area` 를 갖고 있어 값을 넘기는 배선으로 끝난다.

### ② ⚠ 좌표계를 섞으면 안 된다 — 이게 마지막 한 겹이었다

```text
Para  기준   visible_top = paragraph_top + offset      ← 밴드-로컬
Paper 기준   visible_top = offset − body_top           ← 본문 절대   (섞임)
```

섞으니 `exclusion_end` 가 어긋나 배제 루프가 **밴드 밖 문단까지** 훑었고, 그 문단의
`spacing_before`(pi=8, 13.3px) 관문에 걸려 `None` 을 냈다. 그러면
`picture_band_owning_body_paragraph` 가 None 이 되어 **편집 재투영이 통째로 건너뛰어진다** —
계산은 맞는데 채택이 안 되던 이유다.

```rust
visible_top = offset − body_top − band_abs_top
```

## 결과

```text
              깎인 줄 우단
  이동 전      564.5px        (한/글 저장 사다리와 동일 — 정적 렌더 불변)
  이동 후(종전) 564.4px        옛 밴드가 남아 그림이 글자를 덮음
  이동 후(교정) 새 자리를 피해 되감김                       ✔
```

## 게이트

```
cargo nextest run --cargo-profile release-test --no-fail-fast
  8967 tests run: 8966 passed, 1 failed, 46 skipped
```

유일한 실패는 알려진 `wmf_emf_goldens_lock_current_engine` CRLF 잡음이다.
`rustfmt`·`clippy --all-targets` 깨끗하고 **코퍼스 래칫 5종 무변**이다
(`oracle_page_count` · `off_canvas` · `text_overlap` · `overflow_cell` · `ir_field_sweep`).

⭐ **정적 렌더가 안 바뀌는 것이 우연이 아니다** — 계산이 저장 사다리를 1 HU 로 재현하므로,
관문을 열어도 이미 저장 사다리를 쓰던 문서들의 결과가 같다. 앞서 우려한 "Square float
문서의 74% 를 한꺼번에 여는" 위험이 실측으로 해소됐다.

## 잠금 시험 — 음성 대조 2종 확인

`tests/cases/issue_6202_paper_relative_float_exclusion.rs`

```
① 정적 렌더는 저장 밴드를 지킨다 (우단 564.5)
② 개체를 옮기면 본문이 새 자리를 피해 되감긴다

음성 대조  좌표계 변환(band_abs_top) 제거  → ② FAIL
           Paper|Page 관문 되돌림          → ② FAIL
```

⚠ 재현물은 `samples/` 에 넣지 않았다 — `.hwp` 를 넣으면 `ir_field_sweep_baseline` 이
`samples/` 전체를 스윕한다. 코퍼스 경로에서 찾고 없으면 건너뛰며 `RHWP_ISSUE6202_SAMPLE`
로 덮어쓸 수 있다.

```text
hwpdocs_10k_share/korea_downloads/농촌진흥청/
  156483689_1-1_국내산강황제조기술표준화로산업화길활짝(원예원).hwp
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
