### PR TITLE
fix: PR #5953 편집 이력 방어 통합 및 Frontend CI 재사용 검증

### DIFF
--- a/mydocs/orders/20260905.md
+++ b/mydocs/orders/20260905.md
@@ -217,3 +217,12 @@
 - Node 30개, Python 43개 테스트와 JavaScript 구문 검사, actionlint, 구현 후보의 `git diff --check`가 통과했다. 이미 완료한 검증은 반복하지 않았다.
 - Rust/렌더링 변경이 없어 Cargo 회귀 테스트와 시각 증적 산출은 생략했다. 임시 실행 로그는 커밋에 포함하지 않았다.
 - self-review 판정은 승인이다. 최신 원격 CI와 merge 가능 상태 확인, 작업지시자의 merge 승인은 남아 있다. controller 변경을 포함한 이 PR 자체의 최초 post-merge Full CI는 예상된 안전 동작이다.
+
+## PR #5953: 최신 devel 정렬 및 Frontend-only 통합 검토
+
+- [원 PR #5953](https://github.com/edwardkim/rhwp/pull/5953)에 reviewer jangster77을 사전 지정하고 최신 devel `a7b95f404`를 정상 merge로 반영했다. 정렬 head는 `f1b5f2cfe`이며 CI가 완료됐다.
+- 기능 commit 세 개를 `review/5953-frontend-reuse-20260905`에 provenance 보존 체리픽했다. 통합 code candidate `c788cdc0a`는 정렬한 원 PR과 전체 tree가 같았고 충돌은 없었다.
+- [개별 검토 기록](../pr/archives/pr_5953_review.md)의 판정은 승인이다. 메인터너 source 보정은 추가하지 않았다.
+- 관련 테스트 26개, Vite SSR 경로·스냅샷 예산 동작, TypeScript와 code candidate diff 검사가 통과했다. 임시 로그는 포함하지 않았다.
+- 원 PR의 최신 CI는 기존 녹색 후보와 current-base merge-tree 일치로 worker를 재사용했다. 모든 worker를 새로 실행했다고 기록하지 않는다.
+- 승인된 upstream 통합 PR에서는 최종 head의 Frontend package와 필요한 CodeQL/Canvas 검증을 확인하고, merge 승인 뒤 PR #6780의 post-merge 재사용과 duration 갱신 skip을 실제 run으로 검증한다. 이 실증은 아직 미완료다.

--- a/mydocs/pr/archives/pr_5953_review.md
+++ b/mydocs/pr/archives/pr_5953_review.md
@@ -1,0 +1,108 @@
+# PR #5953 검토 기록
+
+## 최종 판정
+
+판정: 승인
+
+검토한 변경 범위에서 추가 blocker를 발견하지 않았다. contributor 기능 변경을 그대로 수용하며 메인터너 source 보정은 추가하지 않았다. 통합 PR의 최신 CI, 필요한 Canvas 검증, 작업지시자의 merge 승인은 별도 조건이다.
+
+## Metadata와 적용 경로
+
+| 항목 | 내용 |
+| --- | --- |
+| 원 PR | [#5953](https://github.com/edwardkim/rhwp/pull/5953) |
+| 작성자 | lpaiu-cs |
+| 사전 지정 reviewer | jangster77 |
+| 원 head repository / branch | lpaiu-cs/rhwp / cleanup/5769-review |
+| 정렬 전 head | 91b70532a241829d22e2e07108664e5219a4a8a7 |
+| devel 정렬 후 head | f1b5f2cfe1b7037982c0421bc51b6901a62ce0ec |
+| 정렬한 devel | a7b95f4041ef5d7d3574c4becfea5cb636eaf836 |
+| 통합 branch | review/5953-frontend-reuse-20260905 |
+| 통합 code candidate | c788cdc0a40b0f6087dc2a260f67e9c1f782a6d9 |
+| 원 PR 고유 변경 | Frontend source 2개와 테스트 7개; 60줄 추가, 9줄 삭제 |
+| 작성 시점 원 PR 상태 | OPEN, MERGEABLE, CLEAN; 정렬 후 head 기준 CI 완료 |
+| 검토일 | 2026-09-05 |
+
+GitHub의 정상 Update branch 경로로 최신 devel을 원 source에 병합했다. contributor 이력을 rebase/force-push하지 않았다. 이후 동일 devel 위의 통합 branch에 기능 commit 세 개만 `cherry-pick -x`로 적용했다. base 병합 commit 자체는 체리픽하지 않았다.
+
+| 원 commit | 통합 commit | 범위 |
+| --- | --- | --- |
+| 24f52a136df6df80d3f5df7bd1110f72ccfbe821 | 563195408 | 교차 구역 선택의 스냅샷 폴백 |
+| c4d678c95f7175527b0e679e5034cda823badede | 0e74386e0 | recordWithoutExecute 예산 강제 |
+| 91b70532a241829d22e2e07108664e5219a4a8a7 | c788cdc0a | 위치 판정 가드 7개를 codeOnly로 전환 |
+
+충돌 없이 적용됐다. 통합 code candidate와 정렬 후 원 PR의 전체 Git tree가 모두 `0ac7d0c362342867e488b2dd6ebde1f99184ffb3`로 같았다. 이 기록과 오늘할일은 그 다음 문서 전용 commit이다.
+
+## 변경 검토와 판정 근거
+
+### 교차 구역 삭제의 스냅샷 폴백
+
+같은 구역의 일반 선택은 기존 FragmentDeleteCommand를 유지하고, 다른 구역으로 걸친 일반 선택은 SnapshotCommand로 분기한다. 기존 셀 경로와 selectionBefore의 범위·F3 단계 보존은 유지한다.
+
+이 변경은 단일 구역 조각 캡처의 전제를 피하는 방어 보강이다. 실제 교차 구역 삭제 API의 처리 범위를 확장한 구현으로 판단하지 않았다. 원 PR도 실제 재현 문서를 확보하지 못했다고 명시했다. 아래 로컬 확인 역시 객체 경로와 상태 보존을 확인한 것이며, 실제 다구역 문서의 삭제·undo 완전성을 입증한 것은 아니다.
+
+### 스냅샷 예산 강제
+
+recordWithoutExecute의 일반 push, redo 폐기, maxSize 축출 이후에 기존 예산 강제 함수를 호출한다. wasm이 없는 기존 호출 형태와 command를 실행하지 않는 의미는 보존한다.
+
+100개의 1-slot 모의 command를 기록한 동작 확인에서 실제 execute는 0회였고, 오래된 두 command를 폐기한 뒤 live snapshot 수가 98로 유지됐다. 현재 snapshot을 보유하지 않는 record command를 미래에 확장할 때의 방어이며, 임의의 snapshot 보유 mergeWith 구현까지 보장한다고 확대 해석하지 않는다.
+
+### 위치 판정 가드
+
+위치 비교에 사용하던 원문에서 주석을 공백으로 치환해 주석 속 이름 인용에 대한 오탐을 줄였다. 기존 codeOnly helper는 문자열과 줄 구조를 유지한다.
+
+주석을 구간 경계로 사용하는 두 파일은 원문에서 먼저 구간을 자른 뒤 codeOnly를 적용한다. 따라서 경계 표지가 사라져 추출이 실패하는 문제를 피했다. 이 PR은 모든 source guard를 전수 전환한 변경이 아니며, 기존 helper의 정규식 리터럴 처리 범위를 넓히지도 않는다.
+
+## 완료한 검증
+
+| 항목 | 실제 결과 |
+| --- | --- |
+| 변경된 테스트 7개를 `node --test`로 실행 | 26개 통과, 실패 0개, skip 0개 |
+| Vite SSR 런타임 확인 | 같은 구역 fragment, 교차 구역 snapshot 분기와 선택 단계 보존 통과 |
+| Vite SSR history 동작 확인 | 100개 record 후 live 98, 오래된 두 항목 폐기, execute 호출 0회 |
+| `npx --no-install tsc --noEmit` | 통과 |
+| `git diff --check upstream/devel...HEAD` | code candidate에서 통과 |
+| 신뢰된 CI classifier로 변경 경로 분류 | classified, rust_required=false, native_skia_required=false, frontend_mode=package |
+
+classifier는 추가로 render_required=true, codeql_languages=javascript-typescript를 반환했다. 따라서 Frontend-only는 Render Diff나 JavaScript CodeQL까지 불필요하다는 뜻이 아니다. 통합 PR에서 요구되는 worker 결과를 확인한다.
+
+Rust source는 변경하지 않아 Cargo 전체 회귀와 WASM 재빌드는 반복하지 않았다. 원시 로그 및 임시 산출물은 커밋하지 않았다.
+
+## 원 PR의 실제 CI와 skip 근거
+
+정렬 후 [CI run 33969878202](https://github.com/edwardkim/rhwp/actions/runs/33969878202)의 Build & Test와 preflight가 성공했다. Frontend를 포함한 heavy worker는 이번 head에서 다시 실행되지 않았다.
+
+preflight는 기존 code head `91b70532a241829d22e2e07108664e5219a4a8a7`의 성공 CI를 찾았고, 현재 base 병합 tree가 일치함을 확인했다.
+
+- DETECTED_REASON: direct-source-build-and-test-green:success
+- MERGE_TREE_VERIFIED: true
+- MERGE_TREE_REASON: current-base-merge-tree-match
+- 최종 fast-pass 경로: current-base-update-merge-tree-green
+
+[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33969878193), [Adapter](https://github.com/edwardkim/rhwp/actions/runs/33969878196), [Proptest](https://github.com/edwardkim/rhwp/actions/runs/33969878206), [Render Diff](https://github.com/edwardkim/rhwp/actions/runs/33969878091)도 preflight 성공 및 정책상 worker skip으로 완료했다. 이 결과를 이번 head의 모든 worker를 새로 실행한 결과라고 기록하지 않는다.
+
+## 시각 증적 범위
+
+renderer/layout/paint 코드와 문서 fixture는 변경하지 않았다. 특정 HWP/PDF의 페이지 출력 개선을 주장하지 않으므로 별도의 PDF 변환이나 visual sweep 이미지를 만들지 않았다. 편집 이력의 경로·예산 검증은 위의 실제 런타임 및 source contract 결과로 기록한다. 통합 PR의 Canvas visual diff가 실행되면 그 실제 결과를 CI 근거로 추가 확인하며, 로컬에서 하지 않은 문서 시각 검증을 완료했다고 표시하지 않는다.
+
+## PR #6780 CI 개선의 실제 검증 계획
+
+[PR #6780](https://github.com/edwardkim/rhwp/pull/6780)은 동일 저장소 PR의 Frontend-only 최종 head 증거를 이용한 post-merge 재사용을 추가했다. fork 원 PR은 같은 저장소 조건을 만족하지 않으므로, 작업지시자 승인에 따라 upstream 임시 branch의 통합 PR로 검증한다.
+
+1. 검토 기록과 오늘할일을 첫 push에 포함해 최종 head의 Frontend package worker를 실제 실행한다. 과거 fork CI나 문서-only skip만으로 새 경로를 검증했다고 판단하지 않는다.
+2. 최신 통합 PR의 CI, JavaScript CodeQL, 필요한 Render Diff와 aggregate를 확인한다.
+3. merge 승인과 모든 gate 충족 뒤 일반 merge commit으로 병합한다.
+4. 실제 merge SHA의 devel push에서 reuse=true 및 선택된 Frontend worker skip을 확인한다. Rust duration artifact가 없는 Frontend-only 경로에서는 refresh_duration_data=false이고 duration 갱신도 skip이어야 한다.
+5. CI 성공만 보지 않고 재사용 reason, source_run_id, jobs, artifact 여부를 대조한다. 실패 또는 예상 밖 Full lane이면 정상 동작이라고 보고하지 않는다.
+
+현재 이 post-merge 실증은 미완료다. 이번 검토 판정과 향후 CI 최적화 실증 결과를 구분한다.
+
+## Merge 후 contributor PR comment 계획
+
+[post_merge.md](../../manual/pr_review/post_merge.md)를 따른다. 통합 PR의 merge SHA와 devel 검증 결과가 확정된 뒤에만 처리한다.
+
+- 원 PR에 contributor의 기능 commit 세 개를 provenance 보존 체리픽으로 수용한 사실, 통합 PR·merge SHA, 실제 PR/devel CI와 로컬 검증 결과를 한 번 기록한다.
+- 기존 comment를 확인해 중복 게시하지 않는다. UTF-8 body file로 게시하고 API로 본문을 재조회한다.
+- 이 검토 문서는 merge SHA에 고정한 GitHub 파일 링크로 남긴다. 시각 이미지를 판단 근거로 쓰지 않았으므로 임시 PNG·SVG·JSON·로그를 첨부하지 않는다.
+- 원 PR은 직접 merge가 아닌 통합 수용임을 설명한 뒤 승인 범위에서 close한다. contributor fork branch는 보존한다.
+- #5769, #6332, #2328, #3416 등의 배경 참조를 포괄적인 이슈 해결 또는 자동 close 지시로 해석하지 않는다.

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -998,6 +998,19 @@ export class DeleteSelectionCommand implements EditCommand {
         );
         return { ...start };
       });
+    } else if (start.sectionIndex !== end.sectionIndex) {
+      // 교차 구역 선택 — 조각 캡처는 단일 구역 전제(start.sectionIndex 만 사용,
+      // delete_fragment.rs)라 다른 구역의 문단 인덱스를 넘기면 캡처 단계에서
+      // 오류가 나거나 잘못된 범위를 잡는다. 스냅샷은 통째 복원이라 어떤 선택
+      // 모양이든 되돌릴 수 있다 — 방어적 폴백.
+      this.fragment = null;
+      this.snapshot = new SnapshotCommand('deleteSelection', end, start, (wasm) => {
+        wasm.deleteRange(
+          start.sectionIndex, start.paragraphIndex, start.charOffset,
+          end.paragraphIndex, end.charOffset,
+        );
+        return { ...start };
+      });
     } else {
       // 비셀 선택 — 조각 경로 (#5769)
       this.snapshot = null;

--- a/rhwp-studio/src/engine/history.ts
+++ b/rhwp-studio/src/engine/history.ts
@@ -242,6 +242,14 @@ export class CommandHistory {
       const evicted = this.undoStack.shift();
       if (wasm) evicted?.discard?.(wasm);
     }
+
+    // [#6332] 예산 불변식(live id <= SNAPSHOT_ID_BUDGET)의 남은 push 진입점.
+    // 현재 record 경로 커맨드는 스냅샷을 들지 않아 no-op 이지만, 스냅샷 보유
+    // 커맨드가 이 경로에 추가되면 execute 와 같은 강제 없이는 무통보 축출이
+    // 재발한다(#2328). push·축출 이후에 강제해야 방금 명령이 계수에 반영된다.
+    if (wasm) {
+      this.enforceSnapshotBudget(wasm);
+    }
   }
 
   canUndo(): boolean { return this.undoStack.length > 0; }

--- a/rhwp-studio/tests/cell-ctrl-up-para-start.test.ts
+++ b/rhwp-studio/tests/cell-ctrl-up-para-start.test.ts
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { codeOnly } from './support/source-guard.ts';
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 
@@ -16,7 +17,8 @@ function cellBranchBlock(): string {
   assert.notEqual(cellStart, -1, 'cell branch not found');
   const cellEnd = cursor.indexOf('// ─── 단어 단위 이동', cellStart);
   assert.notEqual(cellEnd, -1, 'cell branch end not found');
-  return cursor.slice(cellStart, cellEnd);
+  // [Task #6759 후속] 구간 경계는 주석 표지로 잡고, 위치 판정은 코드만 본다.
+  return codeOnly(cursor.slice(cellStart, cellEnd));
 }
 
 test('Ctrl+Up inside a table cell stops at current paragraph start when mid-paragraph', () => {

--- a/rhwp-studio/tests/char-properties-cursor-nested-cell.test.ts
+++ b/rhwp-studio/tests/char-properties-cursor-nested-cell.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { codeOnly } from './support/source-guard.ts';
 
 // [#2756] getCharPropertiesAtCursor() 의 중첩 셀 좌표 축 가드.
 //
@@ -21,7 +22,7 @@ import { fileURLToPath } from 'node:url';
 // comparePositions 쪽(selection-ordering-nested-cell.test.ts)에서 실경로로 확보한다.
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
-const src = readFileSync(join(rootDir, 'src/engine/input-handler.ts'), 'utf8');
+const src = codeOnly(readFileSync(join(rootDir, 'src/engine/input-handler.ts'), 'utf8'));
 
 /** `NAME(` 시그니처부터 매칭 중괄호가 닫힐 때까지 메서드 본문을 추출. */
 function methodBody(name: string): string {

--- a/rhwp-studio/tests/command-history-snapshot.test.ts
+++ b/rhwp-studio/tests/command-history-snapshot.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { codeOnly } from './support/source-guard.ts';
 
 // [Task #2328] 스냅샷 상한 정합 + 예외 안전 스택 이동 소스 가드.
 //
@@ -12,7 +13,7 @@ import { fileURLToPath } from 'node:url';
 // 별도 수행한다 (PR 검증 섹션).
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
-const source = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+const source = (rel: string): string => codeOnly(readFileSync(join(rootDir, rel), 'utf8'));
 
 /** `undo(...) {` ~ 다음 메서드 전까지의 블록을 추출한다. */
 function methodBlock(src: string, signature: string): string {

--- a/rhwp-studio/tests/command-history-snapshot.test.ts
+++ b/rhwp-studio/tests/command-history-snapshot.test.ts
@@ -190,6 +190,19 @@ test('[결함1] 스냅샷 예산은 WASM 상한에서 순간 여유를 뺀 값�
     'execute 가 push 이후에 enforceSnapshotBudget 를 호출해야 함(전이면 미반영)');
 });
 
+test('[#6332] recordWithoutExecute 도 스냅샷 예산을 강제한다', () => {
+  // 예산 불변식의 undoStack push 진입점은 execute 와 recordWithoutExecute 둘이다.
+  // execute 쪽 강제는 위 [결함1] 이 고정한다 — 이 테스트는 record 경로가 미보호로
+  // 남지 않게 고정한다. 현재 record 커맨드는 스냅샷 0개라 no-op 방어지만, 스냅샷
+  // 보유 커맨드가 이 경로에 추가되면 강제 없이는 무통보 축출이 재발한다(#2328).
+  const block = methodBlock(history, 'recordWithoutExecute(command: EditCommand, wasm?: WasmBridge): void {');
+  const idxPush = block.indexOf('this.undoStack.push(command)');
+  const idxEnforce = block.indexOf('this.enforceSnapshotBudget(wasm)');
+  assert.ok(idxPush !== -1, 'push 지점을 찾지 못함 — 시그니처가 바뀌었으면 가드 갱신');
+  assert.ok(idxEnforce !== -1 && idxPush < idxEnforce,
+    'recordWithoutExecute 가 push 이후에 enforceSnapshotBudget 를 호출해야 함');
+});
+
 test('[#5769] undo 도 스냅샷 id 를 늘리므로 undo 경로에서 예산을 강제한다', () => {
   // after 지연 저장 이후 undo 는 엔트리를 1슬롯 → 2슬롯으로 바꾼다. execute 에서만
   // 강제하면 예산을 채운 뒤 연속 undo 할 때 store 가 MAX 를 넘어 #2328 무통보 축출이

--- a/rhwp-studio/tests/issue-5690-block-selection-phase.test.ts
+++ b/rhwp-studio/tests/issue-5690-block-selection-phase.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createServer } from 'vite';
-import { functionBodyFrom } from './support/source-guard.ts';
+import { codeOnly, functionBodyFrom } from './support/source-guard.ts';
 
 // [#5690] F3 블록 선택 삭제를 undo 하면 **확장 단계까지** 되돌아와야 한다.
 //
@@ -22,7 +22,7 @@ import { functionBodyFrom } from './support/source-guard.ts';
 // 단어 범위(16~27)에 머물렀을 것이다.
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
-const src = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+const src = (rel: string): string => codeOnly(readFileSync(join(rootDir, rel), 'utf8'));
 
 test('[#5690] 삭제 커맨드가 블록 확장 단계를 함께 들고 있다', async () => {
   const vite = await createServer({

--- a/rhwp-studio/tests/issue-5769-zorder-inverse.test.ts
+++ b/rhwp-studio/tests/issue-5769-zorder-inverse.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { codeOnly } from './support/source-guard.ts';
 
 // [#5769 후속] z 순서 역연산화 소스 가드 — 클래스 라이프사이클 전용.
 //
@@ -14,7 +15,7 @@ import { fileURLToPath } from 'node:url';
 // 은 Rust 게이트 tests/cases/issue_5769_zorder_inverse_byte_identity.rs 다.
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
-const cmdSrc = readFileSync(join(rootDir, 'src/engine/command.ts'), 'utf8');
+const cmdSrc = codeOnly(readFileSync(join(rootDir, 'src/engine/command.ts'), 'utf8'));
 
 test('SetZOrderCommand 배선 핀 — probe 선차단, 캡처 선행, undo 는 old 대입 뒤 raw 복원', () => {
   const start = cmdSrc.indexOf('export class SetZOrderCommand');

--- a/rhwp-studio/tests/table-keyboard-navigation.test.ts
+++ b/rhwp-studio/tests/table-keyboard-navigation.test.ts
@@ -3,11 +3,22 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { codeOnly } from './support/source-guard.ts';
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 
 function source(path: string): string {
   return readFileSync(join(rootDir, path), 'utf8');
+}
+
+/**
+ * [Task #6759 후속] 위치 판정은 코드만 본다.
+ *
+ * 구간 경계는 주석 표지(`// ─── …`)로 잡으므로 원문에서 잘라야 하고, 잘라낸 구간의
+ * 위치 비교는 주석 인용에 뚫리면 안 되므로 그때 `codeOnly` 를 씌운다.
+ */
+function codeSlice(src: string, from: number, to: number): string {
+  return codeOnly(src.slice(from, to));
 }
 
 function tabCaseBlock(): string {
@@ -16,7 +27,7 @@ function tabCaseBlock(): string {
   const end = keyboard.indexOf("case 'Insert': {", start);
   assert.notEqual(start, -1, 'Tab case not found');
   assert.notEqual(end, -1, 'Insert case after Tab not found');
-  return keyboard.slice(start, end);
+  return codeSlice(keyboard, start, end);
 }
 
 function exitTableBlock(): string {
@@ -25,7 +36,7 @@ function exitTableBlock(): string {
   const end = cursor.indexOf('// ─── 캐럿 좌표 갱신', start);
   assert.notEqual(start, -1, 'exitTable method not found');
   assert.notEqual(end, -1, 'exitTable method end not found');
-  return cursor.slice(start, end);
+  return codeSlice(cursor, start, end);
 }
 
 test('Tab in a table cell uses cell navigation before inserting a tab character', () => {

--- a/rhwp-studio/tests/undo-history-jumped.test.ts
+++ b/rhwp-studio/tests/undo-history-jumped.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { codeOnly } from './support/source-guard.ts';
 
 // [Task #2339] history-jumped 이벤트 소스 가드.
 //
@@ -11,7 +12,7 @@ import { fileURLToPath } from 'node:url';
 // 관례) 소스 배선을 핀한다. 행위 증명은 브라우저 실동작으로 별도 수행(PR 검증 섹션).
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
-const source = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+const source = (rel: string): string => codeOnly(readFileSync(join(rootDir, rel), 'utf8'));
 
 const inputHandler = source('src/engine/input-handler.ts');
 const findDialog = source('src/ui/find-dialog.ts');


### PR DESCRIPTION
## 원 PR 및 목적

[PR #5953](https://github.com/edwardkim/rhwp/pull/5953)의 기능 commit 3개를 최신 devel 위에 provenance 보존 체리픽으로 통합합니다. [PR #6780](https://github.com/edwardkim/rhwp/pull/6780)의 Frontend-only post-merge CI 재사용도 동일 저장소 PR에서 실제 검증합니다.

원 PR에는 최신 devel을 정상 merge로 반영했고, 정렬 head `f1b5f2cfe1b7037982c0421bc51b6901a62ce0ec`의 CI 완료를 확인했습니다. fork 원 PR의 history를 rebase/force-push하지 않았습니다.

## 변경

- 교차 구역 선택 삭제가 단일 구역 전제의 fragment 캡처 대신 snapshot을 사용하도록 방어적 폴백
- recordWithoutExecute의 push 및 축출 이후 snapshot 예산 강제
- 위치 비교 source guard 7개를 codeOnly로 전환
- 원 PR 번호의 한국어 검토 기록과 오늘할일 포함

메인터너 source 보정은 없으며, Git 전체 tree는 문서 추가 전 정렬된 원 PR과 동일했습니다. source commit은 `24f52a136`, `c4d678c95`, `91b70532a`이며 통합 commit은 `563195408`, `0e74386e0`, `c788cdc0a`입니다.

## 검토 결과

판정: 승인. 최신 통합 PR CI와 필요한 Render Diff, 작업지시자의 merge 승인은 별도 gate입니다.

- 관련 테스트 7파일: 26개 통과, 실패 0개
- Vite SSR: 같은 구역 fragment/교차 구역 snapshot, 선택 단계 보존 확인
- Vite SSR: 100개 snapshot record 후 live 98, 오래된 두 항목 폐기, execute 호출 0회 확인
- TypeScript, code candidate diff 검사 통과
- classifier: rust_required=false, native_skia_required=false, frontend_mode=package, render_required=true, codeql_languages=javascript-typescript

실제 다구역 HWP 문서의 삭제 정확성을 입증한 변경은 아니며, 해당 방어 범위 이상을 주장하지 않습니다. Rust source·renderer·fixture를 바꾸지 않아 Cargo 전체 회귀와 PDF/visual sweep 생성은 반복하지 않았습니다. 원시 로그와 임시 이미지는 포함하지 않았습니다.

## CI 검증 구분

원 PR의 정렬 후 CI는 기존 녹색 candidate와 current-base merge-tree 일치를 확인해 heavy worker를 skip했습니다. 이 통합 PR은 문서까지 첫 push에 포함했으며 최종 head의 Frontend package worker를 실제 실행해야 합니다.

merge 승인 후에는 실제 merge SHA의 devel push에서 `reuse=true`, 실제 `source_run_id`, Frontend worker skip, `refresh_duration_data=false`와 duration 갱신 skip을 대조합니다. 아직 post-merge 재사용 실증을 완료했다고 주장하지 않습니다.

## 기록 및 후속 처리

- `mydocs/pr/archives/pr_5953_review.md`
- `mydocs/orders/20260905.md`

성공 merge와 devel 검증 뒤 원 PR에는 통합 수용 사실과 실제 증거를 중복 없이 기록하고 close합니다. contributor fork branch는 보존합니다. 배경 이슈 #5769/#6332/#2328/#3416을 이 통합 PR로 일괄 close하지 않습니다. owner를 reviewer로 자동 지정하지 않습니다.
