### PR TITLE
Task #6769: 건드리지 않은 위치 오프셋을 패치에 싣지 않는다

### DIFF
--- a/rhwp-studio/src/ui/picture-props-apply-model.ts
+++ b/rhwp-studio/src/ui/picture-props-apply-model.ts
@@ -197,14 +197,38 @@ export function displayedMm(hwp: number): string {
  * 비교는 **표시 정밀도로 정규화해서** 한다 — 문자열을 그대로 견주면 같은 값의 다른 표기
  * (`"10"` 과 `"10.00"`)가 변경으로 잡힌다.
  */
+function untouchedMm(raw: string | undefined, current: number): boolean {
+  return numberOr(raw, 0).toFixed(2) === displayedMm(current);
+}
+
 function addChangedSize(
   patch: PicturePropsPatch,
   key: string,
   raw: string | undefined,
   current: number,
 ): void {
-  if (numberOr(raw, 0).toFixed(2) === displayedMm(current)) return;
+  if (untouchedMm(raw, current)) return;
   patch[key] = Math.max(0, mmToHwp(raw));
+}
+
+/**
+ * [Task #6769] 위치 오프셋 전용 — 판정은 크기와 같고, 0 클램프만 두지 않는다.
+ *
+ * 오프셋도 같은 mm 2자리를 왕복하므로 무변경 확인에서 값이 흔들린다. 크기와 달리
+ * 엔진 클램프가 없어 눈에 보이는 파손은 없지만, `horizontal_offset`/`vertical_offset`
+ * 은 `shape_transform_fingerprint`(`object_ops/common.rs`)의 구성 요소다 — 1 HWPUNIT
+ * 만 흔들려도 지문이 달라져 #6740 이 지키려던 한컴 원본 `raw_rendering` 이 지워진다.
+ *
+ * 음수 오프셋이 정당하므로 크기와 달리 `Math.max(0, ...)` 을 쓰지 않는다.
+ */
+function addChangedOffset(
+  patch: PicturePropsPatch,
+  key: string,
+  raw: string | undefined,
+  current: number,
+): void {
+  if (untouchedMm(raw, current)) return;
+  patch[key] = mmToHwp(raw);
 }
 
 function hexToColorRef(hex: string): number {
@@ -265,10 +289,10 @@ function appendCommonPosition(
     addChanged(patch, 'horzRelTo', form.horzRelTo, props.horzRelTo);
   }
   addChanged(patch, 'horzAlign', form.horzAlign, props.horzAlign);
-  addChanged(patch, 'horzOffset', mmToHwp(form.horzOffset), props.horzOffset);
+  addChangedOffset(patch, 'horzOffset', form.horzOffset, props.horzOffset);
   addChanged(patch, 'vertRelTo', form.vertRelTo, props.vertRelTo);
   addChanged(patch, 'vertAlign', form.vertAlign, props.vertAlign);
-  addChanged(patch, 'vertOffset', mmToHwp(form.vertOffset), props.vertOffset);
+  addChangedOffset(patch, 'vertOffset', form.vertOffset, props.vertOffset);
   addChanged(patch, 'restrictInPage', form.restrictInPage, props.restrictInPage ?? true);
   addChanged(patch, 'allowOverlap', form.allowOverlap, props.allowOverlap ?? false);
 }

--- a/rhwp-studio/src/ui/picture-props-dialog.ts
+++ b/rhwp-studio/src/ui/picture-props-dialog.ts
@@ -2154,10 +2154,10 @@ export class PicturePropsDialog {
       ? 'TakePlace'
       : this.props.horzRelTo;
     this.horzAlignSelect.value = this.props.horzAlign;
-    this.horzOffsetInput.value = hwpToMm(this.props.horzOffset).toFixed(2);
+    this.horzOffsetInput.value = displayedMm(this.props.horzOffset);
     this.vertRelSelect.value = this.props.vertRelTo;
     this.vertAlignSelect.value = this.props.vertAlign;
-    this.vertOffsetInput.value = hwpToMm(this.props.vertOffset).toFixed(2);
+    this.vertOffsetInput.value = displayedMm(this.props.vertOffset);
     this.pageAreaLimitCheck.checked = this.props.restrictInPage ?? true;
     this.overlapAllowCheck.checked = this.props.allowOverlap ?? false;
     this.descInput.value = this.props.description;

--- a/rhwp-studio/tests/picture-props-apply-model.test.ts
+++ b/rhwp-studio/tests/picture-props-apply-model.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { codeOnly } from './support/source-guard.ts';
+import { codeOnly, functionBodyFrom } from './support/source-guard.ts';
 import type { CellPathLike, PictureProperties, ShapeProperties } from '../src/core/types.ts';
 import {
   buildPicturePropsPatch,
@@ -734,3 +734,56 @@ test('[#6758] 다이얼로그가 크기 칸을 공용 서식으로 채운다', (
     '높이 칸을 공용 서식으로 채우지 않는다');
 });
 
+test('[#6769] 건드리지 않은 위치 오프셋은 패치에 실리지 않는다', () => {
+  // group-box.hwp 의 가로선 실측값. 8554 HWPUNIT 은 "30.18" 로 보이고 되돌리면 8555 라
+  // 사용자가 아무것도 안 고쳐도 종전에는 변경으로 판정됐다. 한글 2024 는 같은 조작에서
+  // 이 값을 그대로 둔다(#6769 실측 — 설정만 누르고 저장한 파일이 원본과 필드 동일).
+  const props = pictureProps({ horzOffset: 8554, vertOffset: 16620 });
+  const form = applyForm();
+  form.common.horzOffset = '30.18';
+  form.common.vertOffset = '58.63';
+
+  const patch = buildPicturePropsPatch('shape', props, shapeProps(), form);
+
+  assert.equal('horzOffset' in patch, false, '표시값 그대로 돌아온 가로 오프셋은 무변경이다');
+  assert.equal('vertOffset' in patch, false, '표시값 그대로 돌아온 세로 오프셋은 무변경이다');
+});
+
+test('[#6769] 실제로 고친 오프셋은 그대로 실린다', () => {
+  const props = pictureProps({ horzOffset: 8554, vertOffset: 16620 });
+  const form = applyForm();
+  form.common.horzOffset = '40.00';
+  form.common.vertOffset = '58.63';
+
+  const patch = buildPicturePropsPatch('shape', props, shapeProps(), form);
+
+  assert.equal(patch.horzOffset, Math.round(40 * (7200 / 25.4)), '고친 값은 보낸다');
+  assert.equal('vertOffset' in patch, false, '안 고친 칸은 함께 실리지 않는다');
+});
+
+test('[#6769] 오프셋 판정은 크기의 0 클램프를 물려받지 않는다', () => {
+  // 크기는 `Math.max(0, ...)` 로 음수를 막지만 오프셋에 음수는 정당하다.
+  // 클램프를 함께 복사하면 왼쪽/위쪽으로 나간 개체를 0 으로 끌어당긴다.
+  const model = codeOnly(
+    readFileSync(
+      join(dirname(dirname(fileURLToPath(import.meta.url))), 'src/ui/picture-props-apply-model.ts'),
+      'utf8',
+    ),
+  );
+  const body = functionBodyFrom(model, 'function addChangedOffset');
+  assert.match(body, /untouchedMm\(raw, current\)/, '판정은 크기와 같은 소유자를 쓴다');
+  assert.doesNotMatch(body, /Math\.max\(/, '오프셋에 0 클램프를 두지 않는다');
+});
+
+test('[#6769] 다이얼로그가 오프셋 칸도 공용 서식으로 채운다', () => {
+  const dialog = codeOnly(
+    readFileSync(
+      join(dirname(dirname(fileURLToPath(import.meta.url))), 'src/ui/picture-props-dialog.ts'),
+      'utf8',
+    ),
+  );
+  assert.match(dialog, /this\.horzOffsetInput\.value = displayedMm\(this\.props\.horzOffset\);/,
+    '가로 오프셋 칸을 공용 서식으로 채우지 않는다');
+  assert.match(dialog, /this\.vertOffsetInput\.value = displayedMm\(this\.props\.vertOffset\);/,
+    '세로 오프셋 칸을 공용 서식으로 채우지 않는다');
+});


### PR DESCRIPTION
관련 이슈: #6769

> **2026-09-05 갱신 — 스택 해소.** 이 PR 은 #6763 위에 쌓아 올렸는데, #6763 이 통합 #6774 로 devel 에 반영됐다. 최신 devel(`1f861362a`) 위로 다시 세워 **이제 커밋 하나(`Task #6769`)만 남는다.**

## 문제

개체 속성에서 아무것도 고치지 않고 확인만 눌러도 위치 오프셋이 1 HWPUNIT 흔들리고, 그 흔들림이 `shape_transform_fingerprint` 를 바꿔 #6740 이 지키려던 한컴 원본 `raw_rendering` 을 지운다. 한글 2024 는 같은 조작에서 어느 필드도 건드리지 않는다.

#6763 이 크기 칸에 도입한 표시값 판정이 위치 칸에는 적용돼 있지 않아, **#6763 이 착지해도 `{"horzOffset":8555}` 가 그대로 남는다.**

## 원인

`appendCommonPosition` 이 되돌린 HWPUNIT 과 모델 값을 견준다.

```ts
addChanged(patch, 'horzOffset', mmToHwp(form.horzOffset), props.horzOffset);
```

mm 2자리는 저장 단위를 잃는다 — 0.01mm 는 약 2.83 HWPUNIT 이라, 8554 는 `"30.18"` 로 보이고 되돌리면 8555 다. 사용자가 아무것도 안 고쳐도 **왕복 손실이 "변경" 으로 판정돼** 패치에 실린다. 0~19999 중 왕복이 값을 보존하는 것은 35.3% 뿐이다.

그 1 을 지문이 본다. `shape_transform_fingerprint`(`object_ops/common.rs`)는 `horizontal_offset`·`vertical_offset` 을 포함하고, 오프셋을 쓰는 `apply_common_obj_attr_from_json`(`common.rs:95-99`)은 지문 채취(`shape.rs:393`)와 재판정(`shape.rs:636`) **사이**에 있다.

## 변경

"사용자가 이 칸을 건드렸는가" 판정을 `untouchedMm` 하나로 빼고, 위치용 변형을 더한다.

```ts
function untouchedMm(raw: string | undefined, current: number): boolean {
  return numberOr(raw, 0).toFixed(2) === displayedMm(current);
}

function addChangedOffset(patch, key, raw, current): void {
  if (untouchedMm(raw, current)) return;
  patch[key] = mmToHwp(raw);   // 오프셋은 0 클램프를 두지 않는다
}
```

크기의 `Math.max(0, ...)` 는 **가져오지 않는다** — 음수 오프셋은 정당하다(이 표본의 묶음이 `v_off = -776`). 클램프를 함께 복사하면 왼쪽·위쪽으로 나간 개체를 0 으로 끌어당긴다.

다이얼로그의 오프셋 칸도 `displayedMm` 으로 통일한다(`picture-props-dialog.ts:2157·2160`). 판정이 표시값과 견주므로 서식이 갈라지면 판정이 늘 "바뀌었다" 가 되어 이 결함이 되살아난다 — #6763 이 크기에서 같은 이유로 소유자를 하나로 둔 것과 동형이다.

테스트 4건 추가 — 무변경 미전송 / 실제 변경만 전송 / 0 클램프 미상속 / 다이얼로그 서식 일치(소스 가드).

## 검증

devel `1f861362a` 기준(재검증).

**한글 2024 실측** — `samples/group-box.hwp` 의 가로선(`s0p2c0`). 개체 속성을 열어 **설정(D)** 만 누르고 저장한 것(B)과, 아무 조작 없이 저장만 한 것(A)을 rhwp 로 파싱해 대조했다.

| | h_off | v_off | 너비 | 높이 | `raw_rendering` |
|---|---|---|---|---|---|
| 원본 | 8554 | 16620 | 17716 | 1 | 146B |
| A — 한컴, 무조작 저장 | 8554 | 16620 | 17716 | 1 | 146B |
| **B — 한컴, 설정 누르고 저장** | **8554** | **16620** | **17716** | **1** | **146B** |

절차와 화면은 #6769 본문에 있다.

**수정 전 실패 증명** — `set_shape_properties_native` 에 오프셋 하나만 넘긴 실측. 대조군은 "편집이라면 무엇이든 하는" `section.raw_stream = None` 만 적용한 저장본이다.

| 적용 (묶음 `s0p0c2`, 원본 287) | `raw_rendering` | 대조군과 first_diff |
|---|---|---|
| 원본값 `287` 재적용 | 146B → **146B** | `None` |
| 왕복 드리프트 `286` | 146B → **0B** | `Some(632)` |

**음성 확인 — 시험이 실제로 잡는가**: `addChangedOffset` 배선을 종전 `addChanged` 로 되돌리면 🔴 무변경 미전송이 실패하고, 다이얼로그 서식만 `hwpToMm(...).toFixed(2)` 로 되돌리면 🔴 소스 가드가 실패한다. 복구 후 38/38 통과.

**게이트**

- `node --test tests/*.test.ts` — **1375 pass / 0 fail**.
- `npx tsc --noEmit` — `@wasm/rhwp.js` 미해결 외 오류 0(이 워크트리에 wasm-pack 산출물이 없어 나는 기존 것).
- `scripts/rust-unit-test-tiers.mjs --check --base-ref origin/devel` 통과, `rust-test-suite-manifest.mjs --prepare` 무변경. Rust 변경 없음.

## 딸려 오는 동작 변경 — 셀 그림 클램프 (자기리뷰에서 찾음)

밝혀 둘 것이 하나 있다. 이 PR 은 studio 만 고치지만, 엔진의 한 분기가 **패치에 오프셋 키가 있는지**로 켜진다.

```rust
// object_ops/table.rs:1344 — set_cell_picture_properties_by_path_native
let clamp_horz = restrict_enabled_by_this_call || json_i32(props_json, "horzOffset").is_some();
```

`clamp_direct_owner_cell_picture_offsets`(`table.rs:235`, Task #1282)를 켜는 조건이다. 뜻은 "쪽 영역 제한을 켰거나 **사용자가 개체를 옮겼으면** 셀 안으로 되당긴다" 인데, 종전에는 오프셋이 무변경에도 늘 실렸으므로 **사실상 항상 켜져 있었다.** `picture-props-dialog.ts:2074` 가 같은 패치를 이 API 로 보내므로 도달한다.

이 PR 뒤로는 이렇게 갈린다.

| 사용자가 한 일 | 종전 | 이 PR 뒤 |
|---|---|---|
| 오프셋을 실제로 고침 | 클램프 | **클램프(불변)** |
| 「쪽 영역 안으로 제한」을 켬 | 클램프 | **클램프(불변)** |
| 둘 다 안 하고 확인만(또는 폭만 고침) | 클램프 | 클램프 안 함 |

달라지는 것은 마지막 줄뿐이다. **그 줄에서 한컴이 무엇을 하는지 실측했다** — 처음에는 논증만 적었는데, 셀 그림 경로는 본문 도형과 같지 않을 수 있어 따로 쟀다.

절차는 위 검증과 같다. 표본을 한글 2024 로 열어 셀 안 그림의 개체 속성에서 **설정(D)** 만 누르고 저장한 뒤 rhwp 로 파싱했다.

**(가) 떠 있는 셀 그림** — `samples/basic/issue1994_behindtext_table_20200830.hwp`, 「글자처럼 취급」 꺼짐 · 「쪽 영역 안으로 제한」 켜짐. 세로 오프셋이 음수(`-1.29 mm`)인 개체다.

![떠 있는 셀 그림 — 위치 활성, 세로 -1.29 mm](https://raw.githubusercontent.com/lpaiu-cs/rhwp/assets/offset-roundtrip-fingerprint/3-float-cell.png)

| | h_off | v_off |
|---|---|---|
| 원본 | 97 | **-365** |
| **한컴 — 설정만 누름** | **97** | **-365** |

한컴은 **음수 세로 오프셋까지 그대로 둔다.** rhwp 의 클램프는 `v.max(0)` 이므로 종전에는 무변경 확인만으로 이것이 0 이 됐다 — 즉 **종전 동작이 한컴과 어긋나 있었고, 이 PR 이 그 어긋남을 없앤다.**

**(나) 글자처럼 취급 셀 그림** — `samples/hwp-multi-001.hwp` 머리 표의 로고. 위치 칸이 회색으로 비활성인데 값은 보인다(`가로 27.15 mm` = 7696).

![글자처럼 취급 셀 그림 — 위치 비활성](https://raw.githubusercontent.com/lpaiu-cs/rhwp/assets/offset-roundtrip-fingerprint/4-tac-cell.png)

| | h_off | v_off |
|---|---|---|
| 원본 / 한컴 무조작 저장 | 7695 | 20745 |
| **한컴 — 설정만 누름** | **0** | **0** |

이쪽은 다르다 — 한컴이 **0 으로 정규화한다.** 화면만 보고 "보존한다" 고 읽었다가 저장 바이트에 뒤집힌 항목이라 적어 둔다.

`samples/**/*.hwp` 의 범위 밖 60건은 **떠 있는 개체 47 + 글자처럼 취급 13** 이다. 즉 다수(47)에서 이 PR 은 rhwp 를 한컴 쪽으로 옮긴다. 소수(13)에서는 셋 중 어느 둘도 같지 않다 — 한컴 0, 종전 rhwp `max_horz` 클램프, 이 PR 은 보존. 다만 종전 rhwp 도 한컴과 달랐으므로 이 PR 이 만든 어긋남은 아니고, 글자처럼 취급 개체에서 이 값은 배치에 쓰이지 않는다.

**「글자처럼 취급 개체의 위치 오프셋을 한컴은 확인 시 0 으로 정규화한다」는 이번에 처음 잰 별개 동작이다.** 다만 정규화는 **그 상태에 한정된다** — 같은 대화상자에서 「글자처럼 취급」 체크를 **끄고** 설정을 누르면 한컴은 값을 그대로 둔다.

| 조작 | h_off | v_off | treatAsChar |
|---|---|---|---|
| 원본 | 7695 | 20745 | true |
| 한컴 — 확인만 | **0** | **0** | true |
| 한컴 — 글자처럼 취급 끄고 설정 | **7695** | **20745** | false |

즉 "죽은 값을 지운다" 가 아니라 "글자처럼 취급인 동안에는 0 을 쓴다" 에 가깝다. rhwp 에는 이 정규화가 없지만(`apply_common_obj_attr_from_json` 부터 저장기까지 해당 경로 없음), **떠 있는 개체로 바꾸는 경로에서는 한컴과 rhwp 가 같은 값을 쓴다.** 어긋남이 드러나려면 "확인 먼저 → 나중에 언토글" 2단계가 필요한데 그 조합은 재지 않았다. 그래서 별건 이슈로 세우지 않고 여기 실측만 남긴다.

`e2e/table-picture-resize-1282.test.mjs` 는 오프셋을 **명시적으로** 넘기므로(`horzOffset: negativeMove`, `hancomCell.width * 2`) 이 PR 에 영향받지 않는다. 다만 그 e2e 가 `buildPicturePropsPatch` 를 거치지 않으므로 **이 경로를 지켜주지도 않는다** — 그래서 코드가 아니라 이 글로 남긴다.

클램프 조건 자체를 넓히는 것(예: 폭 변경으로 셀 밖으로 밀린 그림도 되당기기)은 별개의 설계 판단이라 이 PR 에서 건드리지 않았다.

## 범위 외

- **음수 오프셋의 표시** — getter(`common.rs:180-181`)가 `c.horizontal_offset` 을 `u32` 그대로 방출해, `-776` 인 개체는 다이얼로그에서 터무니없는 mm 로 보일 것으로 읽힌다. 코드상 그렇게 보이지만 **화면으로 확인하지 않았고**, 이 PR 의 판정은 양쪽이 같은 값을 쓰므로 부호와 무관하게 성립한다. 별건으로 남긴다.
- **표·그림 등 다른 개체 종류** — 위 실측은 도형(선·묶음) 경로다. 그림·OLE 도 같은 `buildPicturePropsPatch` 를 타므로 이 수정이 함께 덮는다. 드래그·이동 경로(`input-handler-*`)는 HWPUNIT 으로 직접 계산해 왕복이 없다.
- **표 셀 속성 다이얼로그** — `table-cell-props-dialog.ts:1303·1306` 이 오프셋을 `toFixed(1)` 로 채우고(0.1mm ≈ 28.35 HWPUNIT), `newTableProps` 를 객체 리터럴로 만들어 **변경분 필터 없이 전 필드를 보낸다**. 다만 표는 `patch_raw_ctrl_field` 제자리 덧쓰기라 raw 캐시를 파괴하지 않고, 지문 판정도 없다 — 남는 대가는 0.05mm 이하 이동과 유령 undo 엔트리다. 기제가 달라 이 PR 에 넣지 않았다.
- **여백·테두리 등 다른 mm 칸** — `outerMargin*`·`borderWidth` 등도 같은 왕복을 거치지만, 지문에 들어가지 않고 클램프도 없어 이 결함의 기제가 성립하지 않는다. 같은 헬퍼로 덮을 수 있으나 근거를 재지 않았으므로 범위 밖으로 둔다.






