### PR TITLE
수정(layout): 사다리 적합 판정에 1px 반올림 여유를 둔다 (#6718 잔여 pi=62, #6721 유실분)

### DIFF
--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -3877,6 +3877,11 @@ fn paragraph_saved_vpos_reset_starts_new_page_after(
 /// 쪽 중간에서 인정하면 한 문서 안에서 가드가 연쇄 발동해 쪽수가 늘어난다
 /// (`156633519 산업활동동향`: pi 501개 이동 +3쪽). 이 조건 하나로 PI 코호트 회귀가
 /// 2건에서 0건이 됐고, 50·75·90% 가 모두 같은 결과라 가장 조인 값을 쓴다.
+/// [#6718] 저장 사다리가 지시한 쪽 경계를 "이 문단은 어차피 넘치지 않는다"로 걸러낼 때
+/// 쓰는 반올림 여유. 27469 `pi=62` 는 7줄 합 246.4 vs 예산 247.2 로 **0.8px** 차이로
+/// 들어가 사다리(@6)를 못 따랐다 — 그 0.8px 은 조판 차이가 아니라 계산 오차 규모다.
+const LADDER_FIT_EPSILON_PX: f64 = 1.0;
+
 const STORED_VPOS_REWIND_MIN_FILL: f64 = 0.90;
 
 /// 저장 `vpos` 가 되돌아가는 자리 — 한글이 거기서 쪽을 끊었다는 신호다 [#3837].
@@ -18203,11 +18208,11 @@ impl TypesetEngine {
             let ladder_page_is_full = |k: usize| -> bool {
                 let upto = fmt.line_advances_sum(cursor_line..k);
                 let next = fmt.line_advances_sum(k..k + 1);
-                upto + next > avail_for_lines + 0.5
+                upto + next > avail_for_lines - LADDER_FIT_EPSILON_PX
             };
             if st.profile.hwp5_stored_pagination_layout()
                 && end_line > cursor_line + 1
-                && cumulative > avail_for_lines
+                && cumulative > avail_for_lines - LADDER_FIT_EPSILON_PX
             {
                 let rewind_line = (cursor_line + 1..end_line).find(|&k| {
                     match (para.line_segs.get(k - 1), para.line_segs.get(k)) {

--- a/tests/cases/issue_6718_native_hwp5_zero_vpos_rewind.rs
+++ b/tests/cases/issue_6718_native_hwp5_zero_vpos_rewind.rs
@@ -13,8 +13,12 @@
 //!
 //! ```text
 //!   수정 전   넘침 16 · 용지밖 1 · 글자겹침 7      (12쪽, 한/글 2020 도 12쪽)
-//!   수정 후   넘침 10 · 용지밖 0 · 글자겹침 2
+//!   수정 후   넘침  9 · 용지밖 1 · 글자겹침 2
 //! ```
+//!
+//! ⚠ `pi=62`(9쪽)는 예산을 **0.8px** 차이로 통과해(7줄 합 246.4 vs 예산 247.2) 사다리
+//! (@6)를 못 따르고 있었다. 그 0.8px 은 조판 차이가 아니라 계산 오차 규모라
+//! `LADDER_FIT_EPSILON_PX = 1.0` 을 둔다.
 //!
 //! ⚠ 승격은 두 겹으로 좁혔다 — 조각이 쪽 하단 30% 안에서 시작하고, 사다리대로 끊은
 //! 뒤 한 줄을 더 얹으면 예산을 넘어야 한다. 둘째 겹이 없으면 `#2070` 시장구조조사가
@@ -95,5 +99,20 @@ fn page4_zero_vpos_rewind_is_honored() {
     assert!(
         worst < 10.0,
         "4쪽 본문이 쪽 규모로 하한을 넘으면 안 된다 — #6718 회귀          (초과 {worst:.1}px, 본문 하한 {bottom:.1}; 수정 전 +108.8px)"
+    );
+}
+
+/// 10쪽 — `pi=62` 는 예산을 0.8px 차이로 통과해 사다리(@6)를 못 따랐다.
+///
+/// 수정 전 `+20.5px`.
+#[test]
+fn page10_rewind_survives_a_sub_pixel_fit() {
+    let bytes = sample();
+    let core = DocumentCore::from_bytes(&bytes).expect("문서 로드");
+
+    let (bottom, worst) = body_overflow(&core, 9).expect("10쪽 render tree");
+    assert!(
+        worst < 5.0,
+        "10쪽 본문이 하한을 넘으면 안 된다 — #6718 회귀          (초과 {worst:.1}px, 본문 하한 {bottom:.1}; 수정 전 +20.5px)"
     );
 }


### PR DESCRIPTION
#6718 의 잔여 `pi=62` 입니다. **PR #6721 이 첫 커밋만 반영된 채 닫혀** 이 커밋이 유실됐습니다 —
현행 devel 위로 다시 올립니다.

## 근인 — 예산이 아니라 **0.8px 반올림**

이슈 본문이 "추가 규명이 필요하다"고 남긴 자리입니다.

```text
pi=62  cur_line=0  end_line=7  n=44
       cum = 246.4   avail = 247.2      ← 7줄이 0.8px 차이로 들어간다
       → `cumulative > avail_for_lines` 가 거짓이라 사다리(@6)를 **아예 안 본다**
```

그 0.8px 은 조판 차이가 아니라 계산 오차 규모라, `LADDER_FIT_EPSILON_PX = 1.0` 을 두고
바깥 관문과 `ladder_page_is_full` 두 곳에 같은 여유를 줍니다.

## 현행 devel 기준 실측 (`27469`, 한/글 2020 = rhwp = 12쪽)

```text
                넘침  용지밖  겹침  글자겹침
devel             6      0      0      2
devel + 이 수정   5      0      0      2      ← 10쪽 +20.5px 소멸
```

`#2070` 시장구조조사 **315쪽 유지**. 코퍼스 래칫 5종 무변.

⭐ devel 에 이미 들어간 첫 커밋 이후, 8쪽 용지 밖 이탈(+121.2px)과 `pi=47` 자리가
사라져 있습니다(용지밖 1 → 0). 제가 "갈라내지 못했다"고 남긴 그 자리입니다 — 그 뒤에
들어온 다른 수정이 닫은 것으로 보입니다.

## 게이트

```
cargo nextest run --cargo-profile release-test --no-fail-fast
  9010 tests run: 9009 passed, 1 failed, 46 skipped
```

유일한 실패는 알려진 `wmf_emf_goldens_lock_current_engine`(CRLF, WMF/EMF 미변경)입니다.

## 잠금 시험

`tests/cases/issue_6718_native_hwp5_zero_vpos_rewind.rs` 에 10쪽 축을 더합니다
(수정 전 `+20.5px`). devel 에 들어간 판에서 `sample()` 이 `Vec<u8>` 로 바뀐 것에 맞췄습니다.

음성 대조: 여유를 되돌리면 10쪽 축이 FAIL 합니다.

⚠ `layout-anomaly` 의 `page=` 는 **0 기준**입니다 — `page=9` 는 10쪽입니다. 시험을 9쪽으로
잡았다가 음성 대조를 통과시켰습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
