### PR TITLE
fix(ci): 완료 audit의 최초 policy controller 취소 방지 (#6819)

### DIFF
--- a/.github/workflows/ci-impact-policy.yml
+++ b/.github/workflows/ci-impact-policy.yml
@@ -18,6 +18,10 @@ permissions: {}
 # Completion events for one candidate serialize on the exact head SHA. The newest event
 # recomputes all workflow evidence, so completion order cannot overwrite a failure with
 # partial success from another workflow.
+# [#6819] Completion audits must wait for the running controller: their default-branch
+# checks cannot replace a cancelled pull_request_target check on the PR head. Keep one
+# shared group so the initial publisher cannot race an audit and overwrite its status.
+# Only a new pull_request_target event may supersede a running controller for this head.
 concurrency:
   group: >-
     ci-impact-policy-${{
@@ -25,7 +29,7 @@ concurrency:
       || github.event.workflow_run.head_sha
       || github.run_id
     }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
 
 jobs:
   controller:

--- a/scripts/tests/test_ci_impact_policy_workflow.py
+++ b/scripts/tests/test_ci_impact_policy_workflow.py
@@ -106,7 +106,23 @@ class CiImpactPolicyWorkflowTests(unittest.TestCase):
         self.assertIn("input.currentHeadSha = process.env.CURRENT_HEAD_SHA", self.workflow)
         self.assertIn("github.rest.pulls.get({", self.workflow)
         self.assertIn("livePull.head.sha !== process.env.HEAD_SHA", self.workflow)
-        self.assertIn("cancel-in-progress: true", self.workflow)
+
+    def test_completion_audit_cannot_cancel_running_pr_head_controller(self) -> None:
+        concurrency = self.workflow.split("\nconcurrency:\n", 1)[1].split("\njobs:\n", 1)[0]
+        cancel_policy = concurrency.split("  cancel-in-progress: ", 1)[1].strip()
+        self.assertEqual(
+            cancel_policy,
+            "${{ github.event_name == 'pull_request_target' }}",
+        )
+
+    def test_publish_and_audit_share_exact_source_head_serialization(self) -> None:
+        concurrency = self.workflow.split("\nconcurrency:\n", 1)[1].split("\njobs:\n", 1)[0]
+        group = concurrency.split("  group: >-\n", 1)[1].split("  cancel-in-progress:", 1)[0]
+        self.assertEqual(
+            " ".join(group.split()),
+            "ci-impact-policy-${{ github.event.pull_request.head.sha "
+            "|| github.event.workflow_run.head_sha || github.run_id }}",
+        )
 
     def test_cancelled_controller_cannot_summarize_or_publish(self) -> None:
         guarded = "if: ${{ always() && !cancelled() && steps.resolve.outputs.active == 'true' }}"


### PR DESCRIPTION
## 변경 요약

PR #6818에서 관찰한 policy controller 취소 충돌을 수정합니다. 문서 trailing CI/CodeQL은 재사용에 성공했지만, 최초 `pull_request_target` controller가 취소되어 PR head에 취소 체크가 남았습니다.

- 동일한 source head 기반 concurrency 그룹은 유지합니다. publish와 audit을 이벤트별 그룹으로 분리하지 않아 status 게시가 병렬로 진행되지 않게 합니다.
- `cancel-in-progress`를 `${{ github.event_name == 'pull_request_target' }}`로 제한합니다. `workflow_run` 완료 알림은 실행 중인 controller를 취소하지 않고 기다립니다.
- PR 이벤트의 기존 취소 정책, 전체 same-head workflow 증거 재수집, exact-head 확인, 취소된 실행의 status 게시 금지, 최소 권한과 신뢰 경계는 변경하지 않습니다.
- 완료 알림의 취소 금지와 동일 source head 직렬화를 고정하는 Python 계약 테스트 2개를 추가합니다.

기준: `upstream/devel`의 `4f039316ff2b0726742f4266ebac7d6e497d4686`.
변경은 workflow와 Python 계약 테스트 2개 파일뿐이며 #6818의 renderer 코드와 문서, 샘플은 포함하지 않습니다.

## 관련 이슈 및 재현 근거

Ref #6819. 관련 배경: #3790, #6816.

- 최초 controller 취소: https://github.com/edwardkim/rhwp/actions/runs/34041820666/job/101509851411
- 성공한 후속 audit: https://github.com/edwardkim/rhwp/actions/runs/34041890886/job/101510045877
- 정상 CI fast-pass: https://github.com/edwardkim/rhwp/actions/runs/34041821818/job/101509879227
- 정상 CodeQL fast-pass: https://github.com/edwardkim/rhwp/actions/runs/34041821778/job/101509871734

취소 annotation은 동일 head의 더 높은 우선순위 대기 요청을 명시했습니다. 후속 audit의 Actions check는 기본 branch SHA에 연결되므로 PR head에 남은 최초 취소 체크를 대체하지 못합니다. 이번 수정은 #6816의 trusted post-merge merge-bridge 후보 탐색과 별도입니다.

## 검증

- [x] `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_ci_impact_policy_workflow scripts.tests.test_ci_impact_workflow`: 48개 통과, 3.341초.
- [x] `actionlint .github/workflows/ci-impact-policy.yml`: 통과.
- [x] `git diff --check`, `git diff --cached --check`: 통과.
- Rust source/test, renderer, Studio, WASM 변경이 없으므로 Cargo 전체 회귀, Clippy, WASM 빌드와 시각 증적 생성은 범위 밖으로 실행하지 않았습니다.
- 위 테스트는 workflow 정의와 기존 신뢰 계약의 로컬 검증입니다. GitHub의 실제 concurrency 실행 결과를 새 설정으로 검증했다는 의미는 아닙니다.

## 적용 경계와 남은 검증

**이 controller workflow는 기본 branch `main`에서 등록됩니다. 이 PR을 `devel`에 merge하는 것만으로 실제 이벤트의 concurrency 설정이 바뀌지는 않습니다.** 일반 배포 경로로 `main`에 반영된 뒤 실제 최초 publish와 완료 audit, PR head check와 최종 merge 상태를 확인해야 합니다.

이 때문에 `Closes` 대신 `Ref #6819`로 연결합니다. 이번 PR에서 `main` 직접 push, branch protection 변경, 기존 실행 취소/재실행, #6818 merge/close/cleanup은 수행하지 않습니다. 운영 적용 전 새 PR에 기존 controller 취소 현상이 발생하더라도 로컬 수정이 실제 이벤트에 반영됐다고 보고하지 않습니다.

검증 결과와 후속 처리는 이 PR 본문과 코멘트에 기록합니다. PR review 문서, 오늘할일, 문서 trailing commit 및 후속 문서 PR은 추가하지 않습니다.

## 성능 영향 및 시각 자료

제품 성능·렌더링 영향은 없습니다. 같은 head에서 진행 중인 controller를 완료 audit이 기다리므로 audit 시작이 늦어질 수 있지만, 취소된 PR-head check가 남는 현상과 publish/audit 간 병렬 갱신을 피하는 것이 목적입니다. 실제 대기 시간은 `main` 적용 후 측정하며 현재 수치를 추정하지 않습니다. 스크린샷은 해당하지 않습니다.
