### PR TITLE
수정(renderer): 그러데이션의 step·stepCenter 를 렌더 stop 으로 편다 (#6822)

### DIFF
--- a/src/renderer/layout/utils.rs
+++ b/src/renderer/layout/utils.rs
@@ -322,12 +322,15 @@ pub(crate) fn drawing_to_shape_style(
             } else {
                 g.positions.iter().map(|&p| p as f64 / 100.0).collect()
             };
+            // [#6822] `step`(띠 개수)·`step_center`(전이 위치)를 stop 으로 편다.
+            let (colors, positions) =
+                super::super::expand_gradient_steps(&g.colors, &positions, g.blur, g.step_center);
             Box::new(GradientFillInfo {
                 gradient_type: g.gradient_type,
                 angle: g.angle,
                 center_x: g.center_x,
                 center_y: g.center_y,
-                colors: g.colors.clone(),
+                colors,
                 positions,
             })
         }),

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -510,9 +510,106 @@ pub struct GradientFillInfo {
     /// 세로 중심 (%)
     pub center_y: i16,
     /// 색상 목록 (ColorRef)
+    ///
+    /// [`expand_gradient_steps`] 가 편 **띠 단위 stop** 이다 — 모델의 색 목록과 1:1 이
+    /// 아니다. `positions` 와 길이가 같고, 같은 offset 이 두 번 나오면 하드 경계다.
     pub colors: Vec<ColorRef>,
     /// 색상 위치 (0.0~1.0 정규화)
     pub positions: Vec<f64>,
+}
+
+/// 두 색 사이를 채널별로 선형 보간한다.
+fn lerp_color(from: ColorRef, to: ColorRef, t: f64) -> ColorRef {
+    let t = t.clamp(0.0, 1.0);
+    let mut out = 0u32;
+    for shift in [0, 8, 16] {
+        let a = ((from >> shift) & 0xff) as f64;
+        let b = ((to >> shift) & 0xff) as f64;
+        let v = (a + (b - a) * t).round().clamp(0.0, 255.0) as u32;
+        out |= v << shift;
+    }
+    out
+}
+
+/// `(colors, positions)` 가 이루는 색 램프를 `t`(0~1) 에서 표집한다.
+fn sample_ramp(colors: &[ColorRef], positions: &[f64], t: f64) -> ColorRef {
+    match colors.len() {
+        0 => 0,
+        1 => colors[0],
+        n => {
+            let at = |i: usize| -> f64 {
+                positions
+                    .get(i)
+                    .copied()
+                    .unwrap_or(i as f64 / (n - 1) as f64)
+            };
+            let t = t.clamp(0.0, 1.0);
+            for i in 1..n {
+                let (p0, p1) = (at(i - 1), at(i));
+                if t <= p1 || i == n - 1 {
+                    let span = p1 - p0;
+                    let local = if span.abs() < f64::EPSILON {
+                        0.0
+                    } else {
+                        (t - p0) / span
+                    };
+                    return lerp_color(colors[i - 1], colors[i], local);
+                }
+            }
+            colors[n - 1]
+        }
+    }
+}
+
+/// HWP 그러데이션의 `step`(띠 개수)·`step_center`(전이 위치 %)를 렌더 stop 목록으로 편다.
+///
+/// [#6822] 한/글은 그러데이션 축을 **`step` 개의 띠**로 잘라 각 띠를 단색으로 칠하고,
+/// 띠 경계들의 가운데를 `step_center`% 지점에 놓는다. 렌더 IR 은 이 두 값을 담지 않아
+/// 전이가 언제나 50% 에 고정됐다.
+///
+/// 실측(`samples/issue6551/113424_evaluation_guideline.hwpx`, 한/글 2024 정본):
+///
+/// ```text
+///   step=2  stepCenter=8   장 제목 막대  초록→흰색 하드 경계가 축의 8% 지점
+///   step=50 stepCenter=50  구분 막대     균등한 50개 띠 (사실상 매끄러운 램프)
+/// ```
+///
+/// `step <= 1` 이거나 색이 둘 미만이면 띠를 만들지 않고 원본을 그대로 돌려준다 —
+/// 값이 없는 문서의 현행 동작을 바꾸지 않기 위해서다.
+pub fn expand_gradient_steps(
+    colors: &[ColorRef],
+    positions: &[f64],
+    step: i16,
+    step_center: u8,
+) -> (Vec<ColorRef>, Vec<f64>) {
+    let bands = step.max(0) as usize;
+    if bands <= 1 || colors.len() < 2 {
+        return (colors.to_vec(), positions.to_vec());
+    }
+
+    // 띠 경계는 균등 위치 `m` 을 두 구간 선형으로 옮겨 가운데(m=0.5)가 `c` 에 오게 한다.
+    // `c == 0.5` 면 항등이므로 기본값 문서는 지금 그리는 것과 같은 균등 띠가 된다.
+    let c = (step_center as f64 / 100.0).clamp(0.0, 1.0);
+    let warp = |m: f64| -> f64 {
+        if m <= 0.5 {
+            2.0 * m * c
+        } else {
+            c + (m - 0.5) * 2.0 * (1.0 - c)
+        }
+    };
+
+    let mut out_colors = Vec::with_capacity(bands * 2);
+    let mut out_positions = Vec::with_capacity(bands * 2);
+    for i in 0..bands {
+        let color = sample_ramp(colors, positions, i as f64 / (bands - 1) as f64);
+        let start = warp(i as f64 / bands as f64);
+        let end = warp((i + 1) as f64 / bands as f64);
+        out_colors.push(color);
+        out_positions.push(start.clamp(0.0, 1.0));
+        out_colors.push(color);
+        out_positions.push(end.clamp(0.0, 1.0));
+    }
+    (out_colors, out_positions)
 }
 
 /// 선 렌더링 스타일

--- a/src/renderer/style_resolver.rs
+++ b/src/renderer/style_resolver.rs
@@ -873,12 +873,15 @@ fn resolve_single_border_style(bf: &BorderFill) -> ResolvedBorderStyle {
             } else {
                 g.positions.iter().map(|&p| p as f64 / 100.0).collect()
             };
+            // [#6822] `step`(띠 개수)·`step_center`(전이 위치)를 stop 으로 편다.
+            let (colors, positions) =
+                super::expand_gradient_steps(&g.colors, &positions, g.blur, g.step_center);
             Some(Box::new(GradientFillInfo {
                 gradient_type: g.gradient_type,
                 angle: g.angle,
                 center_x: g.center_x,
                 center_y: g.center_y,
-                colors: g.colors.clone(),
+                colors,
                 positions,
             }))
         }),

--- a/tests/cases/issue_6822_gradation_step_center.rs
+++ b/tests/cases/issue_6822_gradation_step_center.rs
@@ -1,0 +1,174 @@
+//! [Issue #6822] 그러데이션의 `step`(띠 개수)·`stepCenter`(전이 위치 %)가 렌더 IR 에
+//! 실리지 않아 색 전이가 **언제나 축의 50%** 에 고정되던 결함의 가드.
+//!
+//! ## 계약
+//!
+//! 한/글은 그러데이션 축을 `step` 개의 **띠**로 잘라 각 띠를 단색으로 칠하고, 띠 경계들의
+//! 가운데를 `stepCenter`% 지점에 놓는다. `stepCenter == 50` 이면 균등이므로 **기본값 문서의
+//! 그림은 달라지지 않는다.**
+//!
+//! ## 실측 — `samples/issue6551/113424_evaluation_guideline.hwpx`
+//!
+//! 이 문서 하나가 결함군과 통제군을 함께 갖는다. 정본은
+//! `pdf/113424_evaluation_guideline-2024.pdf`(한/글 2024, 저장 제품 `hancom-office-2024`)다.
+//!
+//! ```text
+//!   결함군  7쪽 장 제목 막대   step=2  stepCenter=8   #339966 → #FFFFFF
+//!           한/글: 축의 7.9% 지점에서 하드 경계, 왼쪽 초록 · 오른쪽 흰색
+//!           수정 전: 막대 전폭에 매끄러운 램프 — 상자 안쪽 픽셀의 91.3% 가 오차 Δ>16
+//!           수정 후: 8.00% 하드 경계 — 오차 픽셀 7.2% (잔여는 축 각도 결함, 별건)
+//!
+//!   통제군  29쪽 구분 막대     step=50 stepCenter=50  #000080 → #99CCFF
+//!           한/글: 균등한 50개 띠(경계 간격 7.86pt × 50 = 막대 폭 392.4pt)
+//!           수정 전후 모두 띠 중앙에서 한/글과 Δ<=2 — 회귀 없음
+//! ```
+//!
+//! ⚠ 통제군이 이 수정의 핵심 안전장치다. `stepCenter` 를 무시하고 균등 분포로 두는 현행
+//! 동작이 `stepCenter == 50` 문서에서는 **맞다**. 전이 위치를 바꾸는 어떤 판이든 여기를
+//! 깨뜨리면 안 된다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+use rhwp::renderer::{expand_gradient_steps, GradientFillInfo};
+use rhwp::wasm_api::HwpDocument;
+
+const SAMPLE: &str = "samples/issue6551/113424_evaluation_guideline.hwpx";
+
+/// 0-based — 결함군(장 제목 `Ⅰ 총 칙`)이 있는 물리 7쪽.
+const DEFECT_PAGE: u32 = 6;
+/// 0-based — 통제군(구분 막대)이 있는 물리 29쪽.
+const CONTROL_PAGE: u32 = 28;
+
+// `ColorRef` 는 리틀엔디언 BGR 이다 — `color_to_svg` 가 `r = color & 0xFF`,
+// `b = (color >> 16) & 0xFF` 로 읽는다. 아래는 문서가 선언한 RGB 를 그 순서로 적은 값이다.
+/// `#339966`
+const GREEN: u32 = 0x0066_9933;
+/// `#FFFFFF`
+const WHITE: u32 = 0x00ff_ffff;
+/// `#000080`
+const NAVY: u32 = 0x0080_0000;
+/// `#99CCFF`
+const SKY: u32 = 0x00ff_cc99;
+
+const EPS: f64 = 1e-6;
+
+fn document() -> HwpDocument {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = std::fs::read(&path)
+        .unwrap_or_else(|error| panic!("#6822 공개 fixture 읽기 {}: {error}", path.display()));
+    HwpDocument::from_bytes(&bytes).expect("parse 113424")
+}
+
+fn collect_gradients(node: &RenderNode, out: &mut Vec<GradientFillInfo>) {
+    if let RenderNodeType::Rectangle(rect) = &node.node_type {
+        if let Some(grad) = &rect.gradient {
+            out.push((**grad).clone());
+        }
+    }
+    for child in &node.children {
+        collect_gradients(child, out);
+    }
+}
+
+/// 시작색으로 대상 그러데이션을 집는다 — 각 쪽에서 유일하다.
+fn gradient_starting_with(page: u32, first: u32) -> GradientFillInfo {
+    let tree = document()
+        .build_page_render_tree(page)
+        .unwrap_or_else(|error| panic!("쪽 idx {page} render tree: {error:?}"));
+    let mut all = Vec::new();
+    collect_gradients(&tree.root, &mut all);
+    let mut hit: Vec<GradientFillInfo> = all
+        .into_iter()
+        .filter(|g| g.colors.first().copied() == Some(first))
+        .collect();
+    assert_eq!(
+        hit.len(),
+        1,
+        "쪽 idx {page} 에 #{first:06x} 로 시작하는 그러데이션이 정확히 하나여야 한다"
+    );
+    hit.pop().expect("대상 그러데이션")
+}
+
+/// 결함군 — `step=2 stepCenter=8` 은 축의 8% 에서 끊긴 **두 띠**여야 한다.
+#[test]
+fn step_two_gradation_is_a_hard_two_band_split_at_step_center() {
+    let grad = gradient_starting_with(DEFECT_PAGE, GREEN);
+
+    assert_eq!(
+        grad.colors,
+        vec![GREEN, GREEN, WHITE, WHITE],
+        "두 띠는 각각 단색이어야 한다 — 회귀 시 [초록, 흰색] 두 stop 의 매끄러운 램프가 된다"
+    );
+    let expected = [0.0, 0.08, 0.08, 1.0];
+    assert_eq!(grad.positions.len(), expected.len());
+    for (got, want) in grad.positions.iter().zip(expected) {
+        assert!(
+            (got - want).abs() < EPS,
+            "전이 위치가 stepCenter(8%)와 달라졌다 — got {:?}, want {expected:?}",
+            grad.positions
+        );
+    }
+}
+
+/// 통제군 — `step=50 stepCenter=50` 은 균등한 50개 띠이고, 그림이 달라지면 안 된다.
+#[test]
+fn default_step_center_keeps_fifty_uniform_bands() {
+    let grad = gradient_starting_with(CONTROL_PAGE, NAVY);
+
+    assert_eq!(grad.colors.len(), 100, "50개 띠 × stop 2개여야 한다");
+    assert_eq!(grad.positions.len(), grad.colors.len());
+    assert_eq!(grad.colors[0], NAVY, "첫 띠는 시작색 그대로여야 한다");
+    assert_eq!(
+        *grad.colors.last().expect("마지막 stop"),
+        SKY,
+        "마지막 띠는 끝색 그대로여야 한다"
+    );
+
+    // stepCenter == 50 이면 경계가 균등하다 — 이 등식이 깨지면 기본값 문서의 그림이 바뀐다.
+    for band in 0..50usize {
+        let (start, end) = (grad.positions[band * 2], grad.positions[band * 2 + 1]);
+        assert!(
+            (start - band as f64 / 50.0).abs() < EPS
+                && (end - (band + 1) as f64 / 50.0).abs() < EPS,
+            "띠 {band} 의 경계가 균등하지 않다 — {start}..{end}"
+        );
+    }
+}
+
+/// 음성 통제군 — 띠를 만들 수 없는 값이면 원본을 그대로 둔다.
+///
+/// `step` 이 없는(0) 문서까지 건드리면 코퍼스 전체의 그림이 바뀐다.
+#[test]
+fn degenerate_step_values_leave_the_ramp_untouched() {
+    let colors = vec![GREEN, WHITE];
+    let positions = vec![0.0, 1.0];
+
+    for step in [0i16, 1, -3] {
+        let (c, p) = expand_gradient_steps(&colors, &positions, step, 8);
+        assert_eq!(c, colors, "step={step} 이면 색을 그대로 둬야 한다");
+        assert_eq!(p, positions, "step={step} 이면 위치를 그대로 둬야 한다");
+    }
+
+    // 색이 하나뿐이면 띠를 나눌 수 없다.
+    let single = vec![GREEN];
+    let (c, p) = expand_gradient_steps(&single, &[0.0], 50, 8);
+    assert_eq!(c, single);
+    assert_eq!(p, vec![0.0]);
+}
+
+/// `stepCenter == 50` 은 항등 사상이어야 한다 — 임의의 띠 개수에서 균등 분포가 나온다.
+#[test]
+fn step_center_fifty_is_the_identity_warp() {
+    let colors = vec![NAVY, SKY];
+    for bands in [2i16, 3, 7, 50, 100] {
+        let (_, p) = expand_gradient_steps(&colors, &[0.0, 1.0], bands, 50);
+        for band in 0..bands as usize {
+            let want = band as f64 / bands as f64;
+            assert!(
+                (p[band * 2] - want).abs() < EPS,
+                "bands={bands} 띠 {band} 시작이 {}, 기대 {want}",
+                p[band * 2]
+            );
+        }
+    }
+}


### PR DESCRIPTION
`#6822` 을 닫는다.

## 근인

한/글은 그러데이션 축을 `step` 개의 **띠**로 잘라 각 띠를 단색으로 칠하고, 띠 경계들의
가운데를 `stepCenter`% 지점에 놓는다. 파서·모델·직렬화기는 두 값을 온전히 지니는데
(`GradientFill::blur`·`step_center`) **렌더 IR 이 담지 않아** 색 전이가 언제나 축의
50% 에 고정됐다.

## 고친 방법 — IR 필드를 늘리지 않고 stop 으로 편다

`GradientFillInfo` 에 필드를 더하지 않았다. 변환 두 곳(`style_resolver` borderFill ·
`layout/utils` 도형 fill)에서 띠를 **stop 목록으로 펴서** 기존 `colors`/`positions` 에
담는다. 소비자 넷(SVG · web canvas · skia · paint JSON)이 모두 `positions[i]` 를 색
인덱스로 읽으므로 **한 곳만 고쳐 엔진 전역이 함께 고쳐진다.**

띠 경계는 균등 위치 `m` 을 두 구간 선형으로 옮겨 가운데(`m=0.5`)가 `c = stepCenter/100`
에 오게 한다.

```text
  warp(m) = 2·m·c                  (m <= 0.5)
          = c + (m−0.5)·2·(1−c)    (m >  0.5)
```

`c == 0.5` 면 **항등**이다 — 그래서 기본값 문서의 그림은 달라지지 않는다. 경험적 상수가
아니라 "경계의 가운데를 stepCenter 에 놓는다" 에서 유도된다. `step <= 1` 이거나 색이 둘
미만이면 원본을 그대로 돌려줘 값 없는 문서의 동작을 건드리지 않는다.

## 실측

문서 하나가 결함군과 통제군을 함께 갖는다 — `samples/issue6551/113424_evaluation_guideline.hwpx`.
정본은 저장소에 이미 있는 `pdf/113424_evaluation_guideline-2024.pdf`
(engine 2024, 저장 제품 `hancom-office-2024`)다. **새 fixture·새 정본이 없다.**

### 결함군 — 7쪽 장 제목 막대 (`step=2 stepCenter=8`)

상자 안쪽 150,514 픽셀에서 글자 잉크를 뺀 정본 대조다.

| | Δ>16 인 픽셀 | 평균 Δ |
| --- | --- | --- |
| 수정 전 | 137,347 (**91.3%**) | 93.4 |
| 수정 후 | 10,863 (**7.2%**) | 14.1 |

전이 위치도 맞는다 — 한/글 하드 경계 **7.9%**, 이 수정 **8.00%**.

```text
  grad2 stop:  0.0% #339966 · 8.0% #339966 · 8.0% #ffffff · 100.0% #ffffff
```

### 통제군 — 29쪽 구분 막대 (`step=50 stepCenter=50`)

정본은 **균등한 50개 띠**다(1200dpi 주사로 경계 간격 7.86pt × 50 = 막대 폭 392.4pt 확인).
띠 중앙 8곳에서 대조했다.

```text
  띠  1  한/글(3,4,129)    rhwp(3,4,131)     Δ2
  띠  5  한/글(14,19,139)  rhwp(16,21,141)   Δ2
  띠 10  한/글(31,41,153)  rhwp(31,42,154)   Δ1
  띠 20  한/글(61,83,179)  rhwp(62,83,180)   Δ1
  띠 25  한/글(78,103,191) rhwp(78,104,193)  Δ2
  띠 30  한/글(92,124,204) rhwp(94,125,206)  Δ2
  띠 40  한/글(124,166,231) rhwp(125,167,232) Δ1
  띠 48  한/글(148,199,251) rhwp(150,200,252) Δ2
                                       최대 Δ 2 — 수정 전과 동등, 회귀 없음
```

⚠ 처음에 임의 좌표 `x=274pt` 에서 Δ4 가 나와 회귀로 보였는데, 그 지점이 띠 경계
(21.99/50)에 정확히 놓인 **표집 artifact** 였다. 띠 중앙으로 다시 재면 전부 Δ≤2 다.

## 남는 오차는 별건이다 — `#6845`

수정 후 잔여 7.2% 는 전부 **축 각도 왜곡**이다. `angle_to_svg_coords` 가 각도를
objectBoundingBox 백분율로 내보내 상자 가로세로비(여기서는 16.5:1)만큼 축이 눕는다.

```text
  등색선 기울기 dx/dy   한/글 −0.37 (수직에서 20.1°, angle=110 과 일치)
                        rhwp  +3.72
```

띠 경계가 하드해지면서 드러난 것으로, 고치려면 `gradientUnits="userSpaceOnUse"` 로
바꿔야 하고 `build_fill_attr` 를 거치는 사각형·타원·패스 호출부를 모두 손봐야 한다.
코퍼스의 모든 그러데이션에 영향이 가므로 [#6845](https://github.com/edwardkim/rhwp/issues/6845)
로 분리했다. 이 PR 은 그와 독립으로 12.6배 개선한다.

## 시험

기존 공개 fixture 와 기존 정본만 쓴다.

- `step_two_gradation_is_a_hard_two_band_split_at_step_center` — 결함군 양성 계약
- `default_step_center_keeps_fifty_uniform_bands` — **통제군**, 50개 띠 경계가 균등한지
- `degenerate_step_values_leave_the_ramp_untouched` — 음성. `step<=1`·색 1개는 원본 보존
- `step_center_fifty_is_the_identity_warp` — `c=50` 이 항등임을 띠 개수 5종에서 확인

## 게이트

이 수정은 코퍼스의 **모든 그러데이션 문서 픽셀**을 바꾸므로 코퍼스 래칫을 전부 돌렸다.

```text
  issue_6822 신규 4건                     4 passed
  text_overlap + off_canvas              32 passed
  overflow_cell                          16 passed
  ir_field_sweep                          4 passed
  oracle_page_count                      16 passed
  cargo fmt --all -- --check             통과
  cargo clippy --lib                     경고 0
```

⚠ `clipping_gate.py` 는 exit 0 · 회귀 0 이지만 **실질 미검증**이다 —
`render_page_controlset.tsv` 의 92개 문서가 전부 저장소 밖(비공개 코퍼스)이라
`ERR/누락=92 baseline없음=92` 로 한 건도 검사되지 않았다. "이상 없음"이 아니라
"검사 대상 0" 이므로 그대로 적는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FrNUEuhgCgRHTwuM6yybM
