### PR TITLE
fix(studio): 색상 버튼의 키보드 활성화 복원 (#6635)

### DIFF
--- a/mydocs/pr/archives/pr_6786_review.md
+++ b/mydocs/pr/archives/pr_6786_review.md
@@ -1,0 +1,156 @@
+---
+kind: snapshot
+status: historical
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-09-06
+pr: 6786
+issue: 6635
+author: baba9811
+reviewer: postmelee
+---
+
+# PR #6786 리뷰 — 색상 버튼 키보드 활성화 복원
+
+## 최종 판정
+
+**승인.** 원 기여의 표준 click 활성화와 선택 보존 구현을 수용한다. 같은 색상 도구에 한정해
+collaborator가 숨겨진 글자색 input의 Tab 포커스를 제외하고, 형광펜 팔레트의 Escape 닫기와
+트리거 포커스 복귀를 추가했다. 보정 code candidate는
+`cc21183ab622d13071acfa7be3224903a048526b`이며 범위 안 구현 blocker는 없다.
+
+이 문서는 기술 검토 판정이다. GitHub Approve 리뷰는 작업지시자에게 초안을 보여주고 승인받은 뒤에만
+등록한다. 문서 trailing head의 최신 checks와 merge 가능 상태를 다시 확인해야 하며, merge·issue close·
+contributor comment는 아직 수행하지 않았다.
+
+## 라우팅과 metadata
+
+| 항목 | 검토 기준 |
+| --- | --- |
+| PR / 이슈 | [#6786](https://github.com/edwardkim/rhwp/pull/6786) / [#6635](https://github.com/edwardkim/rhwp/issues/6635) |
+| 작성자 / 리뷰 요청 대상 | `baba9811` / `postmelee` |
+| base | `devel@51ad998e33ef7f5191b0e1b0b656dc44cef33a1c` |
+| 원 contributor head | `d0179dd0410757aea8d116ba4be7b38438e406e9` |
+| 보정 code candidate | `cc21183ab622d13071acfa7be3224903a048526b` |
+| source | `baba9811/rhwp:fix/6635-color-keyboard` |
+| 문서 추가 전 규모 | 6 files, +214/-3, 원 기여 2 commits와 보정 1 commit |
+| 작성 시점 참고값 | Open, non-draft, `maintainerCanModify=true`, `MERGEABLE` |
+| assignee / labels / milestone | `baba9811` / `bug`, `rhwp-studio`, `test`, `typescript` / `v1.0.0` |
+
+[PR review workflow](../../manual/pr_review_workflow.md)와 [선택표](../../manual/pr_review/README.md)에 따라
+기본 [collaborator 외부 PR 경로](../../manual/pr_review/collaborator_external_pr.md)를 적용했다.
+보조 문서는 [접수·검토](../../manual/pr_review/intake_and_review.md),
+[로컬 검증](../../manual/pr_review/local_validation.md),
+[첫 기여자](../../manual/pr_review/first_time_contributor.md),
+[review-only fast-pass](../../manual/pr_review/review_only_fast_pass.md)다.
+원 PR source head에 보정을 직접 추가하는 경로이며 별도 integration PR은 만들지 않았다.
+
+## 원 기여와 collaborator 보정
+
+| commit | 작성자와 역할 |
+| --- | --- |
+| `67a5d00b832589fd14ec60e7b10f577c8b949d5c` | baba9811: 버튼 click 활성화 복원, 숨긴 형광펜 input을 button 밖으로 이동, focused E2E와 반응형 검사 갱신 |
+| `d0179dd0410757aea8d116ba4be7b38438e406e9` | baba9811: 기존 #6202 E2E의 MANIFEST 등록 누락 보완 |
+| `cc21183ab622d13071acfa7be3224903a048526b` | postmelee: 글자색 input `tabindex=-1`, 팔레트 Escape 닫기·포커스 복귀, 회귀 추가 |
+
+원 contributor 두 commit의 author와 SHA를 유지했다. rebase, amend, squash 또는 force-push하지 않았다.
+보정과 이 리뷰 문서는 별도 commit으로 나눴다. 실행 순서는 [보정·통합 기록](pr_6786_review_impl.md)에 적었다.
+
+## 구현 검토
+
+1. `mousedown`의 `preventDefault()`는 편집기의 선택 영역 보존을 담당한다. 실제 명령을 표준 `click`으로
+   옮겨 Enter/Space가 만드는 버튼 활성화와 마우스 입력을 같은 경로로 처리한다.
+2. `다른 색`의 color input을 button 밖으로 이동해 중첩 interactive element와 input click의 부모 button
+   재진입을 없앤다. `색 없음`도 같은 원인에 대한 click 보정을 적용한다.
+3. 기존 글자색 input은 크기·투명도로만 숨겨져 Tab 순서에 남아 있었다. `tabindex=-1`로 제외해 글자색과
+   형광펜 버튼 사이를 Tab/Shift+Tab 한 번으로 이동한다. 버튼에서 호출하는 color picker는 유지된다.
+4. Escape 핸들러는 열린 형광펜 dropdown 안에서만 처리한다. 형광펜 버튼, `색 없음`, `다른 색`에
+   포커스가 있을 때 팔레트를 닫고 형광펜 버튼으로 돌려준다. 전역 Escape 처리나 서식 명령을 추가하지 않는다.
+5. 보정 E2E는 실제 키 입력으로 닫기, 포커스, 선택 영역, 서식, undo 깊이를 함께 확인한다. 기존 색 적용,
+   취소, 마우스 활성화 검증도 유지한다. #6202 manifest 한 줄은 실행 파일 등록이며 제품 변경이 아니다.
+
+## 외부 기여자 검증 절차 확인
+
+PR의 해당 목차는 **Studio 단독 변경에 적용할 Rust 검증 범위와 별도 review 환경의 준비 순서에 대한 질문**이다.
+기여자는 `cargo fmt --all -- --check`가 파생 suite 28개 누락으로 실패한 사실을 공개했고, 이를 성공으로
+집계하거나 파생 파일을 PR에 추가하지 않았다.
+
+기준 SHA의 [CONTRIBUTING.md](https://github.com/edwardkim/rhwp/blob/51ad998e33ef7f5191b0e1b0b656dc44cef33a1c/CONTRIBUTING.md)는
+fmt를 제출 전 필수로 표현하면서 일반 contributor source checkout에서 파생 suite를 준비하지 않도록 안내한다.
+파생 파일을 source PR에 넣지 않는 목적은 독립 PR 사이의 harness·manifest 충돌 방지다. Rust 검증이 필요할 때
+별도 review worktree에서 `--prepare` 후 검사한다는 연결과 Studio 단독 변경의 적용 범위가 공개 체크리스트에서
+충분히 명확하지 않았다.
+
+원 head의 review worktree에서 같은 누락을 재현했고, `node scripts/rust-test-suite-manifest.mjs --prepare` 후
+`cargo fmt --all -- --check`와 manifest `--check`가 통과했다. Rust source·Cargo.toml 수정은 없었다.
+이는 준비된 review 환경의 결과이며 기여자의 source checkout 실패를 성공으로 바꿔 기록하지 않는다.
+생성된 suite·manifest는 검증 산출물로만 두고 stage하지 않았다.
+
+이번 PR과 보정은 Studio HTML/TypeScript/E2E 변경이다. CI 분류도 `rust_required=false`,
+`frontend_mode=package`다. 변경 범위별 로컬 검증 정책에 따라 Rust 전체 workspace Clippy·nextest를 추가로
+실행하지 않았다. 공개 가이드 보완은 작업지시자가 요청한 별도 작업으로 분리하며 이 PR의 제출자 결함으로
+판정하지 않는다.
+
+## 실제 로컬 검증
+
+검토 worktree는 `/private/tmp/rhwp-pr6786-review`이며 아래 결과는 collaborator가 직접 실행했다.
+
+| 검증 | 결과 |
+| --- | --- |
+| fresh WASM: `scripts/wasm-pack-locked.sh --target web --out-dir pkg --no-opt` | 성공; native 진단 빌드 |
+| 보정 전 production 코드 + 신규 E2E | 7건 예상 실패: 양방향 Tab 2, Escape 닫기 3, 포커스 복귀 2 |
+| `npm --prefix rhwp-studio run e2e:issue-6635` | 기본 구성 64/64 통과 |
+| 위 E2E, `RHWP_WITHOUT_HWPCTRL=1` | 64/64 통과 |
+| `npm --prefix rhwp-studio test` | 1,425 pass, 기존 skip 1, fail 0 |
+| `npm --prefix rhwp-studio run build` / `build:no-hwpctrl` | 두 구성의 TypeScript·production build 성공 |
+| `npm --prefix rhwp-studio run e2e:responsive` | 1,082 pass, fail 0 |
+| `node --test scripts/frontend-wasm-bindings.test.mjs scripts/frontend-editor-embed.test.mjs` | 3/3 통과 |
+| `python3 scripts/check_e2e_manifest.py` | 128 files / 128 rows, 오류 0 |
+
+WASM은 원 PR Rust 입력으로 새로 빌드했고, 후속 보정은 Rust 입력을 바꾸지 않아 재사용했다.
+`CARGO_TARGET_DIR`는 공용 review cache `target/pr-review`를 사용했다.
+WASM SHA-256: `540dcfabf60dc725e2a6ae05b794cf5d02a7db323816ad444911e7a5162f80e9`.
+Docker daemon이 실행되지 않아 native 진단 경로를 사용했으며 Docker 최적화 배포 빌드를 검증했다고 주장하지 않는다.
+E2E는 로컬 Chrome을 지정하고 `VITE_PORT=7787`로 실행했다.
+
+### 사람의 확인과 자동화의 범위
+
+- 작업지시자는 보정 전 원 PR에서 글자색·`다른 색`의 네이티브 색상 창 Esc 닫기, 형광펜 버튼의
+  Enter/Space 재활성화로 닫기, 영역 밖 마우스 클릭으로 닫기를 통과했다고 확인했다.
+- 새로 추가한 형광펜 팔레트 Escape 및 한 번의 Tab 이동은 위 자동화로 확인했다. 작업지시자가 이 보정까지
+  직접 재확인했다고 기록하지 않는다.
+- 자동화는 실제 키보드·마우스가 color input을 한 번 활성화하는지 검사한다. 색 적용 부분에서는 input
+  이벤트를 대신 전달하므로 OS 네이티브 색상 창 내부의 색 선택까지 자동 검증한 것은 아니다.
+- renderer/layout/paint를 바꾸지 않는 도구 모음 입력 변경이므로 로컬 PDF/SVG Visual Sweep은 수행하지 않았다.
+  브라우저 상호작용 결과를 한컴 기준 출력과 대조한 시각 검증으로 표현하지 않는다.
+
+## 보정 code candidate GitHub CI
+
+아래 run은 모두 `cc21183ab622d13071acfa7be3224903a048526b`에 속한다. 원 head의 과거 성공을
+보정 head의 결과로 재사용하지 않는다. 외부 fork workflow 실행 승인 대기를 해제한 후 모든 관련 workflow와 required `Build & Test` 성공을 확인했다.
+
+| workflow | 결과 / 증적 |
+| --- | --- |
+| CI | 성공 — [34021282412](https://github.com/edwardkim/rhwp/actions/runs/34021282412) |
+| CodeQL | 성공 — [34021282542](https://github.com/edwardkim/rhwp/actions/runs/34021282542) |
+| Render Diff | 성공 — [34021282182](https://github.com/edwardkim/rhwp/actions/runs/34021282182) |
+| Adapter inter-diff | 성공 — [34021282384](https://github.com/edwardkim/rhwp/actions/runs/34021282384) |
+| Proptest roundtrip | 성공 — [34021282306](https://github.com/edwardkim/rhwp/actions/runs/34021282306) |
+
+CI 영향축은 frontend package, render, JavaScript CodeQL이다. Rust lint·native Skia·Rust shard는
+정책상 미해당 skipped이며 실행 성공으로 집계하지 않는다. 별도 `WASM Build` skip과 frontend package
+내부의 fresh WASM build도 구분한다.
+
+## 후속 범위와 merge 전 조건
+
+- 다른 도구 모음·팝업의 숨긴 input, 중첩 interactive element, Tab 순서, Escape·포커스 복귀는 별도 접근성
+  조사 대상으로 남긴다. 이번 PR에서 전역 변경하지 않았고 별도 이슈가 등록됐다고 주장하지 않는다.
+- 오늘할일은 source branch에 `mydocs/orders/20260906.md`가 없고 최신 devel에 다른 PR 기록으로 존재한다.
+  변경되지 않은 추가 경계가 없어 원본에 다른 PR 기록을 복사하거나 문서만을 위해 base를 병합하지 않았다.
+  선택적 오늘할일 갱신 대신 이번 처리 이력은 이 archive review와 implementation 기록에 남긴다.
+- 최신 devel `016fe3ceed904633e74e70127a4cceaa1f18a756`과 code candidate의 merge simulation은 충돌 없이
+  통과했다. 문서 commit 뒤에도 최신 base의 merge tree·diff·Markdown 링크를 확인한다.
+- code candidate CI 성공 후 archive 두 문서만 trailing commit으로 push한다. 최신 head의 실제 preflight가
+  review-only fast-pass를 허용하는지 확인하고, 허용하지 않으면 전체 해당 CI 완료를 기다린다.
+- 마지막 head SHA·required checks·`MERGEABLE` 상태를 다시 확인하고 GitHub Approve 초안 승인을 받는다.
+  merge는 별도 승인 대상이다. merge 후 원 기여자에게 첫 기여 감사, 기여/보정 구분과 실제 검증을 전달하고,
+  #6635 자동 close 여부를 확인한다. 이 문서 작성 시 이러한 원격 후속 조치는 미실행이다.

--- a/mydocs/pr/archives/pr_6786_review_impl.md
+++ b/mydocs/pr/archives/pr_6786_review_impl.md
@@ -1,0 +1,68 @@
+---
+kind: snapshot
+status: historical
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-09-06
+pr: 6786
+issue: 6635
+---
+
+# PR #6786 collaborator 보정·통합 기록
+
+[검토 판정과 증적](pr_6786_review.md)을 기준으로 원 contributor branch에 최소 보정과 review 기록을
+순서대로 추가한다. 별도 integration PR, source history 재작성, 자동 merge는 이 경로에 포함하지 않는다.
+
+## 승인 범위와 실행 단계
+
+작업지시자는 보정, 검증, 보정 commit push, review 문서 push와 CI 확인까지 요청했다.
+최종 GitHub Approve 리뷰는 **초안을 먼저 보여주고 사용자 승인 후 등록**하도록 경계를 명시했다.
+
+| 단계 | 상태 | 실행 내용 / 완료 조건 |
+| --- | --- | --- |
+| 1. 접수·원 head 검토 | 완료 | `d0179dd0410757aea8d116ba4be7b38438e406e9`, issue #6635, 원 diff·CI·공개 검증 안내 확인 |
+| 2. 격리·권한 확인 | 완료 | 승인된 review worktree, `maintainerCanModify=true`, remote/source/local 시작 SHA 일치 |
+| 3. 보정 | 완료 | hidden 글자색 input의 Tab 제외, 형광펜 Escape 닫기·트리거 focus 복원 |
+| 4. 보정 검증 | 완료 | 신규 회귀 red 7건, green 64건씩 두 모드, unit·responsive·build·계약·manifest 성공 |
+| 5. 코드 push | 완료 | 원 두 commit 보존, `cc21183ab622d13071acfa7be3224903a048526b`를 source branch에 push |
+| 6. 코드 CI | 성공 | 보정 head의 CI, CodeQL, Render Diff, Adapter, Proptest 성공 확인 |
+| 7. archive 문서 | 이 trailing commit | review와 implementation 두 문서만 추가; generated 파일과 다른 작업의 변경은 제외 |
+| 8. 문서 push·최신 checks | 문서 작성 뒤 수행 | LFS 판독, diff/link/merge 검증, remote dry-run, source push, 최신 head 집계 확인 |
+| 9. GitHub Approve | 사용자 승인 대기 | 전체 초안과 최신 검증 상태를 보여준 뒤 명시적 승인 후 등록 |
+| 10. merge·후속 정리 | 미실행 | 별도 승인, 최신 head 재확인, merge SHA 확인, issue 상태·기여자 감사·로컬 정리 |
+
+## commit 경계와 source 보존
+
+| SHA / 제목 | 경계 |
+| --- | --- |
+| `67a5d00b832589fd14ec60e7b10f577c8b949d5c` — `fix(studio): 색상 버튼의 키보드 활성화 복원 (#6635)` | 원 기여자 baba9811, 수정하지 않음 |
+| `d0179dd0410757aea8d116ba4be7b38438e406e9` — `docs(e2e): #6202 회귀 테스트를 목록에 등록` | 원 기여자 baba9811, 수정하지 않음 |
+| `cc21183ab622d13071acfa7be3224903a048526b` — `fix(studio): 색상 도구의 Tab 이동과 Escape 닫기 보완 (#6635)` | collaborator 코드·회귀·MANIFEST 보정 |
+| 이 문서를 포함하는 trailing commit | `mydocs/pr/archives/pr_6786_review.md`, `pr_6786_review_impl.md`만 포함 |
+
+원 source는 `baba9811/rhwp:fix/6635-color-keyboard`다. local review branch는
+`codex/pr6786-color-keyboard-review`, worktree는 `/private/tmp/rhwp-pr6786-review`다.
+루트 checkout의 별도 #6788 작업은 checkout·stage·수정하지 않았다.
+
+코드 push 전 변경 경로의 Git attribute가 LFS 대상이 아님을 확인하고, `git lfs status`, `git diff --check`,
+remote SHA 확인과 `GIT_LFS_SKIP_PUSH=1 git push --dry-run`을 통과했다. 실제 push 후 GitHub PR head와
+remote branch가 보정 SHA로 일치했다. 문서 push도 같은 검사를 적용한다. 다른 hook은 비활성화하지 않는다.
+
+## 보정 내용과 검증 책임
+
+- production 보정은 HTML input attribute 하나와 dropdown에 한정한 Escape 핸들러다.
+- E2E는 양방향 Tab과 trigger/색 없음/다른 색 각각에서 Escape 닫기, 포커스·선택·서식·undo 보존을 검증한다.
+- 보정 전 코드에 새 회귀를 실행해 실패를 확인한 뒤 보정을 복원하고 두 모드 모두 재실행했다.
+- native picker 취소의 사용자 수동 확인은 원 head 결과다. 새 Escape 보정의 자동화 결과와 구분한다.
+- 보정 코드·Rust 입력·workflow를 문서 commit에서 바꾸지 않는다. latest head가 바뀌면 새 diff에 따라
+  검증 범위를 다시 판단하며 과거 CI 결과를 그대로 승계하지 않는다.
+- 선택적 오늘할일 파일의 source/devel add/add 위험과 공개 가이드·전역 접근성 조사 분리 사유는 review에 남겼다.
+
+## rollback과 미완료 원격 조치
+
+보정 회귀가 발견되면 merge를 보류하고 이 보정만 수정하는 새 commit을 만든다. 보정을 철회해야 하면
+`cc21183ab622d13071acfa7be3224903a048526b`의 변경을 revert하는 별도 commit으로 처리한다.
+어떤 경우에도 contributor 두 commit을 rewrite하거나 source branch를 force-push하지 않는다.
+
+Approve 리뷰 등록, merge, PR·issue comment와 close는 실행하지 않았다. 코드 CI와 문서 checks가 모두 성공한
+경우에도 사용자의 최종 리뷰 초안 승인을 기다린다. merge 후 cleanup 때 contributor fork branch는 유지하고,
+검토 전용 worktree·branch·서버·산출물만 범위를 확인해 정리한다.

--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -81,6 +81,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `issue-595.test.mjs` | 진단 | hold | Issue #595 진단 e2e | exam_math.hwp | 수동 | legacy-name · #595 진단 (assertion 0) |
 | `issue-6099-probe.mjs` | 진단 | active | #6099 90° 회전 그림 DOM frame/img 실측과 스크린샷 생성 프로브 | samples 하위 지정 파일 | 수동 | legacy-name · 일회성 실측 프로브 |
 | `issue-6117-cell-underline-canvas2d.test.mjs` | 상시 | active | #6117 표 칸 안 밑줄이 우측 괘선을 넘어 그려지지 않는 Canvas2D 잉크 경계 | issue6117/52690_higher_education_decree.hwp | 수동 | 9쪽 실제 fixture, `output/6117` 증적 |
+| `issue-6202-picture-move-reflow.test.mjs` | 상시 | active | #6202 어울림 그림 이동 뒤 본문 화면 갱신 | 143E433F503322BD33.hwp | 수동 | legacy-name |
 | `line-spacing.test.mjs` | 상시 | active | 줄간격 변경에 따른 페이지 넘김 검증 | — | 수동 |  |
 | `loading-busy-cursor.test.mjs` | 상시 | active | #5740 대형 문서 로딩 중 busy 상태와 wait cursor 표시 계약 | 2025 행정업무운영 편람(최종).hwp | npm e2e:loading-busy-cursor |  |
 | `merged-cell-boundary-drag.test.mjs` | 상시 | active | #6557 세로 병합 셀 표에서 하위 행만 선택하고 열 경계를 드래그 — 선택 필터의 병합 셀 포함·걸친 모든 행의 이웃 보상·균일 결과 무마킹 세 층이 함께 고쳐져야 경계가 전 행에서 같은 x 로 이동 | — | npm e2e:issue-6557-merged-col | dev server 필요 — run-with-vite.mjs 경유 · 증적 [assets/merged-cell-resize-evidence](https://github.com/jeong-sik/rhwp/tree/assets/merged-cell-resize-evidence) |

--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -129,7 +129,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `theme-auto-dark.test.mjs` | 상시 | active | Chrome Auto Dark Mode 대응 | — | 수동 |  |
 | `theme-bootstrap.test.mjs` | 상시 | active | 초기 테마 bootstrap | — | 수동 |  |
 | `theme-mode.test.mjs` | 상시 | active | 보기 > 테마 | — | 수동 |  |
-| `toolbar-color-activation-issue6635.test.mjs` | 상시 | active | #6635 색상 버튼 Enter/Space·마우스 활성화, 선택 보존과 색 적용·undo | 없음 | npm e2e:issue-6635 | dev server 필요, native picker 창 표시는 별도 검증 |
+| `toolbar-color-activation-issue6635.test.mjs` | 상시 | active | #6635 색상 버튼 Enter/Space·마우스 활성화, Tab 이동·Esc 닫기·포커스 복원, 선택 보존과 색 적용·undo | 없음 | npm e2e:issue-6635 | dev server 필요, native picker 창 표시는 별도 검증 |
 | `toolbox-visibility.test.mjs` | 상시 | active | 기본 도구 상자 접기/펴기와 표시 상태 저장·복원 | — | npm e2e:toolbox-visibility |  |
 | `topmost-hittest.test.mjs` | 상시 | active | E2E 테스트 (Issue #1280 v2): 겹침 클릭 = "최상단 개체" 선택 | textbox-under-image.hwp | 수동 |  |
 | `topmost-lifecycle.test.mjs` | 상시 | active | E2E 테스트 (Issue #1280 v2): 겹침 최상단 선택 → 연산 lifecycle | textbox-under-image.hwp | 수동 |  |

--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -128,6 +128,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `theme-auto-dark.test.mjs` | 상시 | active | Chrome Auto Dark Mode 대응 | — | 수동 |  |
 | `theme-bootstrap.test.mjs` | 상시 | active | 초기 테마 bootstrap | — | 수동 |  |
 | `theme-mode.test.mjs` | 상시 | active | 보기 > 테마 | — | 수동 |  |
+| `toolbar-color-activation-issue6635.test.mjs` | 상시 | active | #6635 색상 버튼 Enter/Space·마우스 활성화, 선택 보존과 색 적용·undo | 없음 | npm e2e:issue-6635 | dev server 필요, native picker 창 표시는 별도 검증 |
 | `toolbox-visibility.test.mjs` | 상시 | active | 기본 도구 상자 접기/펴기와 표시 상태 저장·복원 | — | npm e2e:toolbox-visibility |  |
 | `topmost-hittest.test.mjs` | 상시 | active | E2E 테스트 (Issue #1280 v2): 겹침 클릭 = "최상단 개체" 선택 | textbox-under-image.hwp | 수동 |  |
 | `topmost-lifecycle.test.mjs` | 상시 | active | E2E 테스트 (Issue #1280 v2): 겹침 최상단 선택 → 연산 lifecycle | textbox-under-image.hwp | 수동 |  |

--- a/rhwp-studio/e2e/responsive.test.mjs
+++ b/rhwp-studio/e2e/responsive.test.mjs
@@ -415,7 +415,7 @@ async function run() {
           const charfxOpened = charfxDropdown.classList.contains('open');
           charfxItem.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
 
-          highlightButton.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+          highlightButton.click();
           const highlightOpened = highlightDropdown.classList.contains('open');
           highlightSwatch.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
 

--- a/rhwp-studio/e2e/toolbar-color-activation-issue6635.test.mjs
+++ b/rhwp-studio/e2e/toolbar-color-activation-issue6635.test.mjs
@@ -1,0 +1,155 @@
+/**
+ * #6635: 실제 Tab/Enter/Space와 마우스로 색상 버튼을 활성화한다.
+ * native picker의 OS 창 표시는 검사하지 않는다. input으로 전달되는 click을 관찰하고,
+ * 색상 적용 검증에서만 picker의 input 이벤트를 대신 전달한다.
+ */
+import {
+  assert, clickEditArea, createNewDocument, runTest, setTestCase, typeText,
+} from './helpers.mjs';
+
+const OTHER = '#highlight-palette button:nth-of-type(2)';
+const NONE = '#highlight-palette button:first-of-type';
+const PICKER = '#highlight-palette input[type="color"]';
+
+async function tabTo(page, selector) {
+  await page.click('#font-size');
+  for (let i = 0; i < 30; i++) {
+    await page.keyboard.press('Tab');
+    if (await page.$eval(selector, element => element === document.activeElement)) return;
+  }
+  throw new Error(`Tab으로 버튼에 도달하지 못함: ${selector}`);
+}
+
+async function isOpen(page) {
+  return page.$eval('#highlight-dropdown', element => element.classList.contains('open'));
+}
+
+async function openPalette(page) {
+  if (!await isOpen(page)) await page.click('#btn-highlight');
+}
+
+async function selection(page) {
+  return page.evaluate(() => JSON.stringify(window.__inputHandler.cursor.getSelection()));
+}
+
+async function properties(page) {
+  return page.evaluate(() => window.__wasm.getCharPropertiesAt(0, 0, 1));
+}
+
+async function selectText(page) {
+  await clickEditArea(page);
+  await page.keyboard.down('Control');
+  await page.keyboard.press('KeyA');
+  await page.keyboard.up('Control');
+}
+
+runTest('색상 버튼 표준 활성화와 선택 보존 (#6635)', async ({ page }) => {
+  // 처음 실행하는 브라우저에서도 실제 버튼으로 스킨 안내를 마친다.
+  if (await page.$('.skin-onboarding-card')) {
+    await page.click('.skin-onboarding-card');
+    await page.click('.dialog-btn-primary');
+  }
+  await createNewDocument(page);
+  await clickEditArea(page);
+  await typeText(page, 'color selection');
+  await selectText(page);
+  const selected = await selection(page);
+  assert(selected !== 'null', '본문 텍스트 선택이 존재한다');
+  const before = await properties(page);
+  const undoDepth = await page.evaluate(() => window.__inputHandler.history.undoStack.length);
+
+  await page.evaluate(() => {
+    window.__colorPickerClicks = { text: 0, highlight: 0 };
+    document.querySelector('#text-color-picker').addEventListener('click', () => {
+      window.__colorPickerClicks.text++;
+    });
+    document.querySelector('#highlight-palette input[type="color"]').addEventListener('click', () => {
+      window.__colorPickerClicks.highlight++;
+    });
+  });
+
+  for (const key of ['Enter', 'Space']) {
+    setTestCase(`${key}: Tab으로 이동한 세 버튼의 표준 활성화`);
+    await tabTo(page, '#btn-text-color');
+    const beforeText = await page.evaluate(() => window.__colorPickerClicks.text);
+    await page.keyboard.press(key);
+    assert(await page.evaluate(() => window.__colorPickerClicks.text) === beforeText + 1,
+      `${key}: 글자색 input이 정확히 한 번 활성화된다`);
+    await page.keyboard.press('Escape');
+
+    await tabTo(page, '#btn-highlight');
+    await page.keyboard.press(key);
+    assert(await isOpen(page), `${key}: 형광펜 팔레트가 열린다`);
+    await page.keyboard.press(key);
+    assert(!await isOpen(page), `${key}: 다시 누르면 팔레트가 닫힌다`);
+
+    await tabTo(page, '#btn-highlight');
+    await openPalette(page);
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    assert(await page.$eval(OTHER, element => element === document.activeElement), '다른 색 버튼에 포커스');
+    const beforeOther = await page.evaluate(() => window.__colorPickerClicks.highlight);
+    await page.keyboard.press(key);
+    assert(await page.evaluate(() => window.__colorPickerClicks.highlight) === beforeOther + 1,
+      `${key}: 다른 색 input이 정확히 한 번 활성화된다`);
+    await page.keyboard.press('Escape');
+    assert(await selection(page) === selected, `${key}: 선택 영역이 보존된다`);
+    await page.click('#btn-highlight');
+  }
+
+  setTestCase('마우스 활성화와 유효한 색상 input 구조');
+  for (const [button, counter] of [['#btn-text-color', 'text'], [OTHER, 'highlight']]) {
+    if (counter === 'highlight') await openPalette(page);
+    const before = await page.evaluate(name => window.__colorPickerClicks[name], counter);
+    await page.click(button);
+    assert(await page.evaluate(name => window.__colorPickerClicks[name], counter) === before + 1,
+      `마우스: ${counter} input이 정확히 한 번 활성화된다`);
+    await page.keyboard.press('Escape');
+    assert(await selection(page) === selected, `마우스: ${counter} 선택 영역 보존`);
+  }
+  assert(await page.$eval(PICKER, input => !input.closest('button')), 'color input은 button에 중첩되지 않는다');
+  assert(JSON.stringify(await properties(page)) === JSON.stringify(before), '색을 고르지 않으면 서식이 바뀌지 않는다');
+  assert(await page.evaluate(() => window.__inputHandler.history.undoStack.length) === undoDepth,
+    '열기와 취소만으로 undo 기록이 생기지 않는다');
+
+  setTestCase('선택한 글자에 색 적용, 색 없음 키보드 활성화와 undo');
+  await page.$eval(PICKER, input => {
+    input.value = '#00ff00';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  assert((await properties(page)).shadeColor === '#00ff00', '선택한 글자에 사용자 지정 형광펜 색이 적용된다');
+  assert(!await isOpen(page), '색 적용 후 팔레트가 닫힌다');
+  assert(await page.evaluate(() => window.__inputHandler.history.undoStack.length) === undoDepth + 1,
+    '색 적용은 undo 한 단계다');
+  assert(await page.evaluate(() => document.activeElement === window.__inputHandler.textarea),
+    '색 적용 후 편집기 입력 포커스가 복원된다');
+  assert(await selection(page) === selected, '색 적용 후 선택 범위가 보존된다');
+
+  for (const activation of ['Enter', 'Space', 'mouse']) {
+    // 본문 서식 undo는 기존 계약상 선택을 해제한다. 다음 적용 전에 다시 선택한다.
+    await selectText(page);
+    await tabTo(page, '#btn-highlight');
+    await openPalette(page);
+    await page.keyboard.press('Tab');
+    assert(await page.$eval(NONE, element => element === document.activeElement), '색 없음 버튼에 포커스');
+    if (activation === 'mouse') await page.click(NONE);
+    else await page.keyboard.press(activation);
+    assert((await properties(page)).shadeColor === '#ffffff', `${activation}: 색 없음이 적용된다`);
+    assert(!await isOpen(page), `${activation}: 색 없음 적용 후 팔레트가 닫힌다`);
+    await page.evaluate(() => window.__inputHandler.performUndo());
+    assert((await properties(page)).shadeColor === '#00ff00', `${activation}: undo로 형광펜 색이 복원된다`);
+  }
+  await page.evaluate(() => window.__inputHandler.performUndo());
+  assert((await properties(page)).shadeColor === before.shadeColor, 'undo로 원래 서식이 복원된다');
+
+  setTestCase('글자색 적용과 undo');
+  await selectText(page);
+  await page.$eval('#text-color-picker', input => {
+    input.value = '#ff0000';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  assert((await properties(page)).textColor === '#ff0000', '선택한 글자에 글자색이 적용된다');
+  assert(await selection(page) === selected, '글자색 적용 후 선택 범위가 보존된다');
+  await page.evaluate(() => window.__inputHandler.performUndo());
+  assert((await properties(page)).textColor === before.textColor, 'undo로 원래 글자색이 복원된다');
+});

--- a/rhwp-studio/e2e/toolbar-color-activation-issue6635.test.mjs
+++ b/rhwp-studio/e2e/toolbar-color-activation-issue6635.test.mjs
@@ -58,6 +58,40 @@ runTest('색상 버튼 표준 활성화와 선택 보존 (#6635)', async ({ page
   const before = await properties(page);
   const undoDepth = await page.evaluate(() => window.__inputHandler.history.undoStack.length);
 
+  setTestCase('숨겨진 색상 input을 건너뛰는 양방향 Tab 이동');
+  await tabTo(page, '#btn-text-color');
+  await page.keyboard.press('Tab');
+  assert(await page.$eval('#btn-highlight', button => button === document.activeElement),
+    '글자색에서 Tab 한 번으로 형광펜 버튼에 도달한다');
+  await tabTo(page, '#btn-highlight');
+  await page.keyboard.down('Shift');
+  await page.keyboard.press('Tab');
+  await page.keyboard.up('Shift');
+  assert(await page.$eval('#btn-text-color', button => button === document.activeElement),
+    '형광펜에서 Shift+Tab 한 번으로 글자색 버튼에 도달한다');
+
+  for (const [target, tabs] of [['형광펜 버튼', 0], ['색 없음', 1], ['다른 색', 2]]) {
+    setTestCase(`${target}: Escape로 닫기와 포커스·선택 보존`);
+    await tabTo(page, '#btn-highlight');
+    await page.keyboard.press('Enter');
+    assert(await isOpen(page), `${target}: 키보드로 팔레트가 열린다`);
+    for (let i = 0; i < tabs; i++) await page.keyboard.press('Tab');
+    const selector = tabs === 0 ? '#btn-highlight' : tabs === 1 ? NONE : OTHER;
+    assert(await page.$eval(selector, button => button === document.activeElement),
+      `${target}: Escape를 누를 요소에 포커스가 있다`);
+    await page.keyboard.press('Escape');
+    assert(!await isOpen(page), `${target}: Escape로 팔레트가 닫힌다`);
+    assert(await page.$eval('#btn-highlight', button => button === document.activeElement),
+      `${target}: 형광펜 버튼으로 포커스가 복원된다`);
+    assert(await selection(page) === selected, `${target}: 선택 영역이 보존된다`);
+    assert(JSON.stringify(await properties(page)) === JSON.stringify(before),
+      `${target}: 닫기만으로 서식이 바뀌지 않는다`);
+    assert(await page.evaluate(() => window.__inputHandler.history.undoStack.length) === undoDepth,
+      `${target}: 닫기만으로 undo 기록이 생기지 않는다`);
+    // 수정 전 실패를 확인할 때도 다음 사례의 시작 상태를 일정하게 유지한다.
+    if (await isOpen(page)) await page.click('#btn-highlight');
+  }
+
   await page.evaluate(() => {
     window.__colorPickerClicks = { text: 0, highlight: 0 };
     document.querySelector('#text-color-picker').addEventListener('click', () => {

--- a/rhwp-studio/index.html
+++ b/rhwp-studio/index.html
@@ -625,7 +625,7 @@
                   <span class="sb-color-visual"><span class="sb-ga">가</span><span id="color-bar"></span></span>
                   <span class="sb-dd">▾</span>
                 </button>
-                <input id="text-color-picker" type="color" value="#000000" aria-label="글자 색 선택" />
+                <input id="text-color-picker" type="color" value="#000000" tabindex="-1" aria-label="글자 색 선택" />
               </span>
               <!-- 형광펜 -->
               <span id="highlight-dropdown" class="sb-dropdown">

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -23,6 +23,7 @@
     "gate:bridge:quick": "node ../scripts/gate_bridge.mjs --no-e2e --no-hwpctrl-gate",
     "e2e": "node e2e/text-flow.test.mjs",
     "e2e:toolbox-visibility": "node e2e/toolbox-visibility.test.mjs --mode=headless",
+    "e2e:issue-6635": "node e2e/run-with-vite.mjs -- node e2e/toolbar-color-activation-issue6635.test.mjs --mode=headless",
     "e2e:form-edit-escape": "node e2e/form-edit-escape-cancel.test.mjs --mode=headless",
     "e2e:unsaved-guard": "node e2e/unsaved-changes-guard.test.mjs",
     "e2e:undo": "node e2e/undo-contracts.test.mjs",

--- a/rhwp-studio/src/ui/toolbar.ts
+++ b/rhwp-studio/src/ui/toolbar.ts
@@ -443,6 +443,14 @@ export class Toolbar {
       this.highlightDropdown.classList.toggle('open');
     });
 
+    this.highlightDropdown.addEventListener('keydown', (event) => {
+      if (event.key !== 'Escape' || !this.highlightDropdown.classList.contains('open')) return;
+      event.preventDefault();
+      event.stopPropagation();
+      this.highlightDropdown.classList.remove('open');
+      this.btnHighlight.focus();
+    });
+
     // 외부 클릭 시 닫기
     document.addEventListener('mousedown', (e) => {
       if (!this.highlightDropdown.contains(e.target as Node)) {

--- a/rhwp-studio/src/ui/toolbar.ts
+++ b/rhwp-studio/src/ui/toolbar.ts
@@ -346,8 +346,11 @@ export class Toolbar {
 
   /** 글자색 피커 이벤트 */
   private setupColorPicker(): void {
+    // 선택은 mousedown에서 보존하고, 키보드도 발생시키는 click에서 활성화한다.
     this.btnTextColor.addEventListener('mousedown', (e) => {
       e.preventDefault();
+    });
+    this.btnTextColor.addEventListener('click', () => {
       this.colorPicker.click();
     });
 
@@ -379,6 +382,8 @@ export class Toolbar {
     btnNone.textContent = '색 없음';
     btnNone.addEventListener('mousedown', (e) => {
       e.preventDefault();
+    });
+    btnNone.addEventListener('click', () => {
       this.highlightColor = '#ffffff';
       this.highlightBar.style.background = '#ffffff';
       this.eventBus.emit('format-char', { shadeColor: '#ffffff' } as CharProperties);
@@ -388,11 +393,14 @@ export class Toolbar {
     btnOther.textContent = '다른 색...';
     const hiddenPicker = document.createElement('input');
     hiddenPicker.type = 'color';
+    hiddenPicker.tabIndex = -1;
+    hiddenPicker.setAttribute('aria-label', '형광펜 색 선택');
     hiddenPicker.value = this.highlightColor;
     hiddenPicker.style.cssText = 'position:absolute;width:0;height:0;opacity:0;';
-    btnOther.appendChild(hiddenPicker);
     btnOther.addEventListener('mousedown', (e) => {
       e.preventDefault();
+    });
+    btnOther.addEventListener('click', () => {
       hiddenPicker.click();
     });
     hiddenPicker.addEventListener('input', () => {
@@ -403,6 +411,7 @@ export class Toolbar {
     });
     actRow.appendChild(btnNone);
     actRow.appendChild(btnOther);
+    actRow.appendChild(hiddenPicker);
     palette.appendChild(actRow);
 
     // 색상 스워치 행들
@@ -429,6 +438,8 @@ export class Toolbar {
     this.btnHighlight.addEventListener('mousedown', (e) => {
       e.preventDefault();
       e.stopPropagation();
+    });
+    this.btnHighlight.addEventListener('click', () => {
       this.highlightDropdown.classList.toggle('open');
     });
 


### PR DESCRIPTION
## 변경 요약

글자색·형광펜·‘다른 색’ 버튼이 `mousedown`에서만 동작해 Enter/Space로 활성화되지 않는 문제를 고칩니다. 선택 보존용 mousedown 처리는 유지하고 명령을 표준 click으로 옮깁니다. 같은 원인의 ‘색 없음’ 버튼도 함께 수정하고, ‘다른 색’의 color input을 button 밖으로 이동합니다.

실제 키보드·마우스 활성화, 선택 보존, 취소 시 무변경, 색 적용과 undo를 확인하는 E2E를 추가했습니다. 기존 반응형 테스트의 형광펜 활성화도 표준 click 기준으로 갱신했습니다. E2E 목록 검사에서 발견한 기존 #6202 테스트의 등록 누락은 별도 커밋으로 MANIFEST 한 줄만 보완했습니다.

## 관련 이슈

Closes #6635

## 테스트

기준 devel: `51ad998e33ef7f5191b0e1b0b656dc44cef33a1c`. 로컬 커밋: `d0179dd0410757aea8d116ba4be7b38438e406e9`.

- [x] `CHROME_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' npm --prefix rhwp-studio run e2e:issue-6635`: 플러그인을 포함한 기본 구성에서 41 assertion 통과. `RHWP_WITHOUT_HWPCTRL=1` 구성에서도 41개 통과. 수정 전 Enter/Space 실패를 실제 Chrome에서 확인했습니다.
- [x] `CHROME_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' VITE_PORT=7731 npm --prefix rhwp-studio run e2e:responsive`: 1,082개 통과, 실패 0.
- [x] `npm --prefix rhwp-studio test`: 1,425 통과, 기존 skip 1, 실패 0.
- [x] `(cd rhwp-studio && npx tsc --noEmit)`: 통과.
- [x] `npm --prefix rhwp-studio run build` 및 `build:no-hwpctrl`: 두 구성의 TypeScript·production build 통과.
- [x] `node --test scripts/frontend-wasm-bindings.test.mjs scripts/frontend-editor-embed.test.mjs`: 3개 계약 검사 통과.
- [x] `python3 scripts/check_e2e_manifest.py`: 128개 / 128행, 오류 0.
- [x] `CARGO_BUILD_JOBS=4 CARGO_TARGET_DIR=target/pr-review scripts/wasm-pack-locked.sh --target web --out-dir pkg --no-opt`: 새 WASM 빌드 통과. Docker 최적화 빌드가 아닌 native 진단 빌드입니다.
- [x] `CARGO_TARGET_DIR=target/pr-review cargo clippy --locked -- -D warnings`: 통과.
- [x] `CARGO_TARGET_DIR=target/pr-review cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown -- -D warnings`: 통과.
- [x] `git diff --check`: 통과.
- [ ] `cargo fmt --all -- --check`: source checkout에 파생 suite 28개가 없어 실패했습니다. Rust 소스와 Cargo.toml은 변경하지 않았습니다. CONTRIBUTING의 외부 기여자 지침에 따라 파생 suite는 생성하지 않았으며, 이 검사를 통과한 것으로 집계하지 않습니다.

Chrome 152.0.7977.82, Node 25.2.1, Rust 1.93.1, wasm-pack 0.15.0에서 실행했습니다. 마지막 upstream 갱신은 검토 문서 한 개뿐이며 검사한 프로덕션 코드·단위 테스트·의존성·Rust 입력은 최종 diff와 같습니다. 색상 E2E 마우스 사례 추가와 기존 반응형 테스트 갱신 후 해당 E2E들을 각각 다시 실행했습니다. Rust workspace 전체 build/Clippy/nextest는 미실행입니다.

Headed Chromium 151.0.7922.171에서는 실제 형광펜 팔레트 표시와 swatch 선택·선택 보존·undo를 확인했습니다. 네이티브 색상 창은 브라우저 도구에서 관찰할 수 없었습니다. E2E는 실제 버튼 입력이 color input을 한 번 활성화하는지 확인하며, 색 적용 검증에서만 input 이벤트를 대신 전달합니다. 네이티브 창 표시나 그 창에서의 색 선택까지 검증했다고 주장하지 않습니다. 공개 sample 파일 대신 새 빈 문서에 직접 입력한 텍스트를 사용했습니다.

## 외부 기여자 검증 절차 확인

`cargo fmt --all -- --check`는 `tests/generated/regression_suite_001.rs`부터 028까지 없다는 오류로 실패했습니다. [CONTRIBUTING.md](https://github.com/edwardkim/rhwp/blob/51ad998e33ef7f5191b0e1b0b656dc44cef33a1c/CONTRIBUTING.md)는 이 검사를 제출 전 필수로 두면서 일반 기여자의 source checkout에서는 파생 suite를 준비하지 말라고 안내합니다.

이번 변경의 CI classifier 결과는 `rust_required=false`, `frontend_mode=package`이며 Rust 소스와 Cargo.toml은 변경하지 않았습니다. 위 지침을 함께 충족할 수 있도록, 이 Studio PR에 적용할 검증 범위와 파생 suite를 생성하지 않는 외부 기여자의 포맷 검사 절차를 확인 부탁드립니다. 실패한 검사를 통과로 표시하거나 파생 파일을 PR에 포함하지 않았습니다.

## 성능 영향 및 측정 결과

이벤트 처리 위치와 DOM 부모만 변경하며 새 의존성은 없습니다. 성능 영향은 예상하지 않으며 별도 성능 측정은 하지 않았습니다.
