### PR TITLE
docs(bridge): getCaretPosition 이 표 셀 컨텍스트를 싣지 않음을 명시

### DIFF
--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -1689,6 +1689,19 @@ export class WasmBridge {
     return JSON.parse(this.doc.getLineInfoInCell(sec, parentPara, controlIdx, cellIdx, cellParaIdx, charOffset));
   }
 
+  /**
+   * 문서에 **저장된** 캐럿 스탬프({@link setCaretPosition} 가 남긴 값,
+   * `doc_properties.caret_list_id/caret_para_id/caret_char_pos`)를 읽는다.
+   *
+   * **표 셀 컨텍스트는 실리지 않는다.** 반환 타입이 `DocumentPosition` 이라
+   * `parentParaIndex`/`controlIndex`/`cellIndex`/`cellPath`/`isTextBox` 가 채워질 것처럼
+   * 보이지만, 이 API 는 위 세 값(`sectionIndex`·`paragraphIndex`·`charOffset`)만 채운다 —
+   * 커서가 표 셀 안에 있어도 마찬가지다. 저장 시점 복원용 좌표라 그렇다.
+   *
+   * 지금 커서가 어느 셀에 있는지가 필요하면 편집 중인 커서를 쓴다:
+   * `InputHandler.getCursorPosition()`(내부적으로 `Cursor.getPosition()`). 스튜디오 자신도
+   * 셀 진입 판정에 그 경로를 쓴다 — `pos.parentParaIndex !== undefined` 로 셀 안을 가른다.
+   */
   getCaretPosition(): DocumentPosition | null {
     if (!this.doc) return null;
     try {


### PR DESCRIPTION
## 배경

`WasmBridge.getCaretPosition()` 의 반환 타입이 `DocumentPosition` 입니다. 이 타입은
`parentParaIndex` / `controlIndex` / `cellIndex` / `cellPath` / `isTextBox` 를 옵셔널로
갖고 있어, 표 셀 안에 커서가 있으면 채워질 것처럼 읽힙니다.

실제로는 저장된 캐럿 스탬프만 읽습니다 — `get_caret_position_native`
(`src/document_core/queries/cursor_nav.rs`)가 `doc_properties.caret_list_id` /
`caret_para_id` / `caret_char_pos` 를 보고 `sectionIndex` · `paragraphIndex` ·
`charOffset` 세 값만 냅니다. 커서가 표 셀 안에 있어도 셀 필드는 비어 있습니다.

타입만 보고 이 API 로 셀 판정을 시도하면 `inCell` 이 항상 false 가 되는데, 옵셔널
필드라 타입 검사도 통과하고 런타임 오류도 나지 않아 원인을 찾기 어렵습니다.

지금 커서가 어느 셀에 있는지는 편집 중인 커서에서 얻어야 합니다 —
`InputHandler.getCursorPosition()`(= `Cursor.getPosition()`). 스튜디오 자신도 셀 진입
판정에 그 경로를 씁니다(`rhwp-studio/src/engine/input-handler.ts`,
`const inCell = !inFootnote && pos.parentParaIndex !== undefined;`).

## 변경

`getCaretPosition()` 에 JSDoc 을 답니다. **동작 변경 없음 — 주석만 추가**합니다.

- 무엇을 읽는지(저장된 캐럿 스탬프)
- 셀 컨텍스트가 실리지 않는다는 점과 그 이유
- 셀이 필요할 때 쓸 경로(`InputHandler.getCursorPosition()`)

타입을 좁히는(예: 전용 반환 타입 신설) 쪽도 생각했지만, 호출부에 파급이 있어 문서화만
제안합니다. 그쪽을 선호하시면 그렇게 다시 올리겠습니다.
