### PR TITLE
Task #6741: 셀 블록 Delete·되돌리기를 한컴에 맞춘다

### DIFF
--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -5,7 +5,7 @@ import type {
   WasmBridge,
 } from '@/core/wasm-bridge';
 import type { DocumentPosition, CharProperties, ParaProperties, CellPathLike, CellPathEntry, SectionDef, CellProperties } from '@/core/types';
-import type { HeaderFooterTextPosition } from './cursor';
+import type { HeaderFooterTextPosition, CellBlockSelectionState } from './cursor';
 import { MAX_PAGE_LOCAL_TEXT_EDIT_CHARS } from './input-edit-invalidation';
 import type { LineEndpoints as LineEndpointsLike } from './object-drag-record';
 import { setObjectProps, type ObjectPropsRef } from './object-props';
@@ -103,7 +103,22 @@ export type HeaderFooterSelectionSnapshot = {
   readonly previewPage: number;
 };
 
-export type EditSelectionSnapshot = BodySelectionSnapshot | HeaderFooterSelectionSnapshot;
+/**
+ * [Task #6741] F5 셀 블록 선택 스냅샷.
+ *
+ * 셀 블록은 `cellAnchor`/`cellFocus` 축이라 본문 텍스트 선택(start/end)을 만들지 않는다.
+ * 그래서 `BodySelectionSnapshot` 에 얹지 못하고 별도 분기로 둔다 — 머리말/꼬리말 서브모드가
+ * `mode` 태그로 갈라지는 것과 같은 형태다.
+ */
+export type CellBlockSelectionSnapshot = {
+  readonly mode: 'cellBlock';
+  readonly state: CellBlockSelectionState;
+};
+
+export type EditSelectionSnapshot =
+  | BodySelectionSnapshot
+  | HeaderFooterSelectionSnapshot
+  | CellBlockSelectionSnapshot;
 
 /** text mutation의 document pagination/flow 경계와 immediate 완료를 함께 전달한다. */
 export interface FocusedCellCursorGeometry {

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -8,6 +8,19 @@ import type { CellSelectionPhase, CellSelectionPoint } from './cell-selection-ph
 
 type CellSelectionReason = 'manual' | 'protected';
 
+/** [Task #6741] undo 복원을 위해 캡처한 셀 블록 선택 상태. */
+export type CellBlockSelectionState = {
+  readonly sec: number;
+  readonly ppi: number;
+  readonly ci: number;
+  readonly cellPath?: CellPathEntry[];
+  readonly anchor: CellSelectionPoint;
+  readonly focus: CellSelectionPoint;
+  readonly phase: CellSelectionPhase;
+  readonly reason: CellSelectionReason;
+  readonly excluded: string[];
+};
+
 export type HeaderFooterTextPosition = {
   sectionIdx: number;
   isHeader: boolean;
@@ -1430,6 +1443,63 @@ export class CursorState {
   getCellSelectionFocus(): CellSelectionPoint | null {
     if (!this._cellSelectionMode || !this.cellFocus) return null;
     return { ...this.cellFocus };
+  }
+
+  /**
+   * [Task #6741] 셀 블록 선택을 undo 복원용으로 캡처한다.
+   *
+   * 한컴은 셀 블록에서 내용을 지우고 되돌리면 지우기 전 블록을 되살린다(#6741 실측).
+   * rhwp 는 히스토리 점프 시 파생 상태를 해제하므로(#2339), 되살리려면 해제 전에
+   * 잡아 둔 값이 필요하다 — F3 확장 단계가 `blockPhase` 로 그렇게 하는 것과 같다(#5691).
+   *
+   * `rowCount`/`colCount` 는 담지 않는다. 복원 시점의 표에서 다시 읽어야 그 사이
+   * 행·열이 바뀐 경우에 유령 범위를 만들지 않는다.
+   */
+  captureCellSelection(): CellBlockSelectionState | null {
+    if (!this._cellSelectionMode || !this.cellAnchor || !this.cellFocus || !this.cellTableCtx) return null;
+    const { sec, ppi, ci, cellPath } = this.cellTableCtx;
+    return {
+      sec, ppi, ci,
+      cellPath: cellPath ? cellPath.map((e) => ({ ...e })) : undefined,
+      anchor: { ...this.cellAnchor },
+      focus: { ...this.cellFocus },
+      phase: this._cellSelectionPhase,
+      reason: this._cellSelectionReason,
+      excluded: [...this.excludedCells],
+    };
+  }
+
+  /**
+   * [Task #6741] 캡처한 셀 블록 선택을 되살린다.
+   *
+   * 표가 사라졌거나 행·열이 줄어 범위가 밖으로 나가면 되살리지 않고 `false` 를 준다 —
+   * 유령 범위를 만들지 않는 것이 #2339 가 세운 규약이다.
+   */
+  restoreCellSelection(state: CellBlockSelectionState): boolean {
+    let dims: { rowCount: number; colCount: number };
+    try {
+      dims = state.cellPath && state.cellPath.length > 0
+        ? this.wasm.getTableDimensionsByPath(state.sec, state.ppi, JSON.stringify(state.cellPath))
+        : this.wasm.getTableDimensions(state.sec, state.ppi, state.ci);
+    } catch {
+      return false;
+    }
+    const inside = (p: CellSelectionPoint) =>
+      p.row >= 0 && p.col >= 0 && p.row < dims.rowCount && p.col < dims.colCount;
+    if (!inside(state.anchor) || !inside(state.focus)) return false;
+
+    this.cellAnchor = { ...state.anchor };
+    this.cellFocus = { ...state.focus };
+    this.cellTableCtx = {
+      sec: state.sec, ppi: state.ppi, ci: state.ci,
+      rowCount: dims.rowCount, colCount: dims.colCount,
+      cellPath: state.cellPath,
+    };
+    this._cellSelectionMode = true;
+    this._cellSelectionPhase = state.phase;
+    this._cellSelectionReason = state.reason;
+    this.excludedCells = new Set(state.excluded);
+    return true;
   }
 
   /** F5 반복: 셀 선택 단계를 다음으로 진행한다. */

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -44,6 +44,30 @@ const PAGINATION_BOUNDARY_KEYS = new Set([
  * 전역 편집 명령이다. 이 모드의 문자 입력은 아래 전용 분기가 소유하지만, 되돌리기와
  * 찾아가기는 문서 전체 명령이므로 조기 반환 전에 dispatcher로 전달해야 한다.
  */
+/**
+ * [Task #6741] 셀 블록 선택을 **유지한 채** 통과시키는 명령.
+ *
+ * 한컴은 셀 블록에서 되돌리기를 해도 블록을 놓지 않는다(실측: undo 뒤 지우기 전 블록이
+ * 되살아난다). 종전 rhwp 는 방향키·Escape 외의 키를 전부 "그 외 키"로 흘려 블록을 먼저
+ * 해제했으므로, undo 가 실행될 때는 되살릴 선택이 이미 없었다.
+ *
+ * 서브모드(머리말/꼬리말·각주)의 우회로보다 좁게 잡는다 — goto·select-all 은 셀 블록을
+ * 들고 있을 이유가 없는 조작이라 종전대로 블록을 해제하고 넘긴다.
+ */
+const CELL_BLOCK_GLOBAL_COMMANDS = new Set([
+  'edit:undo',
+  'edit:redo',
+]);
+
+function dispatchCellBlockGlobalShortcut(this: any, e: KeyboardEvent): boolean {
+  if (!this.dispatcher) return false;
+  const commandId = matchShortcut(e, defaultShortcuts);
+  if (!commandId || !CELL_BLOCK_GLOBAL_COMMANDS.has(commandId)) return false;
+  e.preventDefault();
+  this.dispatcher.dispatch(commandId);
+  return true;
+}
+
 const SUBMODE_GLOBAL_COMMANDS = new Set([
   'edit:undo',
   'edit:redo',
@@ -1229,6 +1253,21 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       this.cursor.exitCellSelectionMode();
       this.cellSelectionRenderer?.clear();
       this.updateCaret();
+      return;
+    }
+
+    // [Task #6741] 되돌리기/다시실행은 블록을 놓지 않고 통과시킨다. 히스토리 점프가
+    // 파생 상태를 해제하면(#2339) undo 쪽은 커맨드가 실어 둔 셀 블록으로 다시 세워진다.
+    if (dispatchCellBlockGlobalShortcut.call(this, e)) return;
+
+    // [Task #6741] 선택한 칸들의 내용을 한 번에 지우고 블록을 유지한다 — 한컴과 같다.
+    // 종전에는 아래 "그 외 키"로 떨어져 블록이 풀리고 캐럿에서 한 글자만 지워졌다.
+    if (e.key === 'Delete' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      e.preventDefault();
+      if (!this.cursor.isProtectedCellSelectionMode()) {
+        this.clearSelectedCellBlock();
+        this.updateCellSelection();
+      }
       return;
     }
     const cellArrowAction = getCellSelectionArrowAction(e);

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -3050,7 +3050,7 @@ export class InputHandler {
       } else if (range.mode === 'cellBlock') {
         // [Task #6741] 한컴은 셀 블록에서 지운 뒤 되돌리면 지우기 전 블록을 되살린다(실측).
         // `resetDerivedStateAfterHistoryJump` 가 방금 해제한 것을 여기서 다시 세운다 —
-        // F3 확장 단계를 `selectRange(start, end, blockPhase)` 로 되살리는 것과 같은 자리다.
+        // F3 확장 단계를 본문 범위와 같은 호출로 되살리는 것과 같은 자리다.
         // 표가 사라졌거나 범위가 밖으로 나가면 `restoreCellSelection` 이 거절한다(#2339 규약).
         if (this.cursor.restoreCellSelection(range.state)) {
           this.caret.hide();

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2436,7 +2436,15 @@ export class InputHandler {
           changed = true;
         }
         // [Task #2370] 이미 빈 칸만 골랐으면 문서가 그대로다 → 기록하지 않는다.
-        return changed ? cursorBefore : null;
+        if (!changed) return null;
+        // 캐럿이 방금 비운 칸 안이면 그 칸의 시작으로 내린다. `moveTo` 는 클램프하지 않으므로
+        // 지우기 전 오프셋을 그대로 돌려주면 빈 칸에 범위 밖 위치가 남고, 이후 편집이
+        // 문단 길이 검사에 걸린다. 문단이 여럿이던 칸은 cellParaIndex 도 범위 밖이 된다.
+        const caretCleared = cursorBefore.cellIndex !== undefined
+          && block.cellIndices.includes(cursorBefore.cellIndex);
+        return caretCleared
+          ? { ...cursorBefore, cellParaIndex: 0, charOffset: 0 }
+          : cursorBefore;
       },
       selectionBefore: selection ? { mode: 'cellBlock', state: selection } : null,
     });

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2395,6 +2395,54 @@ export class InputHandler {
     return { sec: ctx.sec, ppi: ctx.ppi, ci: ctx.ci, cellIndices };
   }
 
+  /**
+   * [Task #6741] 선택한 셀 블록의 내용을 한 번에 지운다.
+   *
+   * 한컴은 셀 블록에서 `Delete` 를 누르면 선택한 칸들의 글자를 모두 지우고 블록을 유지한다
+   * (#6741 실측). 종전 rhwp 에는 이 조작 자체가 없어 `Delete` 가 블록을 해제하고 캐럿에서
+   * 한 글자만 지웠다.
+   *
+   * 지우는 것이 글자만이 아니라 문단·서식·인라인 컨트롤까지라 역연산으로 되돌릴 수 없다 →
+   * 스냅샷으로 기록한다(#3230 로드맵의 "내용 보관이 필요한 조작" 분류).
+   * 지우기 전 셀 블록을 함께 실어 undo 뒤 복원되게 한다.
+   */
+  private clearSelectedCellBlock(): boolean {
+    const block = this.getSelectedCellBlock();
+    if (!block || block.cellIndices.length === 0) return false;
+    const selection = this.cursor.captureCellSelection();
+    const cursorBefore = this.cursor.getPosition();
+
+    this.executeOperation({
+      kind: 'snapshot',
+      operationType: 'clearCellBlock',
+      operation: (wasm) => {
+        let changed = false;
+        for (const cellIdx of block.cellIndices) {
+          if (block.cellPath) {
+            const headJson = JSON.stringify(withCellPathTarget(block.cellPath, cellIdx));
+            const paraCount = wasm.getCellParagraphCountByPath(block.sec, block.ppi, headJson);
+            const lastPara = Math.max(0, paraCount - 1);
+            const lastJson = JSON.stringify(withCellPathTarget(block.cellPath, cellIdx, lastPara));
+            const lastLen = wasm.getCellParagraphLengthByPath(block.sec, block.ppi, lastJson);
+            if (paraCount <= 1 && lastLen === 0) continue;
+            wasm.deleteRangeInCellByPath(block.sec, block.ppi, headJson, 0, 0, lastPara, lastLen);
+          } else {
+            const paraCount = wasm.getCellParagraphCount(block.sec, block.ppi, block.ci, cellIdx);
+            const lastPara = Math.max(0, paraCount - 1);
+            const lastLen = wasm.getCellParagraphLength(block.sec, block.ppi, block.ci, cellIdx, lastPara);
+            if (paraCount <= 1 && lastLen === 0) continue;
+            wasm.deleteRangeInCell(block.sec, block.ppi, block.ci, cellIdx, 0, 0, lastPara, lastLen);
+          }
+          changed = true;
+        }
+        // [Task #2370] 이미 빈 칸만 골랐으면 문서가 그대로다 → 기록하지 않는다.
+        return changed ? cursorBefore : null;
+      },
+      selectionBefore: selection ? { mode: 'cellBlock', state: selection } : null,
+    });
+    return true;
+  }
+
   private getParaFormatTargetsAtCursor(): ParaFormatTarget[] {
     const block = this.getSelectedCellBlock();
     if (block) return this.getParaFormatTargetsForCellBlock(block);
@@ -2991,6 +3039,16 @@ export class InputHandler {
     if ('mode' in range) {
       if (range.mode === 'headerFooter') {
         this.cursor.selectHeaderFooterRange(range.start, range.end, range.previewPage);
+      } else if (range.mode === 'cellBlock') {
+        // [Task #6741] 한컴은 셀 블록에서 지운 뒤 되돌리면 지우기 전 블록을 되살린다(실측).
+        // `resetDerivedStateAfterHistoryJump` 가 방금 해제한 것을 여기서 다시 세운다 —
+        // F3 확장 단계를 `selectRange(start, end, blockPhase)` 로 되살리는 것과 같은 자리다.
+        // 표가 사라졌거나 범위가 밖으로 나가면 `restoreCellSelection` 이 거절한다(#2339 규약).
+        if (this.cursor.restoreCellSelection(range.state)) {
+          this.caret.hide();
+          this.selectionRenderer.clear();
+          this.updateCellSelection();
+        }
       }
       return;
     }

--- a/rhwp-studio/tests/issue-6741-cellblock-delete-undo.test.ts
+++ b/rhwp-studio/tests/issue-6741-cellblock-delete-undo.test.ts
@@ -1,0 +1,111 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { codeOnly, functionBodyFrom } from './support/source-guard.ts';
+
+// [#6741] F5 셀 블록에서 Delete / 되돌리기의 동작을 한컴에 맞춘다.
+//
+// 한글 2024 실측(`samples/table-001.hwp`, 화면 캡처 판정):
+//
+//  | 단계                 | 글자 수 | 셀 블록 |
+//  |----------------------|---------|---------|
+//  | 블록 선택            | 118     | 음영    |
+//  | Delete               | 62      | 유지    |
+//  | Ctrl+Z (undo)        | 118     | 복원    |
+//  | Ctrl+Shift+Z (redo)  | 89      | 해제    |
+//
+// 종전 rhwp 는 방향키·Escape 외의 키를 "그 외 키"로 흘려 블록을 먼저 해제했으므로
+// Delete 는 캐럿에서 한 글자만 지웠고, undo 시점에는 되살릴 선택이 남지 않았다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = (p: string) => readFileSync(join(rootDir, p), 'utf8');
+
+/**
+ * 셀 선택 모드 분기 본문만 잘라낸다.
+ *
+ * `exitCellSelectionMode()` 는 Escape 분기와 "그 외 키" 폴백 양쪽에 있으므로 첫 매치로
+ * 순서를 재면 Escape 쪽에 걸린다. 폴백은 이 분기의 **마지막** 호출이므로 분기 끝을
+ * 명시적으로 잘라 마지막 것을 본다.
+ */
+function cellSelectionBranch(kb: string): string {
+  const at = kb.indexOf('if (this.cursor.isInCellSelectionMode()) {');
+  assert.notEqual(at, -1, '셀 선택 모드 분기를 찾지 못했다');
+  const end = kb.indexOf('handleNavigationShortcut.call(this, e)', at);
+  assert.notEqual(end, -1, '분기 끝(내비게이션 단축키 처리)을 찾지 못했다');
+  return kb.slice(at, end);
+}
+
+test('셀 블록 모드에서 Delete 는 블록을 유지한 채 선택 칸 내용을 지운다', () => {
+  const block = cellSelectionBranch(codeOnly(source('src/engine/input-handler-keyboard.ts')));
+
+  const deleteAt = block.indexOf("e.key === 'Delete'");
+  const fallthroughAt = block.lastIndexOf('this.cursor.exitCellSelectionMode();');
+  assert.notEqual(deleteAt, -1, 'Delete 처리가 없다 — 블록이 해제되고 한 글자만 지워진다');
+  assert.ok(
+    deleteAt < fallthroughAt,
+    'Delete 처리가 "그 외 키" 해제보다 뒤에 있다 — 블록이 먼저 풀린다',
+  );
+  assert.match(
+    block.slice(deleteAt, fallthroughAt),
+    /this\.clearSelectedCellBlock\(\)/,
+    'Delete 가 셀 블록 내용 지우기를 호출하지 않는다',
+  );
+});
+
+test('되돌리기·다시실행은 셀 블록을 해제하지 않고 통과한다', () => {
+  const kb = codeOnly(source('src/engine/input-handler-keyboard.ts'));
+  assert.match(
+    kb,
+    /const CELL_BLOCK_GLOBAL_COMMANDS = new Set\(\[\s*'edit:undo',\s*'edit:redo',\s*\]\)/,
+    '셀 블록에서 유지 통과할 명령 집합이 없다',
+  );
+  const block = cellSelectionBranch(kb);
+  const passAt = block.indexOf('dispatchCellBlockGlobalShortcut.call(this, e)');
+  const fallthroughAt = block.lastIndexOf('this.cursor.exitCellSelectionMode();');
+  assert.notEqual(passAt, -1, '되돌리기 통과 배선이 없다');
+  assert.ok(passAt < fallthroughAt, '통과 배선이 블록 해제보다 뒤에 있다');
+});
+
+test('셀 블록 내용 지우기는 스냅샷으로 기록하고 지우기 전 블록을 함께 싣는다', () => {
+  const ih = codeOnly(source('src/engine/input-handler.ts'));
+  const fn = functionBodyFrom(ih, 'private clearSelectedCellBlock()');
+
+  assert.match(fn, /kind: 'snapshot'/,
+    '내용 지우기는 문단·서식·인라인 컨트롤까지 지우므로 스냅샷이어야 한다(#3230 분류)');
+  assert.match(fn, /this\.cursor\.captureCellSelection\(\)/, '지우기 전 셀 블록을 캡처하지 않는다');
+  assert.match(fn, /selectionBefore:[\s\S]*mode: 'cellBlock'/,
+    '캡처한 셀 블록을 selectionBefore 로 싣지 않는다 — undo 가 되살릴 근거가 없다');
+  // [#2370] 이미 빈 칸만 골랐으면 문서가 그대로다 → 유령 undo 엔트리를 막는다.
+  assert.match(fn, /return changed \? cursorBefore : null;/,
+    '무변경 시 null 을 돌려 기록을 취소해야 한다');
+});
+
+test('undo 는 셀 블록을 되살리고 redo 는 되살리지 않는다 — 한컴 실측', () => {
+  const ih = codeOnly(source('src/engine/input-handler.ts'));
+
+  const undoFn = functionBodyFrom(ih, 'private restoreSelectionAfterUndo(');
+  assert.match(undoFn, /range\.mode === 'cellBlock'/, 'undo 복원에 셀 블록 분기가 없다');
+  assert.match(undoFn, /this\.cursor\.restoreCellSelection\(range\.state\)/,
+    'undo 가 캡처한 셀 블록으로 복원하지 않는다');
+
+  // 한컴은 redo 에서 선택을 해제한다(#3416 본문 선택과 같은 규약) — 되살리면 안 된다.
+  const redoFn = functionBodyFrom(ih, 'private restoreSelectionAfterRedo(');
+  assert.doesNotMatch(redoFn, /cellBlock/,
+    'redo 가 셀 블록을 되살린다 — 한컴은 redo 에서 해제한다');
+});
+
+test('셀 블록 복원은 표가 줄었으면 거절한다', () => {
+  const cursor = codeOnly(source('src/engine/cursor.ts'));
+  const fn = functionBodyFrom(cursor, 'restoreCellSelection(');
+
+  // 복원 시점의 표에서 크기를 다시 읽어야 그 사이 행·열이 바뀐 경우를 걸러낸다.
+  assert.match(fn, /getTableDimensions/, '복원 시점 표 크기를 다시 읽지 않는다');
+  assert.match(fn, /if \(!inside\(state\.anchor\) \|\| !inside\(state\.focus\)\) return false;/,
+    '범위 밖이면 거절해야 한다 — 유령 범위 금지(#2339)');
+
+  // 캡처는 rowCount/colCount 를 담지 않는다(담으면 낡은 값으로 판정하게 된다).
+  const cap = functionBodyFrom(cursor, 'captureCellSelection()');
+  assert.doesNotMatch(cap, /rowCount/, '캡처가 표 크기를 담고 있다 — 복원 시점에 다시 읽어야 한다');
+});

--- a/rhwp-studio/tests/issue-6741-cellblock-delete-undo.test.ts
+++ b/rhwp-studio/tests/issue-6741-cellblock-delete-undo.test.ts
@@ -78,8 +78,21 @@ test('셀 블록 내용 지우기는 스냅샷으로 기록하고 지우기 전 
   assert.match(fn, /selectionBefore:[\s\S]*mode: 'cellBlock'/,
     '캡처한 셀 블록을 selectionBefore 로 싣지 않는다 — undo 가 되살릴 근거가 없다');
   // [#2370] 이미 빈 칸만 골랐으면 문서가 그대로다 → 유령 undo 엔트리를 막는다.
-  assert.match(fn, /return changed \? cursorBefore : null;/,
+  assert.match(fn, /if \(!changed\) return null;/,
     '무변경 시 null 을 돌려 기록을 취소해야 한다');
+});
+
+test('비운 칸 안에 있던 캐럿은 그 칸의 시작으로 내린다', () => {
+  // `cursor.moveTo` 는 클램프하지 않는다(position 을 그대로 대입). 지우기 전 오프셋을
+  // 사후 커서로 돌려주면 빈 칸에 범위 밖 위치가 남고, 이후 편집이 문단 길이 검사에 걸린다.
+  // 문단이 여럿이던 칸은 cellParaIndex 도 범위 밖이 된다.
+  const ih = codeOnly(source('src/engine/input-handler.ts'));
+  const fn = functionBodyFrom(ih, 'private clearSelectedCellBlock()');
+
+  assert.match(fn, /block\.cellIndices\.includes\(cursorBefore\.cellIndex\)/,
+    '캐럿이 비운 칸 안이었는지 판정하지 않는다');
+  assert.match(fn, /\{ \.\.\.cursorBefore, cellParaIndex: 0, charOffset: 0 \}/,
+    '비운 칸 안 캐럿을 칸 시작으로 내리지 않는다 — charOffset 만 내리면 다문단 칸에서 여전히 범위 밖');
 });
 
 test('undo 는 셀 블록을 되살리고 redo 는 되살리지 않는다 — 한컴 실측', () => {

--- a/rhwp-studio/tests/mutation-routing-guard.test.ts
+++ b/rhwp-studio/tests/mutation-routing-guard.test.ts
@@ -211,7 +211,7 @@ const BASELINE: Readonly<Record<string, number>> = {
   'src/ui/table-cell-props-dialog.ts': 2,
   'src/ui/toolbar.ts': 4,
   // engine/input-handler* — 드래그/nudge 등 직접-뮤테이션 최고밀도 영역.
-  'src/engine/input-handler.ts': 33, // +1: 누름틀 제거 이관 시 removeFieldAt 이 양식모드(직접 유지)/일반모드(snapshot) 두 분기로 분리 / +1: Edit 오버레이 커밋이 셀 내부는 setFormValueInCell 로 분기(CheckBox 와 동일 조건 — 기존 flat 호출은 표 컨트롤 슬롯을 가리켜 실패) / +1: 셀 블록 글자 서식이 applyCharFormatInCell 을 executeOperation snapshot 안에서 호출(여러 셀에 걸친 글자 서식 커맨드 부재) / +1: 중첩 셀 블록 글자 서식도 applyCharFormatInCellByPath 를 같은 snapshot 안에서 호출 / +2: 머리말·꼬리말(applyParaFormatInHf)과 각주(applyParaFormatInFootnote) 문단 서식 배선 — 둘 다 snapshot 라우팅 / +2: #4121 HF 범위 치환·부분 글자 서식을 SubmodeSelectionSnapshotCommand 안에서 원자 기록
+  'src/engine/input-handler.ts': 35, // +1: 누름틀 제거 이관 시 removeFieldAt 이 양식모드(직접 유지)/일반모드(snapshot) 두 분기로 분리 / +1: Edit 오버레이 커밋이 셀 내부는 setFormValueInCell 로 분기(CheckBox 와 동일 조건 — 기존 flat 호출은 표 컨트롤 슬롯을 가리켜 실패) / +1: 셀 블록 글자 서식이 applyCharFormatInCell 을 executeOperation snapshot 안에서 호출(여러 셀에 걸친 글자 서식 커맨드 부재) / +1: 중첩 셀 블록 글자 서식도 applyCharFormatInCellByPath 를 같은 snapshot 안에서 호출 / +2: 머리말·꼬리말(applyParaFormatInHf)과 각주(applyParaFormatInFootnote) 문단 서식 배선 — 둘 다 snapshot 라우팅 / +2: #4121 HF 범위 치환·부분 글자 서식을 SubmodeSelectionSnapshotCommand 안에서 원자 기록 / +2: #6741 셀 블록 내용 지우기가 deleteRangeInCell·deleteRangeInCellByPath 를 executeOperation snapshot 안에서 호출(선택 칸 전체를 한 엔트리로)
   'src/engine/input-handler-connector.ts': 1,
   'src/engine/input-handler-keyboard.ts': 21,
   'src/engine/input-handler-mouse.ts': 3,


### PR DESCRIPTION
관련 이슈: #6741

## 문제

F5 셀 블록에서 rhwp 와 한컴이 갈린다. 한컴은 블록을 **유지한 채** 내용을 지우고, 되돌리면 지우기 전 블록을 되살린다. rhwp 는 방향키·Escape 외의 키를 전부 "그 외 키"로 흘려 **블록을 먼저 해제**하므로 `Delete` 는 캐럿에서 한 글자만 지우고, `Ctrl+Z` 시점에는 되살릴 선택이 남지 않는다. 셀 블록 내용을 한 번에 지우는 조작 자체도 없었다.

## 원인

`rhwp-studio/src/engine/input-handler-keyboard.ts` 의 셀 선택 모드 분기는 Escape·방향키·수정자·일부 Alt 단축키만 처리하고 나머지는 아래로 떨어뜨린다.

```ts
// 그 외 키 → 셀 선택 모드 종료 후 기존 처리로 넘김
this.cursor.exitCellSelectionMode();
```

`Delete` 와 `Ctrl+Z` 가 모두 여기 걸린다. 머리말/꼬리말·각주 모드에는 되돌리기를 모드 유지한 채 통과시키는 우회로(`SUBMODE_GLOBAL_COMMANDS`)가 있는데 셀 블록 모드에는 배선되어 있지 않았다.

그리고 선택 스냅샷(`EditSelectionSnapshot`)에 셀 블록을 담을 자리가 없었다. 셀 블록은 `cellAnchor`/`cellFocus` 축이라 본문 텍스트 선택(start/end)을 만들지 않으므로 `BodySelectionSnapshot` 에 얹히지 않는다.

## 변경

**Delete 를 셀 블록 모드가 소유한다.** 선택 칸들의 내용을 한 엔트리로 지우고 블록을 유지한다(`clearSelectedCellBlock`). 글자만이 아니라 문단·서식·인라인 컨트롤까지 지우므로 역연산으로 되돌릴 수 없어 **스냅샷**으로 기록한다 — #3230 로드맵이 "내용 보관이 필요해 스냅샷이 맞다"로 분류한 계열이다. 이미 빈 칸만 골랐으면 `null` 을 돌려 유령 엔트리를 막는다(#2370).

**되돌리기·다시실행을 블록을 놓지 않고 통과시킨다.** `CELL_BLOCK_GLOBAL_COMMANDS = {edit:undo, edit:redo}` — 서브모드 우회로보다 좁게 잡았다. `goto`·`select-all` 은 셀 블록을 들고 있을 이유가 없는 조작이라 종전대로 블록을 해제하고 넘긴다.

**선택 스냅샷에 셀 블록 자리를 만든다.** `CellBlockSelectionSnapshot`(`mode: 'cellBlock'`)을 `EditSelectionSnapshot` union 에 더하고, `cursor` 에 `captureCellSelection()`/`restoreCellSelection()` 을 둔다. 히스토리 점프가 파생 상태를 해제한 뒤(#2339) **undo 쪽만** 커맨드가 실어 둔 블록으로 다시 세운다. F3 확장 단계가 `blockPhase` 라는 전용 자리를 얻어 `selectRange(start, end, blockPhase)` 로 되살아나는 것과 같은 형태다(#5691).

복원은 **그 시점의 표에서 크기를 다시 읽어** 범위가 밖이면 거절한다. 캡처가 `rowCount`/`colCount` 를 담지 않는 이유다 — 낡은 값으로 판정하면 그 사이 행·열이 줄었을 때 유령 범위가 된다(#2339 규약).

추가 테스트 `rhwp-studio/tests/issue-6741-cellblock-delete-undo.test.ts` 5건.

## 검증

devel `1c49df3d3` 기준.

**한컴 실측** — 한글 2024, `samples/table-001.hwp`. 셀 블록을 잡고 `Delete` → `Ctrl+Z` → `Ctrl+Shift+Z`:

| 단계 | 글자 수 | 셀 블록 |
|---|---|---|
| 블록 선택 | 118 | 음영 |
| Delete | 62 | **유지** |
| Ctrl+Z | 118 | **복원 — 지운 범위 그대로** |
| Ctrl+Shift+Z | 89 | **해제** |

마우스 드래그(3칸)와 `F5`(1칸) 양쪽으로 같은 결과를 확인했다. 이미지와 측정 경위는 #6741 본문에 있다. 본문 선택(#3416)·F3 확장 단계(#5690)와 같은 규약이다.

**음성 확인 — 시험이 실제로 잡는가** (각각 교란을 넣고 실패를 확인한 뒤 복구):

| 넣은 교란 | 결과 |
|---|---|
| 셀 블록 모드의 `Delete` 분기 제거 | 🔴 1건 실패 |
| `selectionBefore` 의 셀 블록 적재 제거 | 🔴 3건 실패 |
| `restoreSelectionAfterRedo` 에도 셀 블록 복원 추가 | 🔴 4건 실패 |

**게이트**

- `node --test tests/*.test.ts` — 변경 전 1149 pass / 21 fail, 변경 후 **1154 pass / 21 fail**. 실패 목록 동일(신규 0). 잔여 21건은 이 워크트리에 `node_modules`·wasm 산출물이 없어 나는 기존 실패다.
- `npx tsc --noEmit` — `@wasm/rhwp.js` 미해결 5건만 남는다(`wasm-bridge.ts`·`hwpctl/index.ts`·`plugin/*`, 모두 이 PR 이 건드리지 않은 파일). 변경분에서 나온 오류 0.
- 뮤테이션 표면 원장 baseline 을 `src/engine/input-handler.ts` 33 → 35 로 갱신했다. 두 호출(`deleteRangeInCell`·`deleteRangeInCellByPath`)이 모두 `executeOperation` snapshot 콜백 안이라 라우팅된 사이트다(#2327).

## 자기리뷰 반영 (커밋 2)

게시 뒤 자기리뷰에서 P2 하나를 찾아 같은 PR 에서 고쳤다.

`clearSelectedCellBlock` 이 **지우기 전** 위치를 스냅샷 연산의 사후 커서로 돌려줬다.
`cursor.moveTo` 는 클램프하지 않고 `position` 을 그대로 대입하므로(`engine/cursor.ts`),
캐럿이 방금 비운 칸 안이었으면 `charOffset` 이 범위 밖으로 남는다. 문단이 여럿이던 칸은
`cellParaIndex` 도 범위 밖이 된다. 그 상태로 타이핑하면 `text_editing` 의 문단 길이 검사에 걸린다.

재현 — 표 칸의 글자 중간에 캐럿(offset 3) → `F5` → `Delete` → 칸은 비지만 캐럿은 offset 3
→ `Escape` 후 타이핑.

캐럿의 칸이 지운 집합에 있을 때만 칸 시작(`cellParaIndex` 0 / `charOffset` 0)으로 내린다.
제외 셀로 캐럿 칸이 빠진 경우는 내용이 그대로이므로 종전 위치를 유지한다.
회귀 시험 1건 추가(총 6건), `node --test tests/*.test.ts` **1155 pass / 21 fail**(실패 목록 기준선과 동일).

## 범위 외

- **Backspace** — 한컴에서 실측하니 **아무 일도 하지 않는다**(글자 수 불변, 대화상자 없음, 블록 유지). rhwp 는 종전대로 블록을 해제하고 캐럿 앞 글자를 지운다. 맞출 값어치가 있는지는 별건으로 본다 — 이 PR 은 `Delete` 만 다룬다. 측정은 #6741 본문.
- **셀 블록을 유지해야 하는 다른 키의 전체 목록** — 지금까지 잰 것은 `Delete`·`Backspace`·`Ctrl+Z`/`Ctrl+Shift+Z`·`F5`·방향키다. 서식 단축키 등 나머지는 아직이라, 그 전까지는 종전대로 블록을 해제하고 넘긴다.
- **셀 블록이 활성인 채 무관한 편집을 되돌리는 경우** — 실측했다. 한컴도 **블록을 놓고** 캐럿을 되돌린 편집 지점으로 옮긴다. 이 PR 의 동작(그 커맨드에 셀 블록 스냅샷이 없으므로 복원하지 않음)이 한컴과 같다 — 맞출 것이 없다. 측정은 #6741 본문.
- **`_cellSelectionReason`** — 캡처·복원에 포함했으나 실측은 수동 선택(`manual`)만 다뤘다.


