### PR TITLE
Task #6807: 수식 크기 재계산을 크기 키 부재가 아니라 script·fontSize 변화로 판정한다

### DIFF
--- a/src/document_core/commands/object_ops/equation.rs
+++ b/src/document_core/commands/object_ops/equation.rs
@@ -144,6 +144,12 @@ impl DocumentCore {
     ) {
         use crate::document_core::helpers::{json_i32, json_str, json_u32};
 
+        // [#6807] 자동 크기 재계산의 근거는 "크기 키가 없다" 가 아니라 "크기를 결정하는 값이
+        // 바뀌었다" 다. 종전에는 색·기준선·글꼴 이름만 담은 봉지에도 `intrinsic_size_hwp` 가
+        // 돌아 한컴이 저장한 상자 크기를 rhwp 계산값으로 바꿨다(corpus 수식 2257건 전부 해당).
+        let script_before = eq.script.clone();
+        let font_size_before = eq.font_size;
+
         if let Some(s) = json_str(props_json, "script") {
             eq.script = s;
         }
@@ -169,7 +175,8 @@ impl DocumentCore {
         // 스크립트·글자크기 편집의 자동 크기 재계산은 종전대로 동작한다.
         let explicit_width = json_u32(props_json, "width").is_some();
         let explicit_height = json_u32(props_json, "height").is_some();
-        if !explicit_width || !explicit_height {
+        let size_driver_changed = eq.script != script_before || eq.font_size != font_size_before;
+        if size_driver_changed && (!explicit_width || !explicit_height) {
             let (width, height) =
                 crate::renderer::equation::intrinsic_size_hwp(&eq.script, eq.font_size);
             if !explicit_width {

--- a/tests/cases/issue_6807_equation_partial_bag_size.rs
+++ b/tests/cases/issue_6807_equation_partial_bag_size.rs
@@ -1,0 +1,156 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! [#6807] 수식 속성 봉지에 `width`/`height` 가 없어도, `script`·`fontSize` 가 바뀌지 않았으면
+//! 크기를 다시 계산하지 않아야 한다.
+//!
+//! 표본 `3-09월_교육_통합_2023.hwp` s0p1c0 — 한컴이 저장한 상자 900×2070, rhwp 계산 크기(`intrinsic_size_hwp`)
+//! 855×2196. 종전에는 색만 바꾸는 봉지(`{"color":…}`)도 자동 크기 분기를 타서 900×2070 이 855×2196 이 되고,
+//! `common` 이 바뀌어 #4495 봉인이 어긋나 원본 CTRL_HEADER 패스스루까지 잃었다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+
+const SAMPLE: &str = "samples/3-09월_교육_통합_2023.hwp";
+const AT: (usize, usize, usize) = (0, 1, 0);
+
+fn load() -> DocumentCore {
+    let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    DocumentCore::from_bytes(&std::fs::read(p).expect("표본 로드")).expect("파싱")
+}
+
+fn equation(core: &DocumentCore) -> &rhwp::model::control::Equation {
+    match &core.document().sections[AT.0].paragraphs[AT.1].controls[AT.2] {
+        Control::Equation(e) => e,
+        _ => panic!("표본 전제 위반: 수식이 아니다"),
+    }
+}
+
+fn set(core: &mut DocumentCore, bag: &str) {
+    core.set_equation_properties_native(AT.0, AT.1, AT.2, None, None, bag)
+        .expect("set_equation_properties_native");
+}
+
+fn assert_sample_premise(core: &DocumentCore) -> (u32, u32) {
+    let e = equation(core);
+    let (iw, ih) = rhwp::renderer::equation::intrinsic_size_hwp(&e.script, e.font_size);
+    assert!(
+        (iw, ih) != (e.common.width, e.common.height),
+        "표본 전제: 자동 크기({iw}×{ih}) ≠ 저장 크기({}×{}) 여야 판정이 선다",
+        e.common.width,
+        e.common.height
+    );
+    assert!(
+        e.raw_ctrl_seal.is_some(),
+        "표본 전제: 파서를 거친 raw 봉인이 있어야 한다"
+    );
+    (e.common.width, e.common.height)
+}
+
+#[test]
+fn color_only_bag_keeps_stored_size_and_raw_passthrough() {
+    let mut core = load();
+    let (w0, h0) = assert_sample_premise(&core);
+    let raw0 = equation(&core).raw_ctrl_data.clone();
+    let color = equation(&core).color;
+
+    set(&mut core, &format!("{{\"color\":{}}}", color ^ 0x00ff_ffff));
+
+    let e = equation(&core);
+    assert_eq!(
+        (e.common.width, e.common.height),
+        (w0, h0),
+        "색만 바꿨는데 상자 크기가 재계산됐다"
+    );
+    assert_eq!(e.raw_ctrl_data, raw0, "raw CTRL_HEADER 가 지워졌다");
+    // 봉인은 `common` 다이제스트라, 크기가 그대로면 저장기가 원본 바이트를 그대로 쓴다.
+    assert_eq!(
+        e.raw_ctrl_seal,
+        Some(rhwp::model::raw_provenance::record_digest(&e.common)),
+        "봉인이 어긋나 저장 시 IR 합성으로 내려간다"
+    );
+}
+
+#[test]
+fn empty_bag_is_identity_for_size() {
+    let mut core = load();
+    let (w0, h0) = assert_sample_premise(&core);
+    set(&mut core, "{}");
+    let e = equation(&core);
+    assert_eq!((e.common.width, e.common.height), (w0, h0));
+}
+
+#[test]
+fn baseline_and_font_name_do_not_resize() {
+    let mut core = load();
+    let (w0, h0) = assert_sample_premise(&core);
+    set(&mut core, r#"{"baseline":7,"fontName":"HancomEQN"}"#);
+    let e = equation(&core);
+    assert_eq!((e.common.width, e.common.height), (w0, h0));
+    assert_eq!(e.baseline, 7);
+}
+
+#[test]
+fn script_change_still_recomputes_size() {
+    // 크기를 결정하는 값이 실제로 바뀌면 자동 크기는 종전대로 동작해야 한다.
+    let mut core = load();
+    let (w0, h0) = assert_sample_premise(&core);
+    let new_script = format!("{} + 1 over 2", equation(&core).script);
+    set(
+        &mut core,
+        &format!("{{\"script\":\"{}\"}}", new_script.replace('"', "\\\"")),
+    );
+    let e = equation(&core);
+    let (iw, ih) = rhwp::renderer::equation::intrinsic_size_hwp(&e.script, e.font_size);
+    assert_eq!(
+        (e.common.width, e.common.height),
+        (iw, ih),
+        "스크립트가 바뀌면 자동 크기로 재계산돼야 한다"
+    );
+    assert_ne!(
+        (iw, ih),
+        (w0, h0),
+        "표본 전제: 스크립트 변경이 크기를 바꾼다"
+    );
+}
+
+#[test]
+fn font_size_change_still_recomputes_size() {
+    let mut core = load();
+    assert_sample_premise(&core);
+    let fs = equation(&core).font_size;
+    set(&mut core, &format!("{{\"fontSize\":{}}}", fs * 2));
+    let e = equation(&core);
+    let (iw, ih) = rhwp::renderer::equation::intrinsic_size_hwp(&e.script, e.font_size);
+    assert_eq!((e.common.width, e.common.height), (iw, ih));
+}
+
+#[test]
+fn same_script_and_font_size_do_not_recompute() {
+    // 게터가 낸 값과 같은 script/fontSize 를 되먹여도 재계산하지 않는다 — 부분 봉지 항등.
+    let mut core = load();
+    let (w0, h0) = assert_sample_premise(&core);
+    let (script, fs) = (equation(&core).script.clone(), equation(&core).font_size);
+    set(
+        &mut core,
+        &format!(
+            "{{\"script\":\"{}\",\"fontSize\":{fs}}}",
+            script.replace('"', "\\\"")
+        ),
+    );
+    let e = equation(&core);
+    assert_eq!((e.common.width, e.common.height), (w0, h0));
+}
+
+#[test]
+fn explicit_size_is_still_respected() {
+    // #6350 의 계약 — 명시 크기는 재계산에 덮이지 않는다.
+    let mut core = load();
+    assert_sample_premise(&core);
+    let fs = equation(&core).font_size;
+    set(
+        &mut core,
+        &format!("{{\"fontSize\":{},\"width\":5000,\"height\":4000}}", fs * 2),
+    );
+    let e = equation(&core);
+    assert_eq!((e.common.width, e.common.height), (5000, 4000));
+}


### PR DESCRIPTION
관련 이슈: #6807

## 문제

수식 속성 setter 는 봉지에 `width`/`height` 가 없으면 크기를 `intrinsic_size_hwp` 로 다시 세운다. 그래서 색·기준선·글꼴 이름처럼 크기와 무관한 키만 담은 봉지 — studio 수식 속성 대화상자가 보내는 형태 — 에도 한컴이 저장한 상자 크기가 rhwp 계산값으로 바뀐다(표본: 900×2070 → 855×2196). `common` 이 바뀌므로 #4495 봉인이 어긋나 원본 CTRL_HEADER 패스스루도 잃는다. corpus 의 수식 2257건 전부가 자동 크기 ≠ 저장 크기라 어느 수식이든 해당한다.

## 원인

`object_ops/equation.rs` `apply_equation_properties` — #6350 이 "명시 크기가 있으면 존중" 으로 고칠 때, 키가 **없는** 경우는 스크립트·글자크기 편집의 자동 크기를 위해 종전대로 두었다. 그 조건이 "크기를 결정하는 값이 바뀌었는가" 가 아니라 "크기 키가 없는가" 라서, 무관한 키만 온 봉지도 재계산을 탔다.

```rust
if !explicit_width || !explicit_height {
    let (width, height) = intrinsic_size_hwp(&eq.script, eq.font_size);   // 봉지 내용과 무관하게
    ...
}
```

## 변경

재계산의 근거를 값 변화로 바꾼다 — 적용 전 `script`·`font_size` 를 잡아 두고, 둘 중 하나라도 **실제로 바뀌었을 때만** 크기 키가 없는 축을 다시 계산한다.

```rust
let script_before = eq.script.clone();
let font_size_before = eq.font_size;
// … 키 적용 …
let size_driver_changed = eq.script != script_before || eq.font_size != font_size_before;
if size_driver_changed && (!explicit_width || !explicit_height) { /* 종전 재계산 */ }
```

- 스크립트·글자크기가 바뀌면 종전대로 자동 크기(수식 편집기 경로).
- 명시 `width`/`height` 는 #6350 계약대로 그대로 존중.
- 색·기준선·글꼴 이름·빈 봉지·같은 값 되먹임은 크기를 건드리지 않는다 → 봉인이 유지되어 원본 CTRL_HEADER 가 그대로 나간다.

Rust 1파일 8줄. 회귀 테스트 `tests/cases/issue_6807_equation_partial_bag_size.rs` 7건 — 색만 / 빈 봉지 / 기준선·글꼴 이름 / 같은 script·fontSize 되먹임은 크기·raw·봉인 보존, 스크립트 변경·글자크기 변경은 여전히 재계산, 명시 크기는 여전히 존중.

## 검증

devel `016fe3cee` 기준. 표본 `samples/3-09월_교육_통합_2023.hwp` s0p1c0 — 저장 크기 900×2070, `intrinsic` 855×2196(표본 전제를 시험이 스스로 확인한다).

**수정 전 실패 증명** — 수정 전 devel 에서 🔴 **4건 실패 / 3건 통과** — 실패한 4건이 색만·빈 봉지·기준선/글꼴·같은 값 되먹임이고, 통과한 3건은 "스크립트 변경·글자크기 변경은 재계산"·"명시 크기 존중" 이라는 대조 시험이다(수정 전에도 통과해야 맞다). 원본 CTRL_HEADER 를 export 에서 직접 읽은 실측은 #6807 본문에 있다(원본·get∘set 900×2070, `set({})` 855×2196).

**수정 후** — `issue_6807_equation_partial_bag_size` 7/7, `issue_6350_equation_setter_raw_passthrough` 4/4 통과, `hml_serializer`(스크립트 편집 경로) 31/31 통과(`equation_exports_canonically_escapes_and_reparses_edited_and_untouched_scripts` 포함).

**게이트** — `cargo fmt --check` 통과, `clippy` `--lib --tests -D warnings` 통과, tiers 래칫 통과(src `#[cfg(test)]` 변화 없음), `--prepare` 반영.

## 범위 외

- `intrinsic_size_hwp` 가 한컴 크기와 다른 것(855 vs 900) — 수식 조판 정합 축. 이 PR 은 "바뀌지 않은 것을 다시 계산한다" 만 다룬다.
- `fontName` 이 실제 조판 폭에 영향을 주는가는 재지 않았다 — 지금 `intrinsic_size_hwp` 가 글꼴 이름을 인자로 받지 않으므로 재계산 근거에 넣지 않았다.
- 그림·도형의 get∘set 비항등 — #6806 / 별도 PR.
