### PR TITLE
fix(ci): 문서 merge 뒤 검증된 Full CI 재사용 보완 (#6815)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1061,6 +1061,7 @@ jobs:
         run: |
           node --test scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
           node --test scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs
+          node --test scripts/tests/verify-trusted-postmerge-review-bridge.test.mjs
           python3 -m unittest scripts/tests/test_cache_sweep_workflow.py
           python3 -m unittest scripts/tests/test_cancel_stale_pr_runs_workflow.py
           python3 -m unittest scripts/tests/test_ci_impact_policy_workflow.py

--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -215,16 +215,26 @@ jobs:
           script: |
             const path = require('node:path');
             const { pathToFileURL } = require('node:url');
+            const { execFileSync } = require('node:child_process');
             const { owner, repo } = context.repo;
             let classifyReviewOnlyCommit;
             let evaluateTrustedPostMergeReuse;
             let frontendOnlyCiRunIsReusable;
             let classifyChanges;
+            let currentBaseReviewBridgeSource;
+            let selectTrustedPostMergeCandidate;
+            let verifyPostMergeReviewBridgeTree;
             try {
-              ({ classifyReviewOnlyCommit, evaluateTrustedPostMergeReuse, frontendOnlyCiRunIsReusable } = await import(pathToFileURL(path.join(
+              ({ classifyReviewOnlyCommit, evaluateTrustedPostMergeReuse, frontendOnlyCiRunIsReusable,
+                currentBaseReviewBridgeSource, selectTrustedPostMergeCandidate,
+                verifyPostMergeReviewBridgeTree } = await import(pathToFileURL(path.join(
                 process.env.GITHUB_WORKSPACE,
                 'scripts/verify-trusted-postmerge-ci-reuse.mjs',
               )).href));
+              if ([currentBaseReviewBridgeSource, selectTrustedPostMergeCandidate,
+                verifyPostMergeReviewBridgeTree].some((fn) => typeof fn !== 'function')) {
+                throw new Error('trusted base has no review-bridge verifier');
+              }
               if (process.env.WORKFLOW_FILE === 'ci.yml') {
                 ({ classifyChanges } = require(path.join(
                   process.env.GITHUB_WORKSPACE, 'scripts/ci-impact-classifier.cjs',
@@ -259,7 +269,16 @@ jobs:
               if (pullRequest.length !== 1) {
                 return { mergeCommit, pullRequests, pullFiles: [], workflowRuns: [] };
               }
-              const pr = pullRequest[0];
+              const summary = pullRequest[0];
+              const pr = (await github.rest.pulls.get({
+                owner, repo, pull_number: summary.number,
+              })).data;
+              if (pr.number !== summary.number || pr.head?.sha !== summary.head.sha
+                || pr.merge_commit_sha !== mergeSha || pr.state !== 'closed' || !pr.merged_at
+                || pr.base?.ref !== 'devel'
+                || pr.head?.repo?.full_name !== process.env.GITHUB_REPOSITORY) {
+                throw new Error('PR detail identity mismatch');
+              }
               const mergeParents = (mergeCommit.parents || []).map((parent) => parent.sha);
               const baseParent = mergeParents.length === 1
                 ? mergeParents[0]
@@ -286,18 +305,33 @@ jobs:
                 github.rest.pulls.listCommits,
                 { owner, repo, pull_number: pr.number, per_page: 100 },
               );
+              if (prCommitHeaders.length === 0 || prCommitHeaders.length >= 250
+                || pullFiles.length === 0 || pullFiles.length >= 3000
+                || pullFiles.length !== pr.changed_files) {
+                throw new Error('incomplete PR commit or file inventory');
+              }
               const prCommits = [];
+              let bridgeSha = '';
               for (let index = prCommitHeaders.length - 1; index >= 0; index -= 1) {
                 const commit = (await github.rest.repos.getCommit({
                   owner,
                   repo,
                   ref: prCommitHeaders[index].sha,
                 })).data;
+                if (commit.sha !== prCommitHeaders[index].sha) {
+                  throw new Error('PR commit identity mismatch');
+                }
                 prCommits.unshift(commit);
+                if (currentBaseReviewBridgeSource(commit, baseParent)) {
+                  if (bridgeSha) throw new Error('multiple current-base review bridges');
+                  bridgeSha = commit.sha;
+                  continue;
+                }
                 if (classifyReviewOnlyCommit(commit).kind !== "review") {
                   break;
                 }
               }
+              const sourceSelection = selectTrustedPostMergeCandidate(pr, prCommits, baseParent);
               const mergeTreeEvidenceByRunId = {};
               const createdAt = Date.parse(pr.created_at || '');
               const mergedAt = Date.parse(pr.merged_at || '');
@@ -467,6 +501,46 @@ jobs:
                   }
                 }
               }
+              const reviewBridgeTreeEvidenceByRunId = {};
+              if (sourceSelection?.bridgeSha && requireFullLaneEvidence) {
+                for (const run of workflowRuns) {
+                  const tested = mergeTreeEvidenceByRunId[String(run.id)];
+                  if (!fullLaneRunIds.includes(String(run.id)) || !tested
+                    || tested.parents[0] !== baseParent
+                    || !sourceSelection.fullLaneCandidates.some((c) => c.sha === run.head_sha)) {
+                    continue;
+                  }
+                  try {
+                    // Fetch immutable objects only. Keep the trusted checkout and never run PR code.
+                    const refs = [mergeSha, sourceSelection.bridgeSha, tested.sha];
+                    if (!refs.every((sha) => /^[0-9a-f]{40}$/.test(sha))) {
+                      throw new Error('invalid review-bridge object identity');
+                    }
+                    const gitOptions = { cwd: process.env.GITHUB_WORKSPACE,
+                      timeout: 120000, maxBuffer: 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'] };
+                    const missing = refs.filter((sha) => {
+                      try {
+                        execFileSync('git', ['cat-file', '-e', `${sha}^{commit}`], gitOptions);
+                        return false;
+                      } catch { return true; }
+                    });
+                    if (missing.length) {
+                      execFileSync('git', ['fetch', '--no-tags', '--filter=blob:none', '--depth=1',
+                        '--no-write-fetch-head', 'origin', ...missing], gitOptions);
+                    }
+                    const proof = verifyPostMergeReviewBridgeTree(process.env.GITHUB_WORKSPACE, {
+                      baseSha: baseParent, bridgeSha: sourceSelection.bridgeSha, mergeSha,
+                      candidateSha: run.head_sha, testedMergeSha: tested.sha,
+                    });
+                    if (proof.testedTreeSha !== tested.treeSha) {
+                      throw new Error('review-bridge artifact tree mismatch');
+                    }
+                    reviewBridgeTreeEvidenceByRunId[String(run.id)] = proof;
+                  } catch (error) {
+                    core.warning(`Review-bridge tree proof unavailable for run ${run.id}; running full. ${error.message}`);
+                  }
+                }
+              }
               const evidence = {
                 mergeCommit,
                 pullRequests,
@@ -476,6 +550,7 @@ jobs:
                 prCommits,
                 workflowRuns,
                 mergeTreeEvidenceByRunId,
+                reviewBridgeTreeEvidenceByRunId,
                 frontendOnlyRunIds,
               };
               if (requireFullLaneEvidence) {

--- a/mydocs/manual/pr_review/review_only_fast_pass.md
+++ b/mydocs/manual/pr_review/review_only_fast_pass.md
@@ -2,7 +2,7 @@
 kind: guide
 status: active
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-09-03
+last_verified: 2026-09-06
 ---
 
 # Review-only fast-pass
@@ -124,6 +124,27 @@ Adapter inter-diff와 Proptest roundtrip은 `devel` push에도 required check �
 
 direct push, fork PR, PR 식별 불명확, merge tree 불일치, workflow·CI policy 변경, 비허용 파일, merge
 commit 또는 worker-skip 증거 누락은 재사용하지 않고 Full 실행한다.
+
+### B.2 Full candidate 뒤 문서 merge의 post-merge 재사용
+
+코드 PR의 문서-only trailing 사이에 current-base 충돌 해소 merge가 있으면, CI/CodeQL의 공통
+post-merge verifier가 다음 조건에서만 이전 Full 검증을 재사용한다.
+
+- source 부모 + 최종 devel base 부모 순서의 bridge 한 개이며, 그 앞뒤 commit 계보가 연속이다.
+- 최종 head workflow가 성공했고, 선택한 이전 Full 실행의 PR/branch/repository/SHA/time이 일치한다.
+- CI는 만료되지 않은 B/C/D duration artifact, CodeQL은 실제 분석 성공 증거를 요구한다.
+- Full 실행에 속한 immutable merge-tree artifact의 base/head/tree를 Git 객체와 대조한다.
+- 그 실제 검사 tree와 최종 merge tree 차이는 `mydocs/**` 문서뿐이다.
+  `mydocs/tech/text-ir-v2.md`, `mydocs/tech/canvaskit-parity-implementation.md`는 실행 계약이므로 제외한다.
+
+단순히 부모가 둘이거나 PR fast-pass aggregate가 green이라는 이유로 승인하지 않는다. base의 신뢰
+검증 코드가 객체를 fetch/diff하며 PR head를 checkout/실행하지 않는다. 코드·테스트·기준 PDF 변경,
+stale base, 복수 bridge, 목록 잘림, fetch 실패, 증거 불일치는 Full로 닫는다.
+정상 재사용 시 초기 Full run의 duration artifact로 timing을 갱신하며 required check 이름은 유지한다.
+
+재사용 정책 자체를 바꾸는 PR은 Full 대상이다. trusted verifier는 병합 전 base에서 로드하므로 최초
+적용 PR의 post-merge도 Full일 수 있다. 지원 완료는 이후 코드 PR의 문서 merge 사례에서 실제
+`reuse=true`, CI/CodeQL heavy skip, duration 재사용을 확인한 뒤 판단한다.
 
 ## Full CI fallback
 

--- a/mydocs/working/task_m100_6815_stage1.md
+++ b/mydocs/working/task_m100_6815_stage1.md
@@ -1,0 +1,49 @@
+# #6815 1단계: 문서 merge 뒤 post-merge 재사용 누락 분석
+
+Issue: [#6815](https://github.com/edwardkim/rhwp/issues/6815)
+
+## 범위와 승인
+
+- 기준 `upstream/devel`: `6a193a648dba3df6d5c4cffa0182bc02f3e011ff`.
+- 작업지시: 이슈 등록 후 개선. 로컬 구현·검증·단계별 커밋까지 진행하고 push/PR은 별도 승인한다.
+- GitHub 운영 O3: CI/CodeQL 재사용의 신뢰 계약 변경이다. 제품 Rust/Studio 소스는 변경하지 않는다.
+- 유사 열린 이슈/PR 검색 결과 동일 작업 없음. 선행 #6779는 frontend-only 계약으로 별도 경로다.
+
+## 관찰 및 원인
+
+[CI](https://github.com/edwardkim/rhwp/actions/runs/34030385295)는 14분 13초,
+[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/34030385431)은 17분 3초의 Full 재검증 뒤 성공했다.
+두 실행의 거부 사유는 `candidate-full-lane-evidence-unavailable`이다.
+
+- 초기 Full head `964ef10a6`, 문서 merge `359f4d3ea`, 최종 head `42949b966`.
+- `classifyReviewOnlyCommit`이 부모 2개를 code로 취급해 collector와 selector가 함께 탐색을 중단한다.
+- PR preflight는 이미 current-base merge tree/remerge 검증을 지원하지만 post-merge에는 연결되지 않았다.
+- 초기 검사 merge `c0687162210c4277d44a506bdff325ec3e548861` 대비 최종 head의 mydocs 밖 diff는 0이다.
+- 초기 CI B/C/D duration 및 merge-tree artifact는 만료되지 않았고 CodeQL 3개 언어 분석도 성공했다.
+- 원시 로그·개인 환경 정보는 커밋하지 않는다. 재현 가능한 합성 계보와 실제 run 링크만 기록한다.
+
+## 단계 계획
+
+1. 현재 실패 계보를 테스트로 고정하고 분석과 함께 커밋한다.
+2. current-base bridge 후보 탐색과 Git 객체 기반 tree 검증을 구현한다. base/계보/증거를 결합한
+   positive/negative 계약을 통과시킨 뒤 코드와 분석 결과를 커밋한다.
+3. reusable workflow에 collector, 신뢰 base 코드에 의한 객체 검증, CI 계약 테스트를 연결한다.
+   운영 문서를 갱신하고 집중 검증 후 커밋한다.
+
+허용 조건은 same-repository PR, 정확한 base의 bridge 한 개, 성공한 Full candidate, 후보의 실제
+검사 merge tree와 최종 tree 사이의 허용된 review 문서 차이뿐이다. 실행 계약 문서는 제외한다.
+코드 충돌 해소, stale base, 복수 bridge, 누락/실패/진행 중 증거는 Full로 유지한다.
+PR 코드를 checkout/실행하거나 권한을 늘리지 않는다. B/C/D duration 소비와 required context는 유지한다.
+
+## 검증 결과
+
+- 기존 Node verifier/squash 34개, Python workflow 8개 통과(이전 분석 단계).
+- 신규 합성 계보 테스트는 Full 성공 + 문서 merge + fast-pass tail에서도 증거 없이는 재사용을
+  거부함을 고정한다. 구현 뒤에도 독립 tree 증거 없이는 이 안전 경계를 유지한다.
+- 신규 Node 계보 테스트 1개 통과, `git diff --check` exit 0.
+
+## 적용 후 확인과 복구
+
+이번 개선 PR은 실행 정책 변경이므로 Full 검증 대상이다. 이후 별도 제품 PR에서 동일한 문서 merge
+계보를 만들고 post-merge CI/CodeQL skip 및 초기 B/C/D duration 재사용을 확인하기 전에는 이슈를 닫지 않는다.
+오판 시 이 변경 commit들을 revert하는 독립 PR로 복구한다. 검증 실패를 skip으로 바꾸지 않는다.

--- a/mydocs/working/task_m100_6815_stage2.md
+++ b/mydocs/working/task_m100_6815_stage2.md
@@ -1,0 +1,26 @@
+# #6815 2단계: bridge 후보와 독립 tree 증거
+
+Issue: [#6815](https://github.com/edwardkim/rhwp/issues/6815)
+
+## 구현 계획
+
+- 1단계 `feea62e0e`의 재현 계약을 유지한다.
+- current-base가 두 번째 부모인 bridge 한 개만 후보 탐색에서 통과한다. 일반 merge나 계보 단절은
+  통과시키지 않는다. 단순 candidate 발견은 재사용 승인이 아니다.
+- 후보 workflow의 immutable merge-tree artifact를 Git commit/tree와 대조한다. 실제 검사 base가
+  최종 base와 같고, 최종 tree와의 차이가 실행 계약을 제외한 mydocs뿐이어야 한다.
+- helper는 Git 객체만 읽으며 checkout, shell, PR 코드 실행을 하지 않는다. SHA 입력 검증, 시간/출력
+  제한과 Git 외부 diff/textconv 비활성화를 적용한다.
+- source/head/base/bridge/tested tree/최종 merge SHA가 모두 일치하는 증거를 evaluator에서 요구한다.
+- collector는 아직 바꾸지 않는다. workflow 연결 전에는 기존 Full fallback이 유지된다.
+
+## 검증 결과
+
+- Node verifier/squash/bridge **71개 통과**, diff check exit 0.
+- SHA별 증거 불일치, fork, 실패/진행 중 candidate와 최종 head, artifact 누락, stale base,
+  복수 bridge, 계보 단절 및 코드/실행 정책 변경은 거부했다.
+- 임시 Git 저장소에서 실제 commit/tree 객체를 생성해 문서 변경/동일 tree 수용과
+  source/test/Cargo/PDF/실행 계약 문서 변경 거부를 검증했다. 테스트 종료 때 해당 임시 저장소만 제거한다.
+- 실제 #6813 객체로 helper를 실행해 초기 검사 tree `d205ad5c53988e3533b91c65fa81ab1930141b23`
+  대비 최종 tree `6f613d232cb96bcee2ace0d6785eadd20816ff77`의 허용 문서 차이를 확인했다.
+- 아직 GitHub workflow에 collector를 연결하지 않았으므로 원격 skip 성공이라고 기록하지 않는다.

--- a/mydocs/working/task_m100_6815_stage3.md
+++ b/mydocs/working/task_m100_6815_stage3.md
@@ -1,0 +1,78 @@
+# #6815 3단계: reusable workflow 연결과 제출 전 검증
+
+Issue: [#6815](https://github.com/edwardkim/rhwp/issues/6815)
+
+## 구현 계획
+
+- 2단계 `e0e4faaa2`의 verifier를 reusable workflow의 신뢰 base checkout에서만 import한다.
+- collector는 current-base bridge 한 개를 지나되 파일/commit 목록의 불완전한 경계는 Full로 닫는다.
+- Full candidate에 실제 검사 merge artifact가 있을 때 필요한 commit/tree 객체만 fetch한다.
+  checkout은 계속 신뢰 base이며 객체 fetch 후 candidate 코드를 실행하지 않는다.
+- 독립 Git tree 증거를 evaluator에 전달하고 기존 duration artifact 재사용·출력·required check를 유지한다.
+- CI에 신규 테스트를 연결하고 실제 workflow script를 실행하는 통합 mock으로 collector부터 output까지 검증한다.
+- 운영 문서에 지원 범위와 최초 배포/후속 실측의 차이를 명시한다.
+
+## 검증 결과
+
+2026-09-06 KST, 기준 `upstream/devel`은 `6a193a648dba3df6d5c4cffa0182bc02f3e011ff`다.
+최종 fetch에서도 기준선 변경이 없어 rebase는 필요하지 않았다.
+
+### 구현 중 추가 확인
+
+- 실제 associated-PR API는 `changed_files`를 제공하지 않았다. PR 상세 API로 파일 수를 읽고,
+  요약/상세 응답의 PR·head·merge·repository가 일치하는지 확인하도록 보완했다.
+- `git show --format=%P`는 shallow 경계에서 부모를 숨긴다. runner의 `--depth=1` fetch 뒤에도
+  실제 부모를 읽도록 `git cat-file commit`의 원본 header를 검사하고 replacement object를 비활성화했다.
+- 임시 Git 저장소의 실제 shallow fetch, 실제 workflow JavaScript 실행, API 파일 목록 잘림,
+  fetch 실패, source 충돌 보정, 만료 artifact, 실패한 최종 head를 회귀 테스트로 고정했다.
+
+### 통과한 로컬 검증
+
+```bash
+node --test scripts/tests/ci-impact-classifier.test.cjs \
+  scripts/tests/ci-impact-policy.test.cjs \
+  scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs \
+  scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs \
+  scripts/tests/verify-trusted-postmerge-review-bridge.test.mjs
+python3 -m unittest discover -s scripts/tests -p 'test_*workflow.py'
+actionlint .github/workflows/trusted-postmerge-ci-reuse.yml .github/workflows/ci.yml
+git diff --check
+```
+
+- Node 164개 통과(신규 bridge 계약 49개 포함).
+- Python workflow discovery 162개 통과. 별도 선택 계약 134개도 통과했으며 일부 중복이다.
+- actionlint 오류 0건. 제품 Rust/renderer 변경이 없어 Cargo·WASM·시각 검증은 실행하지 않았다.
+- 변경 문서 4개의 내부 링크와 변경 매뉴얼 metadata를 검사해 통과했다.
+- live `devel` protection의 required context는 `Build & Test`였다. 이름·발행 job·권한을 바꾸지 않았다.
+- 전체 문서 metadata 검사에서는 기준선과 동일한 기존 4개 문서의 필수 필드 누락 16건이 나왔다.
+  `benchmark_vs_alternatives.md`, issue-4964 README, issue-5511 README·CLI inventory가 해당하며
+  모두 이번 diff 밖이다. 관련 없는 metadata 변경은 포함하지 않았다.
+
+### 실제 #6813 데이터의 읽기 전용 재실행
+
+GitHub의 PR/commit/run/job/artifact 응답과 실제 Git 객체를 사용해 현재 workflow script를 실행했다.
+기존 run을 재실행하거나 GitHub 상태를 수정한 결과가 아니다.
+
+| Workflow | 기존 post-merge | 수정 후 판정 | 재사용 source run | timing 재사용 |
+| --- | --- | --- | --- | --- |
+| CI | `candidate-full-lane-evidence-unavailable` | `reuse=true` | [34029158620](https://github.com/edwardkim/rhwp/actions/runs/34029158620) | `true`, B/C/D |
+| CodeQL | `candidate-full-lane-evidence-unavailable` | `reuse=true` | [34029158604](https://github.com/edwardkim/rhwp/actions/runs/34029158604) | `false`, 대상 아님 |
+
+두 판정의 reason은 `current-base-review-bridge-green-pr-workflow-reused`이며 warning은 없었다.
+테스트된 merge tree는 `d205ad5c53988e3533b91c65fa81ab1930141b23`, 최종 squash tree는
+`6f613d232cb96bcee2ace0d6785eadd20816ff77`다. 두 tree의 차이는 허용된 `mydocs/**`뿐이었다.
+따라서 과거 실패 계보를 새 판정으로 통과시키되, 검증하지 않은 소스 변경은 통과시키지 않는 것을 확인했다.
+
+## 제출 및 남은 검증
+
+- 기본 경로: collaborator self-merge. 보조 경로: intake, local validation, review-only fast-pass.
+  `pr_review_workflow.md`, 선택표와 해당 자식 문서, `github_operations.md`의 O3 절차를 적용했다.
+- 작업지시자가 준비 완료 뒤 remote push·PR 생성을 승인했다. PR review와 오늘할일은 **옵션 2**로
+  분리하고 이번 코드 PR에 trailing commit/push하지 않는다. 이 단계별 구현 보고서는 코드와 함께 커밋한다.
+- 이번 PR은 enforcement 변경이라 Full CI 대상이며, 최초 post-merge도 기존 base verifier를 사용하므로
+  Full일 수 있다. PR CI·후속 runner에서 실제 heavy skip을 관찰한 결과로 과장하지 않는다.
+- #6815는 `Ref`로 연결하고 열린 상태를 유지한다. 실제 이후 코드 PR의 current-base 문서 merge에서
+  CI/CodeQL skip, 기존 timing artifact 재사용, required check 정상 유지까지 확인한 뒤 완료를 판단한다.
+- rollback은 이번 변경 commit들의 revert PR로 수행한다. source/workflow 변경이 잘못 skip되거나
+  required aggregate가 사라지면 병합을 중단하고 기존 fail-closed 동작으로 복귀한다.
+- 원본 log, 임시 API JSON, 임시 재실행 script는 커밋하지 않는다. 원격 PR 본문에는 검증 결과만 적는다.

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -112,6 +112,20 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
         self.assertIn(
             "scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs", ci
         )
+        self.assertIn("scripts/tests/verify-trusted-postmerge-review-bridge.test.mjs", ci)
+
+    def test_review_bridge_uses_trusted_object_proof_without_checkout(self) -> None:
+        workflow = REUSABLE.read_text(encoding="utf-8")
+        self.assertIn("currentBaseReviewBridgeSource(commit, baseParent)", workflow)
+        self.assertIn("multiple current-base review bridges", workflow)
+        self.assertIn("selectTrustedPostMergeCandidate(pr, prCommits, baseParent)", workflow)
+        self.assertIn("prCommitHeaders.length >= 250", workflow)
+        self.assertIn("pullFiles.length !== pr.changed_files", workflow)
+        self.assertIn("reviewBridgeTreeEvidenceByRunId", workflow)
+        self.assertIn("verifyPostMergeReviewBridgeTree(process.env.GITHUB_WORKSPACE", workflow)
+        self.assertIn("['fetch', '--no-tags', '--filter=blob:none', '--depth=1'", workflow)
+        self.assertIn("'--no-write-fetch-head', 'origin', ...missing", workflow)
+        self.assertNotIn("execFileSync('git', ['checkout'", workflow)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/verify-trusted-postmerge-review-bridge.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-review-bridge.test.mjs
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { evaluateTrustedPostMergeReuse } from "../verify-trusted-postmerge-ci-reuse.mjs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import {
+  evaluateTrustedPostMergeReuse, selectTrustedPostMergeCandidate,
+  currentBaseReviewBridgeSource, verifyPostMergeReviewBridgeTree,
+} from "../verify-trusted-postmerge-ci-reuse.mjs";
 
 const base = "1".repeat(40), code = "2".repeat(40), docs = "3".repeat(40);
 const bridge = "4".repeat(40), head = "5".repeat(40), merge = "6".repeat(40);
@@ -47,5 +54,136 @@ function fixture() {
 test("#6813: a docs merge between a full candidate and fast-pass head fails closed without tree proof", () => {
   const result = evaluateTrustedPostMergeReuse(fixture());
   assert.equal(result.reuse, false);
-  assert.equal(result.reason, "candidate-full-lane-evidence-unavailable");
+  assert.equal(result.reason, "review-bridge-tree-evidence-unavailable");
+});
+
+function provenFixture() {
+  return { ...fixture(), reviewBridgeTreeEvidenceByRunId: { [fullRunId]: {
+    baseSha: base, bridgeSha: bridge, mergeSha: merge, candidateSha: code,
+    testedMergeSha: testedMerge, testedTreeSha: testedTree, finalTreeSha: tree,
+  } } };
+}
+
+test("#6813: verified docs bridge selects the earlier full run, not the green fast-pass run", () => {
+  const result = evaluateTrustedPostMergeReuse(provenFixture());
+  assert.deepEqual(result, {
+    reuse: true, reason: "current-base-review-bridge-green-pr-workflow-reused",
+    sourceRunId: String(fullRunId), pullNumber: "6813",
+  });
+});
+
+test("verified bridge supports a normal merge as well as squash", () => {
+  const data = provenFixture();
+  data.mergeCommit.parents.push({ sha: head });
+  assert.equal(evaluateTrustedPostMergeReuse(data).reuse, true);
+});
+
+for (const key of ["baseSha", "bridgeSha", "mergeSha", "candidateSha", "testedMergeSha",
+  "testedTreeSha", "finalTreeSha"]) {
+  test(`rejects a stale or mismatched bridge proof: ${key}`, () => {
+    const data = provenFixture();
+    data.reviewBridgeTreeEvidenceByRunId[fullRunId][key] = "a".repeat(40);
+    assert.equal(evaluateTrustedPostMergeReuse(data).reuse, false);
+  });
+}
+
+for (const [name, mutate] of [
+  ["missing full lane artifacts", d => { d.fullLaneRunIds = []; }],
+  ["missing merge artifact", d => { d.mergeTreeEvidenceByRunId = {}; }],
+  ["wrong tested base", d => { d.mergeTreeEvidenceByRunId[fullRunId].parents[0] = docs; }],
+  ["wrong tested head", d => { d.mergeTreeEvidenceByRunId[fullRunId].parents[1] = head; }],
+  ["failed full run", d => { d.workflowRuns[0].conclusion = "failure"; }],
+  ["pending full run", d => { d.workflowRuns[0].status = "in_progress"; }],
+  ["failed final head", d => { d.workflowRuns[1].conclusion = "failure"; }],
+  ["pending final head", d => { d.workflowRuns[1].status = "in_progress"; }],
+  ["missing final head run", d => { d.workflowRuns.pop(); }],
+  ["full run after merge", d => { d.workflowRuns[0].updated_at = "2026-09-07T00:00:00Z"; }],
+  ["fork PR", d => { d.pullRequests[0].head.repo.full_name = "fork/rhwp"; }],
+  ["fork run", d => { d.workflowRuns[0].head_repository.full_name = "fork/rhwp"; }],
+  ["stale base", d => { d.mergeBaseSha = docs; }],
+  ["non-doc code tail", d => { d.prCommits[1].files = [file("src/new.rs")]; }],
+  ["enforcement change", d => { d.pullFiles.push(file(".github/workflows/ci.yml")); }],
+  ["head tree mismatch", d => { d.sourceCommit.commit.tree.sha = docs; }],
+]) {
+  test(`bridge cannot bypass ${name}`, () => {
+    const data = provenFixture();
+    mutate(data);
+    assert.equal(evaluateTrustedPostMergeReuse(data).reuse, false);
+  });
+}
+
+test("only one ordered current-base bridge is traversed", () => {
+  const data = fixture(), pr = data.pullRequests[0];
+  assert.equal(currentBaseReviewBridgeSource(data.prCommits[2], base), docs);
+  assert.equal(currentBaseReviewBridgeSource(commit(bridge, [base, docs], "mydocs/a"), base), "");
+  assert.equal(currentBaseReviewBridgeSource(commit(bridge, [base, base], "mydocs/a"), base), "");
+  assert.equal(currentBaseReviewBridgeSource(commit(bridge, [docs, base, code], "mydocs/a"), base), "");
+  data.prCommits[1].parents.push({ sha: base });
+  assert.equal(selectTrustedPostMergeCandidate(pr, data.prCommits, base), null);
+});
+
+test("bridge source parent must connect to the preceding commit", () => {
+  const data = fixture();
+  data.prCommits[2].parents[0].sha = "a".repeat(40);
+  assert.equal(selectTrustedPostMergeCandidate(data.pullRequests[0], data.prCommits, base), null);
+});
+
+function gitFixture(t, changedPath = "mydocs/pr/review.md") {
+  const directory = mkdtempSync(path.join(tmpdir(), "postmerge-tree-"));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const git = (...args) => execFileSync("git", ["-C", directory, ...args], {
+    encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+  const write = (name, content) => {
+    const target = path.join(directory, name);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, content);
+  };
+  const save = () => {
+    git("add", ".");
+    git("-c", "commit.gpgsign=false", "commit", "--quiet", "--allow-empty", "-m", "fixture");
+    return git("rev-parse", "HEAD");
+  };
+  const tree = () => git("rev-parse", "HEAD^{tree}");
+  git("init", "--quiet");
+  git("config", "user.name", "Test");
+  git("config", "user.email", "test@example.invalid");
+  write("src/lib.rs", "base\n");
+  const baseSha = save();
+  write("src/lib.rs", "reviewed code\n");
+  const candidateSha = save();
+  const testedMergeSha = git("commit-tree", tree(), "-p", baseSha, "-p", candidateSha, "-m", "tested");
+  write(changedPath, "final change\n");
+  const sourceSha = save();
+  const bridgeSha = git("commit-tree", tree(), "-p", sourceSha, "-p", baseSha, "-m", "bridge");
+  const mergeSha = git("commit-tree", tree(), "-p", baseSha, "-m", "squash");
+  return { directory, git, identity: { baseSha, bridgeSha, mergeSha, candidateSha, testedMergeSha } };
+}
+
+test("Git object proof accepts review documents, including spaces and newline paths", t => {
+  const { directory, identity } = gitFixture(t, "mydocs/pr/review with space\nand newline.md");
+  const result = verifyPostMergeReviewBridgeTree(directory, identity);
+  assert.equal(result.mergeSha, identity.mergeSha);
+  assert.notEqual(result.testedTreeSha, result.finalTreeSha);
+});
+
+for (const changedPath of ["src/lib.rs", "tests/cases/a.rs", ".github/workflows/ci.yml",
+  "Cargo.toml", "pdf/new.pdf", "mydocs/tech/text-ir-v2.md",
+  "mydocs/tech/canvaskit-parity-implementation.md"]) {
+  test(`Git object proof rejects untested change: ${changedPath}`, t => {
+    const { directory, identity } = gitFixture(t, changedPath);
+    assert.throws(() => verifyPostMergeReviewBridgeTree(directory, identity), /non-review-tree-change/);
+  });
+}
+
+test("Git object proof accepts identical trees and rejects wrong parents and invalid identities", t => {
+  const { directory, identity, git } = gitFixture(t);
+  const testedTree = git("show", "-s", "--format=%T", identity.testedMergeSha);
+  const mergeSha = git("commit-tree", testedTree, "-p", identity.baseSha, "-m", "identical");
+  const result = verifyPostMergeReviewBridgeTree(directory, { ...identity, mergeSha });
+  assert.equal(result.testedTreeSha, result.finalTreeSha);
+  assert.throws(() => verifyPostMergeReviewBridgeTree(directory, { ...identity, baseSha: identity.candidateSha }), /base-mismatch/);
+  assert.throws(() => verifyPostMergeReviewBridgeTree(directory, { ...identity, candidateSha: identity.baseSha }), /base-mismatch/);
+  assert.throws(() => verifyPostMergeReviewBridgeTree(directory, { ...identity, mergeSha: "--help" }), /invalid-review-bridge-identity/);
+  assert.throws(() => verifyPostMergeReviewBridgeTree(directory, { ...identity, mergeSha: "a".repeat(40) }));
 });

--- a/scripts/tests/verify-trusted-postmerge-review-bridge.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-review-bridge.test.mjs
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, copyFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
 import {
   evaluateTrustedPostMergeReuse, selectTrustedPostMergeCandidate,
   currentBaseReviewBridgeSource, verifyPostMergeReviewBridgeTree,
@@ -156,8 +157,12 @@ function gitFixture(t, changedPath = "mydocs/pr/review.md") {
   write(changedPath, "final change\n");
   const sourceSha = save();
   const bridgeSha = git("commit-tree", tree(), "-p", sourceSha, "-p", baseSha, "-m", "bridge");
+  write("mydocs/pr/tail.md", "trailing review\n");
+  save();
+  const headSha = git("commit-tree", tree(), "-p", bridgeSha, "-m", "tail");
   const mergeSha = git("commit-tree", tree(), "-p", baseSha, "-m", "squash");
-  return { directory, git, identity: { baseSha, bridgeSha, mergeSha, candidateSha, testedMergeSha } };
+  return { directory, git, sourceSha, headSha,
+    identity: { baseSha, bridgeSha, mergeSha, candidateSha, testedMergeSha } };
 }
 
 test("Git object proof accepts review documents, including spaces and newline paths", t => {
@@ -187,3 +192,148 @@ test("Git object proof accepts identical trees and rejects wrong parents and inv
   assert.throws(() => verifyPostMergeReviewBridgeTree(directory, { ...identity, mergeSha: "--help" }), /invalid-review-bridge-identity/);
   assert.throws(() => verifyPostMergeReviewBridgeTree(directory, { ...identity, mergeSha: "a".repeat(40) }));
 });
+
+test("Git object proof works with the runner's depth=1 fetched commits", t => {
+  const { directory, identity, git } = gitFixture(t);
+  const shallow = mkdtempSync(path.join(tmpdir(), "postmerge-shallow-"));
+  t.after(() => rmSync(shallow, { recursive: true, force: true }));
+  const command = (...args) => execFileSync("git", ["-C", shallow, ...args], {
+    encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+  command("init", "--quiet");
+  command("fetch", "--no-tags", "--depth=1", "--no-write-fetch-head", directory,
+    identity.mergeSha, identity.bridgeSha, identity.testedMergeSha);
+  assert.equal(command("rev-parse", "--is-shallow-repository"), "true");
+  assert.equal(command("show", "-s", "--format=%P", identity.bridgeSha), "");
+  const proof = verifyPostMergeReviewBridgeTree(shallow, identity);
+  assert.equal(proof.testedTreeSha, git("rev-parse", `${identity.testedMergeSha}^{tree}`));
+});
+
+// Execute the actual github-script body over real Git objects, with only API/network calls mocked.
+const workflow = readFileSync(new URL("../../.github/workflows/trusted-postmerge-ci-reuse.yml", import.meta.url), "utf8");
+const script = workflow.split("- name: Evaluate exact PR workflow evidence")[1]
+  .split("script: |\n")[1].split("\n").map(line => line.replace(/^ {12}/, "")).join("\n");
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const require = createRequire(import.meta.url);
+
+async function runWorkflow(t, workflowFile = "ci.yml", options = {}) {
+  const f = gitFixture(t, options.changedPath);
+  const { baseSha, candidateSha, bridgeSha, mergeSha, testedMergeSha } = f.identity;
+  const commits = new Map();
+  for (const sha of [baseSha, candidateSha, f.sourceSha, bridgeSha, f.headSha, mergeSha, testedMergeSha]) {
+    const [parents, tree] = f.git("show", "-s", "--format=%P%n%T", sha).split("\n");
+    commits.set(sha, { sha, parents: parents.split(" ").map(sha => ({ sha })),
+      commit: { tree: { sha: tree } }, files: [file(
+        sha === candidateSha ? "src/lib.rs" : "mydocs/pr/review.md",
+      )] });
+  }
+  const data = fixture();
+  const pr = { ...data.pullRequests[0], changed_files: 2, merge_commit_sha: mergeSha,
+    head: { ...data.pullRequests[0].head, sha: f.headSha } };
+  const summary = { ...pr };
+  delete summary.changed_files;
+  const runs = data.workflowRuns.map((run, index) => ({ ...run,
+    head_sha: index === 0 ? candidateSha : f.headSha,
+  }));
+  const headers = [candidateSha, f.sourceSha, bridgeSha, f.headSha].map(sha => ({ sha }));
+  const artifacts = ["b", "c", "d"].map(label => ({
+    name: `nextest-target-durations-${fullRunId}-${label}`, expired: false,
+  }));
+  artifacts.push({ name: `trusted-postmerge-merge-tree-v1-${testedMergeSha}-${commits.get(testedMergeSha).commit.tree.sha}`,
+    expired: false });
+  const state = { pr, runs, headers, artifacts, commits };
+  options.mutate?.(state);
+  const apiCalls = [], gitCalls = [], outputs = {}, warnings = [];
+  const endpoint = name => name;
+  const github = { rest: {
+    repos: {
+      getCommit: async ({ ref }) => {
+        apiCalls.push(["getCommit", ref]);
+        assert.ok(commits.has(ref), `unknown commit ${ref}`);
+        return { data: commits.get(ref) };
+      },
+      compareCommits: async () => ({ data: { merge_base_commit: { sha: baseSha } } }),
+      listPullRequestsAssociatedWithCommit: endpoint("associated"),
+    },
+    pulls: { get: async () => ({ data: pr }), listFiles: endpoint("files"), listCommits: endpoint("commits") },
+    actions: { listWorkflowRuns: endpoint("runs"), listWorkflowRunArtifacts: endpoint("artifacts"),
+      listJobsForWorkflowRun: endpoint("jobs") },
+  }, paginate: async (method, args) => {
+    apiCalls.push([method, args]);
+    switch (method) {
+      case "associated": return [summary];
+      case "files": return [file("src/lib.rs"), file("mydocs/pr/review.md")];
+      case "commits": return headers;
+      case "runs": return runs;
+      case "artifacts": return args.run_id === fullRunId ? artifacts : [];
+      case "jobs": return ["rust", "javascript-typescript", "python"].map(language => ({
+        name: `Analyze (${language})`, status: "completed",
+        conclusion: args.run_id === fullRunId ? "success" : "skipped",
+      }));
+      default: throw new Error(`unexpected API: ${method}`);
+    }
+  } };
+  mkdirSync(path.join(f.directory, "scripts"));
+  for (const name of ["verify-trusted-postmerge-ci-reuse.mjs", "ci-impact-classifier.cjs"]) {
+    copyFileSync(new URL(`../${name}`, import.meta.url), path.join(f.directory, "scripts", name));
+  }
+  const testRequire = name => name === "node:child_process" ? {
+    execFileSync: (command, args, settings) => {
+      gitCalls.push([command, args]);
+      assert.equal(command, "git");
+      assert.ok(["cat-file", "fetch"].includes(args[0]));
+      if (options.fetch && args[0] === "cat-file") throw new Error("object not present yet");
+      if (args[0] === "fetch") {
+        assert.deepEqual(args.slice(0, 7), ["fetch", "--no-tags", "--filter=blob:none", "--depth=1",
+          "--no-write-fetch-head", "origin", mergeSha]);
+        assert.deepEqual(args.slice(7), [bridgeSha, testedMergeSha]);
+        if (options.fetch === "failure") throw new Error("fetch failed");
+        return Buffer.alloc(0);
+      }
+      return execFileSync(command, args, settings);
+    },
+  } : require(name);
+  await new AsyncFunction("require", "github", "context", "core", "process", script)(
+    testRequire, github, { repo: { owner: "edwardkim", repo: "rhwp" } },
+    { setOutput: (key, value) => { outputs[key] = value; }, warning: message => warnings.push(message), info: () => {} },
+    { env: { GITHUB_WORKSPACE: f.directory, GITHUB_REPOSITORY: "edwardkim/rhwp", WORKFLOW_FILE: workflowFile,
+      CALLER_EVENT_NAME: "push", CALLER_REF: "refs/heads/devel", CALLER_SHA: mergeSha,
+      REQUIRE_DURATION_ARTIFACTS: workflowFile === "ci.yml" ? "true" : "false" } },
+  );
+  return { outputs, apiCalls, gitCalls, warnings, candidateSha };
+}
+
+for (const workflowFile of ["ci.yml", "codeql.yml"]) {
+  test(`actual ${workflowFile} collector traverses bridge and reuses the tested full run`, async t => {
+    const result = await runWorkflow(t, workflowFile);
+    assert.deepEqual(result.outputs, { reuse: "true",
+      reason: "current-base-review-bridge-green-pr-workflow-reused", source_run_id: String(fullRunId),
+      refresh_duration_data: workflowFile === "ci.yml" ? "true" : "false" });
+    assert.ok(result.apiCalls.some(([method, ref]) => method === "getCommit" && ref === result.candidateSha));
+    assert.deepEqual(result.warnings, []);
+  });
+}
+
+test("actual workflow fetches only missing immutable objects without checking out PR code", async t => {
+  const result = await runWorkflow(t, "ci.yml", { fetch: "success" });
+  assert.equal(result.outputs.reuse, "true");
+  assert.equal(result.gitCalls.filter(([, args]) => args[0] === "fetch").length, 1);
+});
+
+for (const [name, options] of [
+  ["fetch failure", { fetch: "failure" }],
+  ["code conflict resolution", { changedPath: "src/lib.rs" }],
+  ["expired immutable artifact", { mutate: d => { d.artifacts.at(-1).expired = true; } }],
+  ["missing duration artifact", { mutate: d => { d.artifacts.shift(); } }],
+  ["failed final head", { mutate: d => { d.runs[1].conclusion = "failure"; } }],
+  ["truncated file listing", { mutate: d => { d.pr.changed_files += 1; } }],
+  ["PR commit API cap", { mutate: d => { d.headers.push(...Array(246).fill(d.headers[0])); } }],
+  ["PR detail identity changed", { mutate: d => { d.pr.merge_commit_sha = "f".repeat(40); } }],
+]) {
+  test(`actual workflow preserves full lane on ${name}`, async t => {
+    const { outputs } = await runWorkflow(t, "ci.yml", options);
+    assert.equal(outputs.reuse, "false");
+    assert.equal(outputs.source_run_id, "");
+    assert.equal(outputs.refresh_duration_data, "false");
+  });
+}

--- a/scripts/tests/verify-trusted-postmerge-review-bridge.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-review-bridge.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { evaluateTrustedPostMergeReuse } from "../verify-trusted-postmerge-ci-reuse.mjs";
+
+const base = "1".repeat(40), code = "2".repeat(40), docs = "3".repeat(40);
+const bridge = "4".repeat(40), head = "5".repeat(40), merge = "6".repeat(40);
+const testedMerge = "7".repeat(40), testedTree = "8".repeat(40), tree = "9".repeat(40);
+const fullRunId = 34029158620, tailRunId = 34030157260;
+const file = (filename) => ({ filename, status: "modified" });
+const commit = (sha, parents, filename) => ({
+  sha, parents: parents.map(sha => ({ sha })), files: [file(filename)],
+});
+
+function fixture() {
+  const run = (id, sha) => ({
+    id, head_sha: sha, event: "pull_request", head_branch: "fix/review-bridge",
+    head_repository: { full_name: "edwardkim/rhwp" },
+    status: "completed", conclusion: "success",
+    created_at: "2026-09-06T11:04:00Z", updated_at: "2026-09-06T11:27:30Z",
+  });
+  return {
+    eventName: "push", ref: "refs/heads/devel", repository: "edwardkim/rhwp",
+    mergeSha: merge,
+    mergeCommit: { sha: merge, parents: [{ sha: base }], commit: { tree: { sha: tree } } },
+    sourceCommit: { sha: head, commit: { tree: { sha: tree } } }, mergeBaseSha: base,
+    pullRequests: [{
+      number: 6813, state: "closed", merge_commit_sha: merge,
+      created_at: "2026-09-06T11:03:00Z", merged_at: "2026-09-06T11:29:16Z",
+      base: { ref: "devel" },
+      head: { sha: head, ref: "fix/review-bridge", repo: { full_name: "edwardkim/rhwp" } },
+    }],
+    pullFiles: [file("src/renderer/composer.rs"), file("mydocs/orders/day.md")],
+    prCommits: [
+      commit(code, [base], "src/renderer/composer.rs"),
+      commit(docs, [code], "mydocs/orders/day.md"),
+      commit(bridge, [docs, base], "mydocs/orders/day.md"),
+      commit(head, [bridge], "mydocs/pr/review.md"),
+    ],
+    workflowRuns: [run(fullRunId, code), run(tailRunId, head)],
+    fullLaneRunIds: [String(fullRunId)],
+    mergeTreeEvidenceByRunId: {
+      [fullRunId]: { sha: testedMerge, parents: [base, code], treeSha: testedTree },
+    },
+  };
+}
+
+test("#6813: a docs merge between a full candidate and fast-pass head fails closed without tree proof", () => {
+  const result = evaluateTrustedPostMergeReuse(fixture());
+  assert.equal(result.reuse, false);
+  assert.equal(result.reason, "candidate-full-lane-evidence-unavailable");
+});

--- a/scripts/verify-trusted-postmerge-ci-reuse.mjs
+++ b/scripts/verify-trusted-postmerge-ci-reuse.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { execFileSync } from "node:child_process";
+
 const SHA = /^[0-9a-f]{40}$/;
 
 function denied(reason) {
@@ -73,7 +75,16 @@ export function classifyReviewOnlyCommit(commit) {
   return { kind: "review", parentSha: commit.parents[0].sha };
 }
 
-export function selectTrustedPostMergeCandidate(pullRequest, prCommits) {
+// A structural bridge is only a search hint. Reuse also requires independent tree proof.
+export function currentBaseReviewBridgeSource(commit, baseSha) {
+  const parents = commit?.parents;
+  return validSha(commit?.sha) && validSha(baseSha) && Array.isArray(parents)
+    && parents.length === 2 && parents[1]?.sha === baseSha
+    && validSha(parents[0]?.sha) && parents[0].sha !== baseSha
+    ? parents[0].sha : "";
+}
+
+export function selectTrustedPostMergeCandidate(pullRequest, prCommits, baseSha) {
   if (!validSha(pullRequest?.head?.sha) || !Array.isArray(prCommits) || prCommits.length === 0) {
     return null;
   }
@@ -81,10 +92,22 @@ export function selectTrustedPostMergeCandidate(pullRequest, prCommits) {
   let expectedSha = pullRequest.head.sha;
   let hasReviewOnlyTail = false;
   const fullLaneCandidates = [];
+  let bridgeSha = "";
   for (let index = prCommits.length - 1; index >= 0; index -= 1) {
     const commit = prCommits[index];
     if (commit?.sha !== expectedSha) {
       return null;
+    }
+    const bridgeSource = currentBaseReviewBridgeSource(commit, baseSha);
+    if (bridgeSource) {
+      if (bridgeSha) {
+        return null;
+      }
+      bridgeSha = commit.sha;
+      fullLaneCandidates.push({ sha: commit.sha, hasReviewOnlyTail });
+      expectedSha = bridgeSource;
+      hasReviewOnlyTail = true;
+      continue;
     }
     const classification = classifyReviewOnlyCommit(commit);
     if (classification.kind === "invalid") {
@@ -94,6 +117,7 @@ export function selectTrustedPostMergeCandidate(pullRequest, prCommits) {
       return {
         sha: commit.sha,
         hasReviewOnlyTail,
+        ...(bridgeSha ? { bridgeSha } : {}),
         fullLaneCandidates: [
           ...fullLaneCandidates,
           { sha: commit.sha, hasReviewOnlyTail },
@@ -106,6 +130,57 @@ export function selectTrustedPostMergeCandidate(pullRequest, prCommits) {
   }
 
   return null;
+}
+
+// Run only from the trusted base checkout; the inspected commits are data, never code.
+export function verifyPostMergeReviewBridgeTree(repository, identity) {
+  const { baseSha, bridgeSha, mergeSha, candidateSha, testedMergeSha } = identity;
+  if (![baseSha, bridgeSha, mergeSha, candidateSha, testedMergeSha].every(validSha)) {
+    throw new Error("invalid-review-bridge-identity");
+  }
+  const git = (...args) => execFileSync("git", ["-C", repository, ...args], {
+    encoding: "utf8", timeout: 30000, maxBuffer: 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const readCommit = (sha) => {
+    const [actual, parentLine, treeSha] = git("show", "-s", "--no-show-signature",
+      "--format=%H%n%P%n%T", sha).trim().split("\n");
+    if (actual !== sha || !validSha(treeSha)) {
+      throw new Error("review-bridge-commit-unavailable");
+    }
+    return { sha, treeSha, parents: parentLine.split(" ").map(sha => ({ sha })) };
+  };
+  const bridge = readCommit(bridgeSha);
+  const tested = readCommit(testedMergeSha);
+  const final = readCommit(mergeSha);
+  if (!currentBaseReviewBridgeSource(bridge, baseSha)
+    || tested.parents.length !== 2 || tested.parents[0].sha !== baseSha
+    || tested.parents[1].sha !== candidateSha || candidateSha === baseSha
+    || final.parents.length < 1 || final.parents.length > 2
+    || final.parents[0].sha !== baseSha) {
+    throw new Error("review-bridge-base-mismatch");
+  }
+  const paths = git("diff", "--name-only", "-z", "--no-renames", "--no-ext-diff",
+    "--no-textconv", "--ignore-submodules=none", tested.treeSha, final.treeSha, "--")
+    .split("\0").filter(Boolean);
+  if (!paths.every(path => path.startsWith("mydocs/")
+    && path !== "mydocs/tech/text-ir-v2.md"
+    && path !== "mydocs/tech/canvaskit-parity-implementation.md")) {
+    throw new Error("review-bridge-non-review-tree-change");
+  }
+  return { baseSha, bridgeSha, mergeSha, candidateSha, testedMergeSha,
+    testedTreeSha: tested.treeSha, finalTreeSha: final.treeSha };
+}
+
+function hasReviewBridgeTreeEvidence(input, run, baseSha, bridgeSha, finalTreeSha) {
+  const tested = input.mergeTreeEvidenceByRunId?.[String(run.id)];
+  const proof = input.reviewBridgeTreeEvidenceByRunId?.[String(run.id)];
+  return hasIntermediateCandidateMergeTreeEvidence(input, run)
+    && tested.parents[0] === baseSha
+    && proof?.baseSha === baseSha && proof.bridgeSha === bridgeSha
+    && proof.mergeSha === input.mergeSha && proof.candidateSha === run.head_sha
+    && proof.testedMergeSha === tested.sha && proof.testedTreeSha === tested.treeSha
+    && proof.finalTreeSha === finalTreeSha;
 }
 
 function isDirectReviewOnlyPullRequest(pullRequest, pullFiles, prCommits) {
@@ -364,7 +439,7 @@ export function evaluateTrustedPostMergeReuse(input) {
     };
   }
 
-  const candidateSource = selectTrustedPostMergeCandidate(pullRequest, input.prCommits);
+  const candidateSource = selectTrustedPostMergeCandidate(pullRequest, input.prCommits, baseParent);
   if (!candidateSource) {
     return denied("review-tail-evidence-unavailable");
   }
@@ -400,7 +475,12 @@ export function evaluateTrustedPostMergeReuse(input) {
   let foundCandidateRun = false;
   let foundFullLaneCandidate = false;
   let missingIntermediateCandidateEvidence = false;
+  let missingBridgeEvidence = false;
   let unsuccessfulCandidate = false;
+  if (candidateSource.bridgeSha && (!finalHeadCandidate
+    || finalHeadCandidate.status !== "completed" || finalHeadCandidate.conclusion !== "success")) {
+    return denied("review-bridge-final-head-not-successful");
+  }
   for (const candidateSourceEntry of candidateSource.fullLaneCandidates) {
     const candidate = latestCandidateRun(
       input.workflowRuns,
@@ -420,6 +500,12 @@ export function evaluateTrustedPostMergeReuse(input) {
       unsuccessfulCandidate = true;
       continue;
     }
+    if (candidateSource.bridgeSha && !hasReviewBridgeTreeEvidence(
+      input, candidate, baseParent, candidateSource.bridgeSha, mergeTreeSha,
+    )) {
+      missingBridgeEvidence = true;
+      continue;
+    }
     if (
       candidateSourceEntry.sha !== candidateSource.sha
       && !hasIntermediateCandidateMergeTreeEvidence(input, candidate)
@@ -433,7 +519,9 @@ export function evaluateTrustedPostMergeReuse(input) {
     }
     return {
       reuse: true,
-      reason: candidateSourceEntry.hasReviewOnlyTail
+      reason: candidateSource.bridgeSha
+        ? "current-base-review-bridge-green-pr-workflow-reused"
+        : candidateSourceEntry.hasReviewOnlyTail
         ? "review-tail-green-pr-workflow-reused"
         : "exact-green-pr-workflow-reused",
       sourceRunId: String(candidate.id),
@@ -445,6 +533,9 @@ export function evaluateTrustedPostMergeReuse(input) {
   }
   if (!foundFullLaneCandidate) {
     return denied("candidate-full-lane-evidence-unavailable");
+  }
+  if (missingBridgeEvidence) {
+    return denied("review-bridge-tree-evidence-unavailable");
   }
   if (missingIntermediateCandidateEvidence) {
     return denied("review-tail-candidate-merge-tree-evidence-unavailable");

--- a/scripts/verify-trusted-postmerge-ci-reuse.mjs
+++ b/scripts/verify-trusted-postmerge-ci-reuse.mjs
@@ -138,17 +138,22 @@ export function verifyPostMergeReviewBridgeTree(repository, identity) {
   if (![baseSha, bridgeSha, mergeSha, candidateSha, testedMergeSha].every(validSha)) {
     throw new Error("invalid-review-bridge-identity");
   }
-  const git = (...args) => execFileSync("git", ["-C", repository, ...args], {
+  const git = (...args) => execFileSync("git", ["-C", repository, "--no-replace-objects", ...args], {
     encoding: "utf8", timeout: 30000, maxBuffer: 1024 * 1024,
     stdio: ["ignore", "pipe", "pipe"],
   });
   const readCommit = (sha) => {
-    const [actual, parentLine, treeSha] = git("show", "-s", "--no-show-signature",
-      "--format=%H%n%P%n%T", sha).trim().split("\n");
-    if (actual !== sha || !validSha(treeSha)) {
+    // Pretty-printing hides parents at a depth=1 boundary; raw headers retain the real identity.
+    if (git("cat-file", "-t", sha).trim() !== "commit") {
       throw new Error("review-bridge-commit-unavailable");
     }
-    return { sha, treeSha, parents: parentLine.split(" ").map(sha => ({ sha })) };
+    const headers = git("cat-file", "commit", sha).split("\n\n", 1)[0].split("\n");
+    const trees = headers.filter(line => line.startsWith("tree ")).map(line => line.slice(5));
+    const parents = headers.filter(line => line.startsWith("parent ")).map(line => line.slice(7));
+    if (trees.length !== 1 || !validSha(trees[0]) || !parents.every(validSha)) {
+      throw new Error("review-bridge-commit-unavailable");
+    }
+    return { sha, treeSha: trees[0], parents: parents.map(sha => ({ sha })) };
   };
   const bridge = readCommit(bridgeSha);
   const tested = readCommit(testedMergeSha);


### PR DESCRIPTION
## 변경 요약

PR #6813에서 Full CI 성공 뒤 문서-only trailing과 current-base 충돌 해소 merge를 추가하자, post-merge CI/CodeQL이 이전 Full 성공 head를 찾지 못하고 다시 실행된 문제를 보완합니다.

- collector와 후보 선택기가 current-base merge 한 개를 지나 이전 Full candidate를 탐색합니다.
- 이전 Full 실행의 immutable merge-tree artifact와 실제 Git 객체를 대조하고, 검사 tree와 최종 merge tree의 차이가 허용된 `mydocs/**`뿐일 때 재사용합니다.
- shallow fetch에서도 원본 commit header로 부모를 검증합니다. PR head는 checkout하거나 실행하지 않습니다.
- 실패한 최종 head, 코드 충돌 보정, base/계보 불일치, 복수 merge, 잘린 API 목록, 만료·누락 artifact, 객체 fetch 실패는 Full로 유지합니다.
- 기존 B/C/D duration artifact 재사용, `Build & Test` required check와 최소 권한을 유지합니다.

## 관련 이슈

Ref #6815

로컬 재현 검증과 실제 runner의 적용 후 검증을 구분하기 위해 자동 close하지 않습니다. 후속 코드 PR의 current-base 문서 merge에서 실제 CI/CodeQL heavy skip과 timing 재사용을 확인한 뒤 완료를 판단합니다.

## 검증

- [x] CI impact/classifier, 기존 verifier, squash, 신규 bridge Node 테스트 **164개 통과**
- [x] `test_*workflow.py` 전체 discovery **162개 통과**
- [x] 별도 선택 workflow 계약 **134개 통과**(일부 중복)
- [x] 변경 workflow 2개의 actionlint, `git diff --check` 통과
- [x] 변경 문서 4개의 내부 링크 및 변경 매뉴얼 metadata 통과
- [x] 실제 workflow JavaScript 실행, 실제 depth=1 Git fetch, positive/negative 계약 검증

GitHub 운영 O3 변경으로 제품 Rust/Cargo/WASM/시각 검증은 대상이 아닙니다. 전체 문서 metadata 검사는 변경하지 않은 기존 4개 문서의 누락 16건을 보고했고, 이번 변경 문서에는 신규 오류가 없습니다. 원본 로그와 임시 API JSON은 커밋하지 않았습니다.

## 실제 #6813 데이터 재실행

GitHub의 기존 PR/commit/run/job/artifact 응답과 실제 Git 객체로 현재 workflow script를 읽기 전용 재실행했습니다. GitHub Actions를 재실행한 결과는 아닙니다.

| 대상 | 수정 전 | 수정 후 source run | 판정 |
| --- | --- | --- | --- |
| CI | `candidate-full-lane-evidence-unavailable` | [34029158620](https://github.com/edwardkim/rhwp/actions/runs/34029158620) | `reuse=true`, timing 재사용 |
| CodeQL | 같은 사유로 Full | [34029158604](https://github.com/edwardkim/rhwp/actions/runs/34029158604) | `reuse=true` |

두 결과 모두 `current-base-review-bridge-green-pr-workflow-reused`이고 warning은 없었습니다. 실제 runner 시간 절감은 아직 측정하지 않았습니다.

## 적용 및 기록 계획

- 이 PR은 CI 실행 정책 자체를 바꾸므로 Full 검증 대상입니다. 병합 전 base의 verifier를 사용하므로 최초 post-merge도 Full일 수 있습니다.
- 작업지시자 요청 **옵션 2**: 이번 코드 PR에 review/오늘할일 trailing push를 하지 않고, 해당 기록은 별도 문서 PR로 처리합니다.
- 분석·구현·검증은 세 단계의 일반 커밋으로 나눴습니다. 기록: `mydocs/working/task_m100_6815_stage1.md`, `stage2.md`, `stage3.md`.
- source 변경을 잘못 skip하거나 required check에 문제가 생기면 이 변경을 revert하는 PR로 기존 Full fallback에 복귀합니다.
