### PR TITLE
Task #6740: 묶음 속성 setter 의 변환 파생 상태 무효화를 값 변화 판정으로

### DIFF
--- a/src/document_core/commands/object_ops/common.rs
+++ b/src/document_core/commands/object_ops/common.rs
@@ -7,6 +7,31 @@ use crate::model::control::Control;
 use crate::model::paragraph::Paragraph;
 use crate::model::shape::ShapeObject;
 
+/// [#6740] 변환 파생 상태(`raw_rendering`)의 무효화 판정용 지문.
+///
+/// 직렬화기는 `raw_rendering` 이 비어 있을 때만 변환 행렬을 새로 만든다
+/// (`serializer/control.rs` 의 rendering 블록). 그러므로 setter 가 값 변화 없이
+/// raw 를 비우면 한컴 원본 행렬이 rhwp 재생성본으로 바뀌고, 속성 bag 에는 원본
+/// 바이트가 없으므로 되돌릴 길이 없다(#5890 이중 장부 비용).
+///
+/// #6355 가 그림에서 도입한 판정과 같은 형태다 — 실제로 변환이 바뀐 뒤에만 비운다.
+pub(crate) fn shape_transform_fingerprint(
+    common: &crate::model::shape::CommonObjAttr,
+    attr: &crate::model::shape::ShapeComponentAttr,
+) -> (u32, u32, u32, u32, u32, u32, i16, bool, bool) {
+    (
+        common.width,
+        common.height,
+        common.horizontal_offset,
+        common.vertical_offset,
+        attr.current_width,
+        attr.current_height,
+        attr.rotation_angle,
+        attr.horz_flip,
+        attr.vert_flip,
+    )
+}
+
 impl DocumentCore {
     const COMMON_OBJ_ATTR_KNOWN_MASK: u32 = 0x01
         | (0x03 << 3)

--- a/src/document_core/commands/object_ops/picture.rs
+++ b/src/document_core/commands/object_ops/picture.rs
@@ -224,17 +224,8 @@ impl DocumentCore {
     fn picture_transform_fingerprint(
         pic: &crate::model::image::Picture,
     ) -> (u32, u32, u32, u32, u32, u32, i16, bool, bool) {
-        (
-            pic.common.width,
-            pic.common.height,
-            pic.common.horizontal_offset,
-            pic.common.vertical_offset,
-            pic.shape_attr.current_width,
-            pic.shape_attr.current_height,
-            pic.shape_attr.rotation_angle,
-            pic.shape_attr.horz_flip,
-            pic.shape_attr.vert_flip,
-        )
+        // [#6740] 판정은 도형 경로와 공용이다 — 둘이 갈라지면 같은 결함이 한쪽에만 남는다.
+        super::common::shape_transform_fingerprint(&pic.common, &pic.shape_attr)
     }
     pub(crate) fn picture_rotated_bounds(width: u32, height: u32, angle: i16) -> (u32, u32) {
         if width == 0 || height == 0 || angle.rem_euclid(360) == 0 {

--- a/src/document_core/commands/object_ops/shape.rs
+++ b/src/document_core/commands/object_ops/shape.rs
@@ -389,6 +389,10 @@ impl DocumentCore {
 
         let shape = self.resolve_shape_control_mut(section_idx, parent_para_idx, control_idx)?;
 
+        // [#6740] 변환 파생 상태 무효화 판정용 — 어떤 대입보다 먼저 잰다.
+        let transform_before =
+            super::common::shape_transform_fingerprint(shape.common(), shape.shape_attr());
+
         // CommonObjAttr 업데이트
         // 리사이즈 핸들을 반대편으로 끌어당길 때 studio가 width/height=0 을 보내
         // 도형이 렌더러상 사라지는 버그 방어: 최소 크기 clamp.
@@ -622,11 +626,18 @@ impl DocumentCore {
             if let Some(nh) = new_h {
                 group.shape_attr.current_height = nh;
             }
-            // 회전 중심 갱신
+            // 회전 중심 갱신 — common 에서 다시 세우므로 무변경 시 멱등이다.
             group.shape_attr.rotation_center.x = (group.common.width / 2) as i32;
             group.shape_attr.rotation_center.y = (group.common.height / 2) as i32;
-            // raw_rendering 초기화 → 직렬화 시 스케일 행렬 재생성
-            group.shape_attr.raw_rendering = Vec::new();
+            // [#6740] raw_rendering 초기화는 **실제로 변환이 바뀐 뒤에만** 한다.
+            // 종전에는 `if let Some(..)` 가드 밖에서 무조건 비웠기 때문에, 크기 키가
+            // 없는 속성(예: 빈 JSON)이나 같은 값 재적용에도 한컴 원본 행렬이 사라졌다.
+            // 판정 형태는 #6355(그림)와 같다.
+            if super::common::shape_transform_fingerprint(&group.common, &group.shape_attr)
+                != transform_before
+            {
+                group.shape_attr.raw_rendering = Vec::new();
+            }
         }
 
         if caption_changed {
@@ -769,6 +780,10 @@ impl DocumentCore {
         props_json: &str,
     ) -> bool {
         use crate::document_core::helpers::{json_bool, json_i32, json_str};
+
+        // [#6740] 변환 파생 상태 무효화 판정용 — 어떤 대입보다 먼저 잰다.
+        let transform_before =
+            super::common::shape_transform_fingerprint(shape.common(), shape.shape_attr());
 
         let c = shape.common_mut();
         let new_w = crate::document_core::helpers::json_u32(props_json, "width")
@@ -979,7 +994,12 @@ impl DocumentCore {
             }
             group.shape_attr.rotation_center.x = (group.common.width / 2) as i32;
             group.shape_attr.rotation_center.y = (group.common.height / 2) as i32;
-            group.shape_attr.raw_rendering = Vec::new();
+            // [#6740] 본문 경로(set_shape_properties_native)와 같은 판정 — 실제 변화 시에만.
+            if super::common::shape_transform_fingerprint(&group.common, &group.shape_attr)
+                != transform_before
+            {
+                group.shape_attr.raw_rendering = Vec::new();
+            }
         }
         caption_changed
     }

--- a/tests/cases/issue_6740_group_setter_purity.rs
+++ b/tests/cases/issue_6740_group_setter_purity.rs
@@ -1,0 +1,135 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! [#6740] 묶음(Group) 속성 setter 의 변환 파생 상태 순수성.
+//!
+//! 직렬화기는 `raw_rendering` 이 비어 있을 때만 변환 행렬을 새로 만든다
+//! (`serializer/control.rs` rendering 블록). 재생성본이 원본과 바이트 동일한 문서도
+//! 있지만(파싱된 `render_*` 로 완전 복원되는 경우), 그렇지 않은 문서에서는 한컴 원본
+//! 행렬이 사라진다 — 속성 bag 에 원본 바이트가 없어 되돌릴 길이 없다(#5890).
+//!
+//! 종전에는 `raw_rendering = Vec::new()` 가 `if let Some(new_w/new_h)` 가드 **밖**에
+//! 있어 분기 조건이 "Group 인가" 하나뿐이었다 — 크기 키가 없는 속성이나 같은 값
+//! 재적용에도 원본이 사라졌다. #6355 가 그림에서 쓴 지문 판정을 묶음에도 적용한다.
+//!
+//! 표본은 `group-box.hwp` 다 — 이 문서의 묶음은 `raw_rendering` 파괴가 저장 바이트를
+//! 실제로 바꾼다(수정 전후 오프셋 632에서 갈림). 손실이 드러나지 않는 문서도 있으므로
+//! (`draw-group.hwp`) 판정력이 있는 표본을 골랐다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+
+const GROUP_SAMPLE: &str = "samples/group-box.hwp";
+const SEC: usize = 0;
+const PARA: usize = 0;
+const CTRL: usize = 2;
+
+fn load() -> DocumentCore {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(GROUP_SAMPLE);
+    let bytes = std::fs::read(path).expect("표본 로드");
+    DocumentCore::from_bytes(&bytes).expect("파싱")
+}
+
+fn group_raw_rendering_len(core: &DocumentCore) -> usize {
+    match &core.document().sections[SEC].paragraphs[PARA].controls[CTRL] {
+        Control::Shape(sh) => sh.as_ref().shape_attr().raw_rendering.len(),
+        _ => panic!("표본 전제 위반: ctrl{CTRL} 가 Shape 가 아니다"),
+    }
+}
+
+fn first_diff(a: &[u8], b: &[u8]) -> Option<usize> {
+    let n = a.len().min(b.len());
+    (0..n)
+        .find(|&i| a[i] != b[i])
+        .or((a.len() != b.len()).then_some(n))
+}
+
+/// 대조군 — 편집이라면 무엇이든 하는 구역 패스스루 무효화만 적용한 저장 바이트.
+/// 무변경 속성 적용은 이 대조군을 넘어서는 비용을 내면 안 된다.
+fn passthrough_only_export() -> Vec<u8> {
+    let mut core = load();
+    core.document_mut().sections[SEC].raw_stream = None;
+    core.export_hwp_native().expect("대조군 export")
+}
+
+/// 크기 키가 없는 속성 적용은 변환을 바꾸지 않으므로 원본 행렬을 보존해야 한다.
+#[test]
+fn group_props_without_size_keys_preserves_raw_rendering() {
+    let mut core = load();
+    let before_len = group_raw_rendering_len(&core);
+    assert!(
+        before_len > 0,
+        "표본 전제: 원본 raw_rendering 이 있어야 판정이 의미를 갖는다"
+    );
+
+    core.set_shape_properties_native(SEC, PARA, CTRL, "{}")
+        .expect("빈 속성 적용");
+
+    assert_eq!(
+        group_raw_rendering_len(&core),
+        before_len,
+        "값 변화가 없는데 raw_rendering 이 사라졌다 — 한컴 원본 변환 행렬 손실"
+    );
+    assert_eq!(
+        first_diff(
+            &core.export_hwp_native().expect("export"),
+            &passthrough_only_export()
+        ),
+        None,
+        "무변경 속성 적용이 패스스루 무효화 이상의 바이트 비용을 냈다"
+    );
+}
+
+/// 다이얼로그에서 아무것도 고치지 않고 확인을 누른 것과 동형(get∘set 항등).
+#[test]
+fn group_props_identity_roundtrip_preserves_raw_rendering() {
+    let mut core = load();
+    let before_len = group_raw_rendering_len(&core);
+
+    let props = core
+        .get_shape_properties_native(SEC, PARA, CTRL)
+        .expect("현재 속성 조회");
+    core.set_shape_properties_native(SEC, PARA, CTRL, &props)
+        .expect("같은 값 재적용");
+
+    assert_eq!(
+        group_raw_rendering_len(&core),
+        before_len,
+        "get∘set 항등이 raw_rendering 을 파괴했다"
+    );
+    assert_eq!(
+        first_diff(
+            &core.export_hwp_native().expect("export"),
+            &passthrough_only_export()
+        ),
+        None,
+        "get∘set 항등이 패스스루 무효화 이상의 바이트 비용을 냈다"
+    );
+}
+
+/// 과교정 방지 — 실제로 크기가 바뀌면 파생 행렬은 여전히 무효화돼야 한다.
+#[test]
+fn group_props_real_resize_still_invalidates_raw_rendering() {
+    let mut core = load();
+    assert!(group_raw_rendering_len(&core) > 0, "표본 전제");
+
+    let props = core
+        .get_shape_properties_native(SEC, PARA, CTRL)
+        .expect("현재 속성 조회");
+    let cur: serde_json::Value = serde_json::from_str(&props).expect("getter JSON");
+    let w = cur["width"].as_u64().expect("width") as u32;
+    let h = cur["height"].as_u64().expect("height") as u32;
+
+    core.set_shape_properties_native(
+        SEC,
+        PARA,
+        CTRL,
+        &format!("{{\"width\":{},\"height\":{}}}", w + 1000, h + 1000),
+    )
+    .expect("크기 변경 적용");
+
+    assert_eq!(
+        group_raw_rendering_len(&core),
+        0,
+        "실제 크기 변경인데 옛 변환 행렬이 남았다 — 지문 판정이 과하게 보존한다"
+    );
+}


### PR DESCRIPTION
관련 이슈: #6740

## 문제

묶음(Group) 개체 속성 setter 가 **값이 하나도 바뀌지 않아도** `raw_rendering`(한컴 원본 변환 행렬)을 무조건 비운다. 속성 대화상자를 열어 아무것도 고치지 않고 확인만 눌러도 원본 행렬이 버려지고, 되돌릴 경로가 없어 스냅샷으로만 복구된다(#5890 이중 장부 비용).

#6355 가 그림에서 고친 것과 같은 결함의 묶음 판이다.

## 원인

`src/document_core/commands/object_ops/shape.rs` 의 두 곳이 같은 형태다 — `set_shape_properties_native`(본문 도형 속성)과 `apply_shape_props_inner`(← `set_cell_shape_properties_by_path_native`, 셀 안 도형 속성).

```rust
if let crate::model::shape::ShapeObject::Group(ref mut group) = shape {
    if let Some(nw) = new_w { group.shape_attr.current_width = nw; }
    if let Some(nh) = new_h { group.shape_attr.current_height = nh; }
    group.shape_attr.rotation_center.x = (group.common.width / 2) as i32;
    group.shape_attr.rotation_center.y = (group.common.height / 2) as i32;
    group.shape_attr.raw_rendering = Vec::new();   // ← Some(..) 가드 밖
}
```

`raw_rendering = Vec::new()` 가 `if let Some(nw)` / `if let Some(nh)` **바깥**에 있어 분기 조건이 "Group 인가" 하나뿐이다. `new_w` 는 `json_u32(props_json, "width")` 라 키가 없으면 `None` 인데도 clear 는 실행되고, 키가 있고 값이 같아도 마찬가지다.

직렬화기는 `raw_rendering` 이 비어 있을 때만 행렬을 새로 만든다(`serializer/control.rs` rendering 블록). 재생성본이 원본과 바이트 동일한 문서도 있지만(파싱된 `render_*` 로 완전 복원되는 경우), 그렇지 않은 문서에서는 저장 바이트가 실제로 달라진다.

## 변경

- `object_ops/common.rs` 에 공용 헬퍼 `shape_transform_fingerprint(common, attr)` 를 둔다. 판정 대상은 #6355 가 그림에서 쓰던 것과 같다(common 의 크기·오프셋, shape_attr 의 current 크기·회전각·대칭).
- `picture.rs` 의 `picture_transform_fingerprint` 도 이 헬퍼에 위임한다 — 두 경로가 갈라지면 같은 결함이 한쪽에만 남는다.
- `set_shape_properties_native`·`apply_shape_props_inner` 이 **진입 시** 지문을 재고(어떤 대입보다 먼저), 대입이 끝난 뒤 지문이 달라졌을 때만 `raw_rendering` 을 비운다.
- `rotation_center` 는 `common.width/height` 에서 다시 세우므로 무변경 시 멱등이라 그대로 둔다.

추가 테스트 `tests/cases/issue_6740_group_setter_purity.rs` 3건:

- 무변경 보존 2건 — 빈 속성 `{}` 적용, get∘set 항등(다이얼로그 확인만 누른 것과 동형).
- 과교정 방지 1건 — 실제로 크기가 바뀌면 파생 행렬은 **여전히** 무효화돼야 한다.

측정은 **대조군**과 비교한다. 편집이라면 무엇이든 하는 구역 패스스루 무효화(`section.raw_stream = None`)만 적용한 저장본을 기준으로 두고, 무변경 속성 적용이 그 이상의 비용을 내지 않는지 본다.

## 검증

devel `693c4b6b3` 기준.

- 표본 `samples/group-box.hwp`(sec0 / para0 / ctrl2 = Group, `raw_rendering` 146바이트) — 이 문서는 `raw_rendering` 파괴가 저장 바이트를 실제로 바꾼다. 손실이 드러나지 않는 문서도 있어(`draw-group.hwp` 는 `render_*` 로 완전 복원됨) 판정력 있는 표본을 골랐다.

| | raw_rendering | 대조군 대비 first_diff |
|---|---|---|
| 수정 전 | 146 → **0** | **오프셋 632** |
| 수정 후 | 146 유지 | **None** (대조군과 완전 동일) |

- **수정 전 실패 증명** — `shape.rs` 변경만 되돌리고 같은 테스트를 돌리면 2건이 깨진다.

```
group_props_without_size_keys_preserves_raw_rendering ... FAILED   left: 0  right: 146
group_props_identity_roundtrip_preserves_raw_rendering ... FAILED   left: 0  right: 146
group_props_real_resize_still_invalidates_raw_rendering ... ok      (과교정 가드는 양쪽 통과 — 의도대로)
```

- 표본 스윕 — `raw_rendering` 을 비웠을 때 저장 바이트가 바뀌는 개체가 300건 중 75건이고, 그중 묶음이 4건이다(`group-box.hwp`, `shape-group-02.hwp`, `kps-ai.hwp`, `hwp-3.0-HWPML.hwp`).
- `cargo fmt --all -- --check` 클린, `cargo clippy --all-targets --release` 경고 0.
- `node scripts/rust-unit-test-tiers.mjs --check --base-ref origin/devel` 통과(4205 tests / 298 modules / cfg support items 28 — 증가 없음).
- `cargo test --release` 전체 통과.

## 범위 외

- **커넥터 경로**(`connector.rs` `update_connectors_in_section`) — 코드상 값 비교 없이 `raw_rendering` 을 비우지만 재현되지 않아 제외했다. `2025 행정업무운영 편람(최종).hwp` 의 커넥터 4개로 무변경 호출을 재현하면 `raw_rendering` 이 [146,146,146,146] 그대로고 저장 바이트도 동일하다 — 이 표본의 커넥터는 subject id 가 어떤 도형의 `inst_id` 와도 매칭되지 않아 clear 분기 전에 `continue` 된다. 발동하는 문서를 확보한 뒤 따로 다룬다.
- `scale_group_children`·`move_line_endpoint_native` 의 `raw_rendering` 초기화는 각각 스케일·끝점 이동 경로라 값이 반드시 바뀐다. 손대지 않았다.
- 위 스윕의 비-묶음 71건은 이 PR 범위가 아니다. 그림 경로는 #6355 로 이미 판정이 들어갔고, 나머지 경로별 발동 조건은 따로 봐야 한다.
- 셀 경로(`apply_shape_props_inner`)는 본문 경로와 같은 코드 형태를 근거로 함께 고쳤고, 별도 실측은 하지 않았다.
