### PR TITLE
docs: HWP 2024 MCP 동기 호출 안내를 제거한다

### DIFF
--- a/mydocs/manual/mcp_hwp2024Convert_usage.md
+++ b/mydocs/manual/mcp_hwp2024Convert_usage.md
@@ -2,7 +2,7 @@
 kind: guide
 status: active
 canonical: mydocs/manual/mcp_hwp2024Convert_usage.md
-last_verified: 2026-08-30
+last_verified: 2026-09-04
 ---
 
 # HWP 2024 변환 MCP client 사용법
@@ -41,10 +41,9 @@ PR review 기준 PDF를 만들 때는 기본 engine 값에 의존하지 않고 �
 ## 개요
 
 - MCP server 이름: `hwp2024Convert`
-- 권장 실행 방식: `hwp2024-mcp-convert` CLI의 비동기 `start → status → download` 흐름.
-  다쪽 문서, 변환 시간이 긴 문서와 PR review 기준 PDF는 항상 이 흐름을 사용한다.
-- 동기 `hwp2024-mcp-convert convert` 호출은 소형 문서의 즉시 변환 확인에만 사용한다.
-- VS Code 연동 방식: stdio MCP bridge `hwp2024-mcp-bridge`. 실제 변환은 비동기 tool을 우선한다.
+- 실행 방식: `hwp2024-mcp-convert` CLI의 비동기 `start → status → download` 흐름.
+  모든 문서 변환과 PR review 기준 PDF는 이 흐름을 사용한다.
+- VS Code 연동 방식: stdio MCP bridge `hwp2024-mcp-bridge`. 비동기 tool만 사용한다.
 - 지원 입력: `.hwp`, `.hwpx`
 - 지원 출력: `pdf`, `hwp`, `hwpx`
 - 지원 방향: `.hwp → pdf|hwp|hwpx`, `.hwpx → pdf|hwp`
@@ -52,7 +51,6 @@ PR review 기준 PDF를 만들 때는 기본 engine 값에 의존하지 않고 �
 - PR review 기준 PDF 이름: `lastSavedWith.product`가 `hancom-office-2024`이면 `-2024.pdf`,
   그 외(`null`, 2010, 2018, 2020, 2022, 알 수 없는 구버전)는 `-2020.pdf`
 - 선택적 암호 문서: MCP tool의 `password` 또는 CLI의 비공개 `--password-file`
-- 동기 tool: `convert_local_document`
 - 비동기 tool: `start_local_document_conversion`, `get_local_conversion_status`,
   `save_local_conversion_result`
 - 지원 client 환경: Node.js 22 이상의 macOS, Linux, Windows PowerShell. Windows `cmd.exe`를 쓸 때는
@@ -120,7 +118,7 @@ token은 전송 구간 암호화를 제공하지 않으므로 신뢰할 수 있�
 HTTPS reverse proxy 뒤에 둔다.
 
 암호 문서를 CLI로 변환할 때는 문서 암호를 command line 인자에 직접 넣지 않는다. Git 밖의 현재 사용자만
-읽을 수 있는 단일 행 파일을 만들고 `convert` 또는 `start`에 `--password-file <경로>`를 지정한다.
+읽을 수 있는 단일 행 파일을 만들고 `start`에 `--password-file <경로>`를 지정한다.
 MCP tool에서는 요청의 선택적 `password` 필드로만 전달한다. client는 암호를 결과 JSON, job 상태,
 파일명 또는 로그에 기록하지 않는다.
 
@@ -147,9 +145,8 @@ $EnvFile = 'C:\Users\<사용자>\hwp-convert-2024\.env.local'
 & $Npx --version
 ```
 
-실제 문서 변환은 비동기 `start → status → download`를 기본으로 사용한다. 아래 동기 예제는 설치 확인이나
-수 초 안에 끝나는 소형 문서 smoke test에만 사용한다. `--input`과 `--output-dir`은 모두 client PC의
-local 경로다.
+실제 문서 변환은 비동기 `start → status → download`만 사용한다. `--input`과 `--output-dir`은 모두
+client PC의 local 경로다.
 
 도움말 (macOS/Linux):
 
@@ -165,44 +162,9 @@ npx -y --package="file:$HWP2024_MCP_PACKAGE" -- hwp2024-mcp-convert --help
   -- hwp2024-mcp-convert --help
 ```
 
-### 소형 문서 확인 전용: 동기 변환
+### 비동기 변환
 
-작은 문서는 `convert`가 upload, 원격 변환, download, SHA-256 검증과 local 저장을 한 번에 수행한다.
-
-macOS/Linux:
-
-```bash
-npx -y --package="file:$HWP2024_MCP_PACKAGE" -- hwp2024-mcp-convert convert \
-  --env-file "$HWP2024_MCP_ENV_FILE" \
-  --input "$HOME/rhwp/samples/example.hwp" \
-  --target pdf \
-  --engine 2024 \
-  --output-dir "$HOME/rhwp/pdf" \
-  --output-filename example-2024.pdf \
-  --timeout-seconds 900
-```
-
-Windows PowerShell:
-
-```powershell
-& $Npx -y `
-  "--package=file:$Package" `
-  -- hwp2024-mcp-convert convert `
-  --env-file $EnvFile `
-  --input 'C:\Users\<사용자>\rhwp\samples\example.hwp' `
-  --target pdf `
-  --engine 2024 `
-  --output-dir 'C:\Users\<사용자>\rhwp\pdf' `
-  --output-filename 'example-2024.pdf' `
-  --timeout-seconds 900
-```
-
-성공하면 `status`, `output_path`, `target`, `size`, `sha256`와 server 변환 metadata가 JSON으로
-출력된다. 기존 output file은 덮어쓰지 않는다.
-
-### 권장: 비동기 변환
-
-큰 문서, 변환 시간이 긴 문서와 PR review 기준 PDF는 `start → status → download` 순서로 처리한다.
+모든 문서는 `start → status → download` 순서로 처리한다.
 
 macOS/Linux:
 
@@ -366,34 +328,6 @@ VS Code MCP 접근이 차단되어 있으면 user settings에 다음을 추가�
 
 ## MCP tool 사용
 
-### 동기
-
-macOS/Linux 경로 예시:
-
-```json
-{
-  "input_path": "/home/<사용자>/rhwp/samples/example.hwp",
-  "target": "pdf",
-  "engine": "2024",
-  "output_dir": "/home/<사용자>/rhwp/pdf",
-  "output_filename": "example-2024.pdf",
-  "timeout_seconds": 900
-}
-```
-
-Windows 경로 예시:
-
-```json
-{
-  "input_path": "C:\\Users\\<사용자>\\rhwp\\samples\\example.hwp",
-  "target": "pdf",
-  "engine": "2024",
-  "output_dir": "C:\\Users\\<사용자>\\rhwp\\pdf",
-  "output_filename": "example-2024.pdf",
-  "timeout_seconds": 900
-}
-```
-
 ### 비동기 시작
 
 macOS/Linux 경로 예시:
@@ -452,7 +386,7 @@ Windows 경로 예시:
 `/Users/<사용자>/...`, Windows는 `C:\Users\<사용자>\...`를 쓰며 server 내부 경로를 입력하지 않는다.
 `output_filename`은 경로가 없는 파일명이어야 하며 target 확장자와 일치해야 한다.
 
-암호 문서는 동기 또는 비동기 시작 요청에만 `password`를 추가한다. 상태 확인과 결과 저장 요청에는
+암호 문서는 비동기 시작 요청에만 `password`를 추가한다. 상태 확인과 결과 저장 요청에는
 암호를 다시 넣지 않는다.
 
 ```json
@@ -472,8 +406,7 @@ HTTP MCP server는 여러 client session을 받을 수 있지만 한컴 runtime 
 server process 전체에서 하나씩 직렬 실행한다. 비동기 요청은 기본 8개까지 대기열에 들어간다.
 
 `timeout_seconds` 허용 범위는 10~1800초이고 기본값은 600초다. 일반 문서는 600~900초, 큰 문서·이미지가
-많은 문서·거대 표·중첩 표는 1800초를 권장한다. client의 동기 HTTP request는 변환 timeout에 120초
-여유를 더해 기다린다.
+많은 문서·거대 표·중첩 표는 1800초를 권장한다.
 
 ## HWP5 입력 사전 차단
 
@@ -579,9 +512,9 @@ Get-FileHash -Algorithm SHA256 -LiteralPath 'C:\Users\<사용자>\rhwp\pdf\examp
 - 실제 archive CLI의 비동기 `start`가 engine `2020`, 엔진별 기본 파일명, 비공개 암호 파일을 remote argument로 전달
 - 결과 JSON에는 `status`, `job_id`, `engine`만 있고 암호 값은 없음
 
-2026-08-24 실제 배포 MCP server에는 최신 artifact로 engine `2024`의 작은 HWPX를 동기 `convert`와
-비동기 `start → status → download`로 각각 변환했다. 두 경로 모두 `success`, client/server SHA-256 일치와
-PDF 서명을 확인했고, 비동기 `start`와 `status`의 `engine`은 요청값 `2024`와 일치했다. 또한 Hancom Office
+2026-08-24 실제 배포 MCP server에는 최신 artifact로 engine `2024`의 작은 HWPX를 비동기
+`start → status → download`로 변환했다. `success`, client/server SHA-256 일치와 PDF 서명을 확인했고,
+비동기 `start`와 `status`의 `engine`은 요청값 `2024`와 일치했다. 또한 Hancom Office
 2020 저장본 `kps-ai.hwp`는 `--engine 2020`을 명시한 비동기 흐름에서 `queued → succeeded → success`,
 `start`·`status`의 `engine: "2020"`, PDF 서명 및 SHA-256 일치를 확인했다. `server.engine`은
 `hancom-2024-direct-host` backend 식별자를 반환했고 `server.engine_profile`과 `server.hancom_version`은
@@ -592,9 +525,8 @@ PDF 서명을 확인했고, 비동기 `start`와 `status`의 `engine`은 요청�
 - tarball에서 `hwp2024-mcp-convert --help` 실행 성공
 - stdio initialize와 tool discovery 성공, tool 4개
 - archive 내 `node_modules` 0개, runtime dependency import 0개
-- 동기 HWP→HWPX: `success`, output 67,709 bytes
 - 비동기 HWP→PDF: `queued → succeeded → success`, output 106,341 bytes
-- 두 경로 모두 client/server output byte 수와 SHA-256 일치
+- client/server output byte 수와 SHA-256 일치
 - server engine `hancom-2024-direct-host`, backend `hwp-managed-direct-dll-host`, worker 32-bit
 
 실제 server 주소와 token은 검증 기록에 포함하지 않았다.

--- a/mydocs/pr/archives/pr_6727_review.md
+++ b/mydocs/pr/archives/pr_6727_review.md
@@ -1,0 +1,50 @@
+---
+kind: pr_review
+status: active
+pr: 6727
+---
+
+# PR #6727 검토 기록
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#6727](https://github.com/edwardkim/rhwp/pull/6727) |
+| 작성자·검토자 | `jangster77` self-review |
+| base / head | `devel` / `codex/remove-hwp2024-sync-guide` |
+| 검토 대상 head | `ac033c3b2da0ba33c1e9e0bd7abd135da39997cc` |
+| 변경 규모 | 1개 파일, 15 추가·83 삭제 |
+| 작성 시점 mergeability | `MERGEABLE`; CI 완료 전 `BLOCKED` |
+
+## 검토 범위
+
+- `mydocs/manual/mcp_hwp2024Convert_usage.md`에서 동기 CLI `convert`와 동기 MCP tool
+  `convert_local_document`의 호출 방법을 제거했다.
+- 모든 변환과 암호 문서 요청을 비동기 `start → status → download` 흐름으로만 안내한다.
+- source, test, fixture, client artifact, server 설정은 변경하지 않았다.
+
+## 절차와 검증
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, review_only_fast_pass.md, post_merge.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+  collaborator_self_merge.md, intake_and_review.md,
+  review_only_fast_pass.md, post_merge.md, local_validation.md
+current head: ac033c3b2da0ba33c1e9e0bd7abd135da39997cc
+```
+
+- `git diff --check`를 통과했다.
+- 변경 범위는 `mydocs/`의 사용 가이드 한 파일이다. Markdown link target을 추가·변경하지 않았고,
+  Cargo·npm 검증은 문서 전용 변경이라 실행하지 않았다.
+- renderer, layout, HWP/HWPX fixture, 기준 PDF는 변경하지 않아 시각 검증은 적용하지 않는다.
+
+## 최종 판정
+
+- 판정: 승인
+- 근거: 동기 호출 예제·도구명·암호 전달·과거 사용 기록까지 제거했고, 비동기 요청의 시작·상태 확인·결과
+  저장 순서는 유지했다.
+- merge 전 조건: 최신 PR head의 required GitHub Actions가 모두 성공하고, mergeability와 head SHA를
+  다시 확인한다.
+- 원격 조치: 이 기록은 GitHub approve event를 남기지 않는다. 작업지시자가 승인한 PR 병합만 수행한다.


### PR DESCRIPTION
## 변경 내용

- HWP 2024 MCP 사용 가이드에서 동기 CLI 및 MCP tool 호출 방법을 제거합니다.
- 모든 문서 변환을 비동기 `start → status → download` 흐름으로 안내합니다.

## 검증

- `git diff --check`
