### PR TITLE
Task #6553: IME 조합 오버레이가 soft-wrap 경계에서 이전 줄 끝에 그려짐

### DIFF
--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -3,6 +3,7 @@ import type { DeferredFocusedPagePatch } from '@/core/wasm-bridge';
 import { EventBus } from '@/core/event-bus';
 import { CursorState } from './cursor';
 import { CaretRenderer } from './caret-renderer';
+import { resolveGlyphStartRect } from './line-start-affinity';
 import { FieldMarkerRenderer } from './field-marker-renderer';
 import { SelectionRenderer } from './selection-renderer';
 import { CommandHistory } from './history';
@@ -3497,6 +3498,41 @@ export class InputHandler {
   }
 
   /**
+   * IME 조합 오버레이의 원점 rect 를 돌려준다.
+   *
+   * [Issue #6553] 조합 중인 글자가 soft-wrap 으로 다음 줄로 넘어가면 `anchor.charOffset` 이
+   * 줄 경계 offset 이 되고, 줄 affinity 인자가 없는 exact 조회는 이전 줄 끝을 돌려준다.
+   * 오버레이는 글자가 실제로 그려지는 줄에 놓여야 하므로 시각 줄을 명시해 다시 조회한다.
+   * 머리말/꼬리말·각주와 2단 이상 중첩 셀은 `getCursorRectOnLine` 이 대상 문단을 지목할 수
+   * 없어 제외한다(exact 유지).
+   */
+  private compositionOverlayStartRect(anchor: DocumentPosition, exact: CursorRect): CursorRect {
+    if (this.cursor.isInHeaderFooter() || this.cursor.isInFootnote()) return exact;
+    if ((anchor.cellPath?.length ?? 0) > 1) return exact;
+    const inCell = anchor.parentParaIndex !== undefined;
+    return resolveGlyphStartRect(anchor.charOffset, exact, {
+      lineInfoAt: (charOffset) => (inCell
+        ? this.wasm.getLineInfoInCell(
+            anchor.sectionIndex, anchor.parentParaIndex!, anchor.controlIndex!,
+            anchor.cellIndex!, anchor.cellParaIndex!, charOffset,
+          )
+        : this.wasm.getLineInfo(anchor.sectionIndex, anchor.paragraphIndex, charOffset)),
+      rectAtLineStart: (lineIndex) => {
+        try {
+          return this.wasm.getCursorRectOnLine(
+            anchor.sectionIndex, anchor.paragraphIndex, lineIndex, false,
+            anchor.parentParaIndex ?? 0xFFFFFFFF, anchor.controlIndex ?? 0xFFFFFFFF,
+            anchor.cellIndex ?? 0xFFFFFFFF, anchor.cellParaIndex ?? 0xFFFFFFFF,
+          );
+        } catch {
+          // getCursorRectOnLine 을 내보내지 않는 wasm 빌드 — 기존 exact 동작을 유지한다.
+          return null;
+        }
+      },
+    });
+  }
+
+  /**
    * 캐럿 위치를 갱신한다.
    *
    * @param skipScroll true 시 `scrollCaretIntoView` 호출 skip — cursor 변경 trigger 가 동반되지 않은
@@ -3541,6 +3577,7 @@ export class InputHandler {
               anchor.sectionIndex, anchor.paragraphIndex, anchor.charOffset,
             );
           }
+          startRect = this.compositionOverlayStartRect(anchor, startRect);
           const charWidth = rect.x - startRect.x;
           const text = this.textarea.value || '';
           // 현재 커서 위치의 글꼴 정보

--- a/rhwp-studio/src/engine/line-start-affinity.ts
+++ b/rhwp-studio/src/engine/line-start-affinity.ts
@@ -1,0 +1,44 @@
+import type { CursorRect, LineInfo } from '@/core/types';
+
+/** 시각 줄 affinity 로 rect 를 다시 조회하는 데 필요한 최소 질의 집합. */
+export interface LineAffinityLookup {
+  /** `charOffset` 이 속한 시각 줄 정보. */
+  lineInfoAt(charOffset: number): LineInfo;
+  /** `lineIndex` 줄의 시작 rect. 조회할 수 없으면 null. */
+  rectAtLineStart(lineIndex: number): CursorRect | null;
+}
+
+/**
+ * `charOffset` 에서 시작하는 **글자가 실제로 그려지는 자리**의 rect 를 돌려준다.
+ *
+ * soft-wrap 줄 경계 offset 은 "이전 줄 끝"과 "다음 줄 시작"을 동시에 뜻한다(#785).
+ * 줄 affinity 인자가 없는 `getCursorRect` 는 render tree 를 시각 순서로 훑다 이전 줄의
+ * TextRun 에 먼저 매치돼 그 줄 끝을 돌려준다. 캐럿에는 그 affinity 가 맞지만, 그 offset 의
+ * 글자를 덮어 그리는 오버레이에는 한 줄 위를 가리키는 값이 된다(#6553).
+ *
+ * 모호한 경계(= offset 이 두 번째 이후 줄의 시작)일 때만 시각 줄을 명시해 다시 조회하고,
+ * 그 밖에는 `exact` 를 그대로 돌려준다 — 조합 갱신마다 도는 경로라 불필요한 질의를 늘리지
+ * 않는다.
+ */
+export function resolveGlyphStartRect(
+  charOffset: number,
+  exact: CursorRect,
+  lookup: LineAffinityLookup,
+): CursorRect {
+  const line = lookup.lineInfoAt(charOffset);
+  // 첫 줄은 앞줄이 없어 모호하지 않다.
+  if (line.lineIndex <= 0 || charOffset !== line.charStart) return exact;
+
+  const onLine = lookup.rectAtLineStart(line.lineIndex);
+  if (!onLine) return exact;
+
+  // getCursorRectOnLine 은 셀 bbox 를 싣지 않는다 — 오버레이의 셀 클램프(#1951)가 쓰는
+  // cellBounds 는 exact 쪽 값을 유지한다.
+  return {
+    ...exact,
+    pageIndex: onLine.pageIndex,
+    x: onLine.x,
+    y: onLine.y,
+    height: onLine.height,
+  };
+}

--- a/rhwp-studio/tests/composition-line-affinity.test.ts
+++ b/rhwp-studio/tests/composition-line-affinity.test.ts
@@ -1,0 +1,125 @@
+// [Issue #6553] IME 조합 중인 글자가 soft-wrap 으로 다음 줄로 넘어가면, 조합 오버레이가
+// 넘어가기 전 위치인 이전 줄 끝에 그려져 같은 글자가 두 곳에 보였다.
+//
+// 좌표는 devel 에서 실측한 값이다 — samples/143E433F503322BD33.hwp 구역 0 / 문단 1,
+// wrap 경계 offset 22:
+//   getCursorRect(0, 1, 22) = { x: 394.0, y: 125.8 }   (이전 줄 끝 — 줄 affinity 없는 exact 조회)
+//   getCursorRect(0, 1, 23) = { x: 134.9, y: 147.1 }   (조합 중 캐럿)
+//   getCursorRectOnLine(0, 1, 1, at_end=false) = { x: 121.6, y: 146.5 }  (글자가 놓인 줄의 시작)
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import { resolveGlyphStartRect } from '../src/engine/line-start-affinity.ts';
+import { codeOnly, functionBodyFrom } from './support/source-guard.ts';
+import type { CursorRect, LineInfo } from '../src/core/types.ts';
+
+/** 이전 줄 끝 — 줄 affinity 없는 exact 조회 결과. */
+const EXACT_PREV_LINE_END: CursorRect = { pageIndex: 0, x: 394.0, y: 125.8, height: 21.3 };
+/** 조합 중 캐럿 — 글자가 실제로 놓인 다음 줄. */
+const CARET_ON_NEXT_LINE: CursorRect = { pageIndex: 0, x: 134.9, y: 147.1, height: 21.3 };
+/** 글자가 놓인 줄의 시작. */
+const NEXT_LINE_START: CursorRect = { pageIndex: 0, x: 121.6, y: 146.5, height: 21.3 };
+
+/** offset 22 가 두 번째 줄(lineIndex 1)의 시작인 문단. */
+const WRAP_BOUNDARY_LINE: LineInfo = { lineIndex: 1, lineCount: 2, charStart: 22, charEnd: 45 };
+
+function lookup(
+  line: LineInfo,
+  onLine: CursorRect | null,
+): { calls: { lineInfoAt: number[]; rectAtLineStart: number[] } } & Parameters<typeof resolveGlyphStartRect>[2] {
+  const calls = { lineInfoAt: [] as number[], rectAtLineStart: [] as number[] };
+  return {
+    calls,
+    lineInfoAt(charOffset: number) {
+      calls.lineInfoAt.push(charOffset);
+      return line;
+    },
+    rectAtLineStart(lineIndex: number) {
+      calls.rectAtLineStart.push(lineIndex);
+      return onLine;
+    },
+  };
+}
+
+test('soft-wrap 경계 offset 은 글자가 놓인 줄의 시작으로 해석된다', () => {
+  const deps = lookup(WRAP_BOUNDARY_LINE, NEXT_LINE_START);
+  const resolved = resolveGlyphStartRect(22, EXACT_PREV_LINE_END, deps);
+
+  assert.deepEqual(deps.calls.lineInfoAt, [22]);
+  assert.deepEqual(deps.calls.rectAtLineStart, [1], '모호한 경계에서는 시각 줄을 명시해 다시 조회한다');
+  assert.equal(resolved.x, NEXT_LINE_START.x);
+  assert.equal(resolved.y, NEXT_LINE_START.y);
+  assert.equal(resolved.pageIndex, NEXT_LINE_START.pageIndex);
+  assert.notEqual(resolved.y, EXACT_PREV_LINE_END.y, '이전 줄에 남으면 안 된다');
+});
+
+test('경계에서 조합 오버레이 폭이 음수에서 실제 글자 폭으로 바뀐다', () => {
+  // caret-renderer 의 clampCompositionBox 는 음수 폭을 Math.max(charWidth, height*0.6) 로
+  // 조용히 삼켜, 틀린 줄에 그럴듯한 크기의 박스를 그렸다.
+  const before = CARET_ON_NEXT_LINE.x - EXACT_PREV_LINE_END.x;
+  assert.ok(before < 0, `수정 전 charWidth 는 음수였다: ${before}`);
+
+  const resolved = resolveGlyphStartRect(22, EXACT_PREV_LINE_END, lookup(WRAP_BOUNDARY_LINE, NEXT_LINE_START));
+  const after = CARET_ON_NEXT_LINE.x - resolved.x;
+  assert.ok(after > 0, `수정 후 charWidth 는 양수여야 한다: ${after}`);
+  assert.ok(after < CARET_ON_NEXT_LINE.height, `한 글자 폭이어야 한다: ${after}`);
+});
+
+test('줄 중간 offset 은 exact 를 그대로 쓰고 줄 조회를 추가하지 않는다', () => {
+  const deps = lookup({ lineIndex: 1, lineCount: 2, charStart: 22, charEnd: 45 }, NEXT_LINE_START);
+  const resolved = resolveGlyphStartRect(30, EXACT_PREV_LINE_END, deps);
+
+  assert.deepEqual(resolved, EXACT_PREV_LINE_END);
+  assert.deepEqual(deps.calls.rectAtLineStart, [], '모호하지 않으면 추가 질의를 하지 않는다');
+});
+
+test('첫 줄 시작은 앞줄이 없어 추가 질의 없이 exact 를 쓴다', () => {
+  const deps = lookup({ lineIndex: 0, lineCount: 2, charStart: 0, charEnd: 22 }, NEXT_LINE_START);
+  const resolved = resolveGlyphStartRect(0, EXACT_PREV_LINE_END, deps);
+
+  assert.deepEqual(resolved, EXACT_PREV_LINE_END);
+  assert.deepEqual(deps.calls.rectAtLineStart, []);
+});
+
+test('줄 시작 rect 를 조회할 수 없으면 exact 동작을 유지한다', () => {
+  const resolved = resolveGlyphStartRect(22, EXACT_PREV_LINE_END, lookup(WRAP_BOUNDARY_LINE, null));
+  assert.deepEqual(resolved, EXACT_PREV_LINE_END);
+});
+
+test('셀 오버레이 클램프용 cellBounds 는 줄 재조회 뒤에도 보존된다', () => {
+  // getCursorRectOnLine 은 cellBounds 를 싣지 않는다. 잃어버리면 #1951 의 셀 밖 이탈이 되살아난다.
+  const exactInCell: CursorRect = {
+    ...EXACT_PREV_LINE_END,
+    cellBounds: { x: 100, y: 120, w: 300, h: 60 },
+  };
+  const resolved = resolveGlyphStartRect(22, exactInCell, lookup(WRAP_BOUNDARY_LINE, NEXT_LINE_START));
+
+  assert.deepEqual(resolved.cellBounds, exactInCell.cellBounds);
+  assert.equal(resolved.x, NEXT_LINE_START.x);
+});
+
+test('updateCaret 의 조합 분기가 폭 계산 전에 줄 affinity 를 적용한다', () => {
+  const source = codeOnly(readFileSync(new URL('../src/engine/input-handler.ts', import.meta.url), 'utf8'));
+  const updateCaret = functionBodyFrom(source, 'private updateCaret(');
+
+  const applied = updateCaret.indexOf('startRect = this.compositionOverlayStartRect(anchor, startRect);');
+  const width = updateCaret.indexOf('const charWidth = rect.x - startRect.x;');
+  assert.ok(applied >= 0, '조합 오버레이 원점이 줄 affinity 를 거쳐야 한다');
+  assert.ok(width >= 0);
+  assert.ok(applied < width, '폭 계산 전에 원점을 확정해야 한다');
+
+  const resolver = functionBodyFrom(source, 'private compositionOverlayStartRect(');
+  assert.match(resolver, /resolveGlyphStartRect\(anchor\.charOffset, exact,/);
+  assert.match(
+    resolver,
+    /if \(this\.cursor\.isInHeaderFooter\(\) \|\| this\.cursor\.isInFootnote\(\)\) return exact;/,
+    '머리말・꼬리말·각주는 getCursorRectOnLine 대상이 아니라 exact 를 유지한다',
+  );
+  assert.match(
+    resolver,
+    /if \(\(anchor\.cellPath\?\.length \?\? 0\) > 1\) return exact;/,
+    '2단 이상 중첩 셀은 getCursorRectOnLine 이 문단을 지목할 수 없어 exact 를 유지한다',
+  );
+  assert.match(resolver, /this\.wasm\.getCursorRectOnLine\(/);
+});


### PR DESCRIPTION
관련 이슈: #6553

## 문제

IME 조합 중인 글자가 soft-wrap 으로 다음 줄로 넘어가면, 조합 오버레이(블랙박스)가 넘어가기 전 위치인 **이전 줄 끝**에 그려져 같은 글자가 두 곳에 보인다. 조합 중에는 일반 캐럿이 숨겨지므로(`caret-renderer.ts:108`) 화면의 유일한 캐럿 표시가 틀린 줄에 놓인다.

## 원인

`updateCaret()` 는 조합 오버레이의 기준 좌표를 조합 앵커 offset 으로 조회한다(`rhwp-studio/src/engine/input-handler.ts:3540`, `:3544`, `:3552`).

조합 글자가 줄바꿈되면 `anchor.charOffset` 은 정확히 soft-wrap 경계 offset 이 된다. 이 offset 은 "이전 줄 끝"과 "다음 줄 시작"을 동시에 뜻하는데(`src/wasm_api.rs:2891` 의 `getCursorRectOnLine` 문서 주석이 이 모호성을 명시한다), 줄 affinity 인자가 없는 `getCursorRect` 는 render tree 를 시각 순서로 훑다 이전 줄의 TextRun 에 먼저 매치돼 그 줄 끝을 돌려준다(`src/document_core/queries/cursor_rect.rs:875` 의 양끝 포함 범위 판정 + `find_cursor_in_node` 의 즉시 `return`, `:831`).

그 결과 `charWidth = rect.x - startRect.x` 가 음수가 되는데, 이 값은 `caret-renderer.ts:165` 의

```ts
let w = Math.max(charWidth, rect.height * 0.6);
```

에서 조용히 삼켜져 `줄높이 × 0.6` 폭의 그럴듯한 박스가 이전 줄 끝에 그려진다. `startRect` 와 `rect` 가 서로 다른 줄이라는 사실을 검사하는 곳이 없다.

같은 soft-wrap 모호성은 캐럿 이동 경로에서는 이미 다뤄져 있다 — `cursor.ts:840`(#785), `cursor.ts:904 getCursorRectOnVisualLine`, `cursor.ts:922 isPreviousLineEnd`. 조합 오버레이만 이 판정을 거치지 않았다. #4150 은 `compositionAnchorRect` **캐시** 제거로 고쳤지만, 재조회 자체가 줄 경계에서 이전 줄을 돌려주므로 조합 글자가 직접 줄바꿈되는 이 경우는 남아 있었다.

## 변경

- `rhwp-studio/src/engine/line-start-affinity.ts` (신규) — `resolveGlyphStartRect(charOffset, exact, lookup)`. offset 이 **두 번째 이후 줄의 시작**일 때만(= 모호한 경계일 때만) 시각 줄을 명시해 다시 조회하고, 그 밖에는 `exact` 를 그대로 돌려준다. 조합 갱신마다 도는 경로라 모호하지 않은 offset 에는 질의를 추가하지 않는다.
- `rhwp-studio/src/engine/input-handler.ts` — `compositionOverlayStartRect(anchor, exact)` 를 추가해 오버레이 원점을 이 판정에 태우고, 폭 계산 **전에** 적용한다. 줄 조회는 캐럿 이동이 쓰는 것과 같은 `getLineInfo`/`getLineInfoInCell` + `getCursorRectOnLine` 이다.
- `getCursorRectOnLine` 은 셀 bbox 를 싣지 않으므로, 오버레이 셀 클램프(#1951)가 쓰는 `cellBounds` 는 `exact` 쪽 값을 유지한다.
- 머리말/꼬리말·각주와 2단 이상 중첩 셀은 `getCursorRectOnLine` 이 대상 문단을 지목할 수 없어 기존 `exact` 동작을 유지한다. `getCursorRectOnLine` 을 내보내지 않는 wasm 빌드에서도 마찬가지다.
- 테스트 `rhwp-studio/tests/composition-line-affinity.test.ts` 7건 — 경계 해석, 폭 부호, 비경계 offset 의 질의 미추가, 첫 줄, 조회 실패 폴백, `cellBounds` 보존, 그리고 `updateCaret` 배선 소스 가드(`codeOnly` + `functionBodyFrom` 앵커).

## 검증

devel `693c4b6b3` 기준.

**실제 브라우저 실측** (vite dev + Chrome, 같은 문서·같은 조합 입력으로 수정 전/후 각각 1회. 문단을 1행 끝까지 채운 뒤 조합 글자 하나가 2행으로 넘어가게 함):

| | `.caret-composition` top | width | 판정 |
| --- | --- | --- | --- |
| 수정 전 | 137.73px (1행) | 7.69px | `= 12.81 × 0.6` 폴백 폭, 캐럿(2행)과 다른 줄 |
| 수정 후 | 157.68px (2행) | 12.42px | 한 글자 폭, 캐럿과 같은 줄 |

![수정 전/후 비교](https://raw.githubusercontent.com/lpaiu-cs/rhwp/assets/ime-wrap-ghost/pr-6553-before-after.png)

**엔진 좌표 실측** (이슈 #6553 본문과 동일, `samples/143E433F503322BD33.hwp` 구역 0 / 문단 1, 경계 offset 22): `getCursorRect(0,1,22)` = (394.0, 125.8) 이전 줄 끝, `getCursorRect(0,1,23)` = (134.9, 147.1) 다음 줄, `getCursorRectOnLine(0,1,1,at_end=false)` = (121.6, 146.5). `charWidth` = -259.1. 같은 문서 문단 4·9 에서도 -169.5, -285.2.

**수정 전 실패 증명** (2종):

- `updateCaret` 배선만 되돌림 → 소스 가드 1건 실패 (`조합 오버레이 원점이 줄 affinity 를 거쳐야 한다`), 나머지 6건 통과.
- `resolveGlyphStartRect` 를 항상 `exact` 반환으로 되돌림(수정 전 의미) → 3건 실패, 그중 폭 검사가 `수정 후 charWidth 는 양수여야 한다: -259.1` 로 실제 결함 수치를 그대로 재현.

**게이트**: `npm --prefix rhwp-studio test` 1380 통과 / 0 실패 / 1 skip. `npx tsc --noEmit` 은 이 변경으로 늘어난 오류 없음 — 남는 8건은 모두 `src/core/wasm-bridge.ts` 의 `HwpDocument` 메서드 미존재로, 로컬 prebuilt `pkg/` 가 devel 보다 오래돼서 나며 변경 전 devel 체크아웃에서도 동일하게 재현된다. `git diff --check` 클린.

**측정 환경의 한계**: 브라우저 검증의 studio TypeScript 는 devel `693c4b6b3` 이지만 wasm 엔진은 로컬 prebuilt `pkg/`(2026-08-23 빌드)다. 사용한 엔진 API(`getCursorRect`·`getLineInfo`·`getCursorRectOnLine`)는 그 사이 변경이 없다.

## 범위 외

- 조합 글자가 **다음 쪽**으로 넘어가는 변종(`startRect.pageIndex` 불일치)은 같은 메커니즘으로 보이나 이번에 실측하지 않았다.
- 머리말/꼬리말·각주와 2단 이상 중첩 셀은 위와 같은 이유로 그대로 두었다. 같은 계열을 덮으려면 `getCursorRectOnLine` 에 해당 문맥을 받는 경로가 먼저 필요하다.
- 창 크기 변경 시 조합 오버레이 좌표가 재계산되지 않는 별개 동작은 손대지 않았다.

참고: #4150, #1951, #785
