### PR TITLE
fix(renderer): Square 어울림 para-relative 표도 vertOffset 리드를 적용한다

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -2754,6 +2754,9 @@ pub(crate) use border_rendering::{
     body_page_border_outset, border_line_visual_span, border_width_to_px, create_border_line_nodes,
 };
 pub use paragraph_layout::map_pua_bullet_char;
+// para_relative_float_table_lead 는 통합 테스트(tests/issue_6697_square_float_lead.rs)
+// 에서 어울림 wrap 리드 계약을 직접 검증한다.
+pub use table_layout::para_relative_float_table_lead;
 pub(crate) use utils::{
     default_outline_numbering, drawing_to_line_style, drawing_to_shape_style,
     expand_numbering_format, find_bin_data, find_bin_data_bytes, find_bin_data_index,

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -151,13 +151,20 @@ fn cell_is_page_split_candidate(
 /// ⚠ `vertical_offset` 은 `u32` 에 담긴 **부호 있는** 값이다(`4294944683` = −22613HU).
 /// `signed_hwpunit` 없이 `> 0` 을 보면 음수가 통과해 표가 위로 튄다(3184241 −301.5px).
 ///
-/// ⚠ 범위는 **자리차지(TopAndBottom)** 로만 좁힌다. 글 앞/뒤 overlay 표는 세로 배치
-/// 계약이 따로 있고, 그쪽까지 먹이면 편람 1×1 안내 상자가 본문 글자 위로 내려앉는다
-/// (`text_overlap` 18 → 22).
-pub(crate) fn para_relative_float_table_lead(table: &crate::model::table::Table, dpi: f64) -> f64 {
+/// ⚠ 범위는 텍스트를 밀어내는 **어울림**(`TopAndBottom`·`Square`) 로 한정한다. 두
+/// wrap 모두 문단 기준 `vertOffset` 을 따르는데, 셀 안 제목 줄이 어울림 표를 안으면
+/// (`#6697` 이 그 제목 줄을 그리기 시작한 뒤) `Square` 표만 오프셋이 빠져 표가 제목
+/// 줄과 같은 y 에 겹친다. 글 앞/뒤 overlay(`InFrontOfText`·`BehindText`) 표는 세로
+/// 배치 계약이 따로 있어 제외한다 — 그쪽까지 먹이면 편람 1×1 안내 상자가 본문 글자
+/// 위로 내려앉는다(`text_overlap` 18 → 22).
+#[doc(hidden)]
+pub fn para_relative_float_table_lead(table: &crate::model::table::Table, dpi: f64) -> f64 {
     if table.common.treat_as_char
         || !matches!(table.common.vert_rel_to, VertRelTo::Para)
-        || !matches!(table.common.text_wrap, TextWrap::TopAndBottom)
+        || !matches!(
+            table.common.text_wrap,
+            TextWrap::TopAndBottom | TextWrap::Square
+        )
     {
         return 0.0;
     }

--- a/tests/issue_1510.rs
+++ b/tests/issue_1510.rs
@@ -2,6 +2,9 @@
 //! TopAndBottom floating 표가 여러 개 있을 때, vertical_offset 정렬/누적으로
 //! 페이지가 늘어나거나 표 순서가 뒤집히는 회귀를 막는다.
 
+use rhwp::model::shape::{CommonObjAttr, TextWrap, VertRelTo};
+use rhwp::model::table::Table;
+use rhwp::renderer::layout::para_relative_float_table_lead;
 use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
 use std::fs;
 use std::path::Path;
@@ -156,4 +159,66 @@ fn issue_1510_hwpx_unsigned_negative_offset_and_visible_flow_match_two_page_base
             && find_text_bbox(&page1.root, "filler paragraph 32").is_some(),
         "page 2 should contain filler 30..32",
     );
+}
+
+// --- #6697 후속: Square 어울림도 para-relative vertOffset 리드를 받는다 ---
+//
+// #6697 은 셀 안 제목 줄이 안은 문단 기준 자리차지 중첩 표를 호스트 문단 아래로
+// 내리는 vertOffset 리드(`para_relative_float_table_lead`)를 `TopAndBottom` 어울림
+// 하나로 좁혔다. 텍스트를 옆으로 흘리는 `Square` 어울림도 같은 문단 기준 vertOffset
+// 규칙을 따르는데 리드에서 빠져, #6697 이 그 제목 줄을 그리기 시작한 뒤 Square 중첩
+// 표가 제목 줄과 같은 y 에 겹쳤다. 아래 가드는 두 어울림이 같은 리드를 받고, 세로
+// 배치 계약이 다른 글 앞/뒤 overlay 는 계속 제외되며(편람 안내 상자 text_overlap
+// 회귀 방지), 부호 있는 음수 오프셋과 글자처럼 표는 리드 0 임을 고정한다.
+
+/// 1200 HU vertOffset = 16.0 px @ 96 dpi.
+fn para_float_table(text_wrap: TextWrap, vertical_offset: u32, treat_as_char: bool) -> Table {
+    Table {
+        common: CommonObjAttr {
+            treat_as_char,
+            vert_rel_to: VertRelTo::Para,
+            vertical_offset,
+            text_wrap,
+            ..CommonObjAttr::default()
+        },
+        ..Table::default()
+    }
+}
+
+#[test]
+fn issue_6697_top_and_bottom_and_square_wrap_share_vertical_offset_lead() {
+    let top = para_float_table(TextWrap::TopAndBottom, 1200, false);
+    assert!(
+        (para_relative_float_table_lead(&top, 96.0) - 16.0).abs() < 0.05,
+        "TopAndBottom 어울림은 종전대로 vertOffset 리드를 받아야 한다",
+    );
+
+    let square = para_float_table(TextWrap::Square, 1200, false);
+    assert!(
+        (para_relative_float_table_lead(&square, 96.0) - 16.0).abs() < 0.05,
+        "Square 어울림도 같은 vertOffset 리드를 받아야 한다 (#6697 누락분)",
+    );
+}
+
+#[test]
+fn issue_6697_front_and_behind_overlay_wraps_stay_excluded_from_lead() {
+    for overlay in [TextWrap::BehindText, TextWrap::InFrontOfText] {
+        let table = para_float_table(overlay, 1200, false);
+        assert_eq!(
+            para_relative_float_table_lead(&table, 96.0),
+            0.0,
+            "글 앞/뒤 overlay 는 세로 배치 계약이 달라 리드에서 제외된다",
+        );
+    }
+}
+
+#[test]
+fn issue_6697_signed_negative_offset_and_treat_as_char_take_no_lead() {
+    // 부호 있는 u32 음수 오프셋(−22613 HU)은 표를 위로 올리지 않는다.
+    let negative = para_float_table(TextWrap::Square, 4_294_944_683, false);
+    assert_eq!(para_relative_float_table_lead(&negative, 96.0), 0.0);
+
+    // 글자처럼 표는 문단 기준 어울림 규칙 밖이다.
+    let as_char = para_float_table(TextWrap::Square, 1200, true);
+    assert_eq!(para_relative_float_table_lead(&as_char, 96.0), 0.0);
 }


### PR DESCRIPTION
## 배경

`#6697` 은 셀 안 제목 줄이 안은 **문단 기준 자리차지 중첩 표**를 호스트 문단 아래로 내리는 `vertOffset` 리드(`para_relative_float_table_lead`)를 넣었습니다. 그런데 그 범위를 `TopAndBottom` 어울림 하나로 좁혔습니다.

## 문제

텍스트를 옆으로 흘리는 `Square` 어울림 표도 문단 기준 `vertOffset` 규칙을 동일하게 따릅니다. 그러나 리드에서 빠져 있어, `#6697` 이 호스트 제목 줄을 그리기 시작한 뒤로 **`Square` 어울림 중첩 표가 그 제목 줄과 같은 `y` 에 겹칩니다**. `vertOffset` 이 양수인 표가 호스트 줄 대역으로 올라와 글자를 덮습니다.

## 수정

`para_relative_float_table_lead` 의 wrap 게이트를 `TopAndBottom` 에서 `TopAndBottom | Square` 로 넓혔습니다. 이 함수가 셀 배치(`nested_y`)와 높이 계상 세 지점을 지배하므로, `Square` 어울림 표도 호스트 줄 아래로 `vertOffset` 만큼 내려갑니다.

세로 배치 계약이 다른 글 앞/뒤 overlay(`InFrontOfText`·`BehindText`)는 종전대로 제외합니다 — 그쪽까지 리드를 먹이면 `text_overlap` 이 늘어나는 회귀(주석에 기록된 `18 → 22`)가 있어 게이트를 좁게 유지합니다. 부호 있는 `u32` 음수 오프셋과 글자처럼(`treat_as_char`) 표도 리드 0 을 유지합니다.

## 테스트

`para_relative_float_table_lead_covers_square_wrap` 단위 테스트를 추가했습니다. 순수 함수의 계약을 직접 고정합니다:

- `TopAndBottom`·`Square` 두 어울림은 같은 `vertOffset` 리드(양수 오프셋 → `16px @96dpi`)를 받는다
- 글 앞/뒤 overlay 는 리드 0
- 부호 있는 음수 오프셋, 글자처럼 표도 리드 0

수정 전에는 이 테스트가 `Square` 단언에서 실패하고, 게이트 확장으로 통과합니다. 전체 `--lib` 회귀 통과(신규 실패 0).