### PR TITLE
ci: 프런트엔드 post-merge 재사용과 duration 갱신 분리 (#6779)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
       candidate_sha: ${{ steps.finalize.outputs.candidate_sha || '' }}
       postmerge_reuse: ${{ needs.trusted_postmerge_reuse.outputs.reuse || 'false' }}
       postmerge_source_run_id: ${{ needs.trusted_postmerge_reuse.outputs.source_run_id || '' }}
+      postmerge_refresh_duration_data: ${{ needs.trusted_postmerge_reuse.outputs.refresh_duration_data || 'false' }}
       # [#3790 Stage 4·5B] frontend_mode·render_required·rust_required·
       # native_skia_required는 이 workflow의 worker 조건에 사용한다. codeql_languages는
       # codeql.yml이 같은 trusted-base 판정으로 소비한다. 모든 기본값은 full lane이다.
@@ -1545,6 +1546,10 @@ jobs:
         && github.event_name == 'push'
         && github.ref == 'refs/heads/devel'
         && needs.preflight.result == 'success'
+        && (
+          needs.preflight.outputs.postmerge_reuse != 'true'
+          || needs.preflight.outputs.postmerge_refresh_duration_data == 'true'
+        )
         && needs.preflight.outputs.rust_required == 'true'
         && (
           (

--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -20,7 +20,7 @@ on:
         required: true
         type: string
       require_duration_artifacts:
-        description: Require B/C duration artifacts before permitting CI worker reuse.
+        description: Require B/C/D duration artifacts for accepted Rust CI reuse, not frontend-only CI.
         required: false
         default: false
         type: boolean
@@ -34,6 +34,9 @@ on:
       source_run_id:
         description: Exact successful PR workflow run used as evidence.
         value: ${{ jobs.verify.outputs.source_run_id }}
+      refresh_duration_data:
+        description: Whether accepted CI reuse supplies Rust duration data to refresh.
+        value: ${{ jobs.verify.outputs.refresh_duration_data }}
 
 permissions: {}
 
@@ -50,6 +53,7 @@ jobs:
       reuse: ${{ steps.evaluate.outputs.reuse || steps.defaults.outputs.reuse }}
       reason: ${{ steps.evaluate.outputs.reason || steps.defaults.outputs.reason }}
       source_run_id: ${{ steps.evaluate.outputs.source_run_id || '' }}
+      refresh_duration_data: ${{ steps.evaluate.outputs.refresh_duration_data || 'false' }}
     steps:
       - name: Default to full verification
         id: defaults
@@ -194,6 +198,7 @@ jobs:
           ref: ${{ steps.source-base.outputs.sha }}
           sparse-checkout: |
             scripts/verify-trusted-postmerge-ci-reuse.mjs
+            scripts/ci-impact-classifier.cjs
           sparse-checkout-cone-mode: false
 
       - name: Evaluate exact PR workflow evidence
@@ -213,11 +218,18 @@ jobs:
             const { owner, repo } = context.repo;
             let classifyReviewOnlyCommit;
             let evaluateTrustedPostMergeReuse;
+            let frontendOnlyCiRunIsReusable;
+            let classifyChanges;
             try {
-              ({ classifyReviewOnlyCommit, evaluateTrustedPostMergeReuse } = await import(pathToFileURL(path.join(
+              ({ classifyReviewOnlyCommit, evaluateTrustedPostMergeReuse, frontendOnlyCiRunIsReusable } = await import(pathToFileURL(path.join(
                 process.env.GITHUB_WORKSPACE,
                 'scripts/verify-trusted-postmerge-ci-reuse.mjs',
               )).href));
+              if (process.env.WORKFLOW_FILE === 'ci.yml') {
+                ({ classifyChanges } = require(path.join(
+                  process.env.GITHUB_WORKSPACE, 'scripts/ci-impact-classifier.cjs',
+                )));
+              }
             } catch (error) {
               core.warning(`Trusted base has no compatible verifier; running full. ${error.message}`);
               core.setOutput('reuse', 'false');
@@ -351,6 +363,32 @@ jobs:
                 );
                 await recordMergeTreeEvidence(finalHeadRun, artifacts);
               }
+              // Only the trusted pre-merge classifier sees API metadata here;
+              // no candidate code or candidate-provided lane marker is executed.
+              const frontendOnlyRunIds = [];
+              if (
+                process.env.WORKFLOW_FILE === 'ci.yml'
+                && typeof classifyChanges === 'function'
+                && typeof frontendOnlyCiRunIsReusable === 'function'
+                && finalHeadRun?.status === 'completed'
+                && finalHeadRun?.conclusion === 'success'
+              ) {
+                const impact = classifyChanges({ eventName: 'pull_request', files: pullFiles });
+                if (
+                  impact.classification_status === 'classified'
+                  && impact.rust_required === 'false'
+                  && impact.native_skia_required === 'false'
+                  && ['unit', 'package'].includes(impact.frontend_mode)
+                ) {
+                  const jobs = await github.paginate(
+                    github.rest.actions.listJobsForWorkflowRun,
+                    { owner, repo, run_id: finalHeadRun.id, filter: 'latest', per_page: 100 },
+                  );
+                  if (frontendOnlyCiRunIsReusable(impact, jobs)) {
+                    frontendOnlyRunIds.push(String(finalHeadRun.id));
+                  }
+                }
+              }
               const requireFullLaneEvidence = ["ci.yml", "codeql.yml"]
                 .includes(process.env.WORKFLOW_FILE);
               const reviewOnlyWorker = {
@@ -377,7 +415,9 @@ jobs:
                     const expected = new Set(["b", "c", "d"].map((label) => (
                       `nextest-target-durations-${workflowRun.id}-${label}`
                     )));
-                    const available = new Set(artifacts.map((artifact) => artifact.name));
+                    const available = new Set(artifacts
+                      .filter((artifact) => artifact.expired !== true)
+                      .map((artifact) => artifact.name));
                     if ([...expected].every((name) => available.has(name))) {
                       fullLaneRunIds.push(String(workflowRun.id));
                       await recordMergeTreeEvidence(workflowRun, artifacts);
@@ -436,6 +476,7 @@ jobs:
                 prCommits,
                 workflowRuns,
                 mergeTreeEvidenceByRunId,
+                frontendOnlyRunIds,
               };
               if (requireFullLaneEvidence) {
                 evidence.fullLaneRunIds = fullLaneRunIds;
@@ -466,38 +507,45 @@ jobs:
               };
             }
             if (result.reuse && process.env.REQUIRE_DURATION_ARTIFACTS === 'true') {
-              try {
-                const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
-                  owner,
-                  repo,
-                  run_id: Number(result.sourceRunId),
-                  per_page: 100,
-                });
-                const expected = new Set([
-                  `nextest-target-durations-${result.sourceRunId}-b`,
-                  `nextest-target-durations-${result.sourceRunId}-c`,
-                  `nextest-target-durations-${result.sourceRunId}-d`,
-                ]);
-                const available = new Set(artifacts.map((artifact) => artifact.name));
-                if (![...expected].every((name) => available.has(name))) {
+              if (result.refreshDurationData !== false) {
+                try {
+                  const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                    owner,
+                    repo,
+                    run_id: Number(result.sourceRunId),
+                    per_page: 100,
+                  });
+                  const expected = new Set([
+                    `nextest-target-durations-${result.sourceRunId}-b`,
+                    `nextest-target-durations-${result.sourceRunId}-c`,
+                    `nextest-target-durations-${result.sourceRunId}-d`,
+                  ]);
+                  const available = new Set(artifacts
+                        .filter((artifact) => artifact.expired !== true)
+                        .map((artifact) => artifact.name));
+                  if (![...expected].every((name) => available.has(name))) {
+                    result = {
+                      reuse: false,
+                      reason: 'candidate-duration-artifacts-unavailable',
+                      sourceRunId: '',
+                      pullNumber: '',
+                    };
+                  }
+                } catch (error) {
+                  core.warning(`Could not inspect candidate duration artifacts; running full. ${error.message}`);
                   result = {
                     reuse: false,
-                    reason: 'candidate-duration-artifacts-unavailable',
+                    reason: 'candidate-duration-artifact-check-error',
                     sourceRunId: '',
                     pullNumber: '',
                   };
                 }
-              } catch (error) {
-                core.warning(`Could not inspect candidate duration artifacts; running full. ${error.message}`);
-                result = {
-                  reuse: false,
-                  reason: 'candidate-duration-artifact-check-error',
-                  sourceRunId: '',
-                  pullNumber: '',
-                };
               }
             }
             core.setOutput('reuse', result.reuse ? 'true' : 'false');
             core.setOutput('reason', result.reason);
             core.setOutput('source_run_id', result.sourceRunId || '');
-            core.info(`reuse=${result.reuse} reason=${result.reason} source_run_id=${result.sourceRunId || 'none'}`);
+            core.setOutput('refresh_duration_data',
+              result.reuse && process.env.REQUIRE_DURATION_ARTIFACTS === 'true'
+                && result.refreshDurationData !== false ? 'true' : 'false');
+            core.info(`reuse=${result.reuse} reason=${result.reason} source_run_id=${result.sourceRunId || 'none'} refresh_duration_data=${result.reuse && process.env.REQUIRE_DURATION_ARTIFACTS === 'true' && result.refreshDurationData !== false}`);

--- a/mydocs/orders/20260905.md
+++ b/mydocs/orders/20260905.md
@@ -206,3 +206,14 @@
 - 사용자 승인에 따라 `review/lpaiu-6739-6770-20260905`를 upstream temporary head로 게시하고 devel 대상 통합 PR을 생성한다. 원 PR/이슈 종료와 merge 후 처리는 아직 수행하지 않는다.
 
 - 메인터너 보정 커밋: `f7c53792ca966521567a79078247fb28a2b1111a`.
+
+## PR #6780: Frontend-only post-merge CI 재사용 개선
+
+- 관련 이슈: [#6779](https://github.com/edwardkim/rhwp/issues/6779)
+- PR: [#6780](https://github.com/edwardkim/rhwp/pull/6780)
+- 검토 기록: [PR #6780 self-review](../pr/archives/pr_6780_review.md)
+- 구현 commit: `21f89bf429e10a900f0c9610a268b83e1f12bacf`
+- Frontend-only CI 재사용과 Rust nextest duration 갱신을 분리했다. 최종 head·신뢰된 classifier·정확한 job 계약·merge-tree 증거를 요구하며 Rust artifact 요구와 fail-closed 조건은 유지했다.
+- Node 30개, Python 43개 테스트와 JavaScript 구문 검사, actionlint, 구현 후보의 `git diff --check`가 통과했다. 이미 완료한 검증은 반복하지 않았다.
+- Rust/렌더링 변경이 없어 Cargo 회귀 테스트와 시각 증적 산출은 생략했다. 임시 실행 로그는 커밋에 포함하지 않았다.
+- self-review 판정은 승인이다. 최신 원격 CI와 merge 가능 상태 확인, 작업지시자의 merge 승인은 남아 있다. controller 변경을 포함한 이 PR 자체의 최초 post-merge Full CI는 예상된 안전 동작이다.

--- a/mydocs/pr/archives/pr_6780_review.md
+++ b/mydocs/pr/archives/pr_6780_review.md
@@ -1,0 +1,78 @@
+# PR #6780 검토 기록
+
+## 최종 판정
+
+판정: 승인
+
+로컬 검증을 완료한 후보에 대한 작성자 self-review 판정이다. 최신 GitHub Actions 결과, merge 가능 상태, 작업지시자의 merge 승인은 별도 조건이며 아직 완료로 기록하지 않는다.
+
+## 검토 대상
+
+| 항목 | 내용 |
+| --- | --- |
+| PR | [#6780](https://github.com/edwardkim/rhwp/pull/6780) |
+| 관련 이슈 | [#6779](https://github.com/edwardkim/rhwp/issues/6779) |
+| 작성자 및 검토 방식 | jangster77, collaborator 작성자 self-review |
+| 대상 base | devel |
+| 작업 branch | fix/6779-frontend-postmerge-reuse-20260905 |
+| 구현 기준 base | fdba74164ef7003c68fdb14980a3ee1023957fed |
+| 검증한 구현 commit | 21f89bf429e10a900f0c9610a268b83e1f12bacf |
+| 구현 변경 규모 | workflow 2개, JavaScript 검증기 1개, 계약 테스트 2개; 314줄 추가, 29줄 삭제 |
+| 작성일 | 2026-09-05 |
+| 원격 CI 및 merge 상태 | 작성 시점 최신 결과를 별도로 조회하지 않았다. merge 직전에 최종 head 기준으로 확인해야 한다. |
+
+이 기록과 오늘할일은 구현 검증 뒤 같은 PR에 추가한 문서 전용 후속 commit이다. 저장소 owner를 reviewer로 자동 지정하지 않았다.
+
+## 원인과 변경 범위
+
+PR #6777의 [PR CI](https://github.com/edwardkim/rhwp/actions/runs/33967701594)는 Frontend package lane으로 성공했다. 그러나 [devel push CI](https://github.com/edwardkim/rhwp/actions/runs/33968179761)의 재사용 판정은 `candidate-full-lane-evidence-unavailable`로 거부되었다. Rust가 필요 없는 PR에도 Rust B/C/D nextest duration artifact가 있어야 재사용 후보가 되는 결합이 원인이었다.
+
+PR #6772의 `devel -> main` 승격 검증과 이번 devel post-merge 재사용 판정은 다른 경로다.
+
+이번 변경은 다음 범위로 제한했다.
+
+- merge 전 신뢰된 base에서 classifier와 verifier를 로드한다.
+- GitHub API의 PR 변경 파일을 분류해 Rust와 Native Skia가 불필요한 Frontend unit/package 변경만 추가 경로의 대상으로 삼는다.
+- 최종 PR head의 성공한 CI에서 preflight, aggregate, 선택된 Frontend worker, 예상된 Rust skip을 확인한다.
+- 19개 job 계약에서 누락, 중복, 알 수 없는 job, pending, 실패, 취소, 예상과 다른 skip/success를 거부한다.
+- 기존 PR identity, repository, head, 실행 시각, merge-tree 및 enforcement-surface 검사를 유지한다.
+- 검증되지 않은 최종 review head 뒤에 있는 과거 Frontend run으로 대체하지 않는다.
+- Frontend-only 재사용에서는 duration 갱신을 건너뛰고, Rust CI 재사용에는 기존 B/C/D duration artifact 요구를 유지한다.
+- 만료된 duration artifact를 증거에서 제외한다.
+
+제품 source, renderer, sample, golden, baseline은 변경하지 않았다.
+
+## 완료한 검증
+
+| 명령 | 실제 결과 |
+| --- | --- |
+| `node --check scripts/verify-trusted-postmerge-ci-reuse.mjs` | 통과 |
+| `node --test scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs` | 30개 통과, 실패 0개, skip 0개 |
+| `python3 -m unittest scripts.tests.test_trusted_postmerge_ci_reuse_workflow scripts.tests.test_ci_impact_workflow` | 43개 통과 |
+| `actionlint -shellcheck= .github/workflows/trusted-postmerge-ci-reuse.yml .github/workflows/ci.yml` | 통과; 외부 ShellCheck는 이 명령에서 비활성화 |
+| `git diff --check` | 구현 후보에서 통과 |
+
+기존 계약 테스트를 약화하지 않고 Frontend unit/package 수용과 실패·취소·pending·identity 불일치·증거 누락·과거 head 거부 사례를 추가했다. 완료한 테스트는 커밋·PR 생성 단계에서 다시 실행하지 않았다. 원시 실행 로그는 임시 디렉터리에만 두고 PR에 포함하지 않았다.
+
+## 생략한 검증과 시각 증적
+
+Rust source와 제품 동작을 변경하지 않아 Cargo 전체 회귀 테스트, WASM build, Studio 테스트는 실행하지 않았다. 렌더링·레이아웃·문서 출력 변경이 없어 visual sweep, PDF 변환, 대표 PNG 산출은 필요하지 않다.
+
+로컬 계약 테스트 통과를 실제 GitHub workflow 실행 성공으로 표현하지 않는다. 새 경로를 적용한 실제 post-merge Frontend-only 성공 사례는 아직 확인하지 않았다.
+
+## 위험 및 merge 전 조건
+
+- job 이름이나 topology가 바뀌면 계약이 일치하지 않아 재사용을 거부한다. 조용히 검증 범위를 줄이는 대신 기존 실행 경로로 돌아간다.
+- 이 PR은 controller 및 CI enforcement surface를 바꾸므로 최초 merge의 devel push가 Full CI로 실행되는 것은 예상된 안전 동작이다.
+- 모든 workflow를 무조건 skip하거나 모든 PR에서 duration 갱신만 실행하도록 변경하지 않는다.
+- 최종 PR head의 required check, 관련 aggregate와 실행된 worker, `MERGEABLE`, `CLEAN`을 확인한 뒤 작업지시자 승인을 받아야 merge할 수 있다.
+
+## Merge 후 issue 및 PR comment 계획
+
+[post_merge.md](../../manual/pr_review/post_merge.md)를 따른다. 실제 merge SHA의 devel CI와 관련 aggregate/worker 결과가 확인된 뒤에만 후속 처리한다.
+
+- PR 본문의 `Closes #6779`와 실제 issue 상태를 확인한다.
+- issue #6779의 기존 comment를 확인해 중복 게시를 피하고, merge SHA, 실제 PR/devel CI URL, Frontend 재사용 및 Rust duration 분리 범위, 최초 Full CI가 예상된 이유를 기록한다.
+- 본 검토 문서는 확정된 merge SHA에 고정한 GitHub 파일 링크로 안내한다. 시각 증적을 사용하지 않았으므로 관련 없는 이미지나 임시 로그를 첨부하지 않는다.
+- 게시가 승인된 comment는 UTF-8 body file로 전달하고 API로 본문을 재조회한다.
+- 별도 후속 문서 PR을 만들거나 이미 처리한 PR #6777의 source PR comment/close를 반복하지 않는다.

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -116,3 +116,32 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# #6779: contract checks for trusted frontend evidence and separate timing output.
+import pathlib as frontend_pathlib
+import unittest as frontend_unittest
+
+
+class FrontendOnlyPostmergeReuseWorkflowTests(frontend_unittest.TestCase):
+    def test_frontend_evidence_uses_the_trusted_classifier_and_exact_run_jobs(self):
+        root = frontend_pathlib.Path(__file__).resolve().parents[2]
+        workflow = (root / '.github/workflows/trusted-postmerge-ci-reuse.yml').read_text()
+        self.assertIn('scripts/ci-impact-classifier.cjs', workflow)
+        self.assertIn("ref: ${{ steps.source-base.outputs.sha }}", workflow)
+        self.assertIn("classifyChanges({ eventName: 'pull_request', files: pullFiles })", workflow)
+        self.assertIn("run_id: finalHeadRun.id, filter: 'latest'", workflow)
+        self.assertIn('frontendOnlyCiRunIsReusable(impact, jobs)', workflow)
+        self.assertIn('frontendOnlyRunIds.push(String(finalHeadRun.id))', workflow)
+        self.assertIn('artifact.expired !== true', workflow)
+
+    def test_frontend_reuse_does_not_require_or_refresh_rust_timings(self):
+        root = frontend_pathlib.Path(__file__).resolve().parents[2]
+        workflow = (root / '.github/workflows/trusted-postmerge-ci-reuse.yml').read_text()
+        ci = (root / '.github/workflows/ci.yml').read_text()
+        self.assertIn("if (result.reuse && process.env.REQUIRE_DURATION_ARTIFACTS === 'true')", workflow)
+        self.assertIn('if (result.refreshDurationData !== false)', workflow)
+        self.assertIn("core.setOutput('refresh_duration_data'", workflow)
+        self.assertIn("postmerge_refresh_duration_data: ${{ needs.trusted_postmerge_reuse.outputs.refresh_duration_data || 'false' }}", ci)
+        self.assertIn("needs.preflight.outputs.postmerge_reuse != 'true'", ci)
+        self.assertIn("needs.preflight.outputs.postmerge_refresh_duration_data == 'true'", ci)

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
@@ -352,3 +352,144 @@ test("fails closed when the review-only tail is not linear", () => {
   assert.equal(result.reuse, false);
   assert.equal(result.reason, "review-tail-evidence-unavailable");
 });
+
+// #6779: successful frontend-only CI must not depend on Rust timing artifacts.
+const { default: frontendAssert } = await import('node:assert/strict');
+const { test: frontendTest } = await import('node:test');
+const {
+  frontendOnlyCiRunIsReusable,
+  evaluateTrustedPostMergeReuse: evaluateFrontendReuse,
+} = await import('../verify-trusted-postmerge-ci-reuse.mjs');
+
+function frontendImpact(mode = 'package') {
+  return {
+    classification_status: 'classified', rust_required: 'false',
+    native_skia_required: 'false', frontend_mode: mode,
+  };
+}
+
+function frontendJobs(mode = 'package') {
+  const skipped = [
+    'WASM Build', 'Resolve nextest target duration policy',
+    'Lint (fmt, clippy, WASM check)', 'Native Skia tests',
+    'Workflow promotion preflight', 'Refresh nextest target duration data',
+    ...['a', 'b', 'c', 'd'].flatMap(label => [
+      `build-test-archive-${label}`, `test-archive-${label}-shard-1`,
+    ]),
+  ];
+  return [
+    ...['trusted_postmerge_reuse / Verify trusted post-merge reuse', 'CI preflight', 'Build & Test']
+      .map(name => ({ name, status: 'completed', conclusion: 'success' })),
+    ...['unit', 'package'].map(lane => ({
+      name: `Frontend ${lane} gates`, status: 'completed',
+      conclusion: lane === mode ? 'success' : 'skipped',
+    })),
+    ...skipped.map(name => ({ name, status: 'completed', conclusion: 'skipped' })),
+  ];
+}
+
+function frontendReuseInput(tail = false) {
+  const base = 'a'.repeat(40), code = 'b'.repeat(40);
+  const head = (tail ? 'e' : 'b').repeat(40), merge = 'c'.repeat(40), tree = 'd'.repeat(40);
+  const files = [{ filename: 'rhwp-studio/src/ui/picture-props-apply-model.ts', status: 'modified' }];
+  const run = {
+    id: 6779, event: 'pull_request', head_sha: head, head_branch: 'feature',
+    head_repository: { full_name: 'owner/repo' }, status: 'completed', conclusion: 'success',
+    created_at: '2026-09-05T01:01:00Z', updated_at: '2026-09-05T01:02:00Z',
+  };
+  return {
+    eventName: 'push', ref: 'refs/heads/devel', repository: 'owner/repo', mergeSha: merge,
+    mergeCommit: { sha: merge, parents: [{ sha: base }, { sha: head }], commit: { tree: { sha: tree } } },
+    sourceCommit: { sha: head, commit: { tree: { sha: tree } } }, mergeBaseSha: base,
+    pullRequests: [{
+      number: 6779, state: 'closed', created_at: '2026-09-05T01:00:00Z',
+      merged_at: '2026-09-05T01:03:00Z', merge_commit_sha: merge,
+      base: { ref: 'devel' }, head: { sha: head, ref: 'feature', repo: { full_name: 'owner/repo' } },
+    }],
+    pullFiles: files,
+    prCommits: [
+      { sha: code, parents: [{ sha: base }], files },
+      ...(tail ? [{ sha: head, parents: [{ sha: code }], files: [{ filename: 'mydocs/pr/review.md', status: 'added' }] }] : []),
+    ],
+    workflowRuns: [run], fullLaneRunIds: [], frontendOnlyRunIds: ['6779'],
+  };
+}
+
+for (const mode of ['unit', 'package']) {
+  frontendTest(`accepts the exact ${mode} job contract with normal Rust skips`, () => {
+    frontendAssert.equal(frontendOnlyCiRunIsReusable(frontendImpact(mode), frontendJobs(mode)), true);
+  });
+  for (const conclusion of ['skipped', 'failure', 'cancelled', 'neutral']) {
+    frontendTest(`rejects ${mode} required worker ${conclusion}`, () => {
+      const jobs = frontendJobs(mode);
+      jobs.find(job => job.name === `Frontend ${mode} gates`).conclusion = conclusion;
+      frontendAssert.equal(frontendOnlyCiRunIsReusable(frontendImpact(mode), jobs), false);
+    });
+  }
+}
+
+frontendTest('rejects missing, duplicate, unknown and pending jobs, including a missing aggregate', () => {
+  const original = frontendJobs();
+  for (const jobs of [
+    original.filter(job => job.name !== 'Build & Test'),
+    original.filter(job => job.name !== 'CI preflight'),
+    original.filter(job => job.name !== 'test-archive-b-shard-1'),
+    [...original, original[0]],
+    original.map((job, index) => index ? job : { ...job, name: 'Unknown worker' }),
+    original.map((job, index) => index ? job : { ...job, status: 'in_progress' }),
+    original.map(job => job.name === 'build-test-archive-b' ? { ...job, conclusion: 'success' } : job),
+    original.map(job => job.name === 'Build & Test' ? { ...job, conclusion: 'failure' } : job),
+    null,
+  ]) {
+    frontendAssert.equal(frontendOnlyCiRunIsReusable(frontendImpact(), jobs), false);
+  }
+});
+
+frontendTest('does not weaken Rust, Skia, unknown classification or unsupported lane requirements', () => {
+  for (const impact of [
+    { ...frontendImpact(), rust_required: 'true' },
+    { ...frontendImpact(), native_skia_required: 'true' },
+    { ...frontendImpact(), classification_status: 'full' },
+    { ...frontendImpact(), rust_required: false },
+    frontendImpact('none'), frontendImpact('unknown'), null,
+  ]) {
+    frontendAssert.equal(frontendOnlyCiRunIsReusable(impact, frontendJobs()), false);
+  }
+});
+
+for (const tail of [false, true]) {
+  frontendTest(`reuses exact frontend evidence without timings, review tail=${tail}`, () => {
+    const result = evaluateFrontendReuse(frontendReuseInput(tail));
+    frontendAssert.equal(result.reuse, true);
+    frontendAssert.equal(result.refreshDurationData, false);
+    frontendAssert.equal(result.sourceRunId, '6779');
+    frontendAssert.equal(result.reason, tail
+      ? 'review-tail-final-head-green-frontend-ci-reused' : 'exact-green-frontend-ci-reused');
+  });
+}
+
+frontendTest('frontend evidence cannot bypass failed runs, provenance, tree or enforcement guards', () => {
+  const mutations = [
+    data => { data.workflowRuns[0].conclusion = 'failure'; },
+    data => { data.workflowRuns[0].conclusion = 'cancelled'; },
+    data => { data.workflowRuns[0].status = 'in_progress'; },
+    data => { data.workflowRuns[0].head_sha = 'f'.repeat(40); },
+    data => { data.workflowRuns[0].head_repository.full_name = 'foreign/repo'; },
+    data => { data.workflowRuns[0].updated_at = '2026-09-05T01:04:00Z'; },
+    data => { data.mergeCommit.commit.tree.sha = 'f'.repeat(40); },
+    data => { data.mergeBaseSha = 'f'.repeat(40); },
+    data => { data.pullFiles.push({ filename: '.github/workflows/ci.yml', status: 'modified' }); },
+    data => { data.pullFiles.push({ filename: 'scripts/ci-impact-classifier.cjs', status: 'modified' }); },
+    data => { data.frontendOnlyRunIds = []; },
+  ];
+  for (const mutate of mutations) {
+    const data = frontendReuseInput(); mutate(data);
+    frontendAssert.equal(evaluateFrontendReuse(data).reuse, false);
+  }
+});
+
+frontendTest('does not reuse an earlier frontend run through an untested final review head', () => {
+  const data = frontendReuseInput(true);
+  data.workflowRuns[0].head_sha = 'b'.repeat(40);
+  frontendAssert.equal(evaluateFrontendReuse(data).reuse, false);
+});

--- a/scripts/verify-trusted-postmerge-ci-reuse.mjs
+++ b/scripts/verify-trusted-postmerge-ci-reuse.mjs
@@ -166,6 +166,60 @@ function latestCandidateRun(runs, pullRequest, repository, candidateSha) {
   ))[0];
 }
 
+// A classified frontend-only CI has no Rust timing data to reuse. Require the
+// exact current CI job contract instead of treating any green aggregate as proof.
+// Unknown, duplicate, missing, pending, or unexpectedly skipped jobs fail closed.
+export function frontendOnlyCiRunIsReusable(impact, jobs) {
+  if (
+    impact?.classification_status !== "classified"
+    || impact.rust_required !== "false"
+    || impact.native_skia_required !== "false"
+    || !["unit", "package"].includes(impact.frontend_mode)
+    || !Array.isArray(jobs)
+  ) {
+    return false;
+  }
+  const expected = new Map([
+    ["trusted_postmerge_reuse / Verify trusted post-merge reuse", "success"],
+    ["CI preflight", "success"],
+    ["Build & Test", "success"],
+    ["Frontend unit gates", impact.frontend_mode === "unit" ? "success" : "skipped"],
+    ["Frontend package gates", impact.frontend_mode === "package" ? "success" : "skipped"],
+    ["WASM Build", "skipped"],
+    ["Resolve nextest target duration policy", "skipped"],
+    ["Lint (fmt, clippy, WASM check)", "skipped"],
+    ["Native Skia tests", "skipped"],
+    ["Workflow promotion preflight", "skipped"],
+    ["Refresh nextest target duration data", "skipped"],
+    ...["a", "b", "c", "d"].flatMap((label) => [
+      [`build-test-archive-${label}`, "skipped"],
+      [`test-archive-${label}-shard-1`, "skipped"],
+    ]),
+  ]);
+  if (jobs.length !== expected.size) {
+    return false;
+  }
+  for (const job of jobs) {
+    if (
+      !job
+      || !expected.has(job.name)
+      || job.status !== "completed"
+      || job.conclusion !== expected.get(job.name)
+    ) {
+      return false;
+    }
+    expected.delete(job.name);
+  }
+  return expected.size === 0;
+}
+
+function hasFrontendOnlyEvidence(input, run) {
+  const runId = String(run?.id || "");
+  return Array.isArray(input?.frontendOnlyRunIds)
+    && runId !== ""
+    && input.frontendOnlyRunIds.some((id) => String(id) === runId);
+}
+
 function hasFullLaneEvidence(input, run) {
   if (!Array.isArray(input?.fullLaneRunIds)) {
     return true;
@@ -315,15 +369,22 @@ export function evaluateTrustedPostMergeReuse(input) {
     return denied("review-tail-evidence-unavailable");
   }
 
+  // Frontend evidence is collected only for this exact final PR head. Do not
+  // generalize it to an older code candidate hidden behind a skipped review tail.
+  const frontendOnly = hasFrontendOnlyEvidence(input, finalHeadCandidate);
   if (
     finalHeadCandidate
     && finalHeadCandidate.status === "completed"
     && finalHeadCandidate.conclusion === "success"
-    && hasFullLaneEvidence(input, finalHeadCandidate)
+    && (hasFullLaneEvidence(input, finalHeadCandidate) || frontendOnly)
   ) {
     return {
       reuse: true,
-      reason: !headContainsBase
+      reason: frontendOnly
+        ? (candidateSource.hasReviewOnlyTail
+          ? "review-tail-final-head-green-frontend-ci-reused"
+          : "exact-green-frontend-ci-reused")
+        : !headContainsBase
         ? (candidateSource.hasReviewOnlyTail
           ? "review-tail-exact-merge-tree-green-pr-workflow-reused"
           : "exact-merge-tree-green-pr-workflow-reused")
@@ -332,6 +393,7 @@ export function evaluateTrustedPostMergeReuse(input) {
           : "exact-green-pr-workflow-reused"),
       sourceRunId: String(finalHeadCandidate.id),
       pullNumber: String(pullRequest.number),
+      ...(frontendOnly ? { refreshDurationData: false } : {}),
     };
   }
 


### PR DESCRIPTION
## 관련 이슈

Closes #6779

## 원인

PR #6777의 CI는 Frontend package 검증만 필요했고 성공했지만, merge 후 CI run [33968179761](https://github.com/edwardkim/rhwp/actions/runs/33968179761)의 재사용 판정은 `candidate-full-lane-evidence-unavailable`로 거부되었습니다. 기존 재사용 판정이 Rust B/C/D nextest duration artifact를 필수 증거로 요구했기 때문입니다.

PR #6772는 `devel -> main` 승격의 exact-head workflow 증거를 검증하는 변경으로, 이 devel post-merge 재사용 경로와는 별개입니다.

## 변경 사항

- 신뢰된 merge 전 base의 classifier와 GitHub API의 PR 변경 파일로 Frontend-only 여부를 판정합니다.
- 최종 PR head의 성공한 CI에서 preflight, aggregate, 선택된 Frontend worker와 예상된 Rust skip을 모두 확인합니다. 누락, 중복, 알 수 없는 job, 실패, 취소, pending은 재사용하지 않습니다.
- 최종 head 및 merge-tree 증거가 충족된 Frontend-only 결과는 Rust duration artifact 없이 재사용합니다. 검증되지 않은 trailing head 뒤의 과거 Frontend run은 재사용하지 않습니다.
- CI worker 재사용과 `refresh_duration_data`를 분리합니다. Frontend-only 재사용이면 duration 갱신도 건너뛰며, Rust CI 재사용에는 기존 B/C/D artifact 요구를 유지합니다.
- 만료된 duration artifact는 증거에서 제외합니다. 기존 enforcement-surface 변경 시 fail-closed 동작을 유지합니다.

## 완료한 로컬 검증

- `node --check scripts/verify-trusted-postmerge-ci-reuse.mjs`: 통과
- `node --test scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs`: 30개 통과, 실패 0개
- `python3 -m unittest scripts.tests.test_trusted_postmerge_ci_reuse_workflow scripts.tests.test_ci_impact_workflow`: 43개 통과
- `actionlint -shellcheck= .github/workflows/trusted-postmerge-ci-reuse.yml .github/workflows/ci.yml`: 통과
- `git diff --check`: 통과

Rust source, renderer, sample은 변경하지 않아 Cargo 회귀 테스트와 시각 검증은 실행하지 않았습니다. 이미 완료한 검증은 PR 생성 과정에서 반복하지 않았고, 임시 실행 로그는 커밋하지 않습니다.

## 적용 및 검토 조건

이 PR 자체는 재사용 controller와 CI enforcement surface를 변경하므로 최초 merge의 devel push가 Full CI로 실행되는 것은 예상된 fail-closed 결과입니다. 모든 post-merge 작업을 무조건 skip하는 변경이 아닙니다.

로컬 계약 테스트 통과와 실제 GitHub Actions 성공은 구분합니다. 최신 PR head의 required check와 merge 조건은 merge 전에 확인해야 하며, 이 PR 생성은 merge 승인을 대신하지 않습니다.

PR 번호가 확정되면 작성자 self-review archive와 오늘할일을 동일 PR의 trailing documentation commit으로 포함합니다. owner에게 리뷰를 자동 요청하지 않습니다.
