### PR TITLE
docs: PR #6780 실제 CI 재사용 검증 기록 보완

### DIFF
--- a/mydocs/pr/archives/pr_6780_review.md
+++ b/mydocs/pr/archives/pr_6780_review.md
@@ -4,7 +4,7 @@
 
 판정: 승인
 
-로컬 검증을 완료한 후보에 대한 작성자 self-review 판정이다. 최신 GitHub Actions 결과, merge 가능 상태, 작업지시자의 merge 승인은 별도 조건이며 아직 완료로 기록하지 않는다.
+로컬 계약 검증과 최종 head의 GitHub Actions를 통과한 뒤 일반 merge commit으로 병합했다. 실제 devel push 검증과 후속 처리도 완료했다. 이어 같은 저장소의 Frontend 변경 PR #6781에서 Rust duration artifact 없이 CI 재사용이 성공한 사실까지 확인했다. 이 보완 기록은 2026-09-05에 확인한 실행 결과를 기준으로 한다.
 
 ## 검토 대상
 
@@ -17,11 +17,14 @@
 | 작업 branch | fix/6779-frontend-postmerge-reuse-20260905 |
 | 구현 기준 base | fdba74164ef7003c68fdb14980a3ee1023957fed |
 | 검증한 구현 commit | 21f89bf429e10a900f0c9610a268b83e1f12bacf |
+| 최종 PR head | ecbf49f2591d7ac257bbeb3742d5d7f678c40517 |
+| 실제 merge commit | a7b95f4041ef5d7d3574c4becfea5cb636eaf836 |
+| 병합 시각 | 2026-09-05 13:46:20 UTC |
 | 구현 변경 규모 | workflow 2개, JavaScript 검증기 1개, 계약 테스트 2개; 314줄 추가, 29줄 삭제 |
 | 작성일 | 2026-09-05 |
-| 원격 CI 및 merge 상태 | 작성 시점 최신 결과를 별도로 조회하지 않았다. merge 직전에 최종 head 기준으로 확인해야 한다. |
+| 원격 CI 및 merge 상태 | 최종 head의 required check와 실제 worker 결과를 확인하고 MERGEABLE/CLEAN 상태에서 일반 merge했다. PR 및 devel CI 결과는 아래 표에 기록한다. |
 
-이 기록과 오늘할일은 구현 검증 뒤 같은 PR에 추가한 문서 전용 후속 commit이다. 저장소 owner를 reviewer로 자동 지정하지 않았다.
+최초 검토 기록과 오늘할일은 구현 검증 뒤 같은 PR의 문서 전용 trailing commit에 포함되어 함께 병합됐다. 이번 보완은 작업지시자가 별도로 요청한 문서 전용 후속 PR이며, 오늘할일이나 이미 완료한 issue/PR comment 및 close를 반복하지 않는다. 저장소 owner를 reviewer로 자동 지정하지 않았다.
 
 ## 원인과 변경 범위
 
@@ -42,7 +45,7 @@ PR #6772의 `devel -> main` 승격 검증과 이번 devel post-merge 재사용 �
 
 제품 source, renderer, sample, golden, baseline은 변경하지 않았다.
 
-## 완료한 검증
+## 완료한 로컬 검증
 
 | 명령 | 실제 결과 |
 | --- | --- |
@@ -58,21 +61,89 @@ PR #6772의 `devel -> main` 승격 검증과 이번 devel post-merge 재사용 �
 
 Rust source와 제품 동작을 변경하지 않아 Cargo 전체 회귀 테스트, WASM build, Studio 테스트는 실행하지 않았다. 렌더링·레이아웃·문서 출력 변경이 없어 visual sweep, PDF 변환, 대표 PNG 산출은 필요하지 않다.
 
-로컬 계약 테스트 통과를 실제 GitHub workflow 실행 성공으로 표현하지 않는다. 새 경로를 적용한 실제 post-merge Frontend-only 성공 사례는 아직 확인하지 않았다.
+위 생략 범위는 #6780의 로컬 검증에 대한 설명이다. 실제 GitHub worker 실행과 #6781의 Frontend-only 재사용 결과는 아래에 별도로 기록하며, 이번 문서 보완을 위해 이미 완료한 테스트를 반복 실행하지 않았다.
 
-## 위험 및 merge 전 조건
+## 실제 PR 및 devel 검증: #6780
+
+최종 head `ecbf49f2591d7ac257bbeb3742d5d7f678c40517`의 required check와 aggregate, 실행된 worker를 확인한 뒤 병합했다. 아래 devel 결과는 모두 merge SHA `a7b95f4041ef5d7d3574c4becfea5cb636eaf836`의 push 실행이다.
+
+| Workflow | 최종 PR head | merge SHA의 devel push |
+| --- | --- | --- |
+| CI | [33969065110](https://github.com/edwardkim/rhwp/actions/runs/33969065110), 성공 | [33969863629](https://github.com/edwardkim/rhwp/actions/runs/33969863629), 성공 |
+| CodeQL | [33969065103](https://github.com/edwardkim/rhwp/actions/runs/33969065103), 성공 | [33969863662](https://github.com/edwardkim/rhwp/actions/runs/33969863662), 성공 |
+| Adapter inter-diff | [33969065154](https://github.com/edwardkim/rhwp/actions/runs/33969065154), 성공 | [33969863658](https://github.com/edwardkim/rhwp/actions/runs/33969863658), 성공 |
+| Proptest | [33969065230](https://github.com/edwardkim/rhwp/actions/runs/33969065230), 성공 | [33969863727](https://github.com/edwardkim/rhwp/actions/runs/33969863727), 성공 |
+| Close Issues | 해당 없음 | [33969863494](https://github.com/edwardkim/rhwp/actions/runs/33969863494), 성공 |
+
+- PR과 devel의 CodeQL은 JavaScript, Python, Rust 분석 worker가 실제로 성공했다.
+- devel CI는 preflight, Build & Test, Lint, Native Skia, Frontend package, Rust archive A/B/C/D build 및 test가 성공했다. 선택되지 않은 별도 Frontend unit, WASM 및 promotion 경로는 정책상 skip이었다.
+- [nextest duration 갱신 job](https://github.com/edwardkim/rhwp/actions/runs/33969863629/job/101317697248)도 성공했다.
+- CI enforcement 변경인 #6780에는 Render Diff workflow가 실행되지 않았다. 이를 시각 검증 성공으로 간주하지 않는다.
+
+첫 merge의 [재사용 판정 job](https://github.com/edwardkim/rhwp/actions/runs/33969863629/job/101316335319)은 다음을 출력했다.
+
+```text
+reuse=false reason=pr-changes-ci-enforcement-surface source_run_id=none refresh_duration_data=false
+```
+
+이는 controller 자체를 변경한 PR의 기존 CI 증거를 무조건 신뢰하지 않는 예상된 안전 동작이다. 재사용 출력의 `refresh_duration_data=false`는 Full CI 이후의 일반 duration 갱신까지 막는다는 뜻이 아니다. 이 실행에서는 재사용이 거부되어 Full CI와 일반 duration 갱신이 실제로 수행됐다.
+
+## 실제 Frontend-only 재사용 검증: #6781
+
+[PR #6781](https://github.com/edwardkim/rhwp/pull/6781)은 원 [PR #5953](https://github.com/edwardkim/rhwp/pull/5953)의 Frontend 변경을 provenance-preserving cherry-pick으로 같은 저장소의 임시 branch에 통합한 검증 사례다. 제품 변경은 Studio command/history와 관련 테스트이며, 검토 문서 및 오늘할일을 함께 포함했다. 코드 후보의 tree는 devel에 정렬한 원 PR과 동일한 `0ac7d0c362342867e488b2dd6ebde1f99184ffb3`임을 확인했다.
+
+| 항목 | 실제 확인값 |
+| --- | --- |
+| head repository | edwardkim/rhwp |
+| 최종 PR head | a95d56a7df6327a76ff928adb9285d9e8184c2f6 |
+| merge commit | 656af6bdbdce290a65a00fd2ac35fa18a8f38120 |
+| 병합 시각 | 2026-09-05 14:05:20 UTC |
+| classifier | rust_required=false, frontend_mode=package, native_skia_required=false, render_required=true, codeql_languages=javascript-typescript |
+| merge 직전 상태 | 최종 head의 required check 충족, MERGEABLE/CLEAN |
+
+검토 문서를 포함한 최종 head에서 Frontend package worker가 실제 실행되었다. 원 fork PR의 base-update fast-pass나 이전 코드 head의 성공을 최종 head의 실제 실행으로 대신 기록하지 않았다.
+
+| Workflow | 최종 PR head의 검증 | merge SHA의 devel push |
+| --- | --- | --- |
+| CI | [33970151406](https://github.com/edwardkim/rhwp/actions/runs/33970151406), Frontend package와 Build & Test 성공 | [33970764979](https://github.com/edwardkim/rhwp/actions/runs/33970764979), 재사용 및 aggregate 성공 |
+| CodeQL | [33970151426](https://github.com/edwardkim/rhwp/actions/runs/33970151426), JavaScript 분석 성공 | [33970765020](https://github.com/edwardkim/rhwp/actions/runs/33970765020), 재사용 성공, 분석 worker skip |
+| Adapter inter-diff | [33970151397](https://github.com/edwardkim/rhwp/actions/runs/33970151397), worker 성공 | [33970764988](https://github.com/edwardkim/rhwp/actions/runs/33970764988), 재사용 성공, worker skip |
+| Proptest | [33970151412](https://github.com/edwardkim/rhwp/actions/runs/33970151412), worker 성공 | [33970765087](https://github.com/edwardkim/rhwp/actions/runs/33970765087), 재사용 성공, worker skip |
+| Canvas Render Diff | [33970151348](https://github.com/edwardkim/rhwp/actions/runs/33970151348), 성공 | push에서는 실행되지 않음 |
+| Close Issues | 해당 없음 | [33970764743](https://github.com/edwardkim/rhwp/actions/runs/33970764743), 성공 |
+
+#6781 PR의 CodeQL Python/Rust wrapper 표시를 실제 언어 분석 실행으로 해석하지 않았다. 선택된 분석 언어는 JavaScript였고, 플랫폼 CodeQL check의 NEUTRAL은 정책상 허용된 결과였으며 필수 aggregate 조건은 충족했다.
+
+devel CI의 [실제 재사용 판정](https://github.com/edwardkim/rhwp/actions/runs/33970764979/job/101318740975)은 다음과 같다.
+
+```text
+reuse=true reason=review-tail-final-head-green-frontend-ci-reused source_run_id=33970151406 refresh_duration_data=false
+```
+
+CodeQL, Adapter, Proptest도 각각 위 표의 최종 PR run을 source로 사용했으며, 모두 `reuse=true reason=review-tail-final-head-green-pr-workflow-reused`였다.
+
+- source CI run의 artifact API 결과는 유효한 `trusted-postmerge-merge-tree-v1-...` artifact 1개였으며, Rust B/C/D duration artifact는 없었다. Rust timing artifact 없이 Frontend CI가 실제 재사용됐다.
+- devel의 preflight와 Build & Test는 성공했고, [Frontend package](https://github.com/edwardkim/rhwp/actions/runs/33970764979/job/101318789356), Rust archive build/test, Lint, Native Skia, 별도 WASM worker는 skip이었다.
+- [Refresh nextest target duration data](https://github.com/edwardkim/rhwp/actions/runs/33970764979/job/101318790117)도 skip이었다. Frontend-only 사례에는 갱신할 Rust duration 증거가 없으므로 이것이 의도한 결과다.
+- PR의 [Frontend package worker](https://github.com/edwardkim/rhwp/actions/runs/33970151406/job/101317236095)는 13:53:35~14:00:12 UTC, 6분 37초 동안 실행됐다. devel CI run은 API의 시작·최종 갱신 시각 기준 14:05:22~14:05:53 UTC, 약 31초였다. 서로 다른 범위의 시간값이므로 동일 작업의 정밀 성능 비교로 일반화하지 않는다.
+
+## 검증 범위와 남는 제한
 
 - job 이름이나 topology가 바뀌면 계약이 일치하지 않아 재사용을 거부한다. 조용히 검증 범위를 줄이는 대신 기존 실행 경로로 돌아간다.
-- 이 PR은 controller 및 CI enforcement surface를 바꾸므로 최초 merge의 devel push가 Full CI로 실행되는 것은 예상된 안전 동작이다.
+- #6780의 최초 merge에서 enforcement 변경에 따른 재사용 거부와 Full CI 성공을 확인했다. #6781에서는 변경된 controller가 적용된 뒤의 Frontend package 재사용 성공을 확인했다.
+- 실제 성공 사례는 같은 저장소 `edwardkim/rhwp`의 PR #6781이다. contributor fork의 원 PR #5953 자체에 대한 재사용 허용이나 fork 보안 정책 변경을 검증한 것은 아니다.
+- 실제 원격 성공 사례는 Frontend package 경로다. Frontend unit 전용 경로와 실패·취소·pending 등 거부 조건은 위 로컬 계약 테스트 범위이며, 모든 조합을 실제 Actions에서 재현했다고 주장하지 않는다.
 - 모든 workflow를 무조건 skip하거나 모든 PR에서 duration 갱신만 실행하도록 변경하지 않는다.
-- 최종 PR head의 required check, 관련 aggregate와 실행된 worker, `MERGEABLE`, `CLEAN`을 확인한 뒤 작업지시자 승인을 받아야 merge할 수 있다.
+- Rust가 필요한 PR의 기존 B/C/D duration artifact 요구를 유지한다. 새로운 PR은 해당 최종 head의 required check, 관련 aggregate와 worker, MERGEABLE/CLEAN 조건을 별도로 확인해야 한다.
 
-## Merge 후 issue 및 PR comment 계획
+## 완료한 후속 처리와 증적 보존
 
-[post_merge.md](../../manual/pr_review/post_merge.md)를 따른다. 실제 merge SHA의 devel CI와 관련 aggregate/worker 결과가 확인된 뒤에만 후속 처리한다.
+[post_merge.md](../../manual/pr_review/post_merge.md)에 따라 두 merge SHA의 실제 devel CI 결과를 확인한 뒤 처리했다.
 
-- PR 본문의 `Closes #6779`와 실제 issue 상태를 확인한다.
-- issue #6779의 기존 comment를 확인해 중복 게시를 피하고, merge SHA, 실제 PR/devel CI URL, Frontend 재사용 및 Rust duration 분리 범위, 최초 Full CI가 예상된 이유를 기록한다.
-- 본 검토 문서는 확정된 merge SHA에 고정한 GitHub 파일 링크로 안내한다. 시각 증적을 사용하지 않았으므로 관련 없는 이미지나 임시 로그를 첨부하지 않는다.
-- 게시가 승인된 comment는 UTF-8 body file로 전달하고 API로 본문을 재조회한다.
-- 별도 후속 문서 PR을 만들거나 이미 처리한 PR #6777의 source PR comment/close를 반복하지 않는다.
+- PR #6780 본문의 `Closes #6779`를 확인했다. GraphQL closingIssuesReferences는 비어 있었지만, [Close Issues bot 기록](https://github.com/edwardkim/rhwp/issues/6779#issuecomment-5552235357)과 API의 CLOSED 상태 및 2026-09-05 13:46:32 UTC 종료 시각을 확인했다.
+- [PR #6780 후속 comment](https://github.com/edwardkim/rhwp/pull/6780#issuecomment-5552358693)와 [issue #6779 후속 comment](https://github.com/edwardkim/rhwp/issues/6779#issuecomment-5552358810)에 실제 merge SHA, PR/devel CI, 최초 Full CI의 이유와 #6781 재사용 성공을 기록했다.
+- [PR #6781 후속 comment](https://github.com/edwardkim/rhwp/pull/6781#issuecomment-5552358524)를 게시했다. 원 [PR #5953 수용 comment](https://github.com/edwardkim/rhwp/pull/5953#issuecomment-5552358253)에 #6781 체리픽 통합 수용 사실을 남기고 2026-09-05 14:08:30 UTC에 CLOSED 처리했다. 원 PR은 직접 merge하지 않았으며 contributor fork branch는 보존했다.
+- comment는 UTF-8 body file로 한 번씩 게시하고 API로 본문 일치를 확인했다. 이번 문서 보완에서 comment, issue close, source PR close를 다시 수행하지 않는다.
+- 두 merge SHA의 upstream/devel 포함과 기본 devel 작업공간의 clean 상태를 확인하고, 이 작업 소유 local branch만 정리했다. upstream 임시 remote branch, contributor fork branch, 기본 작업공간 및 공유 target은 보존했다.
+- 증적은 위 Actions run/job 및 comment permalink로 보존한다. 시각 비교가 판단 근거가 아니므로 무관한 이미지, PDF, 임시 원시 로그를 추가하지 않는다.
+- 이 보완 문서 PR은 작업지시자의 별도 요청에 따른 기록 갱신이다. 제품 source, test, workflow, golden/baseline, sample, 신규 LFS 및 오늘할일은 변경하지 않고, 이미 완료한 PR #6777의 source PR 처리도 반복하지 않는다.


### PR DESCRIPTION
## 목적

[PR #6780](https://github.com/edwardkim/rhwp/pull/6780)의 검토 기록을 실제 병합 및 GitHub Actions 검증 결과로 보완하는 문서 전용 후속 PR입니다. 작업지시자의 별도 요청으로 생성합니다.

## 보완 내용

- #6780의 최종 head, merge SHA `a7b95f4041ef5d7d3574c4becfea5cb636eaf836`, 실제 PR/devel CI 결과를 기록했습니다.
- controller enforcement 변경으로 최초 devel 재사용이 `pr-changes-ci-enforcement-surface`로 거부되고 Full CI 및 일반 duration 갱신이 성공한 사실을 구분했습니다.
- [PR #6781](https://github.com/edwardkim/rhwp/pull/6781)의 merge SHA `656af6bdbdce290a65a00fd2ac35fa18a8f38120`에서 `review-tail-final-head-green-frontend-ci-reused`로 실제 재사용된 run/job 증거를 기록했습니다.
- Rust B/C/D duration artifact가 없는 Frontend package 사례에서 Frontend·Rust worker 및 duration 갱신이 skip되고 aggregate가 성공한 결과를 기록했습니다.
- 같은 저장소 PR의 실제 성공 사례와 fork PR, Frontend unit 전용 경로 등 검증하지 않은 범위를 분리했습니다.
- 완료한 issue/PR comment permalink, 원 PR #5953의 체리픽 수용 및 close, 정리 결과를 보존했습니다.

## 변경 범위

`mydocs/pr/archives/pr_6780_review.md` 한 파일만 변경합니다. 제품 source, test, workflow, golden/baseline, sample, 신규 LFS, 임시 로그 및 오늘할일은 변경하지 않습니다.

## 검증 근거

- #6780 로컬 검증: 기존 Node 계약 테스트 30개, Python 계약 테스트 43개 및 당시 문서에 명시한 구문/actionlint/diff 검증 통과 기록을 유지합니다.
- #6780 실제 devel [CI](https://github.com/edwardkim/rhwp/actions/runs/33969863629) 및 [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/33969863662) 성공을 기록합니다.
- #6781 실제 devel [CI](https://github.com/edwardkim/rhwp/actions/runs/33970764979)와 [재사용 판정 job](https://github.com/edwardkim/rhwp/actions/runs/33970764979/job/101318740975)을 비롯한 확인 완료 결과를 기록합니다.
- 이번 변경은 기존 실증 결과의 문서 보완이므로 테스트를 다시 실행하지 않았습니다. 이 문서 PR 자체의 CI 결과는 아직 확인하지 않았습니다.

## 후속 처리 범위

이미 완료한 #6780/#6781 및 원 PR #5953, issue #6779의 comment/close와 오늘할일 갱신을 반복하지 않습니다. 이 기록을 위한 추가 후속 문서 PR도 만들지 않습니다. owner를 reviewer로 자동 지정하지 않습니다.
