### PR TITLE
Task #6758: 건드리지 않은 크기 칸을 패치에 싣지 않는다

### DIFF
--- a/rhwp-studio/src/ui/picture-props-apply-model.ts
+++ b/rhwp-studio/src/ui/picture-props-apply-model.ts
@@ -172,12 +172,14 @@ function mmToHwp(raw: string | undefined): number {
 }
 
 /**
- * [Task #6758] 다이얼로그가 크기 칸에 처음 채우는 표시값.
+ * [Task #6758] 크기 칸의 표시값 — **이 모듈이 서식의 단일 소유자다.**
  *
- * `picture-props-dialog` 는 `(hwp / HWP_PER_MM).toFixed(2)` 로 채운다. 같은 식을 여기서
- * 다시 만들어 "사용자가 이 칸을 건드렸는가"를 **표시 문자열끼리** 비교한다.
+ * 아래 `addChangedSize` 는 "사용자가 이 칸을 건드렸는가"를 표시값과 견줘 판정한다. 그래서
+ * 다이얼로그가 칸을 채우는 서식과 여기 서식이 반드시 같아야 한다 — 갈라지면 판정이 늘
+ * "바뀌었다"가 되어 #6758(무변경 확인이 치수를 200 으로 부풀림)이 되살아난다.
+ * 두 벌을 두고 가드로 묶는 대신, 다이얼로그가 이 함수를 가져다 쓴다.
  */
-function displayedMm(hwp: number): string {
+export function displayedMm(hwp: number): string {
   return (hwp / HWP_PER_MM).toFixed(2);
 }
 

--- a/rhwp-studio/src/ui/picture-props-apply-model.ts
+++ b/rhwp-studio/src/ui/picture-props-apply-model.ts
@@ -171,6 +171,40 @@ function mmToHwp(raw: string | undefined): number {
   return Math.round(numberOr(raw, 0) * HWP_PER_MM);
 }
 
+/**
+ * [Task #6758] 다이얼로그가 크기 칸에 처음 채우는 표시값.
+ *
+ * `picture-props-dialog` 는 `(hwp / HWP_PER_MM).toFixed(2)` 로 채운다. 같은 식을 여기서
+ * 다시 만들어 "사용자가 이 칸을 건드렸는가"를 **표시 문자열끼리** 비교한다.
+ */
+function displayedMm(hwp: number): string {
+  return (hwp / HWP_PER_MM).toFixed(2);
+}
+
+/**
+ * [Task #6758] 크기 전용 — 사용자가 칸을 건드렸을 때만 패치에 싣는다.
+ *
+ * 종전에는 되돌린 HWPUNIT 과 모델 값을 비교했다(`addChanged`). 그런데 mm 2자리 표시는
+ * 저장 단위를 잃는다 — 높이 1 HWPUNIT 은 `"0.00"` 으로 보이고 되돌리면 `0` 이라 모델의
+ * `1` 과 달라져, **사용자가 아무것도 안 고쳐도 변경으로 판정돼** 패치에 실렸다. 그 `0` 이
+ * 엔진의 최소 크기 클램프(`MIN_SHAPE_SIZE = 200`)에 걸려 가는 선이 200배로 두꺼워졌다.
+ *
+ * 한글 2024 는 같은 표시 정밀도를 쓰면서도 확인에서 치수를 그대로 둔다(#6758 실측).
+ * 입력값이 표시값과 같으면 사용자가 건드리지 않은 것이므로 보내지 않는다.
+ *
+ * 비교는 **표시 정밀도로 정규화해서** 한다 — 문자열을 그대로 견주면 같은 값의 다른 표기
+ * (`"10"` 과 `"10.00"`)가 변경으로 잡힌다.
+ */
+function addChangedSize(
+  patch: PicturePropsPatch,
+  key: string,
+  raw: string | undefined,
+  current: number,
+): void {
+  if (numberOr(raw, 0).toFixed(2) === displayedMm(current)) return;
+  patch[key] = Math.max(0, mmToHwp(raw));
+}
+
 function hexToColorRef(hex: string): number {
   const value = hex.replace('#', '');
   const red = parseInt(value.substring(0, 2), 16);
@@ -211,8 +245,8 @@ function appendCommonSize(
 ): void {
   addChanged(patch, 'sizeProtect', form.sizeProtect, props.sizeProtect ?? false);
   if (form.sizeProtect) return;
-  addChanged(patch, 'width', Math.max(0, mmToHwp(form.width)), props.width);
-  addChanged(patch, 'height', Math.max(0, mmToHwp(form.height)), props.height);
+  addChangedSize(patch, 'width', form.width, props.width);
+  addChangedSize(patch, 'height', form.height, props.height);
 }
 
 function appendCommonPosition(

--- a/rhwp-studio/src/ui/picture-props-dialog.ts
+++ b/rhwp-studio/src/ui/picture-props-dialog.ts
@@ -18,6 +18,7 @@ import { userSettings } from '@/core/user-settings';
 import { enableDialogDrag } from './dialog-drag';
 import {
   buildPicturePropsPatch,
+  displayedMm,
   resolvePicturePropsApplyTarget,
   type PicturePropsApplyForm,
   type PicturePropsApplyTarget,
@@ -2143,8 +2144,9 @@ export class PicturePropsDialog {
         this.picEmbedCheck.checked = true;
       }
     }
-    this.widthInput.value = hwpToMm(this.props.width).toFixed(2);
-    this.heightInput.value = hwpToMm(this.props.height).toFixed(2);
+    // [Task #6758] 크기 칸의 서식 소유자는 apply-model 이다 — 판정이 이 표시값과 견준다.
+    this.widthInput.value = displayedMm(this.props.width);
+    this.heightInput.value = displayedMm(this.props.height);
     this.sizeFixedCheck.checked = this.props.sizeProtect ?? false;
     this.treatAsCharCheck.checked = this.props.treatAsChar;
     this.selectWrap(this.wrapValues.indexOf(this.props.textWrap));

--- a/rhwp-studio/tests/picture-props-apply-model.test.ts
+++ b/rhwp-studio/tests/picture-props-apply-model.test.ts
@@ -665,3 +665,51 @@ for (const fixture of targetFixtures) {
     }
   });
 }
+
+// [#6758] 다이얼로그가 크기를 mm 2자리로 보여주고 되돌려 쓰면 저장 단위가 사라진다.
+// 높이 1 HWPUNIT 은 "0.00" 으로 보이고 되돌리면 0 이라, 종전 판정(되돌린 값 vs 모델 값)은
+// **사용자가 아무것도 안 고쳐도** 변경으로 보고 패치에 실었다. 그 0 이 엔진의 최소 크기
+// 클램프(MIN_SHAPE_SIZE = 200)에 걸려 가는 선이 200배로 두꺼워졌다.
+//
+// 한글 2024 는 같은 표시 정밀도를 쓰면서도 확인에서 치수를 그대로 둔다(#6758 실측:
+// 너비 62.50 / 높이 0.00 → 설정 뒤에도 0.00).
+
+test('[#6758] 표시 정밀도로 사라지는 치수는 건드리지 않으면 패치에 실리지 않는다', () => {
+  // 높이 1 HWPUNIT — 다이얼로그는 "0.00" 으로 채운다.
+  const props = pictureProps({ width: 17716, height: 1 });
+  const form = applyForm();
+  form.common.width = '62.50';   // 17716 의 표시값
+  form.common.height = '0.00';   // 1 의 표시값 — 사용자가 손대지 않았다
+
+  const patch = buildPicturePropsPatch('shape', props, shapeProps({ width: 17716, height: 1 }), form);
+
+  assert.equal('height' in patch, false,
+    '건드리지 않은 높이가 패치에 실렸다 — 엔진 클램프에 걸려 200 이 된다');
+  assert.equal('width' in patch, false, '건드리지 않은 너비도 실리면 안 된다');
+});
+
+test('[#6758] 사용자가 실제로 고친 치수는 그대로 실린다', () => {
+  const props = pictureProps({ width: 17716, height: 1 });
+  const form = applyForm();
+  form.common.width = '62.50';
+  form.common.height = '1.00';   // 0.00 → 1.00 으로 고쳤다
+
+  const patch = buildPicturePropsPatch('shape', props, shapeProps({ width: 17716, height: 1 }), form);
+
+  assert.equal(patch.height, 283, '고친 값은 HWPUNIT 으로 실려야 한다');
+  assert.equal('width' in patch, false, '고치지 않은 너비는 실리지 않는다');
+});
+
+test('[#6758] 같은 값의 다른 표기는 변경이 아니다', () => {
+  // 표시값이 "10.00" 인데 폼에 "10" 이 들어와도 사용자가 고친 것이 아니다.
+  const props = pictureProps({ width: 2835, height: 5669 });
+  const form = applyForm();
+  form.common.width = '10';
+  form.common.height = '20';
+
+  const patch = buildPicturePropsPatch('shape', props, shapeProps(), form);
+
+  assert.equal('width' in patch, false, '"10" 과 "10.00" 은 같은 값이다');
+  assert.equal('height' in patch, false, '"20" 과 "20.00" 은 같은 값이다');
+});
+

--- a/rhwp-studio/tests/picture-props-apply-model.test.ts
+++ b/rhwp-studio/tests/picture-props-apply-model.test.ts
@@ -1,5 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { codeOnly } from './support/source-guard.ts';
 import type { CellPathLike, PictureProperties, ShapeProperties } from '../src/core/types.ts';
 import {
   buildPicturePropsPatch,
@@ -711,5 +715,22 @@ test('[#6758] 같은 값의 다른 표기는 변경이 아니다', () => {
 
   assert.equal('width' in patch, false, '"10" 과 "10.00" 은 같은 값이다');
   assert.equal('height' in patch, false, '"20" 과 "20.00" 은 같은 값이다');
+});
+
+test('[#6758] 다이얼로그가 크기 칸을 공용 서식으로 채운다', () => {
+  // `addChangedSize` 는 입력값을 **표시값과 견줘** 사용자가 건드렸는지 판정한다. 그래서
+  // 다이얼로그가 칸을 채우는 서식과 apply-model 의 서식이 갈라지면 판정이 늘 "바뀌었다"가
+  // 되어 #6758 이 되살아난다. 두 벌을 두지 않도록 다이얼로그가 `displayedMm` 를 쓴다.
+  const dialog = codeOnly(
+    readFileSync(
+      join(dirname(dirname(fileURLToPath(import.meta.url))), 'src/ui/picture-props-dialog.ts'),
+      'utf8',
+    ),
+  );
+
+  assert.match(dialog, /this\.widthInput\.value = displayedMm\(this\.props\.width\);/,
+    '너비 칸을 공용 서식으로 채우지 않는다');
+  assert.match(dialog, /this\.heightInput\.value = displayedMm\(this\.props\.height\);/,
+    '높이 칸을 공용 서식으로 채우지 않는다');
 });
 


### PR DESCRIPTION
관련 이슈: #6758

## 문제

개체 속성 대화상자에서 **아무것도 고치지 않고 확인만 눌러도** 200 HWPUNIT(0.7mm) 미만 치수가 200 으로 부풀려진다. 높이 1 HWPUNIT 인 가로선은 확인 한 번에 200배로 두꺼워진다. 한글 2024 는 같은 조작에서 치수를 그대로 둔다.

## 원인

치수가 **mm 2자리를 왕복**하면서 저장 단위를 잃고, 그 잃은 값이 최소 크기 클램프에 걸린다.

1. **표시** — `picture-props-dialog.ts` 가 `(hwp / (7200/25.4)).toFixed(2)` 로 채운다. 1 HWPUNIT ≈ 0.0035 mm 라 `"0.00"` 이 된다.
2. **되돌림** — `picture-props-apply-model.ts` 의 `mmToHwp` 가 `Math.round(mm * HWP_PER_MM)` 로 되돌린다. `"0.00"` → `0`.
3. **전송 판정이 오히려 실어 보낸다** — `appendCommonSize` 가 되돌린 값과 모델 값을 견줬다.

   ```ts
   addChanged(patch, 'height', Math.max(0, mmToHwp(form.height)), props.height);
   ```

   `0 !== 1` 이므로 **사용자가 아무것도 안 고쳐도** 변경으로 판정돼 `height: 0` 이 패치에 실린다. 변경분 필터가 방어가 되지 못하고 왕복 손실을 "사용자 변경"으로 읽는다.
4. **클램프가 0 을 200 으로 올린다** — `object_ops/shape.rs` 의 `json_u32(props_json, "height").map(|h| h.max(MIN_SHAPE_SIZE))`, `MIN_SHAPE_SIZE = 200`.

발동 범위는 왕복이 원본과 달라지는 200 미만 치수 전부다(1 → `"0.00"` → 0, 2 → `"0.01"` → 3, 100 → `"0.35"` → 99 …). 0 은 되돌려도 0 이라 종전 판정에서도 안전했다.

## 변경

크기에만 전용 판정을 쓴다 — **입력값이 다이얼로그가 처음 채운 표시값과 같으면 사용자가 건드리지 않은 것**이므로 보내지 않는다.

```ts
function displayedMm(hwp: number): string {
  return (hwp / HWP_PER_MM).toFixed(2);
}

function addChangedSize(patch, key, raw, current) {
  if (numberOr(raw, 0).toFixed(2) === displayedMm(current)) return;
  patch[key] = Math.max(0, mmToHwp(raw));
}
```

비교는 **표시 정밀도로 정규화**해서 한다. 문자열을 그대로 견주면 같은 값의 다른 표기(`"10"` 과 `"10.00"`)가 변경으로 잡힌다.

최소 크기 클램프 자체는 그대로 둔다 — 리사이즈 핸들을 반대편으로 끌어당길 때 studio 가 0 을 보내는 경로(코드 주석)에는 여전히 필요하다. 이 PR 은 속성창 왕복이 0 을 만들지 않게 한다.

추가 테스트 `rhwp-studio/tests/picture-props-apply-model.test.ts` 3건 — 무변경 미전송 / 실제 변경 전송 / 표기 차이는 변경 아님.

## 검증

devel `1c49df3d3` 기준.

**한글 2024 실측** — `samples/group-box.hwp` 의 가로선(높이 1 HWPUNIT). 개체 속성을 열어 **설정(D)** 만 누른다:

| | 높이 표시 | 확인 후 |
|---|---|---|
| 한컴 2024 | 0.00 mm | **0.00 mm 유지** |
| rhwp (수정 전) | 0.00 mm | **0.70 mm (200 HWPUNIT)** |

이미지와 절차는 #6758 본문에 있다.

**음성 확인 — 시험이 실제로 잡는가**: `addChangedSize` 를 종전 `addChanged` 로 되돌리면 🔴 **2건 실패**(무변경 미전송 / 실제 변경 전송). 복구 후 33/33 통과.

**게이트**

- `node --test tests/*.test.ts` — **1355 pass / 0 fail**.
- `npx tsc --noEmit` — `@wasm/rhwp.js` 미해결 외 오류 0(이 워크트리에 wasm-pack 산출물이 없어 나는 기존 것).
- 기존 `picture-props-apply-model.test.ts` 30건 무변경 통과 — 정규화 덕에 `"10"` 같은 기존 픽스처 표기가 그대로 산다.

## 자기리뷰 반영 (커밋 2)

게시 뒤 자기리뷰에서 P3 하나를 찾아 같은 PR 에서 고쳤다.

`addChangedSize` 는 입력값을 **표시값과 견줘** 판정하는데, 표시 서식이 두 벌이었다 —
다이얼로그의 `hwpToMm(...).toFixed(2)` 와 apply-model 의 `(hwp / HWP_PER_MM).toFixed(2)`.
갈라지면 판정이 늘 "바뀌었다"가 되어 이 PR 이 고친 결함이 그대로 되살아난다(다이얼로그가
정밀도를 바꾸기만 해도).

두 벌을 가드로 묶는 대신 **소유자를 하나로** 뒀다 — `displayedMm` 을 export 하고
다이얼로그가 가져다 쓴다. 재복제를 막는 소스 가드 1건 추가(`codeOnly` 경유).
`node --test tests/*.test.ts` **1356 pass / 0 fail**.

## 범위 외

- **위치 오프셋의 같은 드리프트** — `horzOffset`·`vertOffset` 도 같은 mm 왕복을 거치므로 건드리지 않은 값이 ±1~2 HWPUNIT 흔들릴 수 있다. 클램프가 없어 시각적 파손은 없고, 한컴이 오프셋을 어떻게 두는지는 재지 않았다. 같은 헬퍼로 덮을 수 있으나 이 PR 범위 밖으로 둔다.
  > **2026-09-05 후속.** 재어 보니 무해하지 않았다 — `horizontal_offset`·`vertical_offset` 은 `shape_transform_fingerprint` 의 구성 요소라, 1 HWPUNIT 드리프트가 #6740 이 지키는 한컴 원본 `raw_rendering` 을 지운다. 한글 2024 는 같은 조작에서 오프셋을 그대로 둔다(실측). #6769 로 세우고 이 PR 위에 PR #6770 을 쌓았다.
- **표·그림 등 다른 개체 종류** — 위 실측은 도형(선) 경로다. 같은 왕복이 어디까지 같은지는 재지 않았다.
- **200 이상 치수의 양자화** — 왕복이 값을 바꾸면 이제 "사용자가 고쳤다"로 보지 않으므로 함께 막힌다. 다만 그쪽은 애초에 클램프에 걸리지 않아 시각적 파손이 없었다.


