### PR TITLE
Task #3416: 선택 복원 소스 가드를 주석 오염에서 차단한다

### DIFF
--- a/rhwp-studio/tests/issue-3416-selection-restore.test.ts
+++ b/rhwp-studio/tests/issue-3416-selection-restore.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createServer } from 'vite';
-import { functionBodyFrom } from './support/source-guard.ts';
+import { codeOnly, functionBodyFrom } from './support/source-guard.ts';
 
 // [#3416] undo 뒤 "지우기 전 선택" 복원.
 //
@@ -25,6 +25,15 @@ import { functionBodyFrom } from './support/source-guard.ts';
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 const src = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+/**
+ * 소스 계약 단언용 — 주석을 지운 본문만 본다.
+ *
+ * 아래 단언들은 이름의 **위치**로 순서를 재거나(`indexOf` 비교) 이름의 부재를 단언한다.
+ * 원문 그대로 보면 이 레포의 관습(주석에 선언·호출을 그대로 인용)에 뚫린다 — 실제로
+ * `restoreSelectionAfterUndo` 에 붙은 주석이 `selectRange` 를 인용하자 마지막 시험의
+ * 순서 판정이 뒤집혔다(#6741 작업 중 CI 에서 드러남). #6335 가 세운 규약을 따른다.
+ */
+const code = (rel: string): string => codeOnly(src(rel));
 
 test('[#3416] 선택 삭제 커맨드가 지우기 전 범위를 들고 있다', async () => {
   const vite = await createServer({
@@ -47,7 +56,7 @@ test('[#3416] 선택 삭제 커맨드가 지우기 전 범위를 들고 있다',
 });
 
 test('[#3416] undo 경로가 선택을 되살린다 — redo 경로에는 없다', () => {
-  const handler = src('src/engine/input-handler.ts');
+  const handler = code('src/engine/input-handler.ts');
   const undo = functionBodyFrom(handler, 'private handleUndo()');
   const redo = functionBodyFrom(handler, 'private handleRedo()');
 
@@ -62,7 +71,7 @@ test('[#3416] undo 경로가 선택을 되살린다 — redo 경로에는 없다
 });
 
 test('[#3416] 유효성은 호출부가 아니라 selectRange 안에서 판정된다', () => {
-  const cursor = src('src/engine/cursor.ts');
+  const cursor = code('src/engine/cursor.ts');
   const select = functionBodyFrom(cursor, 'selectRange(');
 
   // 확인이 대입보다 먼저여야 한다 — 뒤면 유령 범위가 이미 선 뒤다.
@@ -73,14 +82,14 @@ test('[#3416] 유효성은 호출부가 아니라 selectRange 안에서 판정�
   assert.match(select, /return false/, '세우지 못하면 그 사실을 돌려줘야 한다');
 
   // 호출부에 같은 판정을 두면 계약이 두 곳으로 갈라진다 — 그때부터 한쪽만 고쳐진다.
-  const handler = src('src/engine/input-handler.ts');
+  const handler = code('src/engine/input-handler.ts');
   const restore = functionBodyFrom(handler, 'private restoreSelectionAfterUndo');
   assert.doesNotMatch(restore, /getParagraphCount|getParagraphLength|parentParaIndex/,
     '실재 판정을 호출부가 되풀이하면 안 된다');
 });
 
 test('[#3416] 해제는 그대로 남는다 — 복원은 그 위에 얹는 향상이다', () => {
-  const handler = src('src/engine/input-handler.ts');
+  const handler = code('src/engine/input-handler.ts');
   const reset = functionBodyFrom(handler, 'private resetDerivedStateAfterHistoryJump');
   assert.match(reset, /exitBlockSelectionMode\(\)/, '#2339 의 해제가 유지돼야 한다');
   assert.match(reset, /exitCellSelectionMode\(\)/);
@@ -138,7 +147,7 @@ test('[#3416] selectRange 는 실재하지 않는 범위를 거절한다 — 실
 });
 
 test('[#3416] 구역을 걸치는 범위는 복원 대상이 아니다 (실측 범위 밖)', () => {
-  const handler = src('src/engine/input-handler.ts');
+  const handler = code('src/engine/input-handler.ts');
   const restore = functionBodyFrom(handler, 'private restoreSelectionAfterUndo');
   assert.match(restore, /sectionIndex !== range\.end\.sectionIndex/, '구역 정책은 호출부가 갖는다');
   const idxPolicy = restore.indexOf('sectionIndex !==');


### PR DESCRIPTION
관련 이슈: #3416

## 문제

`rhwp-studio/tests/issue-3416-selection-restore.test.ts` 의 소스 계약 단언이 **원문을 그대로** 본다. 이 단언들은 이름의 **위치**로 순서를 재거나(`indexOf` 비교) 이름의 부재를 단언하는데, 이 레포는 주석에 선언·호출을 그대로 인용하는 것이 관습이라 그 방식은 뚫린다.

#6335 가 미앵커 pin 508곳을 감사해 고위험 48곳을 `codeOnly` 로 전환했는데 이 파일은 남았다.

## 원인

실제로 발생했다. #6741 작업에서 `restoreSelectionAfterUndo` 에 F3 선례를 설명하는 주석을 붙이며 호출을 그대로 인용했더니, "정책 판정이 먼저다" 단언이 뒤집혔다.

```ts
const restore = functionBodyFrom(handler, 'private restoreSelectionAfterUndo');
const idxPolicy = restore.indexOf('sectionIndex !==');
const idxSelect = restore.indexOf('selectRange');
assert.ok(idxPolicy !== -1 && idxPolicy < idxSelect, '정책 판정이 먼저다');
```

주석이 함수 앞쪽에 있으면 `idxSelect` 가 실제 호출보다 먼저 잡혀 `idxPolicy < idxSelect` 가 깨진다. CI 의 Frontend package gates 에서 드러났고, 그 PR 은 주석에서 리터럴을 빼는 쪽으로 우회했다 — 가드 자체는 그대로 남았다.

같은 취약성이 이 파일의 다른 단언에도 있다. `undo`/`select` 의 순서 비교 두 곳, 그리고 `doesNotMatch(restore, /getParagraphCount|getParagraphLength|parentParaIndex/)` 는 주석이 그 이름을 언급하기만 해도 거짓 실패한다. 반대로 `match` 계열은 주석만으로 **거짓 통과**할 수 있다.

## 변경

소스 계약을 보는 네 테스트가 `codeOnly` 를 거치게 한다.

```ts
const code = (rel: string): string => codeOnly(src(rel));
```

`codeOnly`(#6335 의 `tests/support/source-guard.ts`)는 주석만 공백으로 지우고 문자열·줄 구조를 보존하므로 `functionBodyFrom` 의 중괄호 매칭과 `indexOf` 위치 비교가 그대로 성립한다.

vite 로 실제 모듈을 올려 동작을 검증하는 두 테스트(`DeleteSelectionCommand` 보관, `selectRange` 거절)는 원문과 무관하므로 손대지 않았다.

## 검증

devel `1c49df3d3` 기준.

**음성 확인 — 양방향** (`restoreSelectionAfterUndo` 앞에 `// 교란: F3 는 selectRange(start, end, blockPhase) 로 되살린다.` 를 넣고):

| 상태 | 결과 |
|---|---|
| 전환 후(`codeOnly` 경유) | 🟢 **6/6 통과** — 주석 인용이 더 이상 순서를 뒤집지 못한다 |
| 같은 교란에서 `codeOnly` 만 되돌림 | 🔴 **1건 실패** — 전환이 실제로 값을 한다는 증명 |

교란 제거 후 6/6 복귀, 워킹트리 클린.

- `node --test tests/*.test.ts` **1352 pass / 0 fail**.

## 범위 외

- **다른 파일의 미전환 가드** — 같은 형태(위치 판정)를 쓰는 나머지 7건은 #5953 에서 전환했다(`issue-5690-block-selection-phase`, `undo-history-jumped`, `command-history-snapshot`, `issue-5769-zorder-inverse`, `table-keyboard-navigation`, `cell-ctrl-up-para-start`, `char-properties-cursor-nested-cell`). 그 밖은 넓다. `rhwp-studio/tests` 에서 소스를 읽는 테스트가 145개인데 `codeOnly` 를 거치는 것은 17개다. #6335 는 전수 전환이 아니라 감사에서 고른 고위험 pin(상수·선언 인용) 48곳을 전환한 것이고, 나머지는 그대로다. 이 PR 은 실제로 뚫린 것이 확인된 이 파일만 다룬다.
- **#6335 의 감사 기준이 이 계열을 안 잡았다** — 그 감사는 상수·선언 pin 을 위험군으로 봤는데, 이 파일이 뚫린 것은 `indexOf` 두 개를 비교하는 **위치 판정** 때문이다. 주석 인용이 실제 코드보다 앞에 있기만 하면 순서가 뒤집히므로, 인용된 이름이 상수든 호출이든 무관하다. 같은 형태의 위치 판정을 쓰는 다른 가드를 훑는 일은 별건으로 둔다.
- 순서 비교 자체를 줄 구조 앵커로 바꾸는 것 — `codeOnly` 만으로 이번 계열은 막힌다. 더 강한 앵커는 필요해질 때 따로 본다.


