### PR TITLE
ci: stabilize frontend package gate installs (#6717)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1302,8 +1302,8 @@ jobs:
   frontend-package-gates:
     name: Frontend package gates
     runs-on: ubuntu-latest
-    # [#3284] 러너 hang 을 실패로 드러내는 상한 (성능 목표 아님) — 실험 종료 후에도 유지
-    timeout-minutes: 20
+    # [#6717] 직렬 package 설치가 지연돼도 회귀 gate를 실행할 여유를 두되 hang은 실패로 드러낸다.
+    timeout-minutes: 30
     # [#3268] Frontend는 Lint의 산출물을 읽지 않고 독립 runner에서 별도 target/cache를 쓴다.
     # preflight의 fast-pass·영향 판정만 기다려 Lint와 병렬 시작한다. Lint 실패 시 Frontend가
     # 끝날 수는 있지만 Native/archive는 아래 두 worker의 성공을 모두 계속 요구한다.
@@ -1352,10 +1352,10 @@ jobs:
 
       - name: Install frontend package dependencies
         run: |
-          npm --prefix rhwp-studio ci
-          npm --prefix rhwp-chrome ci
-          npm --prefix rhwp-firefox ci
-          npm --prefix rhwp-vscode ci
+          npm --prefix rhwp-studio ci --no-audit --prefer-offline
+          npm --prefix rhwp-chrome ci --no-audit --prefer-offline
+          npm --prefix rhwp-firefox ci --no-audit --prefer-offline
+          npm --prefix rhwp-vscode ci --no-audit --prefer-offline
 
       - name: Verify WASM bindings and editor embed contract
         run: node --test scripts/frontend-wasm-bindings.test.mjs scripts/frontend-editor-embed.test.mjs

--- a/mydocs/orders/20260904.md
+++ b/mydocs/orders/20260904.md
@@ -1,5 +1,13 @@
 # 2026-09-04
 
+## #6717 Frontend package gates install timeout stabilization
+
+- PR #6715의 exact-head full CI에서 네 package의 직렬 `npm ci`가 두 번 연속 20분 job 상한을
+  잠식한 원인을 [#6717](https://github.com/edwardkim/rhwp/issues/6717)로 등록했다.
+- 제품 source·lockfile은 건드리지 않고 install의 자동 audit 호출 제거, npm cache 우선 사용,
+  30분 hang 상한과 workflow 계약 테스트를 한 O3 운영 변경으로 처리한다.
+- #6717을 `devel`에 먼저 통합한 뒤 PR #6715를 최신 base와 정합시켜 exact-head CI를 재검증한다.
+
 ## #6711 mydocs monthly archive governance
 
 - [#6711](https://github.com/edwardkim/rhwp/issues/6711)을 등록하고 메인테이너에게 할당했다.

--- a/mydocs/orders/20260904.md
+++ b/mydocs/orders/20260904.md
@@ -6,6 +6,12 @@
   잠식한 원인을 [#6717](https://github.com/edwardkim/rhwp/issues/6717)로 등록했다.
 - 제품 source·lockfile은 건드리지 않고 install의 자동 audit 호출 제거, npm cache 우선 사용,
   30분 hang 상한과 workflow 계약 테스트를 한 O3 운영 변경으로 처리한다.
+- [PR #6720](https://github.com/edwardkim/rhwp/pull/6720)의 code candidate
+  `8702ac8fcc392f8320824b555d252c62c05b6f2e`는 Full CI와 CodeQL을 통과했다. Frontend package
+  job은 6분 52초, install은 14초였고 후속 브라우저·build gate도 전부 실행됐다.
+- self-review에서 범위 누출이나 blocker는 발견되지 않아 [승인 판정](../pr/archives/pr_6720_review.md)을
+  남겼다. review-only trailing head는 trusted controller의 A.1 증명과 최신 required check를 다시
+  확인한 뒤 별도 merge 승인을 받는다.
 - #6717을 `devel`에 먼저 통합한 뒤 PR #6715를 최신 base와 정합시켜 exact-head CI를 재검증한다.
 
 ## #6711 mydocs monthly archive governance

--- a/mydocs/plans/task_m100_6717.md
+++ b/mydocs/plans/task_m100_6717.md
@@ -1,0 +1,82 @@
+---
+kind: plan
+status: active
+canonical: mydocs/plans/task_m100_6717.md
+issue: 6717
+last_verified: 2026-09-04
+---
+
+# #6717 Frontend package gates 설치 지연 정상화 수행계획
+
+## 1. 목적과 기준선
+
+- **이슈**: [#6717](https://github.com/edwardkim/rhwp/issues/6717)
+- **브랜치**: `task_m100_6717_frontend_package_timeout`
+- **기준선**: `upstream/devel@009e30fe1f6812b046862589783c68f890b4d363`
+- **운영 분류**: O3 실행 계약 변경
+- **필수 check 이름**: `Build & Test` 유지
+
+PR #6715의 review-only trailing head에서 대량 rename의 commit file 목록이 GitHub API 상한에
+걸려 full lane이 fail-closed로 선택됐다. 이 full lane의 `Frontend package gates`는 네 package의
+`npm ci`를 직렬 실행한 뒤 브라우저·build 검증을 수행하지만 job 전체 상한은 20분이다.
+
+[run 33841590294](https://github.com/edwardkim/rhwp/actions/runs/33841590294)는 같은 head에서
+두 번 연속 이 상한에 도달했다. attempt 1은 dependency 설치 도중 20분 15초에 취소됐고,
+attempt 2는 네 설치가 약 7분, 4분, 3분, 3분 걸린 뒤 undo depth gate 도중 20분 16초에
+취소됐다. 반면 같은 source candidate의
+[정상 run 33837538073](https://github.com/edwardkim/rhwp/actions/runs/33837538073)에서는 네 설치가
+약 28초, 46초, 35초, 4분에 끝나 job이 12분 37초에 성공했다. package lock이나 제품 source의
+변화가 아니라 registry·advisory 응답 변동이 직렬 설치 시간을 잠식하는 운영 결함이다.
+
+## 2. 변경 결정
+
+1. `frontend-package-gates`의 네 설치를
+   `npm --prefix <package> ci --no-audit --prefer-offline`으로 실행한다.
+2. `--no-audit`은 install 중 자동 advisory 조회만 끈다. lockfile 기반 clean install, lifecycle
+   script, package test/build, CodeQL은 그대로 유지한다.
+3. `--prefer-offline`은 setup-node가 복원한 npm cache를 우선하되 cache miss 때 registry 접근을
+   허용한다. `--offline`이나 `--ignore-scripts`는 사용하지 않는다.
+4. job 상한은 20분에서 30분으로 늘린다. 이는 성공 목표가 아니라 registry 지연 뒤에도 실제
+   회귀 gate가 실행될 시간을 확보하면서 hang을 유한 시간 안에 실패시키는 상한이다.
+5. job ID `frontend-package-gates`, 표시 이름 `Frontend package gates`, aggregate와 required
+   check `Build & Test`의 연결은 바꾸지 않는다.
+
+## 3. 보호 불변식
+
+1. 제품 source, package manifest·lockfile, 공개 API를 변경하지 않는다.
+2. 네 package 모두 lockfile 기반 `npm ci`를 사용한다.
+3. WASM build, 브라우저·Studio·VS Code test/build와 aggregate 실패 전파를 생략하지 않는다.
+4. 신뢰 경계와 `contents: read` 최소 권한을 바꾸지 않는다.
+5. audit을 보안 gate처럼 묵시적으로 취급하지 않는다. 차단형 취약점 정책은 별도의 결정적
+   `npm audit` job과 실패 정책이 승인될 때만 추가한다.
+6. review-only fast-pass의 GitHub 300-file fail-closed 문제는 이번 범위에 섞지 않는다.
+
+## 4. 구현과 검증
+
+1. `.github/workflows/ci.yml`의 해당 job만 수정한다.
+2. `scripts/tests/test_ci_impact_workflow.py`에 30분 상한과 네 install option을 고정하고 required
+   check 연결을 기존 테스트가 계속 검증하게 한다.
+3. 다음 로컬 검증을 수행한다.
+
+```bash
+python3 -m unittest scripts.tests.test_ci_impact_workflow
+python3 -m unittest discover -s scripts/tests -p 'test_*workflow.py'
+git diff --check
+```
+
+4. 네 `npm ci --no-audit --prefer-offline`을 실행해 명령·lockfile 불변성을 확인한다.
+5. workflow의 frontend package test/build 명령을 비례 실행하고 결과와 시간을 기록한다.
+6. 원격 적용 뒤 최신 exact head에서 `Frontend package gates`, `Build & Test`, `CI Impact Policy`의
+   성공을 확인한다.
+
+## 5. 통합·복구 순서
+
+1. #6717 변경을 별도 PR로 `devel`에 먼저 통합한다.
+2. PR #6715 branch를 최신 `upstream/devel`과 정합시키고 exact-head CI를 다시 실행한다.
+3. #6715의 full lane이 30분 안에 완료되는지 관찰한 뒤 archive 작업의 merge 여부를 판단한다.
+4. 부작용이 확인되면 #6717 commit을 revert해 기존 명령과 20분 상한으로 복원한다.
+
+## 6. 승인 기록
+
+- 2026-09-04: 메인테이너가 원인 분석과 `--no-audit --prefer-offline`, 30분 상한, workflow
+  계약 테스트, 별도 이슈·branch에서의 정상화 계획을 승인했다.

--- a/mydocs/pr/archives/pr_6720_review.md
+++ b/mydocs/pr/archives/pr_6720_review.md
@@ -1,0 +1,133 @@
+---
+kind: pr_review
+status: approved
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-09-04
+pr: 6720
+issue: 6717
+author: edwardkim
+---
+
+# PR #6720 self-review — Frontend package gates 설치 지연 정상화
+
+## 결론
+
+**승인.** PR #6720은 네 frontend package의 직렬 `npm ci`가 network 응답 변동으로 20분 job
+예산을 잠식해 실제 회귀 gate까지 취소되던 운영 결함을 제한된 O3 변경으로 정상화한다.
+
+code candidate `8702ac8fcc392f8320824b555d252c62c05b6f2e`를 재검토한 결과 변경은
+`frontend-package-gates`의 install option·timeout과 이를 고정하는 계약 테스트에 한정됐다.
+required check 이름, job ID·권한·실행 단계·실패 전파는 유지됐고 제품 source·manifest·lockfile은
+바뀌지 않았다. 로컬 검증과 exact candidate의 Full CI·CodeQL은 모두 성공했으며 blocker나 범위
+누출은 발견하지 않았다.
+
+이 문서의 승인은 작성자 self-review 판정이며 GitHub approve event가 아니다. 자기 PR이므로 reviewer를
+지정하지 않는다. 이 review와 오늘 기록만 추가한 trailing head는 workflow 변경 PR이므로 자체
+preflight만 신뢰하지 않고 trusted controller의 review-only A.1 증명과 최신 required check를 다시
+확인해야 한다. merge는 별도 메인테이너 승인 뒤에만 수행한다.
+
+## 라우팅과 메타데이터
+
+- 기본 경로: `collaborator_self_merge.md`
+- 보조 경로: `intake_and_review.md`, `local_validation.md`, `review_only_fast_pass.md`
+- loaded documents: `pr_review_workflow.md`, `pr_review/README.md`와 위 자식 문서
+- `review_impl`은 추가하지 않는다. [수행계획](../../plans/task_m100_6717.md)과
+  [Stage 1 기록](../../working/task_m100_6717_stage1.md)이 원인·구현·검증·rollback 순서를 고정한다.
+
+| 항목 | 값 |
+| --- | --- |
+| PR / 작성자 | [#6720](https://github.com/edwardkim/rhwp/pull/6720) / @edwardkim |
+| 관련 이슈 | [#6717](https://github.com/edwardkim/rhwp/issues/6717) (`Closes #6717`) |
+| base | `devel@009e30fe1f6812b046862589783c68f890b4d363` |
+| code candidate | `8702ac8fcc392f8320824b555d252c62c05b6f2e` |
+| 규모 | 5 files, `+228/-6`, 1 commit |
+| 작성 시점 GitHub 상태 | Open, 비 Draft, `MERGEABLE`·`CLEAN`; candidate check 전부 완료 |
+| reviewer | self PR이므로 지정하지 않음 |
+
+최신 fetch에서 `upstream/devel`은 candidate의 직접 조상이었고 divergence는 `1/0`이었다.
+`git merge-tree --write-tree upstream/devel HEAD`의 결과 tree는 candidate tree와 같았으며
+merge tree의 `git diff --check`도 통과했다.
+
+## 변경 범위 검토
+
+### workflow 실행 계약
+
+- 네 install 명령은 Studio, Chrome, Firefox, VS Code 순서를 유지하면서 각각
+  `npm ci --no-audit --prefer-offline`을 사용한다.
+- `--no-audit`은 install 중 자동 advisory 조회만 끈다. lockfile clean install, lifecycle script,
+  package test/build와 CodeQL은 그대로다.
+- `--prefer-offline`은 cache를 우선하지만 cache miss의 network 접근을 허용한다. 완전 offline이나
+  `--ignore-scripts`를 사용하지 않는다.
+- timeout은 20분에서 30분으로 늘었다. 지연 뒤 회귀 gate가 실행될 여유를 주되 hang은 여전히 유한
+  시간 안에 실패한다.
+- `frontend-package-gates`, `Frontend package gates`, `contents: read`, `Build & Test` aggregate
+  연결과 후속 gate의 실행 순서는 바뀌지 않았다.
+
+### 계약 테스트
+
+새 테스트는 package job의 30분 상한과 install step의 정확한 네 명령·순서를 단언한다. 또한
+`--offline`과 `--ignore-scripts`의 도입을 거부한다. 단순 문자열 하나의 존재만 확인하지 않고 install
+명령 집합 전체를 비교하므로 package 누락·중복과 option 이탈을 함께 탐지한다.
+
+문서 3개는 #6717의 원인·보안 경계·검증·후속 #6715 복구 순서를 기록한다. renderer, HWP/HWPX/PDF,
+sample·golden·fixture 변경이 없으므로 시각 검증은 비대상이다.
+
+## 로컬 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| PyYAML workflow parse | 통과 |
+| `python3 -m unittest scripts.tests.test_ci_impact_workflow` | 34건 통과 |
+| `python3 -m unittest discover -s scripts/tests -p 'test_*workflow.py'` | 152건 통과 |
+| 네 `npm ci --no-audit --prefer-offline` | 6.05초, 2.16초, 0.95초, 2.71초; 전부 성공 |
+| 표준 Docker WASM build | 성공, 전체 453.59초 |
+| frontend 계약·unit·build 묶음 | 전부 성공, 전체 22.21초 |
+| Markdown 상대 링크 | 오류 0 |
+| `git diff --check`와 merge tree 검사 | 통과 |
+| package manifest·lockfile 변경 | 0 |
+
+새 worktree의 첫 WASM binding 검사는 `pkg/rhwp.d.ts`가 없어 `ENOENT`로 중단됐다. CI와 같은 선행조건인
+Docker WASM build를 완료한 뒤 전체 frontend 묶음을 처음부터 재실행해 모두 통과했다. 이 최초 실패를
+제품 회귀나 최종 통과로 오인하지 않았다.
+
+호스트에 `actionlint`가 없어 PyYAML과 repository workflow 계약 suite를 사용했다. metadata 검사의
+기존 16건은 diff 밖의 네 historical 파일에서 재현됐고 해당 파일은 `upstream/devel`과 차이가 없으므로
+신규 오류가 아니다. Rust source·test가 없어 Cargo lint 묶음은 로컬 변경 범위에서 비대상이다.
+
+## exact candidate GitHub Actions
+
+| 검증 | 결과 |
+| --- | --- |
+| [CI run 33846409061](https://github.com/edwardkim/rhwp/actions/runs/33846409061) | Full CI 성공, `Build & Test` 성공 |
+| `Frontend package gates` | 6분 52초 성공; install 14초 |
+| undo depth / responsive gate | 1분 53초 / 1분 44초 성공 |
+| Studio·Chrome·Firefox·VS Code build | 모두 실제 실행 후 성공 |
+| [CodeQL 33846409056](https://github.com/edwardkim/rhwp/actions/runs/33846409056) | Rust, Python, JavaScript/TypeScript 성공 |
+| [Adapter 33846409173](https://github.com/edwardkim/rhwp/actions/runs/33846409173) | 성공 |
+| [Proptest 33846409068](https://github.com/edwardkim/rhwp/actions/runs/33846409068) | 성공 |
+| [CI Impact Policy](https://github.com/edwardkim/rhwp/actions/runs/33847557964) | 성공 |
+
+이 한 번의 녹색 run은 registry·runner 지연의 재발 가능성을 제거하지 않는다. 다만 수정된 install 명령이
+실행되고, 이전 attempt 2에서 취소됐던 undo gate와 그 이후 모든 build까지 30분 안에 이어졌다는 적용
+증거다.
+
+## 잔여 위험과 rollback
+
+- 실제 network hang이면 실패 감지 상한이 최대 10분 늘어난다. 30분은 성능 목표가 아니라 hang
+  상한이며 무제한 대기를 허용하지 않는다.
+- 네 package의 직렬 설치 구조 자체는 유지된다. 이번 범위는 registry 변동의 비용을 줄이고 후속 gate
+  예산을 확보하는 최소 정정이며, 병렬화·package 통합은 측정 근거가 생길 때 별도 판단한다.
+- 자동 audit 요약을 제거했지만 기존에도 취약점 발견 시 실패시키는 독립 gate는 아니었다. 차단형 정책은
+  별도 `npm audit` job·severity·예외·실패 계약을 승인받아야 한다.
+- 회귀가 확인되면 #6717 commit을 revert해 기존 install과 20분 상한으로 복원할 수 있다.
+
+## 최종 판정과 다음 조건
+
+- 판정: **승인**
+- 판정 대상: code candidate `8702ac8fcc392f8320824b555d252c62c05b6f2e`
+- trailing 조건: 이 review, Stage 1 현행화와 오늘 기록만 추가한 최신 head에서 trusted controller의
+  A.1 증명, required check 전부 성공, `MERGEABLE`·`CLEAN` 재확인
+- merge 조건: 최신 head SHA 고정과 메인테이너의 별도 merge 승인
+- GitHub review: self PR이므로 approve event와 reviewer 지정 없음
+- merge 뒤: #6717 상태와 `devel` 반영을 확인한 뒤 PR #6715 branch를 최신 `devel`과 정합시켜
+  exact-head full lane을 다시 실행한다.

--- a/mydocs/working/task_m100_6717_stage1.md
+++ b/mydocs/working/task_m100_6717_stage1.md
@@ -1,0 +1,109 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/task_m100_6717_stage1.md
+issue: 6717
+last_verified: 2026-09-04
+---
+
+# #6717 Stage 1 — Frontend package gates 설치 지연 정상화
+
+## 1. 판정
+
+**O3 workflow 구현과 로컬 검증은 완료됐다. 원격 push·PR·실제 Actions 효과 검증은 아직 수행하지
+않았다.**
+
+- 기준 branch는 `upstream/devel@009e30fe1f6812b046862589783c68f890b4d363`이며, 구현 완료 뒤
+  다시 fetch한 결과 작업 branch와 divergence는 `0/0`이다.
+- `frontend-package-gates`의 ID·표시 이름·권한·aggregate 배선은 유지했다.
+- job 상한만 20분에서 30분으로 바꾸고 네 직렬 install에
+  `--no-audit --prefer-offline`을 적용했다.
+- package manifest·lockfile·제품 source는 변경하지 않았다.
+
+## 2. 원인 경계와 변경 의미
+
+로컬 npm 11.12.1의 기본 설정은 `audit=true`, `prefer-offline=false`였다. 따라서 변경 전 네
+`npm ci`는 install마다 advisory 조회가 활성화되고 cache보다 최신 network data를 우선할 수 있었다.
+Actions 실패 로그만으로 두 옵션 중 어느 하나를 단독 원인으로 확정하지는 않는다. 확인된 직접 원인은
+네 직렬 install의 network 응답 변동이 20분 job 예산을 잠식했고, 후속 회귀 gate가 실행될 시간을
+보장하지 못했다는 것이다.
+
+`--no-audit`은 현재 차단 조건이 아닌 install 중 자동 advisory 조회를 제거하고,
+`--prefer-offline`은 setup-node npm cache를 우선하되 cache miss의 registry 접근을 허용한다.
+`--offline`과 `--ignore-scripts`는 사용하지 않아 cache miss와 lifecycle script를 숨기지 않는다.
+30분은 성공 시간 목표가 아니라 지연과 hang을 구분하는 유한 상한이다.
+
+## 3. 계약 테스트
+
+`scripts/tests/test_ci_impact_workflow.py`는 다음을 고정한다.
+
+1. package job 상한이 30분이다.
+2. install step의 npm 명령 집합과 순서가 Studio, Chrome, Firefox, VS Code의 정확히 네 줄이다.
+3. 네 명령 모두 `ci --no-audit --prefer-offline`을 사용한다.
+4. 완전 offline과 lifecycle script 생략을 사용하지 않는다.
+
+기존 계약 테스트가 package/full lane 판정, `Build & Test` aggregate 연결과 실패 전파를 계속
+검증하므로 required check 이름을 바꾸지 않았다.
+
+## 4. 로컬 검증 결과
+
+### 4.1 install 명령
+
+CI와 같은 순서로 실행한 결과는 다음과 같다.
+
+| package | elapsed | 결과 |
+| --- | ---: | --- |
+| `rhwp-studio` | 6.05초 | 성공 |
+| `rhwp-chrome` | 2.16초 | 성공 |
+| `rhwp-firefox` | 0.95초 | 성공 |
+| `rhwp-vscode` | 2.71초 | 성공 |
+
+합계는 11.87초이며 lockfile 변경은 0건이다. 이는 명령의 유효성과 local cache 경로를 확인하는
+자료이지 GitHub-hosted runner의 network 성능 보장은 아니다.
+
+### 4.2 WASM과 frontend gate
+
+새 worktree에는 `pkg/rhwp.d.ts`가 없어 첫 WASM binding 계약 검사가 `ENOENT`로 중단됐다. 이는
+CI에서 선행하는 fresh WASM build를 로컬에서 아직 하지 않은 사전조건 실패였다. 기존 checkout의
+`.env.docker` 값을 복제·출력하지 않고 작업 중에만 링크하여 다음 표준 build를 실행했으며, 종료
+trap으로 링크를 제거했다.
+
+```bash
+docker compose --env-file .env.docker run --rm wasm
+```
+
+Docker WASM build는 컨테이너 내부 6분 55초, 전체 453.59초에 성공했다. 그 뒤 다음 묶음을 처음부터
+재실행해 모두 통과했다.
+
+- WASM declaration·editor embed 계약
+- `@rhwp/editor` package test
+- shared·Chrome·Firefox service worker test와 Chrome options test
+- Studio unit test와 production build
+- Chrome·Firefox extension build와 distribution 계약
+- VS Code extension compile·outline keyboard 계약
+- font asset 계약
+
+후속 frontend 묶음의 전체 wall time은 22.21초였다. 변경하지 않은 실제 브라우저 E2E와 Actions
+runner의 30분 상한 효과는 최신 PR head의 원격 full lane에서 최종 확인한다.
+
+### 4.3 workflow·문서
+
+```text
+PyYAML workflow parse: OK
+CiImpactWorkflowTests: 34 tests, OK
+test_*workflow.py discovery: 152 tests, OK
+Markdown links: 611 docs, changed 4, OK
+git diff --check: OK
+```
+
+호스트에 `actionlint`와 Ruby가 없어 PyYAML parse와 저장소 workflow 계약 suite를 사용했다.
+metadata 검사는 기존 `mydocs/tech/**` 네 파일의 16건을 다시 보고했지만 네 파일은
+`upstream/devel`과 byte diff가 없고 이번 문서에서는 신규 오류가 발생하지 않았다.
+
+## 5. 남은 게이트
+
+1. 변경 문서 추가 뒤 link·metadata·diff 검사를 한 번 더 실행한다.
+2. 로컬 변경을 commit하고, 별도 승인 뒤 원격 push와 PR을 생성한다.
+3. 최신 exact head의 `Frontend package gates`, `Build & Test`, `CI Impact Policy` 성공과 실제 job
+   소요 시간을 확인한다.
+4. #6717이 `devel`에 반영된 뒤 PR #6715를 최신 base와 정합시켜 같은 full lane을 재검증한다.

--- a/mydocs/working/task_m100_6717_stage1.md
+++ b/mydocs/working/task_m100_6717_stage1.md
@@ -10,8 +10,8 @@ last_verified: 2026-09-04
 
 ## 1. 판정
 
-**O3 workflow 구현과 로컬 검증은 완료됐다. 원격 push·PR·실제 Actions 효과 검증은 아직 수행하지
-않았다.**
+**O3 workflow 구현·로컬 검증과 code candidate의 원격 Full CI 검증을 완료했다. self-review
+trailing 기록의 원격 검증과 merge는 아직 수행하지 않았다.**
 
 - 기준 branch는 `upstream/devel@009e30fe1f6812b046862589783c68f890b4d363`이며, 구현 완료 뒤
   다시 fetch한 결과 작업 branch와 divergence는 `0/0`이다.
@@ -19,6 +19,9 @@ last_verified: 2026-09-04
 - job 상한만 20분에서 30분으로 바꾸고 네 직렬 install에
   `--no-audit --prefer-offline`을 적용했다.
 - package manifest·lockfile·제품 source는 변경하지 않았다.
+- [PR #6720](https://github.com/edwardkim/rhwp/pull/6720)의 code candidate
+  `8702ac8fcc392f8320824b555d252c62c05b6f2e`에서 Full CI, CodeQL, CI Impact Policy,
+  Adapter inter-diff와 Proptest가 모두 성공했다.
 
 ## 2. 원인 경계와 변경 의미
 
@@ -83,8 +86,11 @@ Docker WASM build는 컨테이너 내부 6분 55초, 전체 453.59초에 성공�
 - VS Code extension compile·outline keyboard 계약
 - font asset 계약
 
-후속 frontend 묶음의 전체 wall time은 22.21초였다. 변경하지 않은 실제 브라우저 E2E와 Actions
-runner의 30분 상한 효과는 최신 PR head의 원격 full lane에서 최종 확인한다.
+후속 frontend 묶음의 전체 wall time은 22.21초였다. 이어서 PR #6720의 GitHub-hosted runner에서
+`Frontend package gates`가 6분 52초에 성공했다. install 단계는 14초였으며, 그 뒤 undo depth
+gate 1분 53초, responsive gate 1분 44초, Studio·확장·VS Code build와 계약 검사가 모두 실제로
+실행됐다. 한 번의 녹색 run은 registry 지연이 다시 발생하지 않는다는 보장은 아니지만, 새 명령과
+후속 gate의 연결 및 30분 상한 안의 정상 완료를 증명한다.
 
 ### 4.3 workflow·문서
 
@@ -102,8 +108,9 @@ metadata 검사는 기존 `mydocs/tech/**` 네 파일의 16건을 다시 보고�
 
 ## 5. 남은 게이트
 
-1. 변경 문서 추가 뒤 link·metadata·diff 검사를 한 번 더 실행한다.
-2. 로컬 변경을 commit하고, 별도 승인 뒤 원격 push와 PR을 생성한다.
-3. 최신 exact head의 `Frontend package gates`, `Build & Test`, `CI Impact Policy` 성공과 실제 job
-   소요 시간을 확인한다.
-4. #6717이 `devel`에 반영된 뒤 PR #6715를 최신 base와 정합시켜 같은 full lane을 재검증한다.
+1. self-review와 오늘 기록만 trailing commit으로 추가하고 문서 link·metadata·diff를 검사한다.
+2. 별도 승인 뒤 trailing commit을 push한다.
+3. workflow 변경 PR의 자체 preflight를 신뢰하지 않고, 기본 branch의 trusted controller가
+   code candidate의 Full CI와 review-only trailing range를 A.1 계약으로 증명했는지 확인한다.
+4. 최신 trailing head의 required check, `MERGEABLE`·`CLEAN`을 다시 확인하고 별도 merge 승인을 받는다.
+5. #6717이 `devel`에 반영된 뒤 PR #6715를 최신 base와 정합시켜 같은 full lane을 재검증한다.

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -670,6 +670,29 @@ class CiImpactWorkflowTests(unittest.TestCase):
         self.assertIn("npm --prefix rhwp-studio run test", package)
         self.assertIn("npm --prefix rhwp-studio run build", package)
 
+    def test_frontend_package_install_uses_cache_first_without_implicit_audit(self) -> None:
+        package = self._job("frontend-package-gates")
+        install = self._step("Install frontend package dependencies", package)
+
+        self.assertIn("timeout-minutes: 30", package)
+        expected_commands = [
+            f"npm --prefix {package_path} ci --no-audit --prefer-offline"
+            for package_path in (
+                "rhwp-studio",
+                "rhwp-chrome",
+                "rhwp-firefox",
+                "rhwp-vscode",
+            )
+        ]
+        actual_commands = [
+            line.strip()
+            for line in install.splitlines()
+            if line.strip().startswith("npm --prefix")
+        ]
+        self.assertEqual(expected_commands, actual_commands)
+        self.assertNotIn("--offline", install)
+        self.assertNotIn("--ignore-scripts", install)
+
     def test_rust_lint_and_archive_builder_require_rust_axis(self) -> None:
         lint = self._job("lint")
         self.assertIn("needs.preflight.outputs.rust_required == 'true'", lint)


### PR DESCRIPTION
## 변경 요약

PR #6715의 exact-head full CI에서 `Frontend package gates`가 네 package의 직렬 `npm ci` 지연으로
두 번 연속 20분 상한에 도달했습니다.

- 네 install을 `npm ci --no-audit --prefer-offline`으로 실행합니다.
- job timeout을 20분에서 30분으로 조정해 network 지연 뒤에도 실제 회귀 gate가 실행될 시간을
  확보합니다.
- install 명령의 정확한 집합·순서·옵션과 30분 상한을 workflow 계약 테스트로 고정합니다.
- job ID·표시 이름·권한과 required check `Build & Test`의 aggregate 배선은 유지합니다.

`--no-audit`은 현재 차단 정책이 아닌 install 중 자동 advisory 조회만 제거합니다. lockfile 기반
clean install, lifecycle script, CodeQL과 frontend test/build는 그대로 유지합니다.
`--prefer-offline`은 cache miss 때 registry 접근을 허용하며 `--offline`은 사용하지 않습니다.

## 관련 이슈

Closes #6717

관련: #6711, #6715

## 테스트

- [x] PyYAML로 `.github/workflows/ci.yml` parse
- [x] `python3 -m unittest scripts.tests.test_ci_impact_workflow` — 34건 성공
- [x] `python3 -m unittest discover -s scripts/tests -p 'test_*workflow.py'` — 152건 성공
- [x] 네 package의 `npm ci --no-audit --prefer-offline` — 각각 6.05초, 2.16초, 0.95초,
  2.71초, lockfile 변경 없음
- [x] `docker compose --env-file .env.docker run --rm wasm` — 표준 Docker WASM build 성공
- [x] WASM/editor 계약, service worker, Studio unit/build, Chrome·Firefox build/dist,
  VS Code compile, font asset 검사 성공
- [x] Markdown 상대 링크와 `git diff --check` 성공
- [x] Rust source·test 변경 없음 — Cargo fmt/clippy/test 비대상
- [x] integration test source·generated suite·manifest 변경 없음

호스트에 `actionlint`가 없어 저장소의 152건 workflow 계약 suite와 PyYAML parse로 구조를
검증했습니다. metadata 검사의 기존 16건은 이번 diff 밖의 변경되지 않은 네 historical 파일이며
신규 오류는 없습니다.

원격 효과 판정은 이 PR 최신 head에서 `Frontend package gates`, `Build & Test`,
`CI Impact Policy`가 성공하고 실제 회귀 단계까지 실행되는지 확인한 뒤 내립니다.

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: npm advisory network 요청 제거와 cache 우선으로 install 지연 분산 감소
- 비용: 진짜 hang의 최대 실패 감지 시간이 20분에서 30분으로 늘어남
- 재현·측정: 로컬 네 install 합계 11.87초. GitHub-hosted runner의 성능 보장은 아니며,
  실패 기준선은 run 33841590294의 20분 15초·20분 16초 timeout 두 건임
- 비교 기준: 같은 source candidate의 이전 정상 run 33837538073에서 package job은 12분 37초에 성공

## 스크린샷

사용자 인터페이스 변경이 없어 비대상입니다.
