### PR TITLE
문서(§4.3.1): 새 fixture 가 거는 코퍼스 래칫을 둘에서 여섯으로 바로잡는다

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -149,7 +149,7 @@ HWP/HWPX → SVG.
     (`LAYOUT_OVERFLOW_CELL` 진단과 같은 조건). top-level 은 문서 합계, `pages[]` 항목은
     페이지별 카운트다. 0 이 아니면 그 페이지의 셀 콘텐츠 일부가 소실 렌더된 것이다 —
     #3236 계열(분할 대신 통짜 배치 후 clip) 조사의 1차 신호. 원장 게이트는
-    [`local_validation.md` 4.3.1](pr_review/local_validation.md#431-새-hwphwpx-fixture의-baseline-등록--ir-sweep--overflow-cell-원장) 참조.
+    [`local_validation.md` 4.3.1](pr_review/local_validation.md#431-새-hwphwpx-fixture의-baseline-등록--코퍼스-래칫-여섯) 참조.
 - `-o`, `-p` (공통)
 - `--show-para-marks` — 문단부호(↵/↓)
 - `--show-control-codes` — 조판부호(문단부호 + 개체 마커)

--- a/mydocs/manual/pr_review/local_validation.md
+++ b/mydocs/manual/pr_review/local_validation.md
@@ -400,10 +400,74 @@ libtest 동시성을 현재 host에 맞춰 조정해야 하면 Cargo 옵션 뒤�
 필터를 해석한다. Docker 표준 WASM 경로가 없는 호스트에서는 개발 환경 안내의 `--no-opt` 진단 경로를
 사용하고, 검토 기록에 Docker 부재와 대체 명령을 함께 남긴다.
 
-## 4.3.1 새 HWP/HWPX fixture의 baseline 등록 — IR sweep + overflow-cell 원장
+## 4.3.1 새 HWP/HWPX fixture의 baseline 등록 — 코퍼스 래칫 여섯
 
 samples 아래 HWP 또는 HWPX fixture를 새로 추가·교체·이동하면 renderer 변경 여부와 무관하게 PR 생성 또는
-draft 해제 전에 **두 baseline 절차**를 수행한다: ① IR field sweep(아래), ② overflow-cell 원장(이 절 말미).
+draft 해제 전에 코퍼스 래칫을 확인한다. 래칫은 여섯이고, 그중 **넷은 `samples/` 를 스스로 훑기 때문에
+파일을 놓는 순간 "신규 발생(baseline 없음)" 으로 실패한다.**
+
+| 래칫 | fixture | 대상 선정 | 새 sample 이 즉시 걸리나 |
+| --- | --- | --- | --- |
+| `ir_field_sweep_baseline` | `tests/fixtures/ir_field_sweep_baseline.tsv` | `samples/` 전수 | **예** |
+| `overflow_cell_baseline` | `tests/fixtures/overflow_cell_baseline.tsv` | `samples/` 전수 | **예** |
+| `off_canvas_baseline` | `tests/fixtures/off_canvas_baseline.tsv` | `samples/` 전수 | **예** |
+| `text_overlap_baseline` | `tests/fixtures/text_overlap_baseline.tsv` | `samples/` 전수 | **예** |
+| `oracle_page_count_baseline` | `tests/fixtures/oracle_page_count_baseline.tsv` | 그 TSV 의 행만 순회 | 아니오 (아래 참조) |
+| `clipping_baseline` | `tests/fixtures/clipping_baseline.tsv` | `tests/fixtures/render_page_controlset.tsv` | 아니오 |
+
+넷을 한 번에 돌리는 필터다. 나머지 둘도 함께 걸어 두면 회귀를 같이 본다.
+
+~~~bash
+cargo nextest run --cargo-profile release-test --no-fail-fast -E \
+ 'test(/ir_field_sweep_does_not_regress|overflow_cell_lines_do_not_grow|off_canvas_does_not_grow|text_overlaps_do_not_grow|oracle_page_count|clipping/)'
+~~~
+
+> ⚠ **IR sweep 과 overflow-cell 둘만 돌리고 "게이트 통과" 로 판단하지 않는다.**
+> `off_canvas` 와 `text_overlap` 은 `samples/` 를 같은 방식으로 훑으므로 새 fixture 가
+> 0 이 아닌 값을 가지면 반드시 실패한다. 로컬에서 둘만 확인하고 올렸다가 CI 에서 그 둘에
+> 걸린 사례가 있다(PR #6804 · #6796).
+
+### 신규 행은 "내 수정 탓인가" 부터 가른다
+
+새 fixture 가 0 이 아닌 값을 갖는다고 곧바로 baseline 에 싣지 않는다. **그 수정이 없는
+빌드를 대조군으로 같은 fixture 를 다시 재서**, 값이 수정 때문에 생긴 것인지 문서 고유의
+것인지 먼저 가른다. 두 값이 같으면 fixture 가 코퍼스에 처음 들어와 래칫이 켜진 것이고,
+수정 후가 더 크면 회귀이므로 **원인을 고친다**.
+
+- `rhwp layout-anomaly <문서> --json` 의 `offCanvasCount` · `textOverlapCount` 가 곧
+  그 두 원장의 값이다. **0 이면 행을 만들지 않는다.**
+- 기존 문서의 수치 **증가**는 회귀다 — baseline 으로 숨기지 않는다.
+- 감소·해소는 통과다. 다만 브랜치 base 가 `devel` 보다 뒤처져 있으면 그 수치가 devel 에서도
+  같다는 보장이 없으므로, **리베이스 없이 감소분으로 래칫을 조이지 않는다.** 실측만 PR 에 적는다.
+- 행을 추가·갱신하면 문서 경로·SHA-256·수치·판정 근거를 review 문서에 적는다.
+
+### `samples/` 를 훑는 넷의 dump 재생성
+
+`off_canvas`·`overflow_cell`·`text_overlap` 은 16개 partition test 가 병렬로 dump 를 쓰므로,
+지정한 경로가 아니라 `<경로>.part00-of16` 부터 `.part15-of16` 까지를 이어 붙여 비교한다.
+파일 안의 행 순서는 판정에 영향이 없다(래칫이 경로→건수 map 으로 읽는다).
+
+| 래칫 | dump 환경변수 |
+| --- | --- |
+| `ir_field_sweep_baseline` | `RHWP_IR_SWEEP_DUMP` (상세는 `RHWP_IR_SWEEP_DETAIL`) |
+| `overflow_cell_baseline` | `RHWP_OVERFLOW_CELL_DUMP` |
+| `off_canvas_baseline` | `RHWP_OFF_CANVAS_DUMP` |
+| `text_overlap_baseline` | `RHWP_TEXT_OVERLAP_DUMP` |
+
+### 정답지 PDF 를 함께 넣었다면 — `oracle_page_count_baseline`
+
+이 래칫은 `samples/` 를 훑지 않고 **자기 TSV 에 이미 있는 행만** 순회한다. 따라서
+`pdf/` 에 한/글 정답지를 새로 넣어도 그 문서는 자동으로 쪽수 축의 보호를 받지 못한다.
+정답지를 추가했으면 픽스처를 재생성해 그 문서를 원장에 넣는다.
+
+~~~bash
+python tools/oracle_page_count/regenerate.py --rhwp target/release-test/rhwp.exe
+~~~
+
+모아 찍기(`printMethod` 4·5) 문서는 한/글이 한 장에 여러 쪽을 실으므로 이 축의 대상이
+아니다 — 재생성 단계에서 제외된다. `rhwp info --json` 의 `printMethodImpliesNup` 으로 확인한다.
+
+### IR field sweep
 
 ~~~bash
 RHWP_IR_SWEEP_DUMP=/tmp/ir_field_sweep_current.tsv \

--- a/mydocs/manual/pr_review/local_validation.md
+++ b/mydocs/manual/pr_review/local_validation.md
@@ -413,14 +413,26 @@ draft 해제 전에 코퍼스 래칫을 확인한다. 래칫은 여섯이고, �
 | `off_canvas_baseline` | `tests/fixtures/off_canvas_baseline.tsv` | `samples/` 전수 | **예** |
 | `text_overlap_baseline` | `tests/fixtures/text_overlap_baseline.tsv` | `samples/` 전수 | **예** |
 | `oracle_page_count_baseline` | `tests/fixtures/oracle_page_count_baseline.tsv` | 그 TSV 의 행만 순회 | 아니오 (아래 참조) |
-| `clipping_baseline` | `tests/fixtures/clipping_baseline.tsv` | `tests/fixtures/render_page_controlset.tsv` | 아니오 |
+| `clipping_baseline` | `tests/fixtures/clipping_baseline.tsv` | `tests/fixtures/render_page_controlset.tsv` | 아니오 (아래 참조) |
 
-넷을 한 번에 돌리는 필터다. 나머지 둘도 함께 걸어 두면 회귀를 같이 본다.
+넷을 한 번에 돌리는 필터다. `oracle_page_count` 도 함께 걸어 두면 쪽수 회귀를 같이 본다.
 
 ~~~bash
 cargo nextest run --cargo-profile release-test --no-fail-fast -E \
- 'test(/ir_field_sweep_does_not_regress|overflow_cell_lines_do_not_grow|off_canvas_does_not_grow|text_overlaps_do_not_grow|oracle_page_count|clipping/)'
+ 'test(/ir_field_sweep_does_not_regress|overflow_cell_lines_do_not_grow|off_canvas_does_not_grow|text_overlaps_do_not_grow|oracle_page_count/)'
 ~~~
+
+> ⚠ **`clipping_gate.py` 는 클론만으로는 아무것도 검사하지 못한다.**
+> `render_page_controlset.tsv` 의 92개 행이 모두 저장소 밖 문서를 가리키므로 실행하면
+> `ERR/누락=92 baseline없음=92 회귀=0` 으로 **exit 0** 이 된다. 이 exit 0 은
+> "이상 없음" 이 아니라 **"검사 대상 0"** 이다 — 게이트 통과로 적지 말고, 검사하지
+> 못했다는 사실을 그대로 적는다. 그 문서들이 있는 환경에서만 의미가 있다.
+>
+> ~~~bash
+> python tools/clipping_gate.py --check tests/fixtures/clipping_baseline.tsv \
+>   --exe target/release/rhwp
+> # 출력 마지막 줄의 `ERR/누락` 과 `baseline없음` 을 반드시 읽는다.
+> ~~~
 
 > ⚠ **IR sweep 과 overflow-cell 둘만 돌리고 "게이트 통과" 로 판단하지 않는다.**
 > `off_canvas` 와 `text_overlap` 은 `samples/` 를 같은 방식으로 훑으므로 새 fixture 가

--- a/mydocs/manual/verification/visual_clipping_detector.md
+++ b/mydocs/manual/verification/visual_clipping_detector.md
@@ -86,4 +86,4 @@ python tools/clipping_gate.py --check <base> --fixture <docs.tsv>            # �
 
 용도 구분: **빠른 1차 신호와 상시 회귀 가드**는 #3668 카운터(스위트에 항상 돈다),
 **요소 단위 정밀 분석·임의 문서군 비교**는 이 문서의 Python 도구. 절차는
-[`local_validation.md` 4.3.1](../pr_review/local_validation.md#431-새-hwphwpx-fixture의-baseline-등록--ir-sweep--overflow-cell-원장) 참조.
+[`local_validation.md` 4.3.1](../pr_review/local_validation.md#431-새-hwphwpx-fixture의-baseline-등록--코퍼스-래칫-여섯) 참조.


### PR DESCRIPTION
## 왜

`local_validation.md` §4.3.1 은 `samples/` 에 fixture 를 새로 넣을 때의 절차로
**IR sweep 과 overflow-cell 둘만** 적고 있습니다. 그런데 `samples/` 를 스스로 훑는
코퍼스 래칫은 **넷**입니다. 문서대로 둘만 돌리고 "게이트 통과" 로 판단하면 CI 에서
나머지 둘에 걸립니다.

제가 실제로 그 순서로 두 번 빨강을 받았습니다.

| PR | CI 가 잡은 것 |
| --- | --- |
| #6804 | `text_overlap_baseline` 35건 · `off_canvas_baseline` 1건 — "신규 발생(baseline 없음)" |
| #6796 | `text_overlap_baseline` 2건 — 같은 사유 |

두 번 다 로컬에서 문서가 적은 둘을 돌려 초록을 확인하고 올린 뒤였습니다.

## 무엇이 사실인가

```text
  samples/ 전수 열거   ir_field_sweep · overflow_cell · off_canvas · text_overlap
  고정 목록 순회       oracle_page_count (자기 TSV 행만) · clipping (controlset 92행)
```

앞의 넷은 `const SAMPLES_ROOT: &str = "samples"` 로 디렉터리를 재귀 열거하므로 파일을
놓는 순간 0 이 아닌 값이면 반드시 실패합니다. 뒤의 둘은 대상이 고정 목록이라 새 sample 이
자동으로 들어오지 않습니다 — 그래서 **보호도 자동으로 붙지 않습니다.**

## 바꾼 것

- 제목: `IR sweep + overflow-cell 원장` → **`코퍼스 래칫 여섯`**
- 여섯을 fixture 경로 · 대상 선정 방식 · **"새 sample 이 즉시 걸리나"** 로 표에 정리
- 넷을 한 번에 도는 `cargo nextest -E` 필터
- **"내 수정 탓인가" 를 먼저 가르는 절차** — 수정 없는 빌드를 대조군으로 같은 fixture 를
  다시 재고, 값이 같으면 코퍼스 신규 등재, 커지면 회귀이므로 원인을 고칩니다.
  `rhwp layout-anomaly --json` 의 `offCanvasCount` · `textOverlapCount` 가 곧 두 원장의 값입니다.
- 리베이스 없이 **감소분으로 래칫을 조이지 말라**는 단서 (브랜치 base 가 devel 보다
  뒤처져 있으면 그 수치가 devel 에서도 같다는 보장이 없습니다)
- 네 래칫의 dump 환경변수 표, partition dump 이어 붙이기, 파일 안 행 순서는 판정에 무관
- **`oracle_page_count_baseline` 절 신설** — 이 래칫은 자기 TSV 행만 순회하므로 `pdf/` 에
  정답지를 새로 넣어도 그 문서는 쪽수 축의 보호를 못 받습니다.
  `tools/oracle_page_count/regenerate.py` 로 원장에 넣어야 합니다.
  모아 찍기(`printMethod` 4·5)는 대상 제외라는 점도 적었습니다.

기존 IR sweep · overflow-cell 절의 본문은 **한 글자도 바꾸지 않고** 순서만 정리했습니다.

## 검증

제목이 바뀌면 앵커가 달라지므로, 이를 참조하던 `cli_commands.md` 와
`visual_clipping_detector.md` 의 링크도 함께 고쳤습니다.

```
python scripts/check_markdown_links.py \
  mydocs/manual/pr_review/local_validation.md \
  mydocs/manual/cli_commands.md \
  mydocs/manual/verification/visual_clipping_detector.md
  → 검사 대상 3개 / 깨진 Markdown 상대 링크: 이상 없음
```

새 heading 에서 계산한 GitHub 앵커
(`#431-새-hwphwpx-fixture의-baseline-등록--코퍼스-래칫-여섯`)가 두 링크와 정확히 일치함을
확인했습니다.

문서만 바꾸는 PR 이라 코드·fixture 변경은 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FrNUEuhgCgRHTwuM6yybM
