### PR TITLE
docs: #6711 월별 아카이브 전수 감사와 최종 보고

### DIFF
--- a/mydocs/orders/20260905.md
+++ b/mydocs/orders/20260905.md
@@ -1,0 +1,20 @@
+# 2026-09-05
+
+## #6711 월별 archive 전수 감사와 최종 보고
+
+- 최신 `upstream/devel@693c4b6b3edd1317934d6648449edcf47b0689e3`에서 Stage 4 전수 감사를
+  수행했다. 기준선의 cutoff 이전 후보 3,844개는 Git rename 3,832개와 SHA-256 동일본 제거
+  12개로 모두 귀결됐고, 기준선 9월 문서 72개와 상이 충돌 4개의 양쪽 보존을 확인했다.
+- [최종 보고서](../report/task_m100_6711_report.md)는 cutoff 이전 root 잔여 0개, 예상 archive
+  목적지 누락 0개, canonical 링크 오류 0개, historical broken 553건 유지, 기존 metadata 오류
+  16건·신규 0건을 기록하며 메인테이너 승인을 받아 `final`로 전환됐다.
+- [PR #6744](https://github.com/edwardkim/rhwp/pull/6744)의 code candidate
+  `a3f2ab3e26939672126bc86d7705a14f74584868`은 계획서와 최종 보고서 2개만 변경한다. exact-head
+  CI·CodeQL·Adapter·Proptest·Impact Policy가 성공했고 `MERGEABLE`·`CLEAN`이다.
+- [self-review](../pr/archives/pr_6744_review.md)는 실제 2개 파일, 전수 감사 수식, 최신 base merge
+  tree와 Actions를 재검토해 `승인`으로 판정했다. 자기 PR이므로 reviewer와 GitHub approve event는
+  만들지 않는다.
+- review·오늘할일과 보고서의 당월 root 수 설명만 추가한 trailing head를 push한 뒤 Actions와 최신
+  `devel` 정합을 다시 확인하고 별도 merge 승인을 받는다. #6711은 merge SHA의 post-merge 검증이
+  성공할 때까지 OPEN으로 유지한다.
+- CodeQL alert #186은 메인테이너가 입력한 `used in tests`를 유지하며, 후속 #6731과 분리한다.

--- a/mydocs/plans/task_m100_6711.md
+++ b/mydocs/plans/task_m100_6711.md
@@ -247,3 +247,5 @@ focused nextest와 Rust 필수 lint/build 묶음을 다시 실행한다.
   `archives/`로 옮기도록 지시했다.
 - 2026-09-04: 메인테이너가 메모리에 의존하던 월별 정리 기준을 canonical 거버넌스로 문서화하고,
   하나의 이슈와 순차 PR로 수행하는 계획을 승인했다.
+- 2026-09-05: 메인테이너가 Stage 4 전수 감사 결과와
+  `mydocs/report/task_m100_6711_report.md` 최종 보고서를 승인했다.

--- a/mydocs/pr/archives/pr_6744_review.md
+++ b/mydocs/pr/archives/pr_6744_review.md
@@ -1,0 +1,148 @@
+---
+kind: pr_review
+status: approved
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-09-05
+pr: 6744
+issue: 6711
+author: edwardkim
+---
+
+# PR #6744 self-review — 월별 archive 전수 감사와 최종 보고
+
+## 결론
+
+**승인.** PR #6744의 code candidate
+`a3f2ab3e26939672126bc86d7705a14f74584868`은 #6711 Stage 4 전수 감사 결과와 메인테이너가
+승인한 최종 보고서를 기록한다. 기준선의 cutoff 이전 후보 3,844개는 Git rename 3,832개와
+SHA-256 동일본 제거 12개로 모두 귀결됐고, 기준선의 9월 문서 72개는 유지됐다. cutoff 이전 root
+잔여와 예상 archive 목적지 누락은 각각 0개이며, 상이 충돌 4개는 기존본과 suffix 보존본이 모두
+남아 있다.
+
+candidate 변경은 수행계획서 2줄과 신규 보고서 한 개뿐이다. Rust source·test, Cargo, WASM,
+workflow, renderer, sample과 PDF bytes는 바뀌지 않았다. 로컬 문서 검사와 exact-head 선택적 CI가
+성공했고 최신 `upstream/devel`과의 merge tree도 깨끗하므로 범위 안 blocker는 없다.
+
+이 문서의 `승인`은 작성자 self-review 판정이다. 자기 PR이므로 reviewer 지정이나 GitHub approve
+event를 만들지 않는다. 이 review·오늘할일과 보고서의 당월 root 수 설명만 추가한 trailing head의
+GitHub Actions, `MERGEABLE`·`CLEAN`, 최신 `devel` 정합을 다시 확인하고 메인테이너의 별도 merge
+승인을 받아야 한다.
+
+## 라우팅과 메타데이터
+
+- 기본 경로: `collaborator_self_merge.md`
+- 보조 경로: `intake_and_review.md`, `local_validation.md`, `review_only_fast_pass.md`
+- loaded documents: `pr_review_workflow.md`, `pr_review/README.md`와 위 자식 문서
+- `review_impl`은 추가하지 않는다. 승인된 [수행계획](../../plans/task_m100_6711.md),
+  [Stage 1](../../working/task_m100_6711_stage1.md),
+  [Stage 2-A](../../working/task_m100_6711_stage2.md),
+  [Stage 2-B](../../working/task_m100_6711_stage2b.md),
+  [Stage 3](../../working/task_m100_6711_stage3.md),
+  [최종 보고서](../../report/task_m100_6711_report.md)가 실행·검증 계보를 고정한다.
+
+| 항목 | 값 |
+| --- | --- |
+| PR / 작성자 | [#6744](https://github.com/edwardkim/rhwp/pull/6744) / @edwardkim |
+| 관련 이슈 | [#6711](https://github.com/edwardkim/rhwp/issues/6711) (`Refs #6711`) |
+| base | `devel@693c4b6b3edd1317934d6648449edcf47b0689e3` |
+| code candidate | `a3f2ab3e26939672126bc86d7705a14f74584868` |
+| 규모 | 2 files, `+172/-0`, 1 commit |
+| 작성 시점 GitHub 상태 | Open, 비 Draft, `MERGEABLE`·`CLEAN`, candidate checks 완료 |
+| assignee / label / milestone | `edwardkim` / `documentation` / `v1.0.0` |
+| reviewer | self PR이므로 지정하지 않음 |
+
+GitHub REST 전수 조회 결과는 `mydocs/plans/task_m100_6711.md` 수정 1개와
+`mydocs/report/task_m100_6711_report.md` 추가 1개로 로컬 diff와 일치한다.
+
+## 전수 감사 재검토
+
+| 항목 | 결과 |
+| --- | ---: |
+| 기준선 direct-root Markdown | 3,916 |
+| cutoff 이전 후보 | 3,844 |
+| 기준선 9월 문서 보존 | 72/72 |
+| Git rename | 3,832 |
+| 그중 byte-identical `R100` | 3,289 |
+| 링크·canonical 정정 포함 rename | 543 |
+| SHA-256 동일본 root 제거 | 12/12 |
+| 상이 충돌 양쪽 보존 | 4/4 |
+| 예상 archive 목적지 누락 | 0 |
+| cutoff 이전 direct-root 잔여 | 0 |
+
+후보 합계는 `3,289 + 543 + 12 = 3,844`로 닫힌다. 이동 commit의 rename·삭제 수는
+Stage 2-A `771/2`, Stage 2-B `830/2`, Stage 3-A `1,111/8`, Stage 3-B `1,120/0`으로
+단계 보고서와 일치한다. 동일본 12개는 기준선 root와 기존 archive의 SHA-256이 모두 같고, 상이
+충돌 4개는 hash가 다른 기존 archive를 덮어쓰지 않았다.
+
+Stage 3-B merge tree의 root 79개는 기준선 생존 72개와 #6711 문서 5개, 동시 작업 #6717 문서
+2개다. 최신 base의 root 80개도 Git 최초 도입일을 전수 판정해 모두 cutoff 이후이고 판정 불가
+경로는 없다. candidate 보고서와 trailing 오늘할일은 9월 생성 문서이므로 root에 남는 것이
+거버넌스에 부합한다.
+
+## 로컬 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `git diff --check upstream/devel...HEAD` | 통과 |
+| `python3 scripts/check_markdown_links.py --changed-from upstream/devel` | 611개 문서, 오류 0 |
+| candidate 보고서 단독 링크 검사 | 오류 0 |
+| 추적 Markdown 전수 | base 13,195개 / candidate 13,196개 |
+| 내부 링크 | base 9,250개 / candidate 9,252개 |
+| 유효 / historical broken | candidate 8,699 / 553, base 대비 broken 증가 0 |
+| `python3 scripts/check_document_metadata.py` | 변경하지 않은 기존 4개 문서의 16건만 재현, 신규 0 |
+| current-base merge tree | `2f44a4a48a19bfe4c6cbeeedf803e7e7461906cc` |
+| 범위 감사 | Rust·Cargo·WASM·workflow 변경 0 |
+
+렌더링·레이아웃과 binary 자산을 바꾸지 않아 시각 검증은 비대상이다. 문서 전용 변경에는 Rust
+lint·build와 WASM 검증을 확장하지 않는 프로젝트 정책을 적용했다.
+
+## GitHub Actions와 최신 base
+
+candidate SHA에 대해 다음 workflow와 exact-head status가 성공했다.
+
+- CI [run 33929368594](https://github.com/edwardkim/rhwp/actions/runs/33929368594)
+- CodeQL [run 33929368585](https://github.com/edwardkim/rhwp/actions/runs/33929368585)
+- Adapter inter-diff [run 33929368578](https://github.com/edwardkim/rhwp/actions/runs/33929368578)
+- Proptest roundtrip [run 33929368737](https://github.com/edwardkim/rhwp/actions/runs/33929368737)
+- CI Impact Policy Controller
+  [run 33929368433](https://github.com/edwardkim/rhwp/actions/runs/33929368433)
+- exact-head `CI Impact Policy`
+  [run 33929400024](https://github.com/edwardkim/rhwp/actions/runs/33929400024)
+
+문서 전용 selective 경로에서 preflight·trusted reuse·`Build & Test`가 성공하고 Rust·WASM·frontend
+등 비대상 job은 정책상 skip됐다. failure·cancelled·timed out·pending check는 0개다.
+`upstream/devel@693c4b6b3e`은 candidate의 직접 parent이며 작성 시점에 전진하지 않았다.
+
+## 잔여 위험과 후속 경계
+
+- historical broken link 553건과 metadata 오류 16건은 #6711이 새로 만든 오류가 아니다. 이번
+  작업에서 범위를 섞어 정정하거나 성공 수치에서 숨기지 않았다.
+- 저장소 밖 소비자가 옛 root 경로를 사용할 가능성은 남는다. 대량 redirect stub은 만들지 않고
+  실제 중요 소비자가 확인될 때 canonical index나 해당 외부 링크를 정정한다.
+- CodeQL alert #186은 메인테이너가 수동 입력한 `used in tests` 분류를 유지한다. 근거화·재발 방지는
+  [#6731](https://github.com/edwardkim/rhwp/issues/6731)에서 별도로 처리하며 이 PR은 alert 상태를
+  변경하지 않는다.
+- #6711은 merge SHA의 post-merge 검증이 성공하기 전까지 OPEN으로 유지한다.
+
+## Merge 후 계획
+
+정상 merge commit이 `devel`에 반영되고 merge SHA의 필수 Actions가 성공한 뒤 다음 순서로 처리한다.
+
+1. PR #6744에 candidate·trailing head·merge SHA와 post-merge 검증 결과를 남긴다.
+2. #6711에 3,844개 후보 귀결, 충돌·링크·metadata 감사와 merge SHA를 기록한다.
+3. #6711의 완료조건을 다시 확인한 뒤 close한다.
+4. 최신 `devel`을 로컬에 fast-forward하고 이번 task의 local·remote branch만 정리한다.
+
+게시 뒤 API로 한글·선두 BOM·`??` 치환과 SHA·run URL을 검증한다. 같은 사실의 maintainer comment가
+이미 있으면 중복 게시하지 않는다. #6731은 OPEN으로 유지한다.
+
+## 최종 판정과 다음 조건
+
+- 판정: **승인**
+- 판정 대상: code candidate `a3f2ab3e26939672126bc86d7705a14f74584868`
+- trailing 조건: 이 review·오늘할일과 보고서 수치 설명만 추가한 최신 head의 GitHub Actions 성공,
+  `MERGEABLE`·`CLEAN`, 최신 `upstream/devel` 정합 재확인
+- merge 조건: 최신 head SHA 고정과 메인테이너의 별도 merge 승인
+- GitHub review: self PR이므로 approve event와 reviewer 지정 없음
+- merge 방식: branch protection을 우회하지 않는 정상 merge commit
+- merge 뒤: post-merge 검증 성공 후 #6711 완료 comment·close와 task branch 정리

--- a/mydocs/report/task_m100_6711_report.md
+++ b/mydocs/report/task_m100_6711_report.md
@@ -101,8 +101,9 @@ Stage 3-B merge tree의 root에는 79개가 있었다. 이는 기준선의 9월 
 
 Stage 4 기준 최신 `devel`에는 #6697의 9월 `working` 문서가 하나 더 들어와 root가 80개다.
 Git 추가 이력을 단일 scan으로 다시 판정한 결과 80/80개 모두 cutoff 이후 문서이고 판정 불가
-경로는 0개다. 이 최종 보고서도 9월 문서이므로 제출 tree에서는 root가 81개가 되는 것이 정상이며,
-다음 달 유지보수 전까지 archive 대상으로 보지 않는다.
+경로는 0개다. 이 최종 보고서를 포함한 code candidate에서는 root가 81개이며, self-review 절차가
+2026-09-05 오늘할일을 추가한 trailing tree에서는 82개다. 두 문서 모두 9월 문서이므로 다음 달
+유지보수 전까지 archive 대상으로 보지 않는다.
 
 ## 6. 링크·metadata·범위 감사
 

--- a/mydocs/report/task_m100_6711_report.md
+++ b/mydocs/report/task_m100_6711_report.md
@@ -1,0 +1,170 @@
+---
+kind: report
+status: final
+canonical: mydocs/report/task_m100_6711_report.md
+issue: 6711
+last_verified: 2026-09-05
+---
+
+# #6711 mydocs 월별 아카이브 거버넌스·첫 전수 정리 최종 보고서
+
+## 1. 최종 판정
+
+**Stage 1~3의 네 순차 PR과 Stage 4 전수 감사는 계획한 보호 불변식을 충족했다.** 기준
+commit의 직접 하위 Markdown 3,916개 중 cutoff 이전 후보 3,844개는 모두 archive 경로로
+귀결됐고, 기준선의 9월 문서 72개는 root에 그대로 남았다. 메인테이너는 2026-09-05에 Stage 4
+보고서를 승인했다. 제출·병합 절차가 남아 있으므로 Issue #6711은 아직 OPEN으로 유지한다.
+
+- 기준선: `devel@3e06867e601b555141bd22ee8b5157f296db9238`
+- 시간 경계: `Asia/Seoul`의 `2026-09-01T00:00:00+09:00`
+- Stage 3-B merge: `d1831146587b1ac2346f9ed1216a64c2943a02f9`
+- Stage 4 감사 기준: `devel@693c4b6b3edd1317934d6648449edcf47b0689e3`
+- 판정: `qualified-monthly-archive-audit`, 메인테이너 승인 완료
+
+이 감사에서 archive 경로는 완료 상태가 아니라 생성 월에 따른 보관 위치라는 거버넌스 결정을
+그대로 적용했다. 문서 이동 자체를 근거로 관련 이슈나 PR의 상태를 바꾸지 않았다.
+
+## 2. 후보 전수 귀결
+
+기준선 tree와 Stage 3-B merge tree를 checkout 시각이나 filesystem mtime 없이 Git path로 직접
+대조했다.
+
+| 폴더 | 기준선 root | cutoff 이전 후보 | 기준선 9월 문서 보존 | 후보 잔여 |
+| --- | ---: | ---: | ---: | ---: |
+| `orders` | 67 | 63 | 4 | 0 |
+| `plans` | 722 | 710 | 12 | 0 |
+| `pr` | 120 | 119 | 1 | 0 |
+| `report` | 722 | 713 | 9 | 0 |
+| `working` | 2,285 | 2,239 | 46 | 0 |
+| 합계 | 3,916 | 3,844 | 72 | 0 |
+
+3,844개 후보의 귀결은 다음 식으로 닫힌다.
+
+| 귀결 | 수 | 검산 근거 |
+| --- | ---: | --- |
+| byte-identical Git rename (`R100`) | 3,289 | 네 이동 commit의 rename similarity |
+| 링크·canonical 정정을 포함한 Git rename | 543 | 같은 commit의 `R055`~`R099` 계보와 단계별 링크 대조 |
+| 기존 archive와 동일한 root 중복 제거 | 12 | 기준선 source·archive SHA-256 12/12 일치 |
+| 합계 | 3,844 | `3,289 + 543 + 12` |
+
+일반·suffix 목적지를 후보별로 다시 계산한 결과 목적지가 없는 후보는 0개다. Git이 rename으로
+추적한 3,832개와 해시로 증명한 동일본 12개를 합치면 계획한 후보 전부가 손실 없이 처리됐다.
+
+## 3. 중복과 상이 충돌 원장
+
+기준선에서 목적지 basename이 이미 존재한 문서는 16개였다. 그중 12개는 source와 기존 archive의
+SHA-256이 같아 archive를 유지하고 root 중복만 제거했다.
+
+- `plans`: `task_m100_1363.md`, `task_m100_1363_v2.md`
+- `pr`: `pr_2331_maintainer_review.md`
+- `report`: `task_m100_1363_report.md`
+- `working`: `task_m100_1363_stage1.md`~`stage5.md`,
+  `task_m100_1363_v2_stage1.md`~`stage3.md`
+
+내용이 다른 4개는 기존 archive를 덮어쓰지 않고 source 최초 도입일과 content hash를 붙인 별도
+경로로 보존했다. Stage 4에서 기존본과 suffix 보존본이 모두 존재함을 4/4 확인했다.
+
+| 원 root | 기존 archive hash | root hash | root의 보존 경로 |
+| --- | --- | --- | --- |
+| `plans/task_m100_1880.md` | `3a524fdc…` | `fb8827e0…` | `plans/archives/task_m100_1880_archived_20260705_fb8827e.md` |
+| `plans/task_m100_2214.md` | `7c01e1f9…` | `60d84809…` | `plans/archives/task_m100_2214_archived_20260712_60d8480.md` |
+| `pr/pr_1844_review.md` | `0cf21421…` | `a72eb2d8…` | `pr/archives/pr_1844_review_archived_20260703_a72eb2d.md` |
+| `pr/pr_2370_review.md` | `da7c3202…` | `100f4495…` | `pr/archives/pr_2370_review_archived_20260725_100f449.md` |
+
+전체 SHA-256 값은 [Stage 1 원장](../working/task_m100_6711_stage1.md)에 보존돼 있다. 이동 뒤
+상대 링크가 달라진 문서는 bytes 자체의 동일성을 주장하지 않고 Git rename 계보와 논리 link target
+보존을 함께 증거로 사용했다.
+
+## 4. 순차 PR과 Git 계보
+
+| 단계 | PR | 후보 | rename / dedupe | code candidate 보수적 경로 | 최종 GitHub files | merge commit |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| Stage 2-A `orders/plans` | [#6713](https://github.com/edwardkim/rhwp/pull/6713) | 773 | 771 / 2 | 1,828 | 1,058 | `009e30fe1f` |
+| Stage 2-B `pr/report` | [#6715](https://github.com/edwardkim/rhwp/pull/6715) | 832 | 830 / 2 | 1,735 | 906 | `c9cc1f7fc7` |
+| Stage 3-A `working` | [#6726](https://github.com/edwardkim/rhwp/pull/6726) | 1,119 | 1,111 / 8 | 2,369 | 1,260 | `9e8e8bc567` |
+| Stage 3-B `working` | [#6730](https://github.com/edwardkim/rhwp/pull/6730) | 1,120 | 1,120 / 0 | 2,347 | 1,229 | `d183114658` |
+
+네 PR은 모두 `MERGED`이며 실제 GitHub file 수가 3,000개 제한 안에 있다. 보수적 경로 수는
+rename을 전혀 인정하지 않는 code candidate 측정값이다. 최종 GitHub file 수에는 self-review 등
+후행 증적 commit이 포함되므로 candidate의 rename-aware 수보다 1~2개 많다.
+
+네 이동 commit `968a35305b`, `15d4a8f25a`, `f73a68590d`, `e44032cb9d`를 `-M`으로 다시
+분석한 결과 rename은 각각 771, 830, 1,111, 1,120개이고 direct-root 삭제는 각각 2, 2, 8,
+0개다. 삭제 12개는 모두 3절의 동일본 원장에 포함되며 예상 밖 삭제는 없다.
+
+## 5. root 감소와 당월 문서 구분
+
+Stage 3-B merge tree의 root에는 79개가 있었다. 이는 기준선의 9월 문서 72개, #6711이 만든
+계획·단계 문서 5개, 동시에 병합된 #6717 문서 2개다. 따라서 물리 root 수는 `3,916 -> 79`,
+3,837개·97.9826% 감소했다. 동시 작업 문서를 제외한 archive 대상 제거율은
+`3,844 / 3,844 = 100%`이고, 기준선 root에서 archive 대상이 차지한 비율은 98.1614%다.
+
+Stage 4 기준 최신 `devel`에는 #6697의 9월 `working` 문서가 하나 더 들어와 root가 80개다.
+Git 추가 이력을 단일 scan으로 다시 판정한 결과 80/80개 모두 cutoff 이후 문서이고 판정 불가
+경로는 0개다. 이 최종 보고서도 9월 문서이므로 제출 tree에서는 root가 81개가 되는 것이 정상이며,
+다음 달 유지보수 전까지 archive 대상으로 보지 않는다.
+
+## 6. 링크·metadata·범위 감사
+
+Stage 3-B merge 시점의 전수 Markdown은 13,186개, 내부 링크 9,224개, 유효 8,671개,
+historical broken 553개였다. Stage 4 최신 기준에서는 다음과 같다.
+
+| 검사 | 결과 |
+| --- | --- |
+| canonical `python3 scripts/check_markdown_links.py` | 609개 문서, 오류 0 |
+| 추적 Markdown 전수 | 13,195개 |
+| 내부 상대 링크 | 9,250개 |
+| 유효 / historical broken | 8,697 / 553 |
+| metadata | 604개 검사, 기존 4개 문서의 16건만 재현 |
+| cutoff 이전 direct Markdown | 0개 |
+| Git 최초 도입일 판정 불가 | 0개 |
+| 예상 archive 목적지 누락 | 0개 |
+| Rust·Cargo·WASM·workflow 변경 | 0개 |
+
+Stage 3-B 뒤 동시 작업으로 Markdown 9개와 유효 링크 26개가 늘었지만 historical broken은
+553개로 변하지 않았다. 네 순차 PR의 단계 보고서도 각 base와 결과 사이의 신규 broken-link와
+metadata 오류가 0개임을 기록한다. 따라서 기존 오류를 이 작업의 성공으로 숨기거나 새 오류를
+추가하지 않았다.
+
+Stage 3-A에서 발견된 Gym 문서의 완성 경로와 분할 `.join(...)` 소비자는 root redirect로
+우회하지 않고 실제 archive 경로로 고쳤다. Stage 3-B의 font evidence generator와 hash contract도
+같은 원칙으로 갱신했다. 이 실패 계보를 반영한 canonical 거버넌스는 Markdown 링크뿐 아니라
+test·tool·generator·fixture의 완성 문자열과 분할 조립 경로를 모두 감사하도록 규정한다.
+
+## 7. 다음 달 재실행 순서
+
+매월 첫 유지보수 구간에 다음 순서로 반복한다.
+
+1. 최신 `upstream/devel`과 clean worktree를 확인한다.
+2. `Asia/Seoul` 당월 1일 00:00을 cutoff로 잡고 다섯 root의 직접 하위 `*.md`만 수집한다.
+3. Git 최초 도입 commit의 author timestamp로 후보를 판정하고, 근거가 없으면 자동 이동하지 않고
+   예외 원장에 남긴다.
+4. 목적지 충돌을 SHA-256으로 나눠 동일본만 제거하고 상이본은 suffix 경로로 양쪽을 보존한다.
+5. Markdown 상대 링크와 실행 경로 소비자를 함께 감사하고 old/new 논리 target을 보존한다.
+6. rename-aware·보수적 경로 수를 측정해 PR file API 3,000개 아래로 순차 batch를 나눈다.
+7. 각 batch를 앞선 merge가 포함된 최신 `devel`에서 만들고 canonical 링크, metadata delta,
+   historical broken-link delta, cutoff 잔여를 검증한다.
+8. 마지막 batch 뒤 전수 감사를 수행하고 이슈·PR 상태는 문서 경로와 별도로 판정한다.
+
+세부 정본은 [문서·Git 워크플로](../manual/codex/docs_and_git_workflow.md#monthly-archive-governance)다.
+
+## 8. 완료 조건과 남은 외부 절차
+
+| 완료 조건 | 판정 |
+| --- | --- |
+| 월별 archive 정본·안내 문서 3개 | 충족 |
+| 후보 3,844개 손실 없이 처리 | 충족 |
+| 기준선 9월 문서 72개 보존 | 충족 |
+| 상이 충돌 4개 양쪽 보존 | 충족 |
+| 신규 내부 링크·metadata 오류 0 | 충족 |
+| 각 PR이 file API 3,000개 미만 | 충족 |
+| cutoff 이전 direct Markdown 0 | 충족 |
+| 최종 보고서 메인테이너 승인 | 충족 |
+
+보고서는 `final`로 전환됐다. 남은 절차는 Stage 4 문서 전용 commit을 만든 뒤 별도 승인에 따라
+push·PR·exact-head CI·self-review·정상 merge를 수행하는 것이다. merge SHA의
+post-merge 검증이 성공한 뒤에만 Issue #6711을 close하고 이번 task branch를 정리한다.
+
+CodeQL alert #186의 최종 분류는 메인테이너가 입력한 `used in tests`를 유지한다. 해당 alert의
+근거화·재발 방지는 [#6731](https://github.com/edwardkim/rhwp/issues/6731)의 별도 범위이며 #6711
+종료를 막지 않는다.


### PR DESCRIPTION
## 변경 요약

- #6711 Stage 4에서 다섯 작업 증적 root의 월별 archive 처리를 전수 감사했습니다.
- 기준선의 cutoff 이전 후보 3,844개가 Git rename 3,832개와 SHA-256 동일본 제거 12개로 모두 귀결됐음을 기록했습니다.
- 기준선 9월 문서 72개 보존, cutoff 이전 root 잔여 0개, 상이 충돌 4개 양쪽 보존을 확인했습니다.
- 수행계획서에 메인테이너의 최종 보고서 승인 기록을 추가했습니다.

## 관련 이슈

Refs #6711

CodeQL alert #186의 메인테이너 분류 `used in tests`는 변경하지 않으며, 근거화·재발 방지는 #6731에서 별도로 추적합니다.

## 테스트

- [x] `git diff --check` 통과
- [x] `python3 scripts/check_markdown_links.py --changed-from upstream/devel` — 611개 문서, 내부 상대 링크 오류 0
- [x] `python3 scripts/check_document_metadata.py` — 기존 4개 문서의 16건만 재현, 신규 오류 0
- [x] 기준선 3,916개와 Stage 3-B merge tree 전수 대조 — 후보 목적지 누락 0, 동일본 SHA-256 12/12 일치
- [x] 최신 `devel` 직접 하위 Markdown 80/80개 Git 최초 도입일 판정 — cutoff 이전 0, 판정 불가 0
- [x] Rust source·test, Cargo, WASM, workflow 변경 0
- [ ] Rust lint·build·WASM — 문서 전용 변경이므로 프로젝트 정책에 따라 비대상
- [ ] SVG·브라우저 시각 확인 — 렌더링·레이아웃 변경이 없어 비대상

## 성능 영향 및 측정 결과

- 예상 영향: 없음
- 재현·측정: 실행 코드와 빌드 산출물을 변경하지 않는 계획서·최종 보고서 2개 변경입니다.

## 스크린샷

문서 기록만 변경하므로 비대상입니다.

## 후속 경계

이 PR의 exact-head CI, self-review, 정상 merge와 merge SHA post-merge 검증이 끝난 뒤에만 Issue #6711을 close합니다.
