### PR TITLE
perf(pdf): compatibility fallback coverage 조회를 캐시한다

### DIFF
--- a/src/renderer/pdf.rs
+++ b/src/renderer/pdf.rs
@@ -549,6 +549,194 @@ fn create_fontdb(options: &PdfExportOptions) -> usvg::fontdb::Database {
     fontdb
 }
 
+// A document with more distinct fallback characters than this is unusual enough
+// that keeping the stock resolver is safer than retaining an unbounded index.
+#[cfg(not(target_arch = "wasm32"))]
+const PDF_FONT_FALLBACK_INDEX_MAX_CHARS: usize = 4_096;
+
+// Coverage is stored as one Option<bool> slot per visited face position. Cap the
+// total logical slot length as well as the number of characters so Vec capacity
+// and HashMap metadata cannot grow with an unbounded system font inventory.
+#[cfg(not(target_arch = "wasm32"))]
+const PDF_FONT_FALLBACK_INDEX_MAX_FACE_SLOTS: usize = 262_144;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug)]
+struct PdfFontFallbackIndex {
+    database: Option<(std::sync::Weak<usvg::fontdb::Database>, usize)>,
+    coverage_by_char: std::collections::HashMap<char, Vec<Option<bool>>>,
+    face_slot_count: usize,
+    disabled: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl PdfFontFallbackIndex {
+    fn new() -> Self {
+        Self {
+            database: None,
+            coverage_by_char: std::collections::HashMap::new(),
+            face_slot_count: 0,
+            disabled: false,
+        }
+    }
+
+    fn disable(&mut self) {
+        self.coverage_by_char.clear();
+        self.face_slot_count = 0;
+        self.disabled = true;
+    }
+
+    fn select(
+        &mut self,
+        c: char,
+        used_fonts: &[usvg::fontdb::ID],
+        fontdb: &std::sync::Arc<usvg::fontdb::Database>,
+        max_chars: usize,
+        max_face_slots: usize,
+    ) -> PdfFontFallbackLookup {
+        if self.disabled {
+            return PdfFontFallbackLookup::Default;
+        }
+
+        // A custom select_font callback may add faces through Arc::make_mut. Cached
+        // IDs and ordering only describe the exact database observed on first use;
+        // fall back globally if that identity or face inventory changes.
+        let database = std::sync::Arc::downgrade(fontdb);
+        let face_count = fontdb.len();
+        match self.database.as_ref() {
+            None => self.database = Some((database, face_count)),
+            Some((cached, cached_face_count))
+                if *cached_face_count != face_count
+                    || !std::sync::Weak::ptr_eq(cached, &database) =>
+            {
+                self.disable();
+                return PdfFontFallbackLookup::Default;
+            }
+            Some(_) => {}
+        }
+
+        if !self.coverage_by_char.contains_key(&c) {
+            if self.coverage_by_char.len() >= max_chars {
+                self.disable();
+                return PdfFontFallbackLookup::Default;
+            }
+            self.coverage_by_char.insert(c, Vec::new());
+        }
+
+        // Preserve usvg 0.45's exact short-circuit order: exclusion and face
+        // compatibility are checked before the potentially expensive cmap probe,
+        // and the first supporting face returns immediately. The index only
+        // replaces has_char calls that stock usvg would otherwise repeat.
+        let base_face = fontdb.face(used_fonts[0]);
+        for (face_index, face) in fontdb.faces().enumerate() {
+            if used_fonts.contains(&face.id) {
+                continue;
+            }
+            let Some(base_face) = base_face else {
+                return PdfFontFallbackLookup::Cached(None);
+            };
+            if base_face.style != face.style
+                && base_face.weight != face.weight
+                && base_face.stretch != face.stretch
+            {
+                continue;
+            }
+
+            let cached = self
+                .coverage_by_char
+                .get(&c)
+                .and_then(|coverage| coverage.get(face_index))
+                .copied()
+                .flatten();
+            let supports_char = match cached {
+                Some(supports_char) => supports_char,
+                None => {
+                    let Some(required_len) = face_index.checked_add(1) else {
+                        self.disable();
+                        return PdfFontFallbackLookup::Default;
+                    };
+                    let current_len = self
+                        .coverage_by_char
+                        .get(&c)
+                        .map_or(0, |coverage| coverage.len());
+                    let additional_slots = required_len.saturating_sub(current_len);
+                    let Some(next_face_slot_count) =
+                        self.face_slot_count.checked_add(additional_slots)
+                    else {
+                        self.disable();
+                        return PdfFontFallbackLookup::Default;
+                    };
+                    if next_face_slot_count > max_face_slots {
+                        self.disable();
+                        return PdfFontFallbackLookup::Default;
+                    }
+
+                    let supports_char = pdf_font_face_has_char(fontdb, face.id, c);
+                    let coverage = self
+                        .coverage_by_char
+                        .get_mut(&c)
+                        .expect("fallback coverage was inserted above");
+                    if coverage.len() < required_len {
+                        coverage.resize(required_len, None);
+                        self.face_slot_count = next_face_slot_count;
+                    }
+                    coverage[face_index] = Some(supports_char);
+                    supports_char
+                }
+            };
+            if supports_char {
+                return PdfFontFallbackLookup::Cached(Some(face.id));
+            }
+        }
+
+        PdfFontFallbackLookup::Cached(None)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+enum PdfFontFallbackLookup {
+    Cached(Option<usvg::fontdb::ID>),
+    Default,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn pdf_font_face_has_char(fontdb: &usvg::fontdb::Database, id: usvg::fontdb::ID, c: char) -> bool {
+    fontdb
+        .with_face_data(id, |font_data, face_index| {
+            ttf_parser::Face::parse(font_data, face_index)
+                .ok()
+                .and_then(|face| face.glyph_index(c))
+                .is_some()
+        })
+        .unwrap_or(false)
+}
+
+/// Builds the bounded fallback selector used by compatibility PDF conversion.
+///
+/// The limits are arguments so integration tests can exercise overflow without
+/// manufacturing a production-sized font database. Callers should normally use
+/// [`svgs_to_pdf_with_options`] instead.
+#[cfg(not(target_arch = "wasm32"))]
+#[doc(hidden)]
+pub fn pdf_font_fallback_selector_with_limits(
+    max_chars: usize,
+    max_face_slots: usize,
+) -> usvg::FallbackSelectionFn<'static> {
+    let index = std::sync::Mutex::new(PdfFontFallbackIndex::new());
+    let default_selector = usvg::FontResolver::default_fallback_selector();
+
+    Box::new(move |c, used_fonts, fontdb| {
+        let lookup = match index.lock() {
+            Ok(mut index) => index.select(c, used_fonts, fontdb, max_chars, max_face_slots),
+            Err(_) => PdfFontFallbackLookup::Default,
+        };
+        match lookup {
+            PdfFontFallbackLookup::Cached(id) => id,
+            PdfFontFallbackLookup::Default => default_selector(c, used_fonts, fontdb),
+        }
+    })
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 fn warn_missing_family(
     fontdb: &usvg::fontdb::Database,
@@ -1024,6 +1212,10 @@ where
     let fontdb = create_fontdb(export_options);
     let mut options = usvg::Options::default();
     options.fontdb = std::sync::Arc::new(fontdb);
+    options.font_resolver.select_fallback = pdf_font_fallback_selector_with_limits(
+        PDF_FONT_FALLBACK_INDEX_MAX_CHARS,
+        PDF_FONT_FALLBACK_INDEX_MAX_FACE_SLOTS,
+    );
     options.image_href_resolver = pdf_image_href_resolver();
 
     let mut alloc = Ref::new(1);

--- a/tests/cases/issue_6679_pdf_font_fallback_cache.rs
+++ b/tests/cases/issue_6679_pdf_font_fallback_cache.rs
@@ -1,0 +1,471 @@
+//! #6679: compatibility PDF의 usvg font fallback이 같은 coverage probe를 반복하지 않는다.
+//!
+//! indexed selector는 usvg 0.45의 후보 순서·used-face 제외·호환 조건을 그대로 유지한다.
+//! 문자·face-slot 상한 중 하나라도 넘으면 앞서 만든 부분 index까지 버리고 stock
+//! selector로 복귀한다.
+
+use rhwp::renderer::pdf::{
+    pdf_font_fallback_selector_with_limits, svgs_to_pdf_with_options, PdfExportOptions,
+};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use usvg::fontdb::{Database, FaceInfo, Language, Source, Stretch, Style, Weight, ID};
+
+const FIXTURE_FONT: &[u8] = include_bytes!("../fixtures/fonts/RHWPBitmapSvgGlyphSmoke.ttf");
+const EXACT_FACE_FIXTURE: &[u8] = include_bytes!("../fixtures/fonts/RHWPExactFaceSmoke.ttc");
+const BASE_FONT: &[u8] = include_bytes!("../fixtures/fonts/RHWPExactKerningSmoke.ttf");
+const FIRST_CHAR: char = '\u{e100}';
+const SECOND_CHAR: char = '\u{e101}';
+
+fn binary_source(bytes: &[u8]) -> Source {
+    Source::Binary(Arc::new(bytes.to_vec()))
+}
+
+fn push_face(
+    database: &mut Database,
+    source: Source,
+    name: &str,
+    style: Style,
+    weight: Weight,
+    stretch: Stretch,
+) -> ID {
+    database.push_face_info(FaceInfo {
+        id: ID::dummy(),
+        source,
+        index: 0,
+        families: vec![(name.to_string(), Language::English_UnitedStates)],
+        post_script_name: name.to_string(),
+        style,
+        weight,
+        stretch,
+        monospaced: false,
+    })
+}
+
+#[test]
+fn indexed_selector_preserves_stock_order_and_used_face_exclusion() {
+    let source = binary_source(FIXTURE_FONT);
+    let mut database = Database::new();
+    let base = push_face(
+        &mut database,
+        binary_source(BASE_FONT),
+        "base",
+        Style::Normal,
+        Weight::NORMAL,
+        Stretch::Normal,
+    );
+    let first = push_face(
+        &mut database,
+        source.clone(),
+        "first",
+        Style::Normal,
+        Weight::NORMAL,
+        Stretch::Normal,
+    );
+    let second = push_face(
+        &mut database,
+        source,
+        "second",
+        Style::Normal,
+        Weight::NORMAL,
+        Stretch::Normal,
+    );
+
+    let indexed = pdf_font_fallback_selector_with_limits(8, 32);
+    let stock = usvg::FontResolver::default_fallback_selector();
+    let mut indexed_database = Arc::new(database.clone());
+    let mut stock_database = Arc::new(database);
+
+    let used = [base];
+    assert_eq!(
+        indexed(FIRST_CHAR, &used, &mut indexed_database),
+        stock(FIRST_CHAR, &used, &mut stock_database)
+    );
+    assert_eq!(
+        indexed(FIRST_CHAR, &used, &mut indexed_database),
+        Some(first),
+        "fontdb insertion order must remain the fallback order"
+    );
+
+    let used = [base, first];
+    assert_eq!(
+        indexed(FIRST_CHAR, &used, &mut indexed_database),
+        stock(FIRST_CHAR, &used, &mut stock_database)
+    );
+    assert_eq!(
+        indexed(FIRST_CHAR, &used, &mut indexed_database),
+        Some(second),
+        "a face already used for shaping must be excluded on a cache hit"
+    );
+}
+
+#[test]
+fn indexed_selector_preserves_usvg_style_weight_stretch_condition() {
+    let source = binary_source(FIXTURE_FONT);
+    let mut database = Database::new();
+    let base = push_face(
+        &mut database,
+        binary_source(BASE_FONT),
+        "base-normal",
+        Style::Normal,
+        Weight::NORMAL,
+        Stretch::Normal,
+    );
+    let all_different = push_face(
+        &mut database,
+        source.clone(),
+        "all-three-differ",
+        Style::Italic,
+        Weight::BOLD,
+        Stretch::Expanded,
+    );
+    let style_matches = push_face(
+        &mut database,
+        source.clone(),
+        "only-style-matches",
+        Style::Normal,
+        Weight::BOLD,
+        Stretch::Expanded,
+    );
+    let weight_matches = push_face(
+        &mut database,
+        source.clone(),
+        "only-weight-matches",
+        Style::Italic,
+        Weight::NORMAL,
+        Stretch::Expanded,
+    );
+    let stretch_matches = push_face(
+        &mut database,
+        source,
+        "only-stretch-matches",
+        Style::Italic,
+        Weight::BOLD,
+        Stretch::Normal,
+    );
+
+    let indexed = pdf_font_fallback_selector_with_limits(8, 32);
+    let stock = usvg::FontResolver::default_fallback_selector();
+    let mut indexed_database = Arc::new(database.clone());
+    let mut stock_database = Arc::new(database);
+    for (used, expected) in [
+        (vec![base], style_matches),
+        (vec![base, style_matches], weight_matches),
+        (vec![base, style_matches, weight_matches], stretch_matches),
+    ] {
+        let indexed_id = indexed(FIRST_CHAR, &used, &mut indexed_database);
+        let stock_id = stock(FIRST_CHAR, &used, &mut stock_database);
+        assert_eq!(indexed_id, stock_id);
+        assert_eq!(indexed_id, Some(expected));
+        assert_ne!(indexed_id, Some(all_different));
+    }
+}
+
+static NEXT_TEMP_DIR: AtomicU64 = AtomicU64::new(0);
+
+struct TempFontFile {
+    dir: std::path::PathBuf,
+    path: std::path::PathBuf,
+}
+
+impl TempFontFile {
+    fn new(file_name: &str, bytes: &[u8]) -> Self {
+        let dir = loop {
+            let serial = NEXT_TEMP_DIR.fetch_add(1, Ordering::Relaxed);
+            let candidate = std::env::temp_dir()
+                .join(format!("rhwp-issue-6679-{}-{serial}", std::process::id()));
+            match std::fs::create_dir(&candidate) {
+                Ok(()) => break candidate,
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(error) => panic!("create isolated font fixture directory: {error}"),
+            }
+        };
+        let path = dir.join(file_name);
+        std::fs::write(&path, bytes).expect("write isolated font fixture");
+        Self { dir, path }
+    }
+
+    fn remove_file(&self) {
+        std::fs::remove_file(&self.path).expect("remove mapped font fixture after lookup");
+    }
+}
+
+impl Drop for TempFontFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+        let _ = std::fs::remove_dir(&self.dir);
+    }
+}
+
+fn file_backed_database(path: &std::path::Path, candidate_count: usize) -> (Database, Vec<ID>) {
+    let source = Source::File(path.to_path_buf());
+    let mut database = Database::new();
+    let mut ids = vec![push_face(
+        &mut database,
+        binary_source(BASE_FONT),
+        "base-without-pua",
+        Style::Normal,
+        Weight::NORMAL,
+        Stretch::Normal,
+    )];
+    ids.extend((0..candidate_count).map(|index| {
+        push_face(
+            &mut database,
+            source.clone(),
+            &format!("face-{index}"),
+            Style::Normal,
+            Weight::NORMAL,
+            Stretch::Normal,
+        )
+    }));
+    (database, ids)
+}
+
+#[test]
+fn repeated_character_reuses_coverage_without_remapping_the_file() {
+    let fixture = TempFontFile::new("fallback.ttf", FIXTURE_FONT);
+    let (database, ids) = file_backed_database(&fixture.path, 1);
+    let selector = pdf_font_fallback_selector_with_limits(8, 32);
+    let mut database = Arc::new(database);
+    let used = [ids[0]];
+
+    assert_eq!(selector(FIRST_CHAR, &used, &mut database), Some(ids[1]));
+    fixture.remove_file();
+    assert_eq!(
+        selector(FIRST_CHAR, &used, &mut database),
+        Some(ids[1]),
+        "a cached coverage result must not reopen or remap the deleted backing file"
+    );
+
+    let stock = usvg::FontResolver::default_fallback_selector();
+    assert_eq!(
+        stock(FIRST_CHAR, &used, &mut database),
+        None,
+        "the stock resolver proves that a fresh face-data mapping now fails"
+    );
+}
+
+#[test]
+fn repeated_character_reuses_negative_coverage_without_remapping_the_file() {
+    let unsupported_fixture = TempFontFile::new("unsupported.ttf", BASE_FONT);
+    let supported_fixture = TempFontFile::new("supported.ttf", FIXTURE_FONT);
+    let mut database = Database::new();
+    let base = push_face(
+        &mut database,
+        binary_source(BASE_FONT),
+        "base-without-pua",
+        Style::Normal,
+        Weight::NORMAL,
+        Stretch::Normal,
+    );
+    let formerly_unsupported = push_face(
+        &mut database,
+        Source::File(unsupported_fixture.path.clone()),
+        "first-file-backed-candidate",
+        Style::Normal,
+        Weight::NORMAL,
+        Stretch::Normal,
+    );
+    let supported = push_face(
+        &mut database,
+        Source::File(supported_fixture.path.clone()),
+        "second-file-backed-candidate",
+        Style::Normal,
+        Weight::NORMAL,
+        Stretch::Normal,
+    );
+    let selector = pdf_font_fallback_selector_with_limits(8, 32);
+    let mut database = Arc::new(database);
+    let used = [base];
+
+    assert_eq!(selector(FIRST_CHAR, &used, &mut database), Some(supported));
+    std::fs::write(&unsupported_fixture.path, FIXTURE_FONT)
+        .expect("replace the negative-probe fixture with a supporting font");
+    assert_eq!(
+        selector(FIRST_CHAR, &used, &mut database),
+        Some(supported),
+        "a cached negative coverage result must not remap the changed backing file"
+    );
+
+    let stock = usvg::FontResolver::default_fallback_selector();
+    assert_eq!(
+        stock(FIRST_CHAR, &used, &mut database),
+        Some(formerly_unsupported),
+        "the stock resolver proves that a fresh probe now observes the earlier face"
+    );
+}
+
+#[test]
+fn character_limit_discards_the_partial_index_and_uses_stock_fallback() {
+    let fixture = TempFontFile::new("char-cap.ttf", FIXTURE_FONT);
+    let (database, ids) = file_backed_database(&fixture.path, 1);
+    let selector = pdf_font_fallback_selector_with_limits(1, 32);
+    let mut database = Arc::new(database);
+    let used = [ids[0]];
+
+    assert_eq!(selector(FIRST_CHAR, &used, &mut database), Some(ids[1]));
+    assert_eq!(
+        selector(SECOND_CHAR, &used, &mut database),
+        Some(ids[1]),
+        "the overflow-triggering lookup must be delegated to stock fallback"
+    );
+
+    fixture.remove_file();
+    assert_eq!(
+        selector(FIRST_CHAR, &used, &mut database),
+        None,
+        "overflow must discard the previously cached character globally"
+    );
+}
+
+#[test]
+fn face_slot_limit_discards_the_partial_index_and_uses_stock_fallback() {
+    let fixture = TempFontFile::new("candidate-cap.ttf", FIXTURE_FONT);
+    let (database, ids) = file_backed_database(&fixture.path, 2);
+    let selector = pdf_font_fallback_selector_with_limits(8, 2);
+    let mut database = Arc::new(database);
+    let used = [ids[0]];
+
+    assert_eq!(selector(FIRST_CHAR, &used, &mut database), Some(ids[1]));
+    assert_eq!(
+        selector(SECOND_CHAR, &used, &mut database),
+        Some(ids[1]),
+        "the face-slot overflow lookup must be delegated to stock fallback"
+    );
+
+    fixture.remove_file();
+    assert_eq!(
+        selector(FIRST_CHAR, &used, &mut database),
+        None,
+        "face-slot overflow must discard the previously cached character globally"
+    );
+}
+
+#[test]
+fn fontdb_change_disables_the_index_and_uses_stock_fallback() {
+    let fixture = TempFontFile::new("database-change.ttf", FIXTURE_FONT);
+    let (database, ids) = file_backed_database(&fixture.path, 1);
+    let selector = pdf_font_fallback_selector_with_limits(8, 32);
+    let mut database = Arc::new(database);
+    let used = [ids[0]];
+
+    assert_eq!(selector(FIRST_CHAR, &used, &mut database), Some(ids[1]));
+    push_face(
+        Arc::make_mut(&mut database),
+        binary_source(BASE_FONT),
+        "added-face-without-pua",
+        Style::Normal,
+        Weight::NORMAL,
+        Stretch::Normal,
+    );
+
+    fixture.remove_file();
+    assert_eq!(
+        selector(FIRST_CHAR, &used, &mut database),
+        None,
+        "an additively changed fontdb must invalidate prior coverage and delegate to stock"
+    );
+}
+
+#[test]
+fn indexed_selector_keeps_stock_pdf_bytes_for_a_controlled_fontdb() {
+    let candidate_source = binary_source(FIXTURE_FONT);
+    let mut database = Database::new();
+    push_face(
+        &mut database,
+        binary_source(BASE_FONT),
+        "controlled-base",
+        Style::Normal,
+        Weight::NORMAL,
+        Stretch::Normal,
+    );
+    push_face(
+        &mut database,
+        candidate_source.clone(),
+        "controlled-first",
+        Style::Normal,
+        Weight::NORMAL,
+        Stretch::Normal,
+    );
+    push_face(
+        &mut database,
+        candidate_source,
+        "controlled-second",
+        Style::Normal,
+        Weight::NORMAL,
+        Stretch::Normal,
+    );
+
+    let svg = format!(
+        concat!(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60">"#,
+            r#"<text x="4" y="16" font-family="controlled-base">{}</text>"#,
+            r#"<text x="4" y="34" font-family="controlled-base">{}</text>"#,
+            r#"<text x="4" y="52" font-family="controlled-base">{}</text>"#,
+            r#"</svg>"#,
+        ),
+        FIRST_CHAR, SECOND_CHAR, FIRST_CHAR,
+    );
+
+    let mut stock_options = usvg::Options::default();
+    stock_options.fontdb = Arc::new(database.clone());
+    let stock_tree = usvg::Tree::from_str(&svg, &stock_options).expect("parse with stock resolver");
+
+    let mut indexed_options = usvg::Options::default();
+    indexed_options.fontdb = Arc::new(database);
+    indexed_options.font_resolver.select_fallback = pdf_font_fallback_selector_with_limits(8, 32);
+    let indexed_tree =
+        usvg::Tree::from_str(&svg, &indexed_options).expect("parse with indexed resolver");
+
+    let conversion = svg2pdf::ConversionOptions {
+        compress: false,
+        ..svg2pdf::ConversionOptions::default()
+    };
+    let stock_pdf = svg2pdf::to_pdf(&stock_tree, conversion, svg2pdf::PageOptions::default())
+        .expect("convert stock tree");
+    let indexed_pdf = svg2pdf::to_pdf(&indexed_tree, conversion, svg2pdf::PageOptions::default())
+        .expect("convert indexed tree");
+    assert_eq!(
+        indexed_pdf, stock_pdf,
+        "the cache must not change font choice, layout, text mapping, or PDF bytes"
+    );
+}
+
+fn tounicode_contains(pdf: &[u8], unicode: &[u8]) -> bool {
+    let Some(block_start) = pdf
+        .windows(b"beginbfchar".len())
+        .position(|window| window == b"beginbfchar")
+    else {
+        return false;
+    };
+    let block = &pdf[block_start + b"beginbfchar".len()..];
+    let Some(block_end) = block
+        .windows(b"endbfchar".len())
+        .position(|window| window == b"endbfchar")
+    else {
+        return false;
+    };
+    block[..block_end]
+        .windows(unicode.len())
+        .any(|window| window == unicode)
+}
+
+#[test]
+fn compatibility_pdf_keeps_the_fallback_text_surface() {
+    let fixture = TempFontFile::new("exact-face.ttc", EXACT_FACE_FIXTURE);
+    let svg = String::from(
+        r#"<svg xmlns="http://www.w3.org/2000/svg" width="120" height="40">
+            <text x="4" y="24" font-family="RHWP Exact Face Zero">&#xE104;</text>
+        </svg>"#,
+    );
+    let mut options = PdfExportOptions::default();
+    options.font_paths.push(fixture.dir.clone());
+
+    let pdf = svgs_to_pdf_with_options(&[svg], &options)
+        .expect("compatibility PDF should render the missing PUA through fallback");
+    assert!(pdf.starts_with(b"%PDF-"));
+    assert!(
+        tounicode_contains(&pdf, b"<E104>"),
+        "compatibility PDF must preserve U+E104 in the searchable text surface"
+    );
+}


### PR DESCRIPTION
## 변경 요약

멀티 렌더러 트래킹 #536의 P43으로, compatibility PDF의 SVG → usvg → svg2pdf 변환에서 같은 문자와 font face 조합에 대한 coverage probe가 반복되는 비용을 줄입니다.

- `(문자, fontdb face 위치)`별 `has_char` 결과를 lazy cache로 재사용합니다.
- 최초 조회는 usvg 0.45.1의 순서와 short-circuit를 그대로 따라 stock resolver보다 더 많은 face를 미리 읽지 않습니다.
- 기존 face 순서, used-face 제외, style/weight/stretch 판정식을 그대로 유지합니다.
- 문자 4,096개와 logical face slot 262,144개로 cache를 제한합니다.
- 상한 초과 또는 fontdb identity/face inventory 변경 시 부분 cache를 버리고 해당 호출부터 stock fallback resolver로 전역 복귀합니다.

이 cache는 fallback 선택 중 반복되는 coverage probe만 줄입니다. 선택된 폰트의 후속 load/embed 경로와 PDF 생성 방식은 바꾸지 않습니다.

## 변경 범위

변경한 곳:

- compatibility PDF의 usvg fallback selector
- positive/negative coverage, 순서, 상한, 무효화, 출력 동등성을 고정하는 integration test

변경하지 않은 곳:

- 시스템 폰트 스캔과 fontdb face 등록 순서
- Skia direct PDF (`layer_trees_to_pdf`)
- 폰트 임베딩·서브셋 경로
- CLI와 DocumentCore
- 선택된 폰트 데이터의 후속 load/embed 동작

폰트 파일 자체를 cache에 보관하지 않고 coverage 결과만 저장합니다. 프로세스 단위 peak RSS는 별도로 계측하지 않았으며, 문자 수와 logical face slot을 hard limit으로 제한해 cache가 무제한 성장하지 않도록 했습니다. cache 수명은 한 번의 export이며, 그동안 등록된 폰트 파일 내용이 바뀌지 않는다는 기존 변환 전제를 따릅니다.

usvg 기본 selector가 선택 때 내는 내부 fallback warning log는 custom selector에서 재현하지 않습니다. fallback 선택 결과와 PDF 출력 동등성은 아래 테스트로 고정합니다.

## 회귀 테스트

`tests/cases/issue_6679_pdf_font_fallback_cache.rs`에 9개 테스트를 추가했습니다.

- stock face 순서와 used-face 제외 결과 일치
- usvg의 style/weight/stretch 호환 판정식 일치
- 같은 문자의 file-backed positive coverage 재사용
- 앞쪽 미지원 file-backed face의 negative coverage 재사용
- 문자 상한 초과 시 부분 cache 폐기 및 stock resolver 복귀
- logical face-slot 상한 초과 시 부분 cache 폐기 및 stock resolver 복귀
- fontdb 변경 시 cache 무효화 및 stock resolver 복귀
- 통제된 fontdb에서 stock/indexed `svg2pdf` 결과의 PDF byte equality
- production compatibility PDF 경로의 PDF header 및 searchable ToUnicode 유지

기존 compatibility PDF focused 회귀도 확인했습니다.

- #3772: 2/2
- #3773: 5/5
- #6612: 2/2
- #6679 신규 회귀: 9/9

## 성능 영향 및 측정 결과

- 예상 영향: 반복 fallback coverage 조회 개선
- 환경: Linux x86_64, 동일 프로세스
- 대상: 동일한 file-backed face와 동일 문자의 isolated coverage probe 20,000회
- stock selector: 739.5ms
- indexed selector: 16.7ms
- 관측 상대값: 약 44.2배

이는 전체 PDF export 시간이 아니라 #6679에서 지적한 반복 `has_char` 구간만 분리한 측정입니다. 실제 문서의 개선 폭은 시스템 폰트 구성과 fallback 반복 횟수에 따라 달라집니다.

## 테스트

- [x] `cargo fmt --all -- --check`
- [x] 새 integration test 원본만 `tests/cases/`에 추가하고 generated suite·manifest·Cargo generated target 제외
- [x] native root/WASM32/workspace all-target Clippy (`-D warnings`)
- [x] workspace build 및 suite manifest 생성기 테스트
- [x] P43 `release-test` focused 회귀: 9/9
- [x] 전체 `release-test` nextest: 9,028/9,028 통과, 46 skipped
- [x] Native Skia library: 3,930 통과, 13 ignored
- [x] Native Skia missing-picture placeholder: 2/2
- [x] Native Skia direct PDF: 4/4
- [x] 표준 Docker WASM package build
- [x] `git diff --check`

별도 스크린샷은 첨부하지 않았습니다. 출력 변경이 아닌 selector 비용 최적화이므로, 통제된 동일 입력의 PDF byte equality와 production compatibility PDF의 searchable text surface를 자동 검증 증적으로 사용했습니다.

Related: #536

Closes #6679
