### PR TITLE
renderer: 글상자 내장 표 셀 도형을 렌더 트리에 보존

### DIFF
--- a/src/renderer/layout/table_cell_content.rs
+++ b/src/renderer/layout/table_cell_content.rs
@@ -661,6 +661,37 @@ impl LayoutEngine {
         // [Task #1138] 표 셀 컨텍스트: (section_idx, outer_para_idx, outer_table_ctrl_idx, cell_idx, cell_para_idx, inner_control_idx)
         table_cell_ctx: Option<(usize, usize, usize, usize, usize, usize)>,
     ) {
+        self.layout_cell_shape_with_parent_path(
+            tree,
+            cell_node,
+            shape,
+            inner_area,
+            para_y,
+            para_alignment,
+            styles,
+            bin_data_content,
+            clamp_header_negative_para_offset,
+            table_cell_ctx,
+            &[],
+        );
+    }
+
+    /// 글상자/중첩 표 경로까지 가진 셀 도형을 레이아웃한다.
+    #[allow(clippy::too_many_arguments)]
+    fn layout_cell_shape_with_parent_path(
+        &self,
+        tree: &mut PageLayoutContext,
+        cell_node: &mut RenderNode,
+        shape: &crate::model::shape::ShapeObject,
+        inner_area: &LayoutRect,
+        para_y: f64,
+        para_alignment: Alignment,
+        styles: &ResolvedStyleSet,
+        bin_data_content: &[BinDataContent],
+        clamp_header_negative_para_offset: bool,
+        table_cell_ctx: Option<(usize, usize, usize, usize, usize, usize)>,
+        parent_cell_path: &[CellPathEntry],
+    ) {
         let child_common = shape.common();
 
         let child_w = hwpunit_to_px(child_common.width as i32, self.dpi);
@@ -737,7 +768,7 @@ impl LayoutEngine {
             styles,
             bin_data_content,
             &empty_map,
-            &[],
+            parent_cell_path,
             shape_table_cell_ref,
             false,
         );
@@ -1113,6 +1144,7 @@ impl LayoutEngine {
                 .zip(cell.paragraphs.iter())
                 .enumerate()
             {
+                let para_y_before_compose = para_y;
                 // enclosing context가 있으면 글상자 경로 + 표 셀 경로를 합성
                 let cell_ctx = enclosing_ctx.map(|(sec_idx, para_idx, parent_path, table_ci)| {
                     let mut path = parent_path.to_vec();
@@ -1289,6 +1321,60 @@ impl LayoutEngine {
                                     pic_y,
                                 );
                             }
+                        }
+                        Control::Shape(shape) => {
+                            let para_alignment = styles
+                                .para_styles
+                                .get(para.para_shape_id as usize)
+                                .map(|style| style.alignment)
+                                .unwrap_or(Alignment::Left);
+                            let shape_y = if shape.common().treat_as_char {
+                                para.line_segs
+                                    .first()
+                                    .map_or(para_y_before_compose, |first_ls| {
+                                        cell_y
+                                            + pad_top
+                                            + hwpunit_to_px(first_ls.vertical_pos, self.dpi)
+                                    })
+                            } else if matches!(
+                                shape.common().vert_rel_to,
+                                crate::model::shape::VertRelTo::Para
+                            ) {
+                                para_y_before_compose
+                            } else {
+                                para_y
+                            };
+                            let (table_cell_ctx, shape_parent_path) = match enclosing_ctx {
+                                Some((sec_idx, outer_pi, parent_path, table_ci)) => {
+                                    let mut path = parent_path.to_vec();
+                                    path.push(CellPathEntry {
+                                        control_index: table_ci,
+                                        cell_index: cell_idx,
+                                        cell_para_index: pidx,
+                                        text_direction: cell.text_direction,
+                                    });
+                                    (
+                                        Some((
+                                            sec_idx, outer_pi, table_ci, cell_idx, pidx, ctrl_idx,
+                                        )),
+                                        path,
+                                    )
+                                }
+                                None => (None, Vec::new()),
+                            };
+                            self.layout_cell_shape_with_parent_path(
+                                tree,
+                                &mut cell_node,
+                                shape,
+                                &inner_area,
+                                shape_y,
+                                para_alignment,
+                                styles,
+                                bin_data_content,
+                                false,
+                                table_cell_ctx,
+                                &shape_parent_path,
+                            );
                         }
                         _ => {}
                     }

--- a/tests/cases/issue_6735_textbox_table_cell_shape.rs
+++ b/tests/cases/issue_6735_textbox_table_cell_shape.rs
@@ -1,0 +1,171 @@
+//! Issue #6735: 글상자 내장 표 셀의 `Control::Shape`가 렌더 트리에서 누락된다.
+//!
+//! `shape_layout::layout_textbox_content`가 글상자 안 표를
+//! `table_cell_content::layout_embedded_table`로 보내지만, 그 경로는 셀 문단의
+//! `Control::Picture`만 하위화했다. 공개 IR로 `TextBox → Table → Cell → Shape`
+//! 구조를 만들고 가장 안쪽 도형의 글상자 문구가 페이지 렌더 트리에 남는지 고정한다.
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::model::document::{Document, Section};
+use rhwp::model::paragraph::Paragraph;
+use rhwp::model::shape::{
+    CommonObjAttr, DrawingObjAttr, RectangleShape, ShapeObject, TextBox, TextWrap,
+};
+use rhwp::model::style::ParaShape;
+use rhwp::model::table::{Cell, Table};
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+use rhwp::serializer::hwpx::serialize_hwpx;
+
+const INNER_LABEL: &str = "NESTED-CELL-SHAPE";
+
+fn paragraph(text: &str) -> Paragraph {
+    Paragraph {
+        text: text.to_string(),
+        char_count: text.chars().count() as u32,
+        char_offsets: (0..text.chars().count() as u32).collect(),
+        ..Default::default()
+    }
+}
+
+fn rectangle_textbox(
+    width: u32,
+    height: u32,
+    treat_as_char: bool,
+    paragraphs: Vec<Paragraph>,
+) -> ShapeObject {
+    ShapeObject::Rectangle(RectangleShape {
+        common: CommonObjAttr {
+            width,
+            height,
+            treat_as_char,
+            text_wrap: TextWrap::InFrontOfText,
+            ..Default::default()
+        },
+        drawing: DrawingObjAttr {
+            text_box: Some(TextBox {
+                max_width: width,
+                paragraphs,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+
+fn document_with_shape_inside_textbox_table_cell(inner_treat_as_char: bool) -> Document {
+    let inner_shape = rectangle_textbox(
+        9_000,
+        2_500,
+        inner_treat_as_char,
+        vec![paragraph(INNER_LABEL)],
+    );
+    let cell_para = Paragraph {
+        controls: vec![Control::Shape(Box::new(inner_shape))],
+        ..Default::default()
+    };
+    let cell = Cell {
+        row_span: 1,
+        col_span: 1,
+        width: 24_000,
+        height: 6_000,
+        paragraphs: vec![cell_para],
+        ..Default::default()
+    };
+    let mut embedded_table = Table {
+        row_count: 1,
+        col_count: 1,
+        cells: vec![cell],
+        ..Default::default()
+    };
+    embedded_table.common.width = 24_000;
+    embedded_table.common.height = 6_000;
+    embedded_table.common.treat_as_char = true;
+
+    let textbox_para = Paragraph {
+        controls: vec![Control::Table(Box::new(embedded_table))],
+        ..Default::default()
+    };
+    let outer_shape = rectangle_textbox(30_000, 12_000, true, vec![textbox_para]);
+
+    let mut doc = Document::default();
+    doc.doc_info.para_shapes = vec![ParaShape::default()];
+    doc.sections.push(Section {
+        paragraphs: vec![Paragraph {
+            controls: vec![Control::Shape(Box::new(outer_shape))],
+            ..Default::default()
+        }],
+        ..Default::default()
+    });
+    doc
+}
+
+fn collect_text(node: &RenderNode, out: &mut String) {
+    if let RenderNodeType::TextRun(run) = &node.node_type {
+        out.push_str(run.display_or_text());
+    }
+    for child in &node.children {
+        collect_text(child, out);
+    }
+}
+
+fn inner_label_context(node: &RenderNode) -> Option<(bool, usize)> {
+    if let RenderNodeType::TextRun(run) = &node.node_type {
+        if run.display_or_text().contains(INNER_LABEL) {
+            return run
+                .cell_context
+                .as_ref()
+                .map(|context| (context.in_textbox, context.path.len()));
+        }
+    }
+    node.children.iter().find_map(inner_label_context)
+}
+
+fn assert_nested_shape_content(inner_treat_as_char: bool) {
+    let document = document_with_shape_inside_textbox_table_cell(inner_treat_as_char);
+    if let Ok(dir) = std::env::var("RHWP_6735_EVIDENCE_DIR") {
+        fs::create_dir_all(&dir).expect("합성 시각 증적 디렉터리 생성");
+        let bytes = serialize_hwpx(&document).expect("합성 HWPX 직렬화");
+        let mode = if inner_treat_as_char {
+            "inline"
+        } else {
+            "floating"
+        };
+        let output =
+            Path::new(&dir).join(format!("issue_6735_textbox_table_cell_{mode}_shape.hwpx"));
+        fs::write(output, bytes).expect("합성 시각 증적 저장");
+    }
+
+    let mut core = DocumentCore::new_empty();
+    core.set_document(document);
+
+    let tree = core
+        .build_page_render_tree(0)
+        .expect("합성 문서 첫 페이지 render tree");
+    let mut text = String::new();
+    collect_text(&tree.root, &mut text);
+
+    assert!(
+        text.contains(INNER_LABEL),
+        "글상자 내장 표 셀의 도형과 도형 내부 텍스트가 누락됐다: {text:?}"
+    );
+    assert_eq!(
+        inner_label_context(&tree.root),
+        Some((true, 3)),
+        "바깥 글상자, 내장 표 셀, 안쪽 도형 글상자의 전체 경로를 보존해야 한다"
+    );
+}
+
+#[test]
+fn textbox_embedded_table_cell_inline_shape_keeps_its_textbox_content() {
+    assert_nested_shape_content(true);
+}
+
+#[test]
+fn textbox_embedded_table_cell_floating_shape_keeps_its_textbox_content() {
+    assert_nested_shape_content(false);
+}


### PR DESCRIPTION
## 변경 요약

- 글상자 안에 내장된 표 셀을 조판할 때 `Control::Shape`도 일반 셀 도형 레이아웃 경로로 전달합니다.
- 중첩 글상자까지 포함한 부모 `CellPathEntry`를 보존해, 도형 내부 텍스트의 렌더 노드가 원래 셀 경로를 유지하도록 합니다.
- 인라인 도형과 플로팅 도형을 각각 검증하는 공개 합성 HWPX 회귀 테스트를 추가합니다.

## 관련 이슈

closes #6735

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, 일반 PR의 Cargo generated test target을 포함하지 않음 (`--sync-cargo-targets` 메인터너 registry PR은 marker 블록만 예외)
- [x] `src/**`의 `#[cfg(test)]` 변경 없음 (unit-test tiers 해당 없음)
- [x] 전체 release-test nextest 통과: 9,020 passed, 46 skipped
- [x] 전체 workspace/native/WASM clippy `-D warnings` 통과
- [x] 공개 합성 HWPX로 변경 전후 SVG 내보내기 및 텍스트 노드 복원 확인
- [x] 웹(WASM) release 빌드 통과 (`wasm-pack 0.15.0`, `--locked`)
- [x] rhwp-studio 편집·UI 변경 없음 (해당 없음)
- [x] 작업 증빙 캡슐 해당 없음 — 공개 합성 fixture, 결정적 회귀 테스트, SVG 해시로 재현 근거를 남김
- [x] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 없음 (해당 없음)

추가 실행 결과:

- `cargo clippy --locked --target-dir target/pr-review -- -D warnings`
- `cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown --target-dir target/pr-review -- -D warnings`
- `cargo build --locked --workspace --target-dir target/pr-review`
- `cargo clippy --locked --workspace --all-targets --target-dir target/pr-review -- -D warnings`
- Native Skia 라이브러리: 4,112 passed, 13 ignored
- Native Skia 통합 테스트: issue #2225 2 passed, direct PDF 4 passed
- issue #6735 집중 회귀: 2 passed
- `node scripts/rust-test-suite-manifest.mjs --check`
- `git diff --check`

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 기존에 누락되던 내장 셀의 도형에만 기존 도형 레이아웃 경로를 적용하므로, 정상 렌더링 경로의 성능 영향은 제한적입니다.
- 재현·측정: 전체 release-test 9,020개와 Native Skia 검증을 통과했습니다. 별도 마이크로벤치마크는 수행하지 않았습니다.

## 스크린샷

공개 합성 HWPX에서 변경 전 SVG는 텍스트 노드가 0개였고, 변경 후에는 도형 내부 라벨을 포함한 17개가 생성됨을 확인했습니다.

- 합성 HWPX SHA-256: `81dd6908fc148dbde0759d07859d3e8fa02218f95527a78d627acaec4cb99948`
- 변경 전 SVG SHA-256: `9543e15a4bc620e3b7959606b9f7efdd07d36543252d81c3bba2fba9eb6de0fb`
- 변경 후 SVG SHA-256: `3096db2593edbb0c9d96bc76d6233703cae956678b922803b05a9cbdcf668841`
- SVG 텍스트 노드: `0 → 17`

생성된 HWPX/SVG는 테스트·검증 산출물이며 PR에는 커밋하지 않았습니다.
