### PR TITLE
Task #6806: objectProps setter 가 값이 바뀔 때만 파생 상태를 따라가게 한다 — get∘set 항등 복원

### DIFF
--- a/src/document_core/commands/object_ops/common.rs
+++ b/src/document_core/commands/object_ops/common.rs
@@ -1,6 +1,5 @@
 //! 공통 개체 속성/헬퍼 + 새 번호 (object_ops 분할, #1904).
 
-use super::MIN_SHAPE_SIZE;
 use crate::document_core::DocumentCore;
 use crate::error::HwpError;
 use crate::model::control::Control;
@@ -199,11 +198,12 @@ impl DocumentCore {
     ) {
         use crate::document_core::helpers::{json_bool, json_i16, json_str, json_u32};
 
+        // [#6806] 퇴화값 0 만 최소 크기로 올린다 — 한컴 문서에는 200 미만 치수가 정당하게 있다.
         if let Some(w) = json_u32(props_json, "width") {
-            c.width = w.max(MIN_SHAPE_SIZE);
+            c.width = super::clamp_degenerate_size(w);
         }
         if let Some(h) = json_u32(props_json, "height") {
-            c.height = h.max(MIN_SHAPE_SIZE);
+            c.height = super::clamp_degenerate_size(h);
         }
         if let Some(tac) = json_bool(props_json, "treatAsChar") {
             c.treat_as_char = tac;
@@ -257,12 +257,13 @@ impl DocumentCore {
                 _ => c.text_wrap,
             };
         }
+        // [#6806] 「쪽 영역 안으로 제한」과 「서로 겹침 허용」은 독립이다 — 한컴은 둘을 동시에 켜서
+        // 저장한다(corpus 그림 70·도형 12·표 39건). 종전의 "제한이면 겹침 해제" 결합은 파싱 경로에는
+        // 없고 setter 에만 있어, 같은 봉지를 되먹이는 것만으로 겹침 허용이 꺼졌다.
         if let Some(v) = json_bool(props_json, "restrictInPage") {
             c.flow_with_text = v;
             if v {
                 c.attr |= 1 << 13;
-                c.allow_overlap = false;
-                c.attr &= !(1 << 14);
             } else {
                 c.attr &= !(1 << 13);
             }
@@ -282,10 +283,6 @@ impl DocumentCore {
             } else {
                 c.attr &= !(1 << 20);
             }
-        }
-        if c.flow_with_text {
-            c.allow_overlap = false;
-            c.attr &= !(1 << 14);
         }
         if let Some(v) = json_u32(props_json, "vertOffset") {
             c.vertical_offset = v;

--- a/src/document_core/commands/object_ops/mod.rs
+++ b/src/document_core/commands/object_ops/mod.rs
@@ -18,3 +18,16 @@ mod table;
 /// Group은 current/original 스케일이 0이 되어 자식이 전부 사라진다.
 /// table_ops의 MIN_CELL_SIZE와 동일한 기준을 사용한다.
 pub(crate) const MIN_SHAPE_SIZE: u32 = 200;
+
+/// [#6806] 크기 봉지의 최소 크기 판정 — **퇴화값 0 만** `MIN_SHAPE_SIZE` 로 올린다.
+///
+/// 클램프의 원 목적은 리사이즈 핸들을 반대편으로 넘길 때 studio 가 보내는 0 이다.
+/// 한컴 문서에는 200 미만 치수(가로선 높이 3·4 등)가 정당하게 저장되어 있으므로
+/// `max(MIN_SHAPE_SIZE)` 는 같은 값 되먹임·undo 봉지까지 부풀렸다.
+pub(crate) fn clamp_degenerate_size(v: u32) -> u32 {
+    if v == 0 {
+        MIN_SHAPE_SIZE
+    } else {
+        v
+    }
+}

--- a/src/document_core/commands/object_ops/picture.rs
+++ b/src/document_core/commands/object_ops/picture.rs
@@ -987,12 +987,18 @@ impl DocumentCore {
         let transform_before = Self::picture_transform_fingerprint(pic);
         let mut rotation_changed = false;
 
-        // 크기 변경
+        // 크기 변경 — [#6806] 키가 있어도 값이 같으면 건드리지 않는다. 종전에는 게터가 낸
+        // 봉지를 그대로 되먹여도 `current_*` 가 `common.*` 로 덮여(파싱값이 1 어긋난 문서가
+        // corpus 에 69건) 지문이 흔들리고 한컴 원본 렌더링 행렬이 지워졌다.
         if let Some(w) = json_u32(props_json, "width") {
-            Self::apply_picture_display_width(pic, w);
+            if w != pic.common.width {
+                Self::apply_picture_display_width(pic, w);
+            }
         }
         if let Some(h) = json_u32(props_json, "height") {
-            Self::apply_picture_display_height(pic, h);
+            if h != pic.common.height {
+                Self::apply_picture_display_height(pic, h);
+            }
         }
 
         // 위치 속성
@@ -1106,10 +1112,14 @@ impl DocumentCore {
             };
         }
 
-        // 회전/대칭
+        // 회전/대칭 — [#6806] "키 존재" 가 아니라 "값 변화" 가 회전 변경이다. 게터는 이 키를
+        // 항상 내보내므로, 종전에는 같은 각도를 되먹여도 `refresh_picture_rotation_layout_for_save`
+        // 가 돌아 `common` 을 `current` 로 다시 세웠다(#6355 지문 판정을 앞단에서 무력화).
         if let Some(v) = json_i16(props_json, "rotationAngle") {
-            pic.shape_attr.rotation_angle = v;
-            rotation_changed = true;
+            if v != pic.shape_attr.rotation_angle {
+                pic.shape_attr.rotation_angle = v;
+                rotation_changed = true;
+            }
         }
         if let Some(v) = json_bool(props_json, "horzFlip") {
             pic.shape_attr.horz_flip = v;

--- a/src/document_core/commands/object_ops/shape.rs
+++ b/src/document_core/commands/object_ops/shape.rs
@@ -397,10 +397,15 @@ impl DocumentCore {
         // 리사이즈 핸들을 반대편으로 끌어당길 때 studio가 width/height=0 을 보내
         // 도형이 렌더러상 사라지는 버그 방어: 최소 크기 clamp.
         let c = shape.common_mut();
+        // [#6806] 클램프는 퇴화값 0(리사이즈 핸들을 반대편으로 넘긴 경우)에만 건다.
+        // 한컴 문서의 가로선은 높이 3·4 로 저장되어 있어(corpus 도형 894 중 95건이 200 미만)
+        // `max(200)` 은 되먹임·undo 봉지의 정당한 값을 200 으로 부풀렸다.
+        let width_before = c.width;
+        let height_before = c.height;
         let new_w = crate::document_core::helpers::json_u32(props_json, "width")
-            .map(|w| w.max(MIN_SHAPE_SIZE));
+            .map(super::clamp_degenerate_size);
         let new_h = crate::document_core::helpers::json_u32(props_json, "height")
-            .map(|h| h.max(MIN_SHAPE_SIZE));
+            .map(super::clamp_degenerate_size);
         Self::apply_common_obj_attr_from_json(c, props_json);
 
         // Polygon/Curve: original_width/height는 생성 시 값으로 유지해야 렌더러의
@@ -423,11 +428,15 @@ impl DocumentCore {
 
         // ShapeComponentAttr 크기/회전/채우기 동기화
         if let Some(d) = shape.drawing_mut() {
-            if let Some(w) = new_w {
+            // [#6806] 값이 실제로 바뀔 때만 `current_*`·`original_*` 를 따라가게 한다.
+            // 게터가 내보내는 `width` 는 `common.width` 라, 종전에는 같은 봉지를 되먹여도
+            // 한컴이 저장한 생성 시 크기(`original_*`)가 현재 크기로 덮였다. Line·Arc 는
+            // `original_*` 가 렌더 스케일 분모라 그 순간 선이 실제로 움직였다.
+            if let Some(w) = new_w.filter(|&w| w != width_before) {
                 d.shape_attr.current_width = w;
                 d.shape_attr.original_width = w;
             }
-            if let Some(h) = new_h {
+            if let Some(h) = new_h.filter(|&h| h != height_before) {
                 d.shape_attr.current_height = h;
                 d.shape_attr.original_height = h;
             }
@@ -619,11 +628,13 @@ impl DocumentCore {
         // Group 리사이즈: original_width 유지, current_width만 변경 (렌더러가 스케일 적용)
         // 한컴 방식: 자식은 변경하지 않고, 컨테이너의 current/original 비율로 스케일 결정
         if let crate::model::shape::ShapeObject::Group(ref mut group) = shape {
-            if let Some(nw) = new_w {
+            // [#6806] 묶음도 값이 바뀔 때만 — 파싱값이 `current ≠ common` 인 묶음(corpus 36건)은
+            // 같은 봉지를 되먹이면 지문이 흔들려 원본 변환 행렬(#6740)이 지워졌다.
+            if let Some(nw) = new_w.filter(|&w| w != width_before) {
                 group.shape_attr.current_width = nw;
                 // original_width는 유지 (스케일 기준)
             }
-            if let Some(nh) = new_h {
+            if let Some(nh) = new_h.filter(|&h| h != height_before) {
                 group.shape_attr.current_height = nh;
             }
             // 회전 중심 갱신 — common 에서 다시 세우므로 무변경 시 멱등이다.
@@ -786,10 +797,15 @@ impl DocumentCore {
             super::common::shape_transform_fingerprint(shape.common(), shape.shape_attr());
 
         let c = shape.common_mut();
+        // [#6806] 클램프는 퇴화값 0(리사이즈 핸들을 반대편으로 넘긴 경우)에만 건다.
+        // 한컴 문서의 가로선은 높이 3·4 로 저장되어 있어(corpus 도형 894 중 95건이 200 미만)
+        // `max(200)` 은 되먹임·undo 봉지의 정당한 값을 200 으로 부풀렸다.
+        let width_before = c.width;
+        let height_before = c.height;
         let new_w = crate::document_core::helpers::json_u32(props_json, "width")
-            .map(|w| w.max(MIN_SHAPE_SIZE));
+            .map(super::clamp_degenerate_size);
         let new_h = crate::document_core::helpers::json_u32(props_json, "height")
-            .map(|h| h.max(MIN_SHAPE_SIZE));
+            .map(super::clamp_degenerate_size);
         Self::apply_common_obj_attr_from_json(c, props_json);
 
         let is_polygon_or_curve = matches!(
@@ -809,11 +825,15 @@ impl DocumentCore {
         };
 
         if let Some(d) = shape.drawing_mut() {
-            if let Some(w) = new_w {
+            // [#6806] 값이 실제로 바뀔 때만 `current_*`·`original_*` 를 따라가게 한다.
+            // 게터가 내보내는 `width` 는 `common.width` 라, 종전에는 같은 봉지를 되먹여도
+            // 한컴이 저장한 생성 시 크기(`original_*`)가 현재 크기로 덮였다. Line·Arc 는
+            // `original_*` 가 렌더 스케일 분모라 그 순간 선이 실제로 움직였다.
+            if let Some(w) = new_w.filter(|&w| w != width_before) {
                 d.shape_attr.current_width = w;
                 d.shape_attr.original_width = w;
             }
-            if let Some(h) = new_h {
+            if let Some(h) = new_h.filter(|&h| h != height_before) {
                 d.shape_attr.current_height = h;
                 d.shape_attr.original_height = h;
             }
@@ -986,10 +1006,11 @@ impl DocumentCore {
         }
 
         if let crate::model::shape::ShapeObject::Group(ref mut group) = shape {
-            if let Some(nw) = new_w {
+            // [#6806] 본문 경로와 동형 — 값이 바뀔 때만.
+            if let Some(nw) = new_w.filter(|&w| w != width_before) {
                 group.shape_attr.current_width = nw;
             }
-            if let Some(nh) = new_h {
+            if let Some(nh) = new_h.filter(|&h| h != height_before) {
                 group.shape_attr.current_height = nh;
             }
             group.shape_attr.rotation_center.x = (group.common.width / 2) as i32;

--- a/tests/cases/issue_6806_getset_identity.rs
+++ b/tests/cases/issue_6806_getset_identity.rs
@@ -1,0 +1,285 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! [#6806] objectProps get∘set 항등 — 게터가 낸 봉지를 그대로 되먹이면 IR·raw·렌더링이
+//! 바뀌지 않아야 한다.
+//!
+//! 표본은 전부 한컴 저장본이고, 각각 결함의 한 층을 판정력 있게 드러낸다.
+//! - 그림 `3-09월_교육_통합_2023.hwp` s0p236c0: 파싱값이 `current_height(7295) ≠ common.height(7296)`.
+//!   종전에는 `rotationAngle` 키 존재만으로 refresh 가 돌고 `height` 키로 `current` 가 덮여
+//!   지문이 흔들려 한컴 원본 렌더링 행렬(146B)이 지워졌다.
+//! - 가로선 `21_언어_기출_편집가능본.hwp` s0p4c0: 높이 4, `original 100×100`. 종전에는 높이가 200 으로
+//!   부풀고 `original` 이 `common` 으로 덮여 렌더 스케일이 바뀌어 424px 선이 1.3px 로 무너졌다.
+//! - 묶음 `text_footnote_tail_overpagination.hwp` s0p4352c1: 높이 76, `current ≠ common`.
+//! - 도형 `143E433F503322BD33.hwp` s0p1c0: 「쪽 영역 제한」과 「겹침 허용」이 동시에 켜진 채 저장됨.
+//!
+//! 대조군은 같은 setter 에 빈 봉지 `{}` — 부수효과(recompose·paginate)는 같고 대입만 없다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+
+fn load(rel: &str) -> DocumentCore {
+    let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    DocumentCore::from_bytes(&std::fs::read(p).expect("표본 로드")).expect("파싱")
+}
+
+fn picture(core: &DocumentCore, si: usize, pi: usize, ci: usize) -> &rhwp::model::image::Picture {
+    match &core.document().sections[si].paragraphs[pi].controls[ci] {
+        Control::Picture(p) => p,
+        _ => panic!("표본 전제 위반: s{si}p{pi}c{ci} 가 그림이 아니다"),
+    }
+}
+
+fn shape(core: &DocumentCore, si: usize, pi: usize, ci: usize) -> &rhwp::model::shape::ShapeObject {
+    match &core.document().sections[si].paragraphs[pi].controls[ci] {
+        Control::Shape(s) => s.as_ref(),
+        _ => panic!("표본 전제 위반: s{si}p{pi}c{ci} 가 도형이 아니다"),
+    }
+}
+
+// ───────────────────────── 그림 ─────────────────────────
+
+const PIC: &str = "samples/3-09월_교육_통합_2023.hwp";
+const PIC_AT: (usize, usize, usize) = (0, 236, 0);
+
+#[test]
+fn picture_getset_keeps_raw_rendering_and_current_size() {
+    let (si, pi, ci) = PIC_AT;
+    let mut core = load(PIC);
+    let before = picture(&core, si, pi, ci);
+    assert_ne!(
+        before.shape_attr.current_height, before.common.height,
+        "표본 전제: current ≠ common 이어야 판정이 의미를 갖는다"
+    );
+    let (raw0, cur_h0, common_h0) = (
+        before.shape_attr.raw_rendering.clone(),
+        before.shape_attr.current_height,
+        before.common.height,
+    );
+    assert!(
+        raw0.len() >= 146,
+        "표본 전제: 한컴 렌더링 행렬이 있어야 한다"
+    );
+
+    let bag = core.get_picture_properties_native(si, pi, ci).expect("get");
+    core.set_picture_properties_native(si, pi, ci, &bag)
+        .expect("set 같은 봉지");
+
+    let after = picture(&core, si, pi, ci);
+    assert_eq!(
+        after.shape_attr.raw_rendering, raw0,
+        "같은 봉지 되먹임이 원본 행렬을 지웠다"
+    );
+    assert_eq!(
+        after.shape_attr.current_height, cur_h0,
+        "current_height 가 common 으로 덮였다"
+    );
+    assert_eq!(after.common.height, common_h0);
+}
+
+#[test]
+fn picture_same_rotation_angle_does_not_refresh_layout() {
+    let (si, pi, ci) = PIC_AT;
+    let mut core = load(PIC);
+    let raw0 = picture(&core, si, pi, ci).shape_attr.raw_rendering.clone();
+    let vo0 = picture(&core, si, pi, ci).common.vertical_offset;
+    let angle = picture(&core, si, pi, ci).shape_attr.rotation_angle;
+
+    core.set_picture_properties_native(si, pi, ci, &format!("{{\"rotationAngle\":{angle}}}"))
+        .expect("같은 각도");
+
+    let after = picture(&core, si, pi, ci);
+    assert_eq!(
+        after.shape_attr.raw_rendering, raw0,
+        "같은 각도인데 회전 재배치가 돌았다"
+    );
+    assert_eq!(
+        after.common.vertical_offset, vo0,
+        "재배치가 오프셋을 재중심화했다"
+    );
+}
+
+#[test]
+fn picture_undo_size_bag_is_identity() {
+    // ResizeObjectCommand.before = { width, height } — 값은 게터의 common.* 다.
+    let (si, pi, ci) = PIC_AT;
+    let mut core = load(PIC);
+    let p0 = picture(&core, si, pi, ci);
+    let (w, h, cur_h0, raw0) = (
+        p0.common.width,
+        p0.common.height,
+        p0.shape_attr.current_height,
+        p0.shape_attr.raw_rendering.clone(),
+    );
+
+    core.set_picture_properties_native(si, pi, ci, &format!("{{\"width\":{w},\"height\":{h}}}"))
+        .expect("undo 봉지");
+
+    let after = picture(&core, si, pi, ci);
+    assert_eq!(after.shape_attr.current_height, cur_h0);
+    assert_eq!(after.shape_attr.raw_rendering, raw0);
+}
+
+#[test]
+fn picture_changed_size_still_applies() {
+    // 되먹임을 막았다고 실제 변경까지 막히면 안 된다.
+    let (si, pi, ci) = PIC_AT;
+    let mut core = load(PIC);
+    let h = picture(&core, si, pi, ci).common.height;
+    core.set_picture_properties_native(si, pi, ci, &format!("{{\"height\":{}}}", h + 400))
+        .expect("실제 변경");
+    let after = picture(&core, si, pi, ci);
+    assert_eq!(after.common.height, h + 400);
+    assert_eq!(
+        after.shape_attr.current_height,
+        h + 400,
+        "실제 변경은 current 도 따라가야 한다"
+    );
+    assert!(
+        after.shape_attr.raw_rendering.is_empty(),
+        "변환이 실제로 바뀌면 원본 행렬은 무효화된다"
+    );
+}
+
+// ───────────────────────── 가로선 ─────────────────────────
+
+const LINE: &str = "samples/21_언어_기출_편집가능본.hwp";
+const LINE_AT: (usize, usize, usize) = (0, 4, 0);
+
+#[test]
+fn thin_line_getset_keeps_height_and_original_size() {
+    let (si, pi, ci) = LINE_AT;
+    let mut core = load(LINE);
+    let s0 = shape(&core, si, pi, ci);
+    let (h0, ow0, oh0) = (
+        s0.common().height,
+        s0.shape_attr().original_width,
+        s0.shape_attr().original_height,
+    );
+    assert!(h0 < 200, "표본 전제: 200 미만 높이의 가로선");
+    assert_ne!(
+        ow0,
+        s0.common().width,
+        "표본 전제: original ≠ common 이어야 스케일 판정이 선다"
+    );
+
+    let bag = core.get_shape_properties_native(si, pi, ci).expect("get");
+    core.set_shape_properties_native(si, pi, ci, &bag)
+        .expect("set 같은 봉지");
+
+    let s1 = shape(&core, si, pi, ci);
+    assert_eq!(s1.common().height, h0, "200 미만 높이가 클램프에 부풀었다");
+    assert_eq!(
+        s1.shape_attr().original_width,
+        ow0,
+        "original_width 가 common 으로 덮였다 — 렌더 스케일 파괴"
+    );
+    assert_eq!(s1.shape_attr().original_height, oh0);
+}
+
+#[test]
+fn thin_line_getset_renders_identically() {
+    // 렌더 스케일 분모(original_*)가 보존되면 SVG 도 같아야 한다 — 대조군은 set({}).
+    let (si, pi, ci) = LINE_AT;
+    let mut control = load(LINE);
+    control
+        .set_shape_properties_native(si, pi, ci, "{}")
+        .expect("대조군");
+    let mut core = load(LINE);
+    let bag = core.get_shape_properties_native(si, pi, ci).expect("get");
+    core.set_shape_properties_native(si, pi, ci, &bag)
+        .expect("set");
+
+    let (a, b) = (
+        control.render_page_svg_native(0).expect("svg"),
+        core.render_page_svg_native(0).expect("svg"),
+    );
+    assert_eq!(a, b, "같은 봉지 되먹임이 0쪽 렌더링을 바꿨다");
+}
+
+#[test]
+fn zero_size_still_clamps_to_min() {
+    // 클램프의 원 목적(핸들을 반대편으로 넘겨 0 이 오는 경우)은 유지한다.
+    let (si, pi, ci) = LINE_AT;
+    let mut core = load(LINE);
+    core.set_shape_properties_native(si, pi, ci, r#"{"width":0,"height":0}"#)
+        .expect("0 크기");
+    let s = shape(&core, si, pi, ci);
+    assert!(
+        s.common().width >= 200 && s.common().height >= 200,
+        "퇴화값 0 은 최소 크기로 올라야 한다"
+    );
+}
+
+// ───────────────────────── 묶음 ─────────────────────────
+
+#[test]
+fn group_getset_keeps_raw_rendering() {
+    let rel = "samples/task1725/text_footnote_tail_overpagination.hwp";
+    let (si, pi, ci) = (0, 4352, 1);
+    let mut core = load(rel);
+    let g0 = shape(&core, si, pi, ci);
+    assert!(
+        matches!(g0, rhwp::model::shape::ShapeObject::Group(_)),
+        "표본 전제: 묶음"
+    );
+    assert_ne!(
+        g0.shape_attr().current_height,
+        g0.common().height,
+        "표본 전제: current ≠ common"
+    );
+    let (raw0, h0, cur_h0) = (
+        g0.shape_attr().raw_rendering.clone(),
+        g0.common().height,
+        g0.shape_attr().current_height,
+    );
+    assert!(raw0.len() >= 146);
+
+    let bag = core.get_shape_properties_native(si, pi, ci).expect("get");
+    core.set_shape_properties_native(si, pi, ci, &bag)
+        .expect("set");
+
+    let g1 = shape(&core, si, pi, ci);
+    assert_eq!(
+        g1.shape_attr().raw_rendering,
+        raw0,
+        "묶음 원본 변환 행렬(#6740)이 지워졌다"
+    );
+    assert_eq!(g1.common().height, h0, "높이 76 이 200 으로 부풀었다");
+    assert_eq!(g1.shape_attr().current_height, cur_h0);
+}
+
+// ───────────────────────── 겹침 허용 ─────────────────────────
+
+#[test]
+fn restrict_in_page_does_not_force_allow_overlap_off() {
+    let (si, pi, ci) = (0, 1, 0);
+    let mut core = load("samples/143E433F503322BD33.hwp");
+    let c0 = shape(&core, si, pi, ci).common();
+    assert!(
+        c0.flow_with_text && c0.allow_overlap,
+        "표본 전제: 한컴이 둘을 동시에 켜서 저장한 개체"
+    );
+    let attr0 = c0.attr;
+
+    let bag = core.get_shape_properties_native(si, pi, ci).expect("get");
+    assert!(bag.contains("\"allowOverlap\":true"));
+    core.set_shape_properties_native(si, pi, ci, &bag)
+        .expect("set");
+
+    let c1 = shape(&core, si, pi, ci).common();
+    assert!(c1.allow_overlap, "같은 봉지 되먹임이 겹침 허용을 껐다");
+    assert_eq!(c1.attr, attr0, "attr bit 14 가 지워졌다");
+    let bag2 = core.get_shape_properties_native(si, pi, ci).expect("get");
+    assert!(bag2.contains("\"allowOverlap\":true"));
+}
+
+#[test]
+fn allow_overlap_can_still_be_turned_off_explicitly() {
+    let (si, pi, ci) = (0, 1, 0);
+    let mut core = load("samples/143E433F503322BD33.hwp");
+    core.set_shape_properties_native(si, pi, ci, r#"{"allowOverlap":false}"#)
+        .expect("명시 해제");
+    let c = shape(&core, si, pi, ci).common();
+    assert!(!c.allow_overlap);
+    assert_eq!(c.attr & (1 << 14), 0);
+}


### PR DESCRIPTION
관련 이슈: #6806

## 문제

`get_*_properties_native` 가 낸 봉지를 그대로 `set_*_properties_native` 에 되먹이면 IR·raw·렌더링이 바뀐다 — get∘set 이 항등이 아니다. 그림은 한컴 원본 렌더링 행렬(146B)이 지워지고, 도형은 `current_*`·`original_*` 이 `common` 으로 덮이며 200 미만 치수가 200 으로 부풀고, 「쪽 영역 제한」이 켜진 개체의 「겹침 허용」이 꺼진다. Line·Arc 는 `original_*` 이 렌더 스케일 분모라 **선이 실제로 움직인다**(424px 가로선이 1.3px 로). 크기 조절 undo 가 `{width, height}` 봉지로 이 경로를 밟아 역연산이 아니다.

## 원인

setter 다섯 곳이 "키가 있으면 변경" 으로 판정하거나 한컴 파일과 어긋나는 불변식을 강제한다(#6806 원인 (1)~(4)·(6)).

| 층 | 자리 | 종전 |
|---|---|---|
| (1) | `picture.rs` `apply_picture_props_inner` | `rotationAngle` 키가 **있기만 하면** `rotation_changed = true` → `refresh_picture_rotation_layout_for_save` → `common` 재설정 → 지문 변화 → `raw_rendering.clear()` |
| (2) | `picture.rs` `apply_picture_display_*`, `shape.rs` 본문·셀 경로 ×2, 묶음 ×2 | `width`/`height` 키가 있으면 값이 같아도 `current_* = w`, `original_* = w` |
| (3) | (2) 의 결과 | Line·Arc 렌더러가 `original_*` 을 스케일 분모로 씀 → `sx` 가 `common/original` → `1.0` |
| (4) | `mod.rs` `MIN_SHAPE_SIZE`, `shape.rs` ×2, `common.rs` `apply_common_obj_attr_from_json` | `w.max(200)` — 한컴 문서의 가로선(높이 3·4)까지 200 으로 |
| (6) | `common.rs` `apply_common_obj_attr_from_json` 끝 | `if c.flow_with_text { allow_overlap = false }` — 봉지에 무엇이 있든 실행 |

지문 판정(#6355·#6740) 자체는 정상 동작한다. 판정 **앞단**에서 setter 가 값을 스스로 흔든 것이 문제다.

## 변경

원칙 하나 — **값이 실제로 바뀔 때만 파생 상태를 따라가게 한다.** 되먹임·undo 봉지는 값이 같으므로 아무것도 건드리지 않는다.

- **(1)** `rotationAngle` 은 `v != rotation_angle` 일 때만 대입·refresh.
- **(2)** 그림: `w != common.width` 일 때만 `apply_picture_display_width`(높이 동형). 도형·묶음: `apply_common_obj_attr_from_json` 전에 `width_before/height_before` 를 잡고 `new_w.filter(|w| w != width_before)` 로만 `current_*`·`original_*` 갱신 — 본문·셀 경로 4곳 동형.
- **(3)** (2) 로 해소 — `original_*` 이 보존되면 스케일 분모가 그대로다.
- **(4)** `MIN_SHAPE_SIZE` 클램프를 **퇴화값 0 에만** 건다(`clamp_degenerate_size`). 클램프의 원 목적(핸들을 반대편으로 넘겨 0 이 오는 경우)은 유지되고, 정당한 200 미만 치수는 통과한다. 도형 두 곳과 공용 `apply_common_obj_attr_from_json` 이 같은 헬퍼를 쓴다.
- **(6)** 「쪽 영역 제한」→「겹침 허용 해제」 결합 두 곳을 제거. 둘은 한컴에서 독립이고 파서는 둘 다 읽어 오므로, 파싱 경로와 setter 경로가 같아진다. 명시적 `allowOverlap:false` 는 그대로 동작한다.

Rust 4파일, 순수 setter 판정 변경. 직렬화기·렌더러·studio 는 건드리지 않았다.

회귀 테스트 `tests/cases/issue_6806_getset_identity.rs` 10건 — 표본 넷이 각각 한 층을 판정력 있게 드러낸다.

| 표본 | 층 | 시험 |
|---|---|---|
| `3-09월_교육_통합_2023.hwp` s0p236c0 (그림, `current_h 7295 ≠ common_h 7296`) | (1)(2) | get∘set 이 행렬·`current_height` 보존 / 같은 각도는 refresh 없음 / undo 봉지 항등 / **실제 변경은 여전히 적용** |
| `21_언어_기출_편집가능본.hwp` s0p4c0 (가로선 높이 4, `original 100×100`) | (2)(3)(4) | 높이·`original` 보존 / **0쪽 SVG 가 대조군과 동일** / `{"width":0,"height":0}` 은 여전히 200 으로 |
| `text_footnote_tail_overpagination.hwp` s0p4352c1 (묶음, 높이 76) | (2)(4)+지문 | 행렬·높이·`current` 보존 |
| `143E433F503322BD33.hwp` s0p1c0 (제한∧겹침허용 동시) | (6) | 되먹임에 `allow_overlap`·`attr` 보존 / 명시 해제는 동작 |

## 검증

devel `016fe3cee` 기준.

**수정 전 실패 증명** — 위 10건을 수정 전 devel 에서 돌리면 🔴 **7건 실패 / 3건 통과** — 실패한 7건이 되먹임·undo 항등이고, 통과한 3건은 "실제 변경은 여전히 적용"·"0 은 여전히 클램프"·"명시 해제는 동작" 이라는 대조 시험이다(수정 전에도 통과해야 맞다). 실측 근거는 #6806 본문(전수 조사 516문서, 레코드 단위 해독, SVG 대조)이다.

**수정 후** — `issue_6806_getset_identity` 10/10 통과. 관련 기존 시험: `issue_6355_picture_transform_raw_rendering`·`issue_6740_group_setter_purity` 7/7·2/2 통과, `object_ops` 단위 시험(`resize_to_zero_width_clamps_to_min` 포함) 통과.

**게이트** — `cargo fmt --check` 통과, `clippy` `--lib --tests -D warnings` 통과, tiers 래칫(`--base-ref origin/devel`) 통과(cfg(test) 항목 증가 없음 — 테스트 모듈 안 `use` 한 줄 이동뿐), `rust-test-suite-manifest.mjs --prepare` 반영.

## 범위 외

- **수식의 반대 방향 결함**(크기 키가 없으면 재계산) — #6807 / 별도 PR.
- **실제 크기 변경 시 `original_*` 을 덮는 기존 동작** — Line 을 실제로 리사이즈하면 종전처럼 `original = new` 가 되어 스케일 기준이 바뀐다. 이 PR 은 "바뀌지 않은 값" 만 다루고, 리사이즈 의미론(한컴은 `original` 을 생성 시 값으로 유지하는가)은 재지 않았다.
- **표** — 게터가 `pub(crate)` 라 같은 항등 조사를 걸지 못했다(#6806 범위 외).
- studio 의 `ResizeObjectCommand.before` 가 게터 값을 그대로 담는 구조는 그대로다 — 엔진이 항등을 지키므로 그 봉지가 무해해졌다.
