### PR TITLE
시험(studio): 어울림 그림 이동 뒤 화면 되감김을 e2e 로 잠근다 (#6202 studio 축 — 결함 아님)

### DIFF
--- a/mydocs/orders/20260904.md
+++ b/mydocs/orders/20260904.md
@@ -14,6 +14,14 @@
   확인한 뒤 별도 merge 승인을 받는다.
 - #6717을 `devel`에 먼저 통합한 뒤 PR #6715를 최신 base와 정합시켜 exact-head CI를 재검증한다.
 
+## #6728 studio 그림 이동 E2E 회귀 계약 검토
+
+- [PR #6728](https://github.com/edwardkim/rhwp/pull/6728)의 reviewer `jangster77`을 사전 배정했다. code candidate `572b66372e558d4208d3875e71f131191ce617a4`는 studio E2E 하나만 추가하며 제품 renderer, layout, WASM, sample, fixture를 바꾸지 않는다.
+- source head에서 `node e2e/run-with-vite.mjs -- node e2e/issue-6202-picture-move-reflow.test.mjs --mode=headless`를 직접 실행했다. 그림 y는 `476.2 -> 548.2`, 그림이 비켜간 자리의 글자 띠 screenshot은 `49456B -> 46692B`로 달라졌고 두 회귀 assertion이 통과했다.
+- code candidate의 CI, CodeQL, Render Diff, Adapter inter-diff, Proptest와 trusted CI impact policy가 성공했다. 직접 package script가 없는 수동 E2E라는 사실은 기존 suite 운용과 같아 단독 머지 차단 사유로 삼지 않았다.
+- [검토 기록](../pr/archives/pr_6728_review.md)은 `승인`으로 판정했다. 다만 #6202 원본 `156483689...` fixture의 저장-재열기와 모든 placement 조합을 검증한 것은 아니며, PR 본문에 closing keyword가 없으므로 Issue #6202는 OPEN으로 유지한다.
+- 이 기록은 source branch의 review-only trailing commit이다. 최신 head의 fast-pass aggregate와 mergeability를 재확인한 뒤 작업지시자 merge 승인을 받으며, merge 뒤 devel CI가 성공하기 전에는 contributor comment나 issue close를 하지 않는다.
+
 ## #6711 mydocs monthly archive governance
 
 - [#6711](https://github.com/edwardkim/rhwp/issues/6711)을 등록하고 메인테이너에게 할당했다.

--- a/mydocs/pr/archives/pr_6728_review.md
+++ b/mydocs/pr/archives/pr_6728_review.md
@@ -1,0 +1,68 @@
+# PR #6728 검토 기록
+
+## 접수 정보
+
+| 항목 | 내용 |
+| --- | --- |
+| PR | [#6728](https://github.com/edwardkim/rhwp/pull/6728) `시험(studio): 어울림 그림 이동 뒤 화면 되감김을 e2e 로 잠근다 (#6202 studio 축 - 결함 아님)` |
+| 작성자 | `planet6897` (`planet6897/rhwp:test/6202-studio-e2e-guard`) |
+| reviewer | `jangster77` (2026-09-04 사전 배정) |
+| base | `devel` |
+| 검토한 code head | `572b66372e558d4208d3875e71f131191ce617a4` |
+| 규모 | 1 file, +99/-0: `rhwp-studio/e2e/issue-6202-picture-move-reflow.test.mjs` |
+| 작성 시점 참고 상태 | `MERGEABLE`, `CLEAN`, non-draft. merge 직전에 최신 head와 required check를 다시 확인해야 한다. |
+
+## 라우팅과 범위
+
+- base route: `collaborator_external_pr.md`
+- modifiers: `intake_and_review.md`, `local_validation.md`, `review_only_fast_pass.md`
+- loaded documents: `pr_review_workflow.md`, `pr_review/README.md`, `pr_review/collaborator_external_pr.md`, `pr_review/intake_and_review.md`, `pr_review/local_validation.md`, `pr_review/review_only_fast_pass.md`, `pr_review/visual_fixture_evidence.md`
+
+이 PR은 제품 renderer, layout, WASM, sample 또는 fixture를 바꾸지 않는다. studio에서 그림 드래그 중 이미 문서 변경과 다시 그리기가 일어난다는 현재 동작을 브라우저 E2E로 고정하는 test-only 변경이다. 따라서 기준 PDF 또는 별도 visual sweep asset을 수용 근거로 사용하지 않았다. 스크린샷 crop은 E2E의 관측 수단이며, 제품 출력 fidelity의 독립적인 visual sweep 통과를 뜻하지 않는다.
+
+## 관련 이슈와 범위 제한
+
+- [#6202](https://github.com/edwardkim/rhwp/issues/6202)는 `156483689_1-1_...hwp`에서 어울림 그림 이동 뒤 본문이 옛 배제 밴드를 유지한다는 현상을 기록한 OPEN 이슈다.
+- 이 PR은 `samples/143E433F503322BD33.hwp`의 square 어울림 그림을 아래로 72px 움직이는 studio 드래그 경로만 검증한다. 원 이슈의 동일 문서, 저장 후 재열기, 모든 placement 조합을 재현하거나 #6202 전체를 닫는 변경이 아니다.
+- PR 본문에는 closing keyword가 없으므로 #6202는 merge 뒤에도 OPEN으로 유지한다. 이 review는 원 이슈의 renderer/layout 결론을 변경하지 않는다.
+
+## 검증
+
+### GitHub code candidate
+
+`572b66372e558d4208d3875e71f131191ce617a4`에서 다음 required aggregate와 실행 worker가 성공했다.
+
+- CI [33868655617](https://github.com/edwardkim/rhwp/actions/runs/33868655617): `Build & Test`, `Frontend package gates` 성공. Rust/WASM/nextest worker는 이 test-only 영향 정책의 expected skip이다.
+- CodeQL [33868655917](https://github.com/edwardkim/rhwp/actions/runs/33868655917): JavaScript/TypeScript, Python, Rust 분석 성공 및 aggregate neutral.
+- Render Diff [33868655371](https://github.com/edwardkim/rhwp/actions/runs/33868655371): preflight와 Canvas visual diff 성공.
+- Adapter inter-diff [33868655618](https://github.com/edwardkim/rhwp/actions/runs/33868655618), Proptest [33868655449](https://github.com/edwardkim/rhwp/actions/runs/33868655449) 성공.
+- trusted CI impact policy [33869501519](https://github.com/edwardkim/rhwp/actions/runs/33869501519) 성공.
+
+### focused browser E2E
+
+검토 source head에서 다음을 실행해 성공했다.
+
+```bash
+cd rhwp-studio
+node e2e/run-with-vite.mjs -- node e2e/issue-6202-picture-move-reflow.test.mjs --mode=headless
+```
+
+- 그림 y: `476.2 -> 548.2`
+- 그림이 비켜간 자리의 글자 띠 puppeteer screenshot: `49456B -> 46692B`, `동일=false`
+- 두 assertion 모두 통과했다. 드래그가 문서에 반영되고, 대상 글자 띠가 이전 픽셀 상태로 남지 않는 것을 확인했다.
+
+`package.json`에 직접 실행 스크립트가 없는 것은 기존 수동 E2E 다수와 같은 운용 범위다. 이를 이 PR 단독의 CI 배선 누락이나 머지 차단 사유로 해석하지 않는다. 반대로 `devel`의 108개 전체 수동 E2E sweep은 이 PR candidate 검증이 아니며, 그 전체 결과를 이 PR의 전체 E2E green 증적으로 사용하지 않았다.
+
+## 검토 결과
+
+### 잔여 risk
+
+- 테스트는 합성 mouse handler 호출과 한 개의 square-wrap 문서를 대상으로 한다. 실제 사용자 입력, 다른 wrap/anchor 조합, #6202 원본의 저장-재열기 경로는 별도 검증 범위다.
+- 신규 E2E는 현재 frontend package gate가 직접 실행하지 않는 수동 E2E 집합에 속한다. 이 저장소의 현행 CI 분류 정책을 바꾸지 않는다.
+
+## 최종 판정: 승인
+
+- 검토 대상 head `572b66372e558d4208d3875e71f131191ce617a4`는 주장한 좁은 studio 드래그 회귀 계약을 focused browser E2E와 해당 head의 GitHub required check로 충족한다.
+- 이 review와 오늘할일은 code candidate 뒤에 추가하는 review-only trailing commit이다. source, test, fixture, workflow 또는 PDF/asset을 추가로 바꾸지 않는다.
+- merge 전 조건: trailing head가 같은 source repository/PR의 green code candidate를 trusted fast-pass로 재사용하는지, 최신 required aggregate가 success 또는 정책상 expected skip인지, `MERGEABLE`/`CLEAN`인지 재확인하고 작업지시자의 merge 승인을 받는다.
+- merge 후 조건: `post_merge.md`에 따라 merge SHA의 devel CI를 확인한다. #6202를 자동 close하거나 현 시점에 contributor comment를 게시하지 않는다.

--- a/rhwp-studio/e2e/issue-6202-picture-move-reflow.test.mjs
+++ b/rhwp-studio/e2e/issue-6202-picture-move-reflow.test.mjs
@@ -1,0 +1,99 @@
+/**
+ * E2E (Issue #6202): 어울림 그림을 드래그로 옮기면 **화면도 다시 그려져야** 한다.
+ *
+ * 엔진은 PR #6709 로 배제 밴드를 다시 계산해 본문을 되감는다. studio 는 이동 기록을
+ * `refresh: 'none'` 으로 실행해 그 결과를 화면에 반영하지 않았다 — 문서만 바뀌고
+ * 화면은 옛 그림이 남는다.
+ *
+ * ⚠ 판별은 **puppeteer 스크린샷**으로 한다. studio 캔버스는 CanvasKit(WebGL) 이라
+ * `getContext('2d').getImageData` 로 읽으면 렌더 백엔드와 무관한 상수만 나온다
+ * (실측: 드래그 전후 잉크 891509 로 완전히 동일 — 판별력 0).
+ * ⚠ 합성 마우스 이벤트는 `target` 을 `ih.container` 로 덮고 `onClickBound` /
+ *   `onMouseMoveBound` / `onMouseUpBound` 로 넣어야 실제 드래그 경로를 탄다.
+ */
+import { runTest, loadHwpFile, assert } from './helpers.mjs';
+
+const SAMPLE = '143E433F503322BD33.hwp';
+
+await runTest('어울림 그림 이동 뒤 화면이 다시 그려진다 (#6202)', async ({ page }) => {
+  await loadHwpFile(page, SAMPLE);
+
+  // ── 대상 선택 (드래그 전 상태 확정)
+  const setup = await page.evaluate(async () => {
+    const wasm = window.__wasm;
+    const ih = window.__inputHandler;
+    const nextFrame = () =>
+      new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    const layout = wasm.getPageControlLayout(0);
+    const target = (layout.controls || []).find((c) => c.wrap === 'square');
+    if (!target) return { error: '어울림(square) 그림을 찾지 못함' };
+    ih.cursor.enterPictureObjectSelectionDirect(0, target.paraIdx, target.controlIdx, 'image');
+    ih.renderPictureObjectSelection();
+    await nextFrame();
+    return { target };
+  });
+  if (setup.error) throw new Error(setup.error);
+
+  // 그림이 **비켜간 뒤 글자가 흘러들어와야 하는 띠**만 잘라 본다. 전체 화면을 비교하면
+  // 드래그 중 미리보기로 그림만 움직여도 달라져 판별력이 없다(음성 대조 통과).
+  const band = await page.evaluate((target) => {
+    const ih = window.__inputHandler;
+    const sc = ih.container.querySelector('#scroll-content');
+    const r = sc.getBoundingClientRect();
+    return {
+      x: Math.round(r.left + 60),
+      y: Math.round(r.top + target.y + target.h + 80),
+      width: 660,
+      height: 110,
+    };
+  }, setup.target);
+
+  const shot = async () => Buffer.from(await page.screenshot({ clip: band, encoding: 'binary' }));
+  const before = await shot();
+
+  // ── 이동 드래그
+  const moved = await page.evaluate(async (target) => {
+    const wasm = window.__wasm;
+    const ih = window.__inputHandler;
+    const nextFrame = () =>
+      new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    const me = (type, x, y) => {
+      const ev = new MouseEvent(type, { button: 0, clientX: x, clientY: y, bubbles: true });
+      Object.defineProperty(ev, 'target', { value: ih.container, configurable: true });
+      return ev;
+    };
+    const sc = ih.container.querySelector('#scroll-content');
+    const rect = sc.getBoundingClientRect();
+    const x = rect.left + target.x + target.w / 2;
+    const y = rect.top + target.y + target.h / 2;
+
+    ih.onClickBound(me('mousedown', x, y));
+    for (let dy = 12; dy <= 72; dy += 12) {
+      ih.onMouseMoveBound(me('mousemove', x, y + dy));
+      await nextFrame();
+    }
+    ih.onMouseUpBound(me('mouseup', x, y + 72));
+    await nextFrame();
+    await nextFrame();
+
+    const after = (wasm.getPageControlLayout(0).controls || [])
+      .find((c) => c.wrap === 'square');
+    return { beforeY: target.y, afterY: after ? after.y : null };
+  }, setup.target);
+
+  const after = await shot();
+
+  const identical = before.length === after.length && before.equals(after);
+  console.log(
+    `[#6202] 그림 y ${moved.beforeY} → ${moved.afterY} · 글자 띠 ${JSON.stringify(band)} · ${before.length}B / ${after.length}B · 동일=${identical}`,
+  );
+
+  assert(
+    moved.afterY !== null && Math.abs(moved.afterY - moved.beforeY) > 4,
+    `드래그가 문서에 반영돼야 한다 (그림 y ${moved.beforeY} → ${moved.afterY})`,
+  );
+  assert(
+    !identical,
+    '그림이 내려온 자리의 글자 띠가 화면에서 다시 흘러야 한다 — #6202 회귀 (띠 스크린샷이 바이트까지 동일 = 본문이 안 되감김)',
+  );
+});


### PR DESCRIPTION
#6202 의 **studio 축을 실측으로 닫습니다** — 결함이 아니었습니다. 코드 변경 없이 e2e 잠금만 추가합니다.

## 무엇을 확인했나

PR #6709(엔진: 용지 기준 배제 밴드 계산) 코멘트에서 *"studio 의 `refresh: 'none'`
(`finishPictureMoveDrag`)은 그대로입니다"* 라고 남겼습니다. 그 항목을 헤드리스 e2e 로
재 보니 **화면은 이미 갱신됩니다.**

`updatePictureMoveDrag` 가 드래그 **중에** `setObjectProperties` 로 문서를 실제로 바꾸고
`document-changed` 를 emit 합니다. 그 경로가 페이지를 다시 그리므로, 마우스를 놓는
시점의 `refresh: 'none'` 은 **중복 재렌더를 건너뛰는 것**일 뿐입니다.

## 실측 (`samples/143E433F503322BD33.hwp`, square 어울림 그림, 아래로 72px 드래그)

```text
그림 y                          476.2 → 548.2      문서에 반영됨
그림이 비켜간 자리의 글자 띠     20322B → 19878B    본문이 되감김

`refresh: 'full'` 로 바꾼 판     20322B → 19878B    ← 바이트까지 동일
```

수정판과 미수정판의 산출이 **완전히 같습니다.** 그래서 소스는 되돌렸습니다.

## ⚠ 계측 함정 둘 — 시험 주석에 남겼습니다

### ① studio 캔버스는 CanvasKit(WebGL) 입니다

`getContext('2d').getImageData` 로 읽으면 렌더 백엔드와 무관한 상수만 나옵니다.
드래그 전후 잉크가 `891509` 로 **완전히 동일**해서 "화면이 안 바뀐다"로 오판했습니다.
판별은 **puppeteer 스크린샷**으로 해야 합니다.

### ② 전체 화면 스크린샷은 판별력이 없습니다

드래그 미리보기로 그림만 움직여도 달라지므로 **음성 대조가 통과**합니다
(수정 전 138784B → 139577B / 수정 후 138784B → 139031B — 둘 다 "달라짐").
**그림이 비켜간 자리의 글자 띠**만 잘라야 갈립니다 — 그리고 그렇게 자르니 수정 전후가
같아 결함이 아님이 드러났습니다.

합성 마우스 이벤트는 `target` 을 `ih.container` 로 덮고 `onClickBound` /
`onMouseMoveBound` / `onMouseUpBound` 로 넣어야 실제 드래그 경로를 탑니다.

## 이 PR 이 잠그는 것

```
① 드래그가 문서에 반영된다              (그림 y 476.2 → 548.2)
② 그림이 비켜간 자리의 글자가 화면에서 다시 흐른다
```

`document-changed` 배선이나 드래그 중 문서 반영이 사라지면 ②가 깨집니다.

## 실행

```bash
cd rhwp-studio
CHROME_PATH="C:\Program Files\Google\Chrome\Application\chrome.exe" \
  node e2e/run-with-vite.mjs -- node e2e/issue-6202-picture-move-reflow.test.mjs --mode=headless
```

Rust 게이트에는 영향이 없습니다(추가 파일은 studio e2e 하나뿐).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
