### PR TITLE
chore(deps): Dependabot 의존성 12건 통합 및 flate2·Skia 호환성 보정

### DIFF
--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -96,7 +96,7 @@ jobs:
           toolchain: 1.93.1
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
+        uses: taiki-e/install-action@5bf6ce016fd2e72eefc647cbca1e4213f65955b8 # v2.87.5
         with:
           tool: nextest
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -101,4 +101,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/.github/workflows/gym-release-gate.yml
+++ b/.github/workflows/gym-release-gate.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate Gym contracts
         run: >-
@@ -77,7 +77,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -167,7 +167,7 @@ jobs:
           cat SHA256SUMS.txt
 
       - name: Attach to release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           files: |

--- a/.github/workflows/run-nextest-archives.yml
+++ b/.github/workflows/run-nextest-archives.yml
@@ -49,7 +49,7 @@ jobs:
           toolchain: 1.93.1
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
+        uses: taiki-e/install-action@5bf6ce016fd2e72eefc647cbca1e4213f65955b8 # v2.87.5
         with:
           tool: nextest
 

--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -193,7 +193,7 @@ jobs:
       # the merged PR head, including a verifier changed by that PR.
       - name: Checkout trusted verifier
         if: ${{ steps.source-base.outputs.sha != '' }}
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.source-base.outputs.sha }}
           sparse-checkout: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
 dependencies = [
  "cipher",
  "cpubits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,9 +2607,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skia-bindings"
-version = "0.99.0"
+version = "0.153.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2d1c3ebd697c0cbded0145e9204a38fa6b268446051b7196d0a096414ea7f3"
+checksum = "eeb2c4e67b9bc757cc62afe8a73ec02dd20dd420c3fc063d150c234142443b6b"
 dependencies = [
  "bindgen",
  "cc",
@@ -2624,9 +2624,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.99.0"
+version = "0.153.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f512ac418a64194842dd05566320805dad1c957c521039db2486fd6368865bc"
+checksum = "bbb3bf4232dee3517b6dcc5b7ad565a384c244e6d41a0dc4d78c16ed207f74ef"
 dependencies = [
  "bitflags 2.13.1",
  "skia-bindings",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,12 +892,12 @@ checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
  "zlib-rs",
 ]
 
@@ -1535,6 +1535,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "ml-dsa"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,7 +1876,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -1879,7 +1889,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -2795,7 +2805,7 @@ dependencies = [
  "fontdb",
  "image",
  "log",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "once_cell",
  "pdf-writer",
  "resvg 0.45.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -316,7 +316,7 @@ usvg = "0.45"
 resvg = { version = "0.47", optional = true }
 pdf-writer = "0.12"
 subsetter = "0.2"
-skia-safe = { version = "0.99.0", optional = true, default-features = false, features = ["binary-cache", "embed-icudtl", "pdf", "textlayout"] }
+skia-safe = { version = "0.153.2", optional = true, default-features = false, features = ["binary-cache", "embed-icudtl", "pdf", "textlayout"] }
 
 # [gym_gpu_raster] GPU 래스터화 스택 (feature = "gpu", 네이티브 전용).
 # vello: Linebender 의 GPU 2D 렌더러(컴퓨트 파이프라인). vello_svg: usvg 트리 → vello Scene.

--- a/rhwp-chrome/package-lock.json
+++ b/rhwp-chrome/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.6",
       "license": "MIT",
       "devDependencies": {
-        "puppeteer": "^25.9.0",
+        "puppeteer": "^25.10.0",
         "typescript": "^7.0.2",
         "vite": "^8.2.2"
       }
@@ -25,13 +25,13 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.1.tgz",
-      "integrity": "sha512-KDz+3qDRdBAlRlMjmKyj6dEs33YHTk/xRHEENSXq6TNnhgoU15ruSHtEBeVF6OZ9tBDY55Se4P0nFMNsipzU9A==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.2.tgz",
+      "integrity": "sha512-q2BU4YfO9h/Wt7IcWPcggpOOqLk2Tbs1hDwolvKZrweRjy751OJBKMN9zO5bfD0pzU7X/tvKw/exQds4pM/LOg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "modern-tar": "^0.8.0",
+        "modern-tar": "^0.8.4",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -1211,18 +1211,18 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "25.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.9.0.tgz",
-      "integrity": "sha512-2JqQszD2pyDTpIvBH1ZCXdrHgENVNdJIeOM6asbwHRgWknFiaLd1gNB91w/B/0hQHNpafkpxa90lPpBaJM87Hw==",
+      "version": "25.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.10.0.tgz",
+      "integrity": "sha512-9ZfkiaZDQWpGPJp9XTS+Bkn/D78hPvYmtjPfIBeybn05oeY6Jj7aiSbYdfcSQD2UMvC0vE7Yi9PSDo179euRzw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "3.2.1",
+        "@puppeteer/browsers": "3.2.2",
         "chromium-bidi": "17.0.2",
         "devtools-protocol": "0.0.1666840",
         "lilconfig": "^3.1.3",
-        "puppeteer-core": "25.9.0",
+        "puppeteer-core": "25.10.0",
         "typed-query-selector": "^2.12.2"
       },
       "bin": {
@@ -1233,17 +1233,17 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "25.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.9.0.tgz",
-      "integrity": "sha512-U61rCwSMha62CA/Opy6tCx2Fx+ck7ouiKnbpEApzSoLYMoEu9F71nuFpHL55vmIt33/GYm6eKZVhH2ev0nAIeg==",
+      "version": "25.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.10.0.tgz",
+      "integrity": "sha512-Hy5eMQshOEMil4JUUx03h5pw1HYkYCso1RG/gcpPlFSd4cYPOcopxcXEAxpLPOkOPJb9LIJtwxuj66bSdvknFg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "3.2.1",
+        "@puppeteer/browsers": "3.2.2",
         "chromium-bidi": "17.0.2",
         "devtools-protocol": "0.0.1666840",
         "typed-query-selector": "^2.12.2",
-        "webdriver-bidi-protocol": "0.4.2",
+        "webdriver-bidi-protocol": "0.4.3",
         "ws": "^8.21.3"
       },
       "engines": {
@@ -1465,9 +1465,9 @@
       }
     },
     "node_modules/webdriver-bidi-protocol": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
-      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.3.tgz",
+      "integrity": "sha512-uuN0goWfxP22B7J/uAgBpOYNPttC+XVseYE+rSY5+rQ+YBeVz/VORw8WbmLVcqW78zNg5A4qnjNXYUWR3il2ig==",
       "dev": true,
       "license": "Apache-2.0"
     },

--- a/rhwp-chrome/package.json
+++ b/rhwp-chrome/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf dist"
   },
   "devDependencies": {
-    "puppeteer": "^25.9.0",
+    "puppeteer": "^25.10.0",
     "typescript": "^7.0.2",
     "vite": "^8.2.2"
   }

--- a/rhwp-studio/package-lock.json
+++ b/rhwp-studio/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@types/chrome": "^0.2.8",
-        "puppeteer-core": "^25.9.0",
+        "puppeteer-core": "^25.10.0",
         "typescript": "^7.0.2",
         "vite": "^8.2.2",
         "vite-plugin-pwa": "^1.3.0",
@@ -1736,13 +1736,13 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.1.tgz",
-      "integrity": "sha512-KDz+3qDRdBAlRlMjmKyj6dEs33YHTk/xRHEENSXq6TNnhgoU15ruSHtEBeVF6OZ9tBDY55Se4P0nFMNsipzU9A==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.2.tgz",
+      "integrity": "sha512-q2BU4YfO9h/Wt7IcWPcggpOOqLk2Tbs1hDwolvKZrweRjy751OJBKMN9zO5bfD0pzU7X/tvKw/exQds4pM/LOg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "modern-tar": "^0.8.0",
+        "modern-tar": "^0.8.4",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -5327,17 +5327,17 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "25.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.9.0.tgz",
-      "integrity": "sha512-U61rCwSMha62CA/Opy6tCx2Fx+ck7ouiKnbpEApzSoLYMoEu9F71nuFpHL55vmIt33/GYm6eKZVhH2ev0nAIeg==",
+      "version": "25.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.10.0.tgz",
+      "integrity": "sha512-Hy5eMQshOEMil4JUUx03h5pw1HYkYCso1RG/gcpPlFSd4cYPOcopxcXEAxpLPOkOPJb9LIJtwxuj66bSdvknFg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "3.2.1",
+        "@puppeteer/browsers": "3.2.2",
         "chromium-bidi": "17.0.2",
         "devtools-protocol": "0.0.1666840",
         "typed-query-selector": "^2.12.2",
-        "webdriver-bidi-protocol": "0.4.2",
+        "webdriver-bidi-protocol": "0.4.3",
         "ws": "^8.21.3"
       },
       "engines": {
@@ -6448,9 +6448,9 @@
       }
     },
     "node_modules/webdriver-bidi-protocol": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
-      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.3.tgz",
+      "integrity": "sha512-uuN0goWfxP22B7J/uAgBpOYNPttC+XVseYE+rSY5+rQ+YBeVz/VORw8WbmLVcqW78zNg5A4qnjNXYUWR3il2ig==",
       "dev": true,
       "license": "Apache-2.0"
     },

--- a/rhwp-studio/package-lock.json
+++ b/rhwp-studio/package-lock.json
@@ -15,7 +15,7 @@
         "pngjs": "^7.0.0"
       },
       "devDependencies": {
-        "@types/chrome": "^0.2.7",
+        "@types/chrome": "^0.2.8",
         "puppeteer-core": "^25.9.0",
         "typescript": "^7.0.2",
         "vite": "^8.2.2",
@@ -2531,9 +2531,9 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.7.tgz",
-      "integrity": "sha512-9kjBozQ+jyDVt1eai3VZqjHDTN95JCuRmbRHOryOltBJmzrTmUw/9r/DznmjRaQ8WlyIfeCA4WNzoj0IvormJA==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.8.tgz",
+      "integrity": "sha512-dznDYMiJUyuc7b+78PxnWhaGOonmbX/OmcWu7NE42sg/yTLJMYnJ7Uah40SLPNFiCh8reqcthk7vOva2+MSvzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -77,7 +77,7 @@
     "e2e:issue-6557-merged-row": "node e2e/run-with-vite.mjs -- node e2e/merged-cell-row-boundary-drag.test.mjs --mode=headless"
   },
   "devDependencies": {
-    "@types/chrome": "^0.2.7",
+    "@types/chrome": "^0.2.8",
     "puppeteer-core": "^25.9.0",
     "typescript": "^7.0.2",
     "vite": "^8.2.2",

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@types/chrome": "^0.2.8",
-    "puppeteer-core": "^25.9.0",
+    "puppeteer-core": "^25.10.0",
     "typescript": "^7.0.2",
     "vite": "^8.2.2",
     "vite-plugin-pwa": "^1.3.0",

--- a/rhwp-vscode/package-lock.json
+++ b/rhwp-vscode/package-lock.json
@@ -21,7 +21,7 @@
         "ts-loader": "^9.6.2",
         "typescript": "npm:@typescript/typescript6@^6.0.2",
         "webpack": "^5.110.3",
-        "webpack-cli": "^7.2.2"
+        "webpack-cli": "^7.2.3"
       },
       "engines": {
         "vscode": "^1.82.0"
@@ -2025,9 +2025,9 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.2.2.tgz",
-      "integrity": "sha512-lD0pALneslq8FfV+rwvm1BMW0AFAJrHHhNupAGN4asYjMvqrtRsenU4iKpiBo09gS4ntMxKGUxl9jhTEzVt0oA==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.2.3.tgz",
+      "integrity": "sha512-vDFU7jrfCctnN7jJQWPl+V26B51GLp11prVZXg50oeonsgeBzSTJEWmXkjHsOjTgMjlPOQM8GWLh33X9RN/0ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2053,7 +2053,7 @@
       "peerDependencies": {
         "js-yaml": "^4.0.0 || ^5.0.0",
         "json5": "^2.2.3",
-        "toml": "^3.0.0 || ^4.0.0",
+        "toml": "^3.0.0 || ^4.0.0 || ^5.0.0",
         "webpack": "^5.101.0",
         "webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
         "webpack-dev-server": "^5.0.0 || ^6.0.0"

--- a/rhwp-vscode/package-lock.json
+++ b/rhwp-vscode/package-lock.json
@@ -20,7 +20,7 @@
         "null-loader": "^4.0.1",
         "ts-loader": "^9.6.2",
         "typescript": "npm:@typescript/typescript6@^6.0.2",
-        "webpack": "^5.110.1",
+        "webpack": "^5.110.3",
         "webpack-cli": "^7.2.2"
       },
       "engines": {
@@ -1982,9 +1982,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.110.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.1.tgz",
-      "integrity": "sha512-gInQB+jxXxgnZyvPwuzT5NGQmECDqeu85oxcrjinrYHqPoBex0hCAN2SFTJVyPVrK0Pq9E44VFP+e89fAc10/w==",
+      "version": "5.110.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.3.tgz",
+      "integrity": "sha512-GuizBzRvo9YPpyoNMf3ag7AzxbaW85qrRSqTha345KyJbAFPt3/cMzBM0h+RWg7SK/7DdzRLINP3LvQ0hvr4hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/rhwp-vscode/package.json
+++ b/rhwp-vscode/package.json
@@ -120,7 +120,7 @@
     "null-loader": "^4.0.1",
     "ts-loader": "^9.6.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "webpack": "^5.110.1",
+    "webpack": "^5.110.3",
     "webpack-cli": "^7.2.2"
   }
 }

--- a/rhwp-vscode/package.json
+++ b/rhwp-vscode/package.json
@@ -121,6 +121,6 @@
     "ts-loader": "^9.6.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "webpack": "^5.110.3",
-    "webpack-cli": "^7.2.2"
+    "webpack-cli": "^7.2.3"
   }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3095,7 +3095,18 @@ mod tests {
             cfb::CompoundFile::open(std::io::Cursor::new(data.to_vec())).expect("cfb open");
         let mut stream = compound.create_stream(path).expect("테스트 스트림 교체");
         stream.write_all(payload).unwrap();
-        compound.into_inner().into_inner()
+        // Stream buffers writes independently of CompoundFile::into_inner().
+        stream.flush().expect("flush replacement stream");
+        let bytes = compound.into_inner().into_inner();
+        let mut reopened = cfb_reader::CfbReader::open(&bytes).expect("reopen CFB fixture");
+        assert_eq!(
+            reopened
+                .read_stream_raw(path)
+                .expect("read replacement stream"),
+            payload,
+            "replacement stream must retain the complete payload"
+        );
+        bytes
     }
 
     /// 기본 CFB reader가 열기 단계에서 거부하지만 LenientCfbReader는 계속 읽을 수 있는
@@ -3284,18 +3295,27 @@ mod tests {
         let oversized_doc_info = raw_deflate(&vec![0; LIMIT + 1]);
         let strict_rejected = replace_raw_stream(&source, "/DocInfo", &oversized_doc_info);
         let mutated = force_lenient_cfb_fallback(&strict_rejected);
+        let lenient = cfb_reader::LenientCfbReader::open(&mutated).expect("lenient fixture");
+        assert_eq!(
+            lenient.read_stream("DocInfo").expect("lenient DocInfo"),
+            oversized_doc_info,
+            "FAT mutation must preserve the oversized DocInfo payload"
+        );
 
         let result = with_document_open_decompression_policy_for_test(
             hwp5_document_open_policy_for_test(LIMIT, LIMIT * 2),
             || parse_document(&mutated),
         );
 
-        assert!(matches!(
-            result,
-            Err(ParseError::CfbError(cfb_reader::CfbError::LimitExceeded(
-                LIMIT
-            )))
-        ));
+        assert!(
+            matches!(
+                result,
+                Err(ParseError::CfbError(cfb_reader::CfbError::LimitExceeded(
+                    LIMIT
+                )))
+            ),
+            "expected DocInfo output limit, got {result:?}"
+        );
     }
 
     /// Lenient fallback에서도 배포 플래그가 켜졌다면 정확한 ViewText hierarchy만

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -369,7 +369,7 @@ impl SkiaLayerRenderer {
                     }
                     if let Ok(data) = std::fs::read(&path) {
                         let skia_data = skia_safe::Data::new_copy(&data);
-                        if let Some(typeface) = font_mgr.new_from_data(&skia_data, None) {
+                        if let Some(typeface) = font_mgr.new_from_data(skia_data, None) {
                             let family = typeface.family_name();
                             into.entry(family).or_insert(typeface);
                         }

--- a/tests/cases/issue_4969_shaping_glyph_lowering.rs
+++ b/tests/cases/issue_4969_shaping_glyph_lowering.rs
@@ -637,7 +637,7 @@ fn issue_4969_q3_c_native_skia_exact_blob_instance_round_trips_coordinates() {
     use skia_safe::{Font, FontArguments, FontMgr, FourByteTag};
 
     let default_typeface = FontMgr::default()
-        .new_from_data(HAPPINESS, Some(0))
+        .new_from_data(skia_safe::Data::new_copy(HAPPINESS), Some(0))
         .expect("Native Skia must construct the exact official variable TTF");
     let coordinates = [
         Coordinate {


### PR DESCRIPTION
## 변경 요약

Dependabot PR 12건을 최신 `devel` 기준으로 통합하고, flate2 및 Skia 갱신에 필요한 메인터너 보정 2건을 추가합니다. 의존성 갱신 commit은 원 저자를 보존했습니다.

| 원 PR | 갱신 내용 |
| --- | --- |
| #6823 | VS Code: webpack 5.110.1 -> 5.110.3 |
| #6824 | Studio: @types/chrome 0.2.7 -> 0.2.8 |
| #6825 | flate2 1.1.9 -> 1.1.10, miniz_oxide 0.9.1 |
| #6826 | VS Code: webpack-cli 7.2.2 -> 7.2.3 |
| #6827 | actions/checkout 4.2.2 -> 7.0.1 |
| #6828 | aes 0.9.2 -> 0.9.3 |
| #6829 | Studio: puppeteer-core 25.9.0 -> 25.10.0 |
| #6830 | Chrome: puppeteer 25.9.0 -> 25.10.0 |
| #6831 | skia-safe / skia-bindings 0.99.0 -> 0.153.2 |
| #6832 | softprops/action-gh-release 3.0.2 -> 3.0.3 |
| #6833 | taiki-e/install-action 2.87.0 -> 2.87.5 |
| #6834 | actions/deploy-pages 5.0.0 -> 5.0.1 |

### 메인터너 보정

- **#6825 / `b70d17b72`**: CFB 테스트 helper가 buffered stream을 flush하지 않은 채 컨테이너를 회수하여 빈 스트림을 만들던 문제를 수정했습니다. flate2 갱신으로 `incomplete deflate stream` 오류가 발생하면서 기존 fixture 작성 문제가 드러났습니다. `flush()` 후 컨테이너를 다시 열어 payload 보존을 검증하고, FAT 변조 후에도 압축 DocInfo 바이트가 유지되는지 확인합니다. production 압축 해제 로직과 출력 크기 제한은 변경하지 않았고, source-side test 수나 기준선도 올리지 않았습니다.
- **#6831 / `da6c49568`**: `FontMgr::new_from_data`가 `Data`를 소유권 이전으로 받는 Skia 0.153 API에 맞춰 `renderer.rs`와 glyph lowering 회귀 테스트의 호출부를 수정했습니다. borrowed `Data` 및 바이트 슬라이스 전달을 새 API에 맞췄습니다.
- package manifest/lockfile의 인접 변경 충돌은 양쪽 의존성 갱신을 모두 유지하도록 해소했습니다.

## 관련 PR

Refs #6823, #6824, #6825, #6826, #6827, #6828, #6829, #6830, #6831, #6832, #6833, #6834

## 테스트

- 변경 범위: Rust 의존성 및 호환성 보정, frontend 개발 의존성, GitHub Actions 버전.
- 검증한 제출 HEAD: `da6c4956884e93581c08f4175c5b784afe167fbc`
- 검증 기준 `devel`: `08bf41c69e4fbdc43b7bf4e2566cbe42a05b2bf5`
- 최종 검증 68단계 모두 exit code 0. 생성된 suite, 검증 로그, 임시 산출물은 PR diff에 포함하지 않았습니다.

| 검증 | 결과 |
| --- | --- |
| 전체 Rust nextest (`--locked --cargo-profile release-test --tests --test-threads 12 --no-fail-fast`) | **9,123 passed, 46 skipped**, 테스트 실행 435.140초 |
| Native Skia lib (`--locked --profile release-test --features native-skia --lib`) | **4,112 passed, 13 ignored** |
| Native Skia missing-picture / direct-PDF fixture | 각각 2개 / 4개 통과 |
| `cargo fmt --all -- --check` | 통과 |
| native / WASM32 lib / workspace all-target / native-skia all-target Clippy | 네 경로 모두 `-D warnings` 통과 |
| workspace build / WASM32 lib check | 통과 |
| integration suite / source-side unit tier 정책 검사 | base 대비 검사 통과 |
| CI lint 계약 및 내부 crate 테스트 | Node 197개, Python 407개, 내부 Rust 318개 통과 |
| 변경한 workflow 6개 `actionlint` | 통과 |
| fresh WASM native `--no-opt` 빌드 | 통과 |
| Studio build / unit test | 통과 / **1,490 passed, 2 skipped** |
| VS Code typecheck 및 webpack production compile | 통과 |
| Chrome 패키지 smoke / Studio 실제 브라우저 E2E | 통과 |
| Firefox build 및 frontend package/embed/font 계약 | 통과 / **152개 통과** |
| agent preflight (`--no-network`) / `git diff --check` | 통과 |

Studio 브라우저 검증은 새 WASM으로 문서를 열고 페이지 번호 7을 삽입한 뒤 상태 표시 7/1, 실제 문서 페이지 수 1을 확인했습니다. Chrome smoke는 viewer/options/print 및 service-worker/content-script 경로를 확인했습니다. frontend font 계약은 Firefox 배포 산출물을 준비한 뒤 재실행하여 통과했습니다.

- [x] 제출 HEAD와 검증 HEAD 일치
- [x] Rust fmt, native/WASM32/workspace Clippy 및 추가 Native Skia Clippy 통과
- [x] 전체 integration, Native Skia 및 해당 fixture 검증 통과
- [x] source-side unit tier와 integration suite 정책 검사 통과, 파생 파일 미포함
- [x] frontend build, unit/package 계약 및 실제 브라우저 검증 통과

### 검증 한계 및 잔여 조건

- Docker를 사용할 수 없어 문서화된 native `--no-opt` WASM 경로로 빌드했습니다. **Docker 기반 최적화 배포 빌드와 wasm-opt 검증을 통과한 것으로 간주하지 않습니다.**
- 성능 전후 비교는 수행하지 않았습니다. 위 시간은 이번 전체 회귀의 실행 시간이며 성능 개선 수치가 아닙니다.
- 원 PR #6825/#6831의 기존 실패와 메인터너 보정 후 통합 HEAD의 검증 결과를 구분합니다. merge 전에는 이 PR의 최신 HEAD GitHub required checks를 별도로 확인해야 합니다.
