### PR TITLE
docs: #6722 source PR 후속 comment 계획 보완

### DIFF
--- a/mydocs/pr/archives/pr_6683_review.md
+++ b/mydocs/pr/archives/pr_6683_review.md
@@ -52,3 +52,16 @@ CARGO_TARGET_DIR=target/pr-review/green-ci-batch-20260904-full \
 추가 메인터너 코드 보정은 필요하지 않다. 현재 보정의 범위가 원 PR의 회귀 계약과
 시각 증적으로 뒷받침되며, 통합 PR을 만들 경우에는 그 최신 head에서 required CI를
 다시 확인한 뒤에만 병합한다.
+
+## Merge 후 contributor PR comment 계획
+
+원 PR은 직접 merge하지 않고 [통합 PR #6722](https://github.com/edwardkim/rhwp/pull/6722)의
+체리픽 통합으로 수용한다. 병합 뒤 comment에는 merge commit
+[`4041acf`](https://github.com/edwardkim/rhwp/commit/4041acf298ffde2f02866587cf8ed4dcacd45f31),
+실제 PR head의 [CI](https://github.com/edwardkim/rhwp/actions/runs/33854487320)·[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33854487302)·[Adapter](https://github.com/edwardkim/rhwp/actions/runs/33854487296)·[Proptest](https://github.com/edwardkim/rhwp/actions/runs/33854487297)·[Render Diff](https://github.com/edwardkim/rhwp/actions/runs/33854487178), devel push의 [CI](https://github.com/edwardkim/rhwp/actions/runs/33856097121)·[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33856096995)·[Adapter](https://github.com/edwardkim/rhwp/actions/runs/33856097070)·[Proptest](https://github.com/edwardkim/rhwp/actions/runs/33856097150) 성공을 적는다.
+
+- 로컬 검증은 `cargo nextest run --profile ci-duration-observation --cargo-profile release-test`의 실제 결과 `9010 passed, 46 skipped`만 기록한다.
+- 시각 증적은 [Visual Sweep 가이드](https://github.com/edwardkim/rhwp/blob/4041acf298ffde2f02866587cf8ed4dcacd45f31/mydocs/manual/verification/visual_sweep_guide.md#github-merge-comment)와 아래 devel asset을 직접 링크한다. Hancom 2020 기준과 Studio 4쪽의 2단·표·도형 범위만 확인했으며, 문서 전체 pixel-perfect 동치를 주장하지 않는다.
+- 기준: `mydocs/pr/assets/pr_6683_6705_20260904/reference-6683-6690-exam-science-p4.png`
+- Studio: `mydocs/pr/assets/pr_6683_6705_20260904/studio-6683-6690-exam-science-p4.png`
+- comment와 close는 이 계획이 devel에 merge되고 devel CI가 성공한 뒤 각각 한 번만 수행한다.

--- a/mydocs/pr/archives/pr_6690_review.md
+++ b/mydocs/pr/archives/pr_6690_review.md
@@ -47,3 +47,14 @@ Studio 출력을 직접 비교했다. `#6683`과 같은 page evidence를 공유�
 
 추가 메인터너 코드 보정은 필요하지 않다. 최종 병합은 통합 PR 최신 head의 required
 CI와 mergeability를 다시 확인하는 일반 절차를 따른다.
+
+## Merge 후 contributor PR comment 계획
+
+원 PR은 직접 merge하지 않고 [통합 PR #6722](https://github.com/edwardkim/rhwp/pull/6722)의
+체리픽 통합으로 수용한다. comment에는 merge commit
+[`4041acf`](https://github.com/edwardkim/rhwp/commit/4041acf298ffde2f02866587cf8ed4dcacd45f31),
+실제 PR head의 [CI](https://github.com/edwardkim/rhwp/actions/runs/33854487320)·[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33854487302)·[Adapter](https://github.com/edwardkim/rhwp/actions/runs/33854487296)·[Proptest](https://github.com/edwardkim/rhwp/actions/runs/33854487297)·[Render Diff](https://github.com/edwardkim/rhwp/actions/runs/33854487178), devel push의 [CI](https://github.com/edwardkim/rhwp/actions/runs/33856097121)·[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33856096995)·[Adapter](https://github.com/edwardkim/rhwp/actions/runs/33856097070)·[Proptest](https://github.com/edwardkim/rhwp/actions/runs/33856097150) 성공을 적는다.
+
+- 로컬 검증은 `cargo nextest run --profile ci-duration-observation --cargo-profile release-test`의 실제 결과 `9010 passed, 46 skipped`만 기록한다.
+- 시각 증적은 [Visual Sweep 가이드](https://github.com/edwardkim/rhwp/blob/4041acf298ffde2f02866587cf8ed4dcacd45f31/mydocs/manual/verification/visual_sweep_guide.md#github-merge-comment)와 `mydocs/pr/assets/pr_6683_6705_20260904/reference-6683-6690-exam-science-p4.png`, `mydocs/pr/assets/pr_6683_6705_20260904/studio-6683-6690-exam-science-p4.png`를 직접 링크한다. page 4의 개체-only 마지막 줄 계약 범위만 기록하며 전체 pixel-perfect 동치를 주장하지 않는다.
+- comment와 close는 이 계획이 devel에 merge되고 devel CI가 성공한 뒤 각각 한 번만 수행한다.

--- a/mydocs/pr/archives/pr_6698_review.md
+++ b/mydocs/pr/archives/pr_6698_review.md
@@ -45,3 +45,14 @@ CARGO_TARGET_DIR=target/pr-review/green-ci-batch-20260904-full \
 
 추가 메인터너 코드 보정은 필요하지 않다. 최종 병합 시에는 통합 PR의 최신 head CI를
 다시 확인한다.
+
+## Merge 후 contributor PR comment 계획
+
+원 PR은 직접 merge하지 않고 [통합 PR #6722](https://github.com/edwardkim/rhwp/pull/6722)의
+체리픽 통합으로 수용한다. comment에는 merge commit
+[`4041acf`](https://github.com/edwardkim/rhwp/commit/4041acf298ffde2f02866587cf8ed4dcacd45f31),
+실제 PR head의 [CI](https://github.com/edwardkim/rhwp/actions/runs/33854487320)·[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33854487302)·[Adapter](https://github.com/edwardkim/rhwp/actions/runs/33854487296)·[Proptest](https://github.com/edwardkim/rhwp/actions/runs/33854487297)·[Render Diff](https://github.com/edwardkim/rhwp/actions/runs/33854487178), devel push의 [CI](https://github.com/edwardkim/rhwp/actions/runs/33856097121)·[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33856096995)·[Adapter](https://github.com/edwardkim/rhwp/actions/runs/33856097070)·[Proptest](https://github.com/edwardkim/rhwp/actions/runs/33856097150) 성공을 적는다.
+
+- 로컬 검증은 `cargo nextest run --profile ci-duration-observation --cargo-profile release-test`의 실제 결과 `9010 passed, 46 skipped`만 기록한다.
+- `mydocs/pr/assets/pr_6683_6705_20260904/reference-6698-exam-eng-p1.png`는 한컴 기준 1쪽의 보관 증적이다. 현재 devel에는 동일 쪽 Studio PNG가 없으므로 comment는 외부 기준과의 시각 동치 통과를 주장하지 않고, NBSP 폭 회귀 계약과 공식 CI 결과만 수용 근거로 적는다.
+- comment와 close는 이 계획이 devel에 merge되고 devel CI가 성공한 뒤 각각 한 번만 수행한다.

--- a/mydocs/pr/archives/pr_6703_review.md
+++ b/mydocs/pr/archives/pr_6703_review.md
@@ -77,8 +77,14 @@ Hancom 2018 저장 원본의 수동 한컴 PDF는
 본문이 설명한 HWP5 저장 조판 계약의 rhwp 기대값은 202이고, 한컴 PDF의 205페이지는
 참고 출력값일 뿐 이 PR의 blocker가 아니다.
 
-## 병합 전 남은 조건
+## 병합 후 상태 및 contributor PR comment 계획
 
-보정 commit을 포함한 최종 통합 PR head에서 required CI, mergeability 및
-`mergeStateStatus=CLEAN`을 다시 확인한다. 이 기록은 원 PR의 GitHub approve, 직접 merge,
-수용 완료 comment를 수행하지 않는다.
+보정 commit을 포함한 [통합 PR #6722](https://github.com/edwardkim/rhwp/pull/6722)는
+`MERGEABLE`·`CLEAN`과 required CI를 확인한 뒤 merge commit
+[`4041acf`](https://github.com/edwardkim/rhwp/commit/4041acf298ffde2f02866587cf8ed4dcacd45f31)로
+병합됐다. 원 PR을 직접 merge하지 않고 이 체리픽 통합으로 수용한다.
+
+- comment에는 실제 PR head의 [CI](https://github.com/edwardkim/rhwp/actions/runs/33854487320)·[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33854487302)·[Adapter](https://github.com/edwardkim/rhwp/actions/runs/33854487296)·[Proptest](https://github.com/edwardkim/rhwp/actions/runs/33854487297)·[Render Diff](https://github.com/edwardkim/rhwp/actions/runs/33854487178), devel push의 [CI](https://github.com/edwardkim/rhwp/actions/runs/33856097121)·[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33856096995)·[Adapter](https://github.com/edwardkim/rhwp/actions/runs/33856097070)·[Proptest](https://github.com/edwardkim/rhwp/actions/runs/33856097150) 성공을 적는다.
+- 로컬 검증은 `cargo nextest run --profile ci-duration-observation --cargo-profile release-test`의 실제 결과 `9010 passed, 46 skipped`만 기록한다.
+- 수용 근거는 공개 fixture와 HWP5 near-top reset의 제한된 본문 계약이다. 한컴 PDF 205쪽과 rhwp 계약 202쪽의 차이는 review에 기록된 참고값이며, visual 동치나 전체 페이지 수 일치를 주장하지 않는다.
+- comment와 close는 이 계획이 devel에 merge되고 devel CI가 성공한 뒤 각각 한 번만 수행한다.

--- a/mydocs/pr/archives/pr_6705_review.md
+++ b/mydocs/pr/archives/pr_6705_review.md
@@ -45,3 +45,14 @@ CARGO_TARGET_DIR=target/pr-review/green-ci-batch-20260904-full \
 
 추가 메인터너 코드 보정은 필요하지 않다. 최종 병합은 통합 PR 최신 head의 required
 CI, mergeability 및 `mergeStateStatus=CLEAN`을 다시 확인한 뒤에만 진행한다.
+
+## Merge 후 contributor PR comment 계획
+
+원 PR은 직접 merge하지 않고 [통합 PR #6722](https://github.com/edwardkim/rhwp/pull/6722)의
+체리픽 통합으로 수용한다. comment에는 merge commit
+[`4041acf`](https://github.com/edwardkim/rhwp/commit/4041acf298ffde2f02866587cf8ed4dcacd45f31),
+실제 PR head의 [CI](https://github.com/edwardkim/rhwp/actions/runs/33854487320)·[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33854487302)·[Adapter](https://github.com/edwardkim/rhwp/actions/runs/33854487296)·[Proptest](https://github.com/edwardkim/rhwp/actions/runs/33854487297)·[Render Diff](https://github.com/edwardkim/rhwp/actions/runs/33854487178), devel push의 [CI](https://github.com/edwardkim/rhwp/actions/runs/33856097121)·[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33856096995)·[Adapter](https://github.com/edwardkim/rhwp/actions/runs/33856097070)·[Proptest](https://github.com/edwardkim/rhwp/actions/runs/33856097150) 성공을 적는다.
+
+- 로컬 검증은 `cargo nextest run --profile ci-duration-observation --cargo-profile release-test`의 실제 결과 `9010 passed, 46 skipped`만 기록한다.
+- `mydocs/pr/assets/pr_6683_6705_20260904/reference-6705-hwp3-p7.png`는 한컴 기준 7쪽의 보관 증적이다. 현재 devel에는 동일 쪽 Studio PNG가 없으므로 comment는 외부 기준과의 시각 동치 통과를 주장하지 않고, continued paragraph floating-picture anchor 회귀 계약과 공식 CI 결과만 수용 근거로 적는다.
+- comment와 close는 이 계획이 devel에 merge되고 devel CI가 성공한 뒤 각각 한 번만 수행한다.

--- a/mydocs/pr/archives/pr_6709_review.md
+++ b/mydocs/pr/archives/pr_6709_review.md
@@ -66,14 +66,15 @@ Hancom 2018 저장 원본은 `printMethod=4` N-up PDF로 출력돼 물리 페이
 | 논리 페이지 매핑 | `../assets/pr_6683_6705_20260904/visual-6709-6710/nup-logical-a4-normalized-page-map.json` | 8 논리 페이지 |
 | 대표 contact sheet | `../assets/pr_6683_6705_20260904/visual-6709-6710/issue6202-a4-normalized-contact-sheet.png` | 8/8 완료, 규칙 후보 0 |
 
-## 병합 전 남은 조건
+## 병합 후 상태 및 contributor PR comment 계획
 
-1. `samples/issue6202` 원본을 `hwp2024-mcp-convert` client의 `engine 2020`으로
-   변환한 기준 PDF를 확정한다.
-2. 기준 PDF와 현재 `rhwp-studio`의 같은 페이지를 직접 대조해, paper-relative
-   float의 exclusion band와 본문 되감기 결과를 시각 증적으로 남긴다.
-3. 보정 commit을 포함한 최종 통합 PR head에서 required CI, mergeability,
-   `mergeStateStatus=CLEAN`을 다시 확인한다.
+정식 fixture와 HWP5 `LIST_HEADER` 보정까지 포함한 [통합 PR #6722](https://github.com/edwardkim/rhwp/pull/6722)는
+`MERGEABLE`·`CLEAN`과 required CI를 확인한 뒤 merge commit
+[`4041acf`](https://github.com/edwardkim/rhwp/commit/4041acf298ffde2f02866587cf8ed4dcacd45f31)로
+병합됐다. 원 PR은 직접 merge하지 않고 이 체리픽 통합으로 수용한다.
 
-위 시각 증적 조건은 추가 renderer 보정 요구가 아니다. 충족 전에는 원 PR을 직접
-병합하거나 수용 완료 댓글을 남기지 않는다.
+- comment에는 실제 PR head의 [CI](https://github.com/edwardkim/rhwp/actions/runs/33854487320)·[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33854487302)·[Adapter](https://github.com/edwardkim/rhwp/actions/runs/33854487296)·[Proptest](https://github.com/edwardkim/rhwp/actions/runs/33854487297)·[Render Diff](https://github.com/edwardkim/rhwp/actions/runs/33854487178), devel push의 [CI](https://github.com/edwardkim/rhwp/actions/runs/33856097121)·[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33856096995)·[Adapter](https://github.com/edwardkim/rhwp/actions/runs/33856097070)·[Proptest](https://github.com/edwardkim/rhwp/actions/runs/33856097150) 성공을 적는다.
+- 로컬 검증은 `cargo nextest run --profile ci-duration-observation --cargo-profile release-test`의 실제 결과 `9010 passed, 46 skipped`만 기록한다.
+- [통합 시각 sweep](pr_6683_6710_green_ci_batch_visual_sweep.md)은 issue6202의 실제 PNG 8쪽·SVG 8쪽과 N-up contact sheet를 보관한다. comment에는 `mydocs/pr/assets/pr_6683_6710_green_ci_batch_20260904/formal-fixture-render/issue6202/png/156483689-turmeric-industry-standardization_001.png`와 `mydocs/pr/assets/pr_6683_6705_20260904/visual-6709-6710/issue6202-a4-normalized-contact-sheet.png`를 직접 표시하고, N-up 물리 시트의 제한 때문에 Hancom PDF와의 pixel/물리 페이지 동치는 주장하지 않는다.
+- 수용 근거는 공개 fixture, fail-closed 테스트 계약, HWP5 직렬화 보정과 공식 CI다. 시각 asset은 현재 rhwp 출력의 검토 범위만 보여 준다.
+- comment와 close는 이 계획이 devel에 merge되고 devel CI가 성공한 뒤 각각 한 번만 수행한다.

--- a/mydocs/pr/archives/pr_6710_review.md
+++ b/mydocs/pr/archives/pr_6710_review.md
@@ -76,13 +76,15 @@ Hancom 2010 저장 원본의 `printMethod=4` 출력은 물리 PDF 시트와 논�
 | 논리 페이지 매핑 | `../assets/pr_6683_6705_20260904/visual-6709-6710/nup-logical-a4-normalized-page-map.json` | 13 논리 페이지 |
 | 대표 contact sheet | `../assets/pr_6683_6705_20260904/visual-6709-6710/issue5057-a4-normalized-contact-sheet.png` | 13/13 완료, 규칙 후보 0 |
 
-## 병합 전 남은 조건
+## 병합 후 상태 및 contributor PR comment 계획
 
-1. `samples/issue5057` 원본을 `hwp2024-mcp-convert` client의 `engine 2020`으로
-   변환한 기준 PDF를 확정한다.
-2. 그 기준 PDF와 현재 `rhwp-studio`의 동일 페이지를 직접 대조해, source-frame
-   allowance가 기대한 쪽 경계를 보존하는지 시각 증적으로 남긴다.
-3. 보정 commit을 포함한 최종 통합 PR head에서 required CI, mergeability,
-   `mergeStateStatus=CLEAN`을 재확인한다.
+정식 fixture와 HWP5 `LIST_HEADER` 보정까지 포함한 [통합 PR #6722](https://github.com/edwardkim/rhwp/pull/6722)는
+`MERGEABLE`·`CLEAN`과 required CI를 확인한 뒤 merge commit
+[`4041acf`](https://github.com/edwardkim/rhwp/commit/4041acf298ffde2f02866587cf8ed4dcacd45f31)로
+병합됐다. 원 PR은 직접 merge하지 않고 이 체리픽 통합으로 수용한다.
 
-위 조건을 충족하기 전에는 원 PR을 직접 병합하거나 수용 완료 댓글을 남기지 않는다.
+- comment에는 실제 PR head의 [CI](https://github.com/edwardkim/rhwp/actions/runs/33854487320)·[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33854487302)·[Adapter](https://github.com/edwardkim/rhwp/actions/runs/33854487296)·[Proptest](https://github.com/edwardkim/rhwp/actions/runs/33854487297)·[Render Diff](https://github.com/edwardkim/rhwp/actions/runs/33854487178), devel push의 [CI](https://github.com/edwardkim/rhwp/actions/runs/33856097121)·[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33856096995)·[Adapter](https://github.com/edwardkim/rhwp/actions/runs/33856097070)·[Proptest](https://github.com/edwardkim/rhwp/actions/runs/33856097150) 성공을 적는다.
+- 로컬 검증은 `cargo nextest run --profile ci-duration-observation --cargo-profile release-test`의 실제 결과 `9010 passed, 46 skipped`만 기록한다.
+- [통합 시각 sweep](pr_6683_6710_green_ci_batch_visual_sweep.md)은 issue5057의 실제 PNG 13쪽·SVG 13쪽과 N-up contact sheet를 보관한다. comment에는 `mydocs/pr/assets/pr_6683_6710_green_ci_batch_20260904/formal-fixture-render/issue5057/png/21484591-gimcheon-sewage-ordinance_007.png`와 `mydocs/pr/assets/pr_6683_6705_20260904/visual-6709-6710/issue5057-a4-normalized-contact-sheet.png`를 직접 표시하고, N-up 물리 시트의 제한 때문에 Hancom PDF와의 pixel/물리 페이지 동치는 주장하지 않는다.
+- 수용 근거는 공개 fixture, fail-closed 테스트 계약, HWP5 직렬화 보정과 공식 CI다. 시각 asset은 현재 rhwp 출력의 검토 범위만 보여 준다.
+- comment와 close는 이 계획이 devel에 merge되고 devel CI가 성공한 뒤 각각 한 번만 수행한다.


### PR DESCRIPTION
## 목적

PR #6722의 merge 후 source PR contributor comment/close를 `post_merge.md` 7.4 규칙에 맞게 처리할 수 있도록, archive review 7건에 누락된 `Merge 후 contributor PR comment 계획`을 보완합니다.

## 변경 범위

- `mydocs/pr/archives/pr_6683_review.md`
- `mydocs/pr/archives/pr_6690_review.md`
- `mydocs/pr/archives/pr_6698_review.md`
- `mydocs/pr/archives/pr_6703_review.md`
- `mydocs/pr/archives/pr_6705_review.md`
- `mydocs/pr/archives/pr_6709_review.md`
- `mydocs/pr/archives/pr_6710_review.md`

코드, 테스트, workflow, fixture, PDF, golden, baseline, 시각 asset은 변경하지 않습니다.

## 사실 기록

- 통합 PR: #6722
- merge commit: `4041acf298ffde2f02866587cf8ed4dcacd45f31`
- PR head CI와 merge 후 devel CI의 실제 성공 URL을 계획에 명시했습니다.
- #6709/#6710은 N-up asset의 실제 범위와 Hancom PDF pixel/물리 페이지 동치를 주장하지 않는 한계를 명시했습니다.
- 이 PR이 merge되고 devel CI가 성공한 뒤에만 원 PR comment/close를 한 번씩 처리합니다.
