### PR TITLE
Task #6738: 조합 오버레이가 성립하지 않는 기하를 폴백 폭으로 덮지 않는다

### DIFF
--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -3582,13 +3582,21 @@ export class InputHandler {
     if (this.cursor.isInHeaderFooter() || this.cursor.isInFootnote()) return exact;
     if ((anchor.cellPath?.length ?? 0) > 1) return exact;
     const inCell = anchor.parentParaIndex !== undefined;
+    // 두 질의 모두 실패를 null 로 알린다 — 여기서 예외가 새면 updateCaret 의 바깥 catch 가
+    // 조합 오버레이를 통째로 접어버려, exact 로 물러나는 것보다 나쁜 결과가 된다.
     return resolveGlyphStartRect(anchor.charOffset, exact, {
-      lineInfoAt: (charOffset) => (inCell
-        ? this.wasm.getLineInfoInCell(
-            anchor.sectionIndex, anchor.parentParaIndex!, anchor.controlIndex!,
-            anchor.cellIndex!, anchor.cellParaIndex!, charOffset,
-          )
-        : this.wasm.getLineInfo(anchor.sectionIndex, anchor.paragraphIndex, charOffset)),
+      lineInfoAt: (charOffset) => {
+        try {
+          return inCell
+            ? this.wasm.getLineInfoInCell(
+                anchor.sectionIndex, anchor.parentParaIndex!, anchor.controlIndex!,
+                anchor.cellIndex!, anchor.cellParaIndex!, charOffset,
+              )
+            : this.wasm.getLineInfo(anchor.sectionIndex, anchor.paragraphIndex, charOffset);
+        } catch {
+          return null;
+        }
+      },
       rectAtLineStart: (lineIndex) => {
         try {
           return this.wasm.getCursorRectOnLine(

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -3,7 +3,7 @@ import type { DeferredFocusedPagePatch } from '@/core/wasm-bridge';
 import { EventBus } from '@/core/event-bus';
 import { CursorState } from './cursor';
 import { CaretRenderer } from './caret-renderer';
-import { resolveGlyphStartRect } from './line-start-affinity';
+import { resolveGlyphStartRect, isCompositionBoxRepresentable } from './line-start-affinity';
 import { FieldMarkerRenderer } from './field-marker-renderer';
 import { SelectionRenderer } from './selection-renderer';
 import { CommandHistory } from './history';
@@ -3650,15 +3650,23 @@ export class InputHandler {
             );
           }
           startRect = this.compositionOverlayStartRect(anchor, startRect);
-          const charWidth = rect.x - startRect.x;
-          const text = this.textarea.value || '';
-          // 현재 커서 위치의 글꼴 정보
-          let fontFamily = 'sans-serif';
-          try {
-            const props = this.getCharPropertiesAtCursor();
-            if (props.fontFamily) fontFamily = props.fontFamily;
-          } catch { /* fallback */ }
-          this.caret.showComposition(startRect, charWidth, zoom, text, fontFamily);
+          if (!isCompositionBoxRepresentable(startRect, rect)) {
+            // [Issue #6738] 머리말/꼬리말·각주·2단계 이상 중첩 셀에는 줄 affinity 를 물을
+            // API 가 없어, 조합 글자가 줄이나 쪽을 넘어가도 시작 좌표를 바로잡을 수 없다.
+            // 틀린 자리에 박스를 그리는 대신 조회 실패와 같은 경로로 일반 캐럿을 보여준다.
+            this.caret.hideComposition();
+            this.caret.update(rect, zoom);
+          } else {
+            const charWidth = rect.x - startRect.x;
+            const text = this.textarea.value || '';
+            // 현재 커서 위치의 글꼴 정보
+            let fontFamily = 'sans-serif';
+            try {
+              const props = this.getCharPropertiesAtCursor();
+              if (props.fontFamily) fontFamily = props.fontFamily;
+            } catch { /* fallback */ }
+            this.caret.showComposition(startRect, charWidth, zoom, text, fontFamily);
+          }
         } catch {
           // getCursorRect 실패 시 일반 캐럿
           this.caret.hideComposition();

--- a/rhwp-studio/src/engine/line-start-affinity.ts
+++ b/rhwp-studio/src/engine/line-start-affinity.ts
@@ -1,9 +1,15 @@
 import type { CursorRect, LineInfo } from '@/core/types';
 
-/** 시각 줄 affinity 로 rect 를 다시 조회하는 데 필요한 최소 질의 집합. */
+/**
+ * 시각 줄 affinity 로 rect 를 다시 조회하는 데 필요한 최소 질의 집합.
+ *
+ * 두 질의 모두 **실패를 null 로 알린다**. 어느 한쪽이라도 예외를 던지면 호출부의 바깥
+ * catch 로 빠져 조합 오버레이가 통째로 사라지는데, 그것은 `exact` 로 물러나는 것보다
+ * 나쁜 결과다. 구현부가 wasm 예외를 삼켜 null 로 바꿔서 넘긴다.
+ */
 export interface LineAffinityLookup {
-  /** `charOffset` 이 속한 시각 줄 정보. */
-  lineInfoAt(charOffset: number): LineInfo;
+  /** `charOffset` 이 속한 시각 줄 정보. 조회할 수 없으면 null. */
+  lineInfoAt(charOffset: number): LineInfo | null;
   /** `lineIndex` 줄의 시작 rect. 조회할 수 없으면 null. */
   rectAtLineStart(lineIndex: number): CursorRect | null;
 }
@@ -16,9 +22,8 @@ export interface LineAffinityLookup {
  * TextRun 에 먼저 매치돼 그 줄 끝을 돌려준다. 캐럿에는 그 affinity 가 맞지만, 그 offset 의
  * 글자를 덮어 그리는 오버레이에는 한 줄 위를 가리키는 값이 된다(#6553).
  *
- * 모호한 경계(= offset 이 두 번째 이후 줄의 시작)일 때만 시각 줄을 명시해 다시 조회하고,
- * 그 밖에는 `exact` 를 그대로 돌려준다 — 조합 갱신마다 도는 경로라 불필요한 질의를 늘리지
- * 않는다.
+ * 조합 갱신마다 도는 경로다. `lineInfoAt` 은 매번 한 번 돌지만, 무거운 쪽인
+ * `rectAtLineStart` 는 모호한 경계(= offset 이 두 번째 이후 줄의 시작)에서만 부른다.
  */
 export function resolveGlyphStartRect(
   charOffset: number,
@@ -26,20 +31,26 @@ export function resolveGlyphStartRect(
   lookup: LineAffinityLookup,
 ): CursorRect {
   const line = lookup.lineInfoAt(charOffset);
+  if (!line) return exact;
   // 첫 줄은 앞줄이 없어 모호하지 않다.
   if (line.lineIndex <= 0 || charOffset !== line.charStart) return exact;
 
   const onLine = lookup.rectAtLineStart(line.lineIndex);
   if (!onLine) return exact;
 
-  // getCursorRectOnLine 은 셀 bbox 를 싣지 않는다 — 오버레이의 셀 클램프(#1951)가 쓰는
-  // cellBounds 는 exact 쪽 값을 유지한다.
+  // `cellBounds`(와 그 파생 `cellOverflowed`)는 그 rect 가 놓인 **쪽의** 셀 bbox 다.
+  // getCursorRectOnLine 은 이 둘을 싣지 않으므로 같은 쪽일 때만 exact 것을 이어 쓴다 —
+  // 쪽이 바뀌었는데 그대로 들고 가면 오버레이의 셀 클램프(#1951)가 다른 쪽 bbox 로
+  // 좌표를 가둔다. 쪽이 다르면 클램프 없이 두는 편이 틀린 곳에 가두는 것보다 낫다.
+  const samePage = onLine.pageIndex === exact.pageIndex;
   return {
     ...exact,
     pageIndex: onLine.pageIndex,
     x: onLine.x,
     y: onLine.y,
     height: onLine.height,
+    cellBounds: samePage ? exact.cellBounds : undefined,
+    cellOverflowed: samePage ? exact.cellOverflowed : undefined,
   };
 }
 

--- a/rhwp-studio/src/engine/line-start-affinity.ts
+++ b/rhwp-studio/src/engine/line-start-affinity.ts
@@ -42,3 +42,19 @@ export function resolveGlyphStartRect(
     height: onLine.height,
   };
 }
+
+/**
+ * 조합 오버레이의 시작 rect 와 캐럿이 **한 줄 안에** 있는지 — 즉 단일 사각형으로 그릴 수
+ * 있는지 판정한다.
+ *
+ * y 비교는 쓸 수 없다. 같은 줄이라도 글꼴 크기가 섞이면 캐럿 y 가 run 마다 다르다(캐럿 y 는
+ * baseline 기준으로 잡힌다). 대신 한 줄 안에서 반드시 성립해야 하는 관계를 본다 — 같은 쪽이고,
+ * 시작이 캐럿보다 오른쪽에 있지 않아야 한다.
+ *
+ * [Issue #6738] 줄 affinity 를 물을 수 없는 문맥(머리말/꼬리말·각주·2단계 이상 중첩 셀)에서는
+ * 조합 글자가 줄을 넘어가도 시작 좌표를 바로잡을 수 없다. 그 상태로 그리면 폭이 음수가 되고
+ * `clampCompositionBox` 의 `height * 0.6` 폴백에 삼켜져 이전 줄에 그럴듯한 박스가 남는다.
+ */
+export function isCompositionBoxRepresentable(start: CursorRect, caret: CursorRect): boolean {
+  return start.pageIndex === caret.pageIndex && start.x <= caret.x;
+}

--- a/rhwp-studio/tests/composition-line-affinity.test.ts
+++ b/rhwp-studio/tests/composition-line-affinity.test.ts
@@ -10,7 +10,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
-import { resolveGlyphStartRect } from '../src/engine/line-start-affinity.ts';
+import { resolveGlyphStartRect, isCompositionBoxRepresentable } from '../src/engine/line-start-affinity.ts';
 import { codeOnly, functionBodyFrom } from './support/source-guard.ts';
 import type { CursorRect, LineInfo } from '../src/core/types.ts';
 
@@ -122,4 +122,40 @@ test('updateCaret 의 조합 분기가 폭 계산 전에 줄 affinity 를 적용
     '2단 이상 중첩 셀은 getCursorRectOnLine 이 문단을 지목할 수 없어 exact 를 유지한다',
   );
   assert.match(resolver, /this\.wasm\.getCursorRectOnLine\(/);
+});
+
+// [Issue #6738] 줄 affinity 를 물을 수 없는 문맥(머리말/꼬리말·각주·2단계 이상 중첩 셀)에서는
+// 조합 글자가 줄을 넘어가도 시작 좌표를 바로잡을 수 없다. 그 상태로 단일 사각형을 그리면
+// 폭이 음수가 되어 clampCompositionBox 의 height*0.6 폴백에 삼켜지고 이전 줄에 박스가 남는다.
+
+test('한 줄 안의 조합은 단일 사각형으로 그릴 수 있다고 판정한다', () => {
+  const start: CursorRect = { pageIndex: 0, x: 121.6, y: 146.5, height: 13.3 };
+  assert.equal(isCompositionBoxRepresentable(start, CARET_ON_NEXT_LINE), true);
+  // 폭 0(막 시작한 조합)도 그릴 수 있다.
+  assert.equal(isCompositionBoxRepresentable(CARET_ON_NEXT_LINE, CARET_ON_NEXT_LINE), true);
+});
+
+test('줄을 넘어간 조합은 그릴 수 없다고 판정한다', () => {
+  // 실측: 이전 줄 끝 x=394.0 > 캐럿 x=134.9 → 폭이 음수가 되는 바로 그 상태
+  assert.equal(isCompositionBoxRepresentable(EXACT_PREV_LINE_END, CARET_ON_NEXT_LINE), false);
+});
+
+test('쪽을 넘어간 조합은 그릴 수 없다고 판정한다', () => {
+  const prevPage: CursorRect = { ...CARET_ON_NEXT_LINE, pageIndex: 0, x: 100 };
+  const nextPage: CursorRect = { ...CARET_ON_NEXT_LINE, pageIndex: 1, x: 121.6 };
+  assert.equal(isCompositionBoxRepresentable(prevPage, nextPage), false);
+});
+
+test('그릴 수 없는 조합은 오버레이 대신 일반 캐럿으로 물러난다', () => {
+  const source = codeOnly(readFileSync(new URL('../src/engine/input-handler.ts', import.meta.url), 'utf8'));
+  const updateCaret = functionBodyFrom(source, 'private updateCaret(');
+
+  assert.match(
+    updateCaret,
+    /if \(!isCompositionBoxRepresentable\(startRect, rect\)\) \{\s*this\.caret\.hideComposition\(\);\s*this\.caret\.update\(rect, zoom\);\s*\} else \{/,
+    '그릴 수 없으면 조회 실패와 같은 경로(hideComposition + 일반 캐럿)로 물러나야 한다',
+  );
+  const guard = updateCaret.indexOf('isCompositionBoxRepresentable(startRect, rect)');
+  const show = updateCaret.indexOf('this.caret.showComposition(');
+  assert.ok(guard >= 0 && show > guard, '오버레이 표시 전에 판정해야 한다');
 });

--- a/rhwp-studio/tests/composition-line-affinity.test.ts
+++ b/rhwp-studio/tests/composition-line-affinity.test.ts
@@ -11,7 +11,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 import { resolveGlyphStartRect, isCompositionBoxRepresentable } from '../src/engine/line-start-affinity.ts';
-import { codeOnly, functionBodyFrom } from './support/source-guard.ts';
+import { balancedFrom, codeOnly, functionBodyFrom } from './support/source-guard.ts';
 import type { CursorRect, LineInfo } from '../src/core/types.ts';
 
 /** 이전 줄 끝 — 줄 affinity 없는 exact 조회 결과. */
@@ -21,11 +21,14 @@ const CARET_ON_NEXT_LINE: CursorRect = { pageIndex: 0, x: 134.9, y: 147.1, heigh
 /** 글자가 놓인 줄의 시작. */
 const NEXT_LINE_START: CursorRect = { pageIndex: 0, x: 121.6, y: 146.5, height: 21.3 };
 
+/** 소스 가드용 — 줄바꿈·연속 공백을 한 칸으로 눌러 서식 의존을 없앤다. */
+const flatten = (src: string) => src.replace(/\s+/g, ' ');
+
 /** offset 22 가 두 번째 줄(lineIndex 1)의 시작인 문단. */
 const WRAP_BOUNDARY_LINE: LineInfo = { lineIndex: 1, lineCount: 2, charStart: 22, charEnd: 45 };
 
 function lookup(
-  line: LineInfo,
+  line: LineInfo | null,
   onLine: CursorRect | null,
 ): { calls: { lineInfoAt: number[]; rectAtLineStart: number[] } } & Parameters<typeof resolveGlyphStartRect>[2] {
   const calls = { lineInfoAt: [] as number[], rectAtLineStart: [] as number[] };
@@ -109,16 +112,18 @@ test('updateCaret 의 조합 분기가 폭 계산 전에 줄 affinity 를 적용
   assert.ok(width >= 0);
   assert.ok(applied < width, '폭 계산 전에 원점을 확정해야 한다');
 
-  const resolver = functionBodyFrom(source, 'private compositionOverlayStartRect(');
-  assert.match(resolver, /resolveGlyphStartRect\(anchor\.charOffset, exact,/);
+  // 아래 가드들은 서식이 아니라 **의미**를 잠근다 — 줄바꿈·들여쓰기·연산자 간격이 바뀌어도
+  // 통과해야 한다(무해한 재포맷에 깨지는 구조 정규식을 쓰지 않는다).
+  const resolver = flatten(functionBodyFrom(source, 'private compositionOverlayStartRect('));
+  assert.match(resolver, /resolveGlyphStartRect\(\s*anchor\.charOffset\s*,\s*exact\s*,/);
   assert.match(
     resolver,
-    /if \(this\.cursor\.isInHeaderFooter\(\) \|\| this\.cursor\.isInFootnote\(\)\) return exact;/,
+    /isInHeaderFooter\(\)\s*\|\|\s*this\.cursor\.isInFootnote\(\)\s*\)\s*return exact;/,
     '머리말・꼬리말·각주는 getCursorRectOnLine 대상이 아니라 exact 를 유지한다',
   );
   assert.match(
     resolver,
-    /if \(\(anchor\.cellPath\?\.length \?\? 0\) > 1\) return exact;/,
+    /anchor\.cellPath\?\.length\s*\?\?\s*0\s*\)\s*>\s*1\s*\)\s*return exact;/,
     '2단 이상 중첩 셀은 getCursorRectOnLine 이 문단을 지목할 수 없어 exact 를 유지한다',
   );
   assert.match(resolver, /this\.wasm\.getCursorRectOnLine\(/);
@@ -150,12 +155,61 @@ test('그릴 수 없는 조합은 오버레이 대신 일반 캐럿으로 물러
   const source = codeOnly(readFileSync(new URL('../src/engine/input-handler.ts', import.meta.url), 'utf8'));
   const updateCaret = functionBodyFrom(source, 'private updateCaret(');
 
-  assert.match(
-    updateCaret,
-    /if \(!isCompositionBoxRepresentable\(startRect, rect\)\) \{\s*this\.caret\.hideComposition\(\);\s*this\.caret\.update\(rect, zoom\);\s*\} else \{/,
-    '그릴 수 없으면 조회 실패와 같은 경로(hideComposition + 일반 캐럿)로 물러나야 한다',
-  );
+  // 블록을 괄호 짝으로 잘라 **무엇을 하는지**만 본다 — 문 사이 서식에 걸리지 않는다.
+  const fallback = balancedFrom(updateCaret, 'if (!isCompositionBoxRepresentable', '{');
+  assert.match(fallback, /this\.caret\.hideComposition\(\)/, '그릴 수 없으면 오버레이를 접어야 한다');
+  assert.match(fallback, /this\.caret\.update\(\s*rect\s*,/, '조회 실패와 같은 경로로 일반 캐럿을 보여야 한다');
+  assert.doesNotMatch(fallback, /showComposition/, '그릴 수 없는데 오버레이를 그리면 안 된다');
   const guard = updateCaret.indexOf('isCompositionBoxRepresentable(startRect, rect)');
   const show = updateCaret.indexOf('this.caret.showComposition(');
   assert.ok(guard >= 0 && show > guard, '오버레이 표시 전에 판정해야 한다');
+});
+
+test('줄 정보를 조회할 수 없으면 exact 동작을 유지한다', () => {
+  // lineInfoAt 이 던지지 않고 null 로 실패를 알리는 계약. 예외가 새면 호출부 바깥 catch 가
+  // 조합 오버레이를 통째로 접어, exact 로 물러나는 것보다 나쁜 결과가 된다.
+  const deps = lookup(null, NEXT_LINE_START);
+  const resolved = resolveGlyphStartRect(22, EXACT_PREV_LINE_END, deps);
+
+  assert.deepEqual(resolved, EXACT_PREV_LINE_END);
+  assert.deepEqual(deps.calls.rectAtLineStart, [], '줄을 모르면 줄 조회로 넘어가지 않는다');
+});
+
+test('줄이 다른 쪽에 있으면 셀 bbox 를 이어 쓰지 않는다', () => {
+  // cellBounds 는 그 rect 가 놓인 쪽의 셀 bbox 다. 쪽이 바뀌었는데 들고 가면
+  // clampCompositionBox 가 다른 쪽 bbox 로 좌표를 가둔다.
+  const exactInCell: CursorRect = {
+    ...EXACT_PREV_LINE_END,
+    cellBounds: { x: 100, y: 120, w: 300, h: 60 },
+    cellOverflowed: true,
+  };
+  const onNextPage: CursorRect = { ...NEXT_LINE_START, pageIndex: 1 };
+  const resolved = resolveGlyphStartRect(22, exactInCell, lookup(WRAP_BOUNDARY_LINE, onNextPage));
+
+  assert.equal(resolved.pageIndex, 1);
+  assert.equal(resolved.cellBounds, undefined);
+  assert.equal(resolved.cellOverflowed, undefined);
+});
+
+test('소스 가드는 서식이 아니라 의미를 잠근다', () => {
+  // [자기리뷰 P3] 구조 정규식은 무해한 재포맷에 깨진다. 위 가드들이 줄바꿈·들여쓰기
+  // 변형을 견디는지 같은 의미의 다른 서식으로 확인한다.
+  const reformatted = `
+private compositionOverlayStartRect(a: X, exact: Y): Y {
+  if (
+    this.cursor.isInHeaderFooter()
+    || this.cursor.isInFootnote()
+  ) return exact;
+  if ((anchor.cellPath?.length ?? 0) > 1) return exact;
+  return resolveGlyphStartRect(
+    anchor.charOffset,
+    exact,
+    { rectAtLineStart: () => this.wasm.getCursorRectOnLine() },
+  );
+}`;
+  const flat = flatten(functionBodyFrom(reformatted, 'private compositionOverlayStartRect('));
+
+  assert.match(flat, /resolveGlyphStartRect\(\s*anchor\.charOffset\s*,\s*exact\s*,/);
+  assert.match(flat, /isInHeaderFooter\(\)\s*\|\|\s*this\.cursor\.isInFootnote\(\)\s*\)\s*return exact;/);
+  assert.match(flat, /anchor\.cellPath\?\.length\s*\?\?\s*0\s*\)\s*>\s*1\s*\)\s*return exact;/);
 });


### PR DESCRIPTION
관련 이슈: #6738

> #6736(#6553 수정)이 통합 PR #6767 로 devel 에 들어가, 이 PR 은 더 이상 그 위에 쌓여 있지 않다. devel `2c144b180` 로 rebase 했고 남은 커밋은 이 PR 의 것 두 개뿐이다.

## 문제

조합 오버레이는 시작 rect 와 캐럿으로 만든 **단일 사각형**이다. 조합 텍스트가 줄이나 쪽을 넘어가면 이 사각형이 성립하지 않는데, 폭이 음수가 되어도 그대로 그려진다. #6553 이 그 경로가 드러난 사례였다.

> **범위 고지.** 이슈 #6738 에서 다섯 문맥의 줄 경계 affinity 를 전부 실측한 결과, 경계 offset 에서 이전 줄을 돌려주는 곳은 **본문뿐**이고 나머지 넷(1단계 셀·중첩 셀·머리말/꼬리말·각주)은 다음 줄을 돌려준다. 즉 **오늘 이 가드가 실제로 발동하는 문맥은 알려진 것이 없다.** 이 PR 은 새 결함을 고치는 것이 아니라, 어긋난 좌표가 와도 그것을 덮어 그리는 경로를 막는 **안전망**이다. 급하지 않으며, 안전망 자체가 불필요하다고 판단되면 닫아도 무방하다.

## 원인

`caret-renderer.ts:165` 가 성립하지 않는 폭을 조용히 대체한다.

```ts
let w = Math.max(charWidth, rect.height * 0.6);
```

음수 폭은 "시작과 캐럿이 다른 줄·쪽"이라는 뜻인데, 이 폴백이 그것을 `줄높이 × 0.6` 짜리 그럴듯한 박스로 바꿔 이전 줄에 그린다. 실측으로 12.81 × 0.6 = 7.69px, 같은 글자의 실제 폭은 12.42px.

#6736 은 본문·1단계 셀의 시작 좌표를 바로잡아 이 상태에 도달하지 않게 했다. 그러나 머리말/꼬리말·각주·2단계 이상 중첩 셀에는 `getLineInfo*` 도 `getCursorRectOnLine*` 도 없어(`src/wasm_api.rs` 기준 0건) **교정을 적용할 수단 자체가 없다** — 그 문맥들이 지금 다음 줄 affinity 인 것은 설계가 아니라 관측된 사실이고, studio 는 그것을 확인할 수도 교정할 수도 없다. 이유는 문맥마다 다르다 — 중첩 셀은 `node_matches_context` 가 `ctx.path[0]` 만 비교하고(`cursor_nav.rs:1090-1097`), 머리말/꼬리말 문단은 `resolve_paragraph`(`cursor_nav.rs:527`)의 대상이 아니며, 각주는 주소 체계가 `(pageNum, footnoteIndex, fnParaIdx)` 라 `(sec, para)` 로 표현되지 않는다. 자세한 근거는 #6738 본문에 있다.

## 변경

- `line-start-affinity.ts` 에 `isCompositionBoxRepresentable(start, caret)` 추가 — 한 줄 안에서 반드시 성립해야 하는 관계(같은 쪽, 시작이 캐럿보다 오른쪽이 아님)만 본다. **y 비교는 쓰지 않는다.** 같은 줄이라도 글꼴 크기가 섞이면 캐럿 y 가 run 마다 다르다(캐럿 y 는 baseline 기준).
- `updateCaret()` 이 오버레이를 그리기 전에 이 판정을 통과시키고, 깨졌으면 **조회 실패와 같은 기존 경로**로 물러난다 — `hideComposition()` + 일반 캐럿. 새 표시 방식을 만들지 않았다.
- 테스트 4건 추가(`composition-line-affinity.test.ts`) — 한 줄 안/줄 넘김/쪽 넘김 판정과, `updateCaret` 이 그리기 전에 판정하고 실패 시 기존 폴백 경로로 물러나는 배선(소스 가드).

## 검증

아래 실측은 devel `693c4b6b3` 에서 잰 값이다. 이후 devel `2c144b180` 로 rebase 했고 게이트를 다시 돌렸다.

**실제 브라우저 실측** (vite dev + Chrome). 줄 affinity 교정이 없는 문맥을 그대로 흉내내기 위해 `compositionOverlayStartRect` 를 `exact` 반환으로 두고, 같은 문서·같은 조합 입력으로 가드 유무만 바꿔 1회씩 측정했다.

| | `.caret-composition` | `.caret` |
| --- | --- | --- |
| 가드 없음 | `display:block`, top 137.73px(1행), width 7.69px | `display:none` |
| 가드 있음 | `display:none` | `display:block`, top 158.36px(2행) |

![가드 전/후](https://raw.githubusercontent.com/lpaiu-cs/rhwp/assets/ime-wrap-ghost/pr-6738-before-after.png)

**수정 전 실패 증명** (2종):

- 배선만 되돌림 → 소스 가드 1건 실패(`그릴 수 없으면 조회 실패와 같은 경로로 물러나야 한다`), 나머지 10건 통과.
- `isCompositionBoxRepresentable` 을 항상 `true` 반환으로 되돌림(수정 전 의미) → 판정 2건 실패(줄 넘김·쪽 넘김).

**부수 확인**: 쪽 경계 변종은 본문에서 #6736 의 교정이 이미 처리함을 실측했다 — 앵커 exact = (688.3, 986.3) pageIndex 0, 캐럿 = (126.3, 132.9) pageIndex 1 인 상태에서 오버레이가 2쪽 줄 시작에 폭 12.42px 로 놓인다. #6736 의 범위 외 항목 하나가 해소된다.

**게이트**: `npm --prefix rhwp-studio test` 1406 통과 / 0 실패 / 1 skip(devel `2c144b180` rebase 후 재실행). `npx tsc --noEmit` 은 이 변경으로 늘어난 오류 없음 — 남는 8건은 모두 `src/core/wasm-bridge.ts` 의 `HwpDocument` 메서드 미존재로, 로컬 prebuilt `pkg/` 가 devel 보다 오래돼서 나며 변경 전 체크아웃에서도 동일하게 재현된다. `git diff --check` 클린.

**측정 환경의 한계**: 브라우저 검증의 studio TypeScript 는 devel `693c4b6b3` 이지만 wasm 엔진은 로컬 prebuilt `pkg/`(2026-08-23 빌드)다. 사용한 엔진 API 는 그 사이 변경이 없다.

## 범위 외

- **세 문맥의 affinity 를 본문과 맞추는 일**(= `getLineInfoInHeaderFooter` / `getLineInfoInFootnote` / `getLineInfoByPath` / `getCursorRectOnLineByPath` 추가)은 하지 않았다. 이 PR 은 성립하지 않는 기하를 그리지 않게 할 뿐, 그 문맥에서 오버레이를 되살리지는 못한다.
- **현재 잔상이 실제로 나는 문맥은 본문뿐이고 #6736 이 그것을 고친다.** 다섯 문맥 실측표는 #6738 본문에 있다. 이 PR 로 동작이 바뀌는 입력은 오늘 알려진 것이 없다.
- 세로쓰기 셀처럼 한 줄 안에서 x 가 증가하지 않는 배치는 이 판정이 "그릴 수 없음"으로 보아 일반 캐럿으로 물러난다. 현재도 그 경우 폭이 음수라 폴백 박스가 그려지므로 동작이 나빠지지는 않는다.
- 조합 문자열 자체가 여러 글자여서 조합 범위가 줄을 걸치는 경우(단일 사각형으로 표현 불가)는 별개 축이다.

참고: #6553, #6736, #4150, #1951, #785

## 자기리뷰 정산 (contribution-review-gate)

#6736·#6739 자기리뷰에서 P1·P2 는 나오지 않았다. P2 미만 4 건은 **이 PR 의 두 번째 커밋에서 정산**했다.

- [x] `LineAffinityLookup` 의 두 질의 중 `rectAtLineStart` 만 실패를 null 로 알리고 `lineInfoAt` 은 계약이 없었다. `lineInfoAt` 이 던지면 `updateCaret` 의 바깥 `catch` 로 빠져 **오버레이가 통째로 사라진다** — `exact` 로 물러나는 것보다 나쁜 결과다. 인터페이스에 두 질의의 실패 계약을 함께 적고 구현부도 맞췄다.
- [x] `cellBounds`(와 파생 `cellOverflowed`)는 그 rect 가 놓인 **쪽의** 셀 bbox 인데, 재조회 결과가 다른 쪽이어도 `exact` 것을 그대로 이어 썼다. 같은 쪽일 때만 잇는다 — 쪽이 다르면 클램프 없이 두는 편이 다른 쪽 bbox 로 가두는 것보다 낫다.
- [x] `resolveGlyphStartRect` 주석이 "불필요한 질의를 늘리지 않는다"고 했으나 `lineInfoAt` 은 매 갱신마다 돈다. 회피되는 것은 `rectAtLineStart` 뿐이라고 고쳤다.
- [x] 소스 가드가 구조 정규식이라 무해한 재포맷에 깨졌다. 폴백 분기는 괄호 짝으로 블록을 잘라 포함 여부만 보고, 나머지는 공백에 관대하게 바꿨다. 재포맷 내성 자체를 잠그는 테스트를 함께 두었다.

수정 전 실패 증명: 앞 두 항목을 되돌리면 해당 테스트 2 건이 실패한다(`줄 정보를 조회할 수 없으면 exact 동작을 유지한다`, `줄이 다른 쪽에 있으면 셀 bbox 를 이어 쓰지 않는다`).

### 저자 판단이 필요한 것 (미해결)

- 깊이 1 셀은 실측상 이미 다음 줄 affinity 다(#6738 표). `compositionOverlayStartRect` 의 셀 분기가 필요한가? 표본이 1 건뿐이라 불필요하다고 단정하지 않았다 — affinity 기전이 규명되면 정리 대상이다.
