### PR TITLE
수정(edit): extract-pages 가 참조 없는 BinData 를 버린다 (#6840)

### DIFF
--- a/src/cli/commands/conversion.rs
+++ b/src/cli/commands/conversion.rs
@@ -182,14 +182,23 @@ pub(crate) fn extract_pages(args: &[String]) -> i32 {
                     "pagesAfter": report.pages_after,
                     "paragraphsKept": report.kept,
                     "paragraphsRemoved": report.removed,
+                    "binDataBefore": report.bin_data_before,
+                    "binDataAfter": report.bin_data_after,
                 }),
                 "extract-pages",
             )
         );
     } else {
         println!(
-            "추출 완료: {output} ({}~{}쪽) — {}쪽 → {}쪽, 문단 {}개 남기고 {}개 제거",
-            from, to, report.pages_before, report.pages_after, report.kept, report.removed
+            "추출 완료: {output} ({}~{}쪽) — {}쪽 → {}쪽, 문단 {}개 남기고 {}개 제거,              BinData {}개 → {}개",
+            from,
+            to,
+            report.pages_before,
+            report.pages_after,
+            report.kept,
+            report.removed,
+            report.bin_data_before,
+            report.bin_data_after
         );
     }
     EXIT_OK

--- a/src/document_core/commands/bin_data_prune.rs
+++ b/src/document_core/commands/bin_data_prune.rs
@@ -1,0 +1,288 @@
+//! [#6840] 참조 없는 `BinData` 정리 — 발췌·부분 제출에서 파일이 줄지 않던 문제.
+//!
+//! `extract-pages` 는 본문·서식은 제대로 걷어내는데 `BinData`(그림) 스트림은 한 개도
+//! 버리지 않았다. 그림이 많은 문서는 쪽을 한 장만 남겨도 파일이 거의 그대로다.
+//!
+//! ```text
+//!   104쪽 6.5MB 문서에서 77쪽 한 장만 남긴 실측
+//!                      파일        BinData            그 외
+//!     원본           6,521,856   204개 6,177,814     209,205
+//!     --from 77 --to 77  5,225,984   204개 5,078,167      24,184
+//!                        ↑ 본문은 88% 줄었는데 파일은 20%       ↑ 스트림 0개 삭제
+//! ```
+//!
+//! 이 모듈은 산출 문서가 실제로 참조하는 항목만 남기고 나머지를 버린다.
+//!
+//! ## 왜 재번호매김이 필요한가
+//!
+//! `ImageAttr.bin_data_id` 는 **1 기준 순번(위치)** 이라 `bin_data_content` 의 인덱스다
+//! (`renderer::layout::utils::find_bin_data_index`). 항목을 지우면 뒤의 참조가 통째로
+//! 한 칸씩 밀려 **그림이 조용히 뒤바뀐다.** 그래서 지우기와 동시에 모든 참조를 옮긴다.
+//!
+//! `BinDataContent.id`(= `BinData.storage_id`, 저장 시 `BIN%04X` 스트림 이름)는 순번과
+//! 다른 값이다. 이 모듈은 storage id 를 **건드리지 않는다** — 이름이 바뀌면 스트림과
+//! 레코드가 어긋나고, 구멍이 있는 문서에서 기존 id 와 충돌한다.
+//!
+//! ## 참조처
+//!
+//! 순회 구조는 `converters::hwpx_to_hwp` 의 `walk_controls`(프로덕션에서 `OleShape` 를
+//! 실제로 갈아끼우는 워커)를 그대로 따른다 — 담는 그릇 목록을 두 벌로 두지 않는다.
+//!
+//! | 참조처 | 어디에 |
+//! | --- | --- |
+//! | `Picture.image_attr.bin_data_id` | `Control::Picture` · `ShapeObject::Picture` |
+//! | `DrawingObjAttr.fill.image.bin_data_id` | 모든 도형의 채우기 |
+//! | `BorderFill.fill.image.bin_data_id` | **DocInfo** — 문단 밖이라 항상 참조로 센다 |
+//! | `OleShape.bin_data_id` | OLE 개체 (`u32`) |
+//!
+//! `BorderFill` 은 문단이 아니라 DocInfo 에 있고 `border_fill_id` 로 참조되므로, 어떤
+//! 문단이 남았는지와 무관하게 **살아 있는 참조로 본다.** 그쪽까지 걷어내려면 문단·셀·
+//! 글자 모양의 `border_fill_id` 를 전수로 다시 세야 하는데, 이 명령의 목적(발췌 크기
+//! 줄이기)에 비해 위험이 크다.
+//!
+//! ## ⚠ 내장 글꼴은 **순번이 아니라 storage id** 로 참조한다
+//!
+//! `Font::resolved_bin_data_id` 와 `SubstFont::resolved_bin_data_id` 는 `BinDataContent.id`
+//! 다 — `load_bounded_embedded_font_bytes` 가 `content.id == font_id` 로 찾는다
+//! (`queries::rendering`). 그림의 1 기준 순번과 **다른 축**이므로
+//!
+//! - 그 storage id 를 가진 항목은 참조가 없어도 남긴다
+//! - 그 참조값은 **옮기지 않는다** (storage id 는 이 정리에서 불변이다)
+//!
+//! 이 축을 빠뜨리면 발췌본에서 내장 글꼴이 통째로 사라진다.
+
+use std::collections::BTreeSet;
+
+use crate::model::control::Control;
+use crate::model::document::Document;
+use crate::model::shape::{DrawingObjAttr, ShapeObject};
+
+/// 정리 결과 요약.
+///
+/// 버린 바이트는 세지 않는다 — `BinDataBytes::len()` 은 `Lazy` 항목을 압축 해제하므로
+/// 버리려고 훑는 것만으로 원본 전체를 메모리에 펴게 된다.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct BinDataPruneReport {
+    /// 정리 전 항목 수
+    pub before: usize,
+    /// 정리 후 항목 수
+    pub after: usize,
+}
+
+impl BinDataPruneReport {
+    /// 버린 항목 수.
+    pub fn removed(&self) -> usize {
+        self.before.saturating_sub(self.after)
+    }
+}
+
+/// 문서 안의 모든 `u16` `bin_data_id` 참조를 방문한다.
+///
+/// `f` 가 값을 바꾸면 그대로 반영된다 — 모으기와 옮기기가 **같은 순회**를 쓰므로 두
+/// 단계가 서로 다른 자리를 볼 수 없다.
+fn visit_bin_data_refs(doc: &mut Document, f: &mut dyn FnMut(&mut u16)) {
+    fn visit_drawing(drawing: &mut DrawingObjAttr, f: &mut dyn FnMut(&mut u16)) {
+        if let Some(image) = drawing.fill.image.as_mut() {
+            f(&mut image.bin_data_id);
+        }
+        if let Some(text_box) = drawing.text_box.as_mut() {
+            visit_paragraphs(&mut text_box.paragraphs, f);
+        }
+        if let Some(caption) = drawing.caption.as_mut() {
+            visit_paragraphs(&mut caption.paragraphs, f);
+        }
+    }
+
+    fn visit_shape(shape: &mut ShapeObject, f: &mut dyn FnMut(&mut u16)) {
+        match shape {
+            // `drawing_mut()` 이 `None` 을 주는 두 변형은 각자 캡션을 갖는다.
+            ShapeObject::Picture(pic) => {
+                f(&mut pic.image_attr.bin_data_id);
+                if let Some(caption) = pic.caption.as_mut() {
+                    visit_paragraphs(&mut caption.paragraphs, f);
+                }
+            }
+            ShapeObject::Group(group) => {
+                for child in &mut group.children {
+                    visit_shape(child, f);
+                }
+                if let Some(caption) = group.caption.as_mut() {
+                    visit_paragraphs(&mut caption.paragraphs, f);
+                }
+            }
+            ShapeObject::Chart(chart) => {
+                visit_drawing(&mut chart.drawing, f);
+                if let Some(caption) = chart.caption.as_mut() {
+                    visit_paragraphs(&mut caption.paragraphs, f);
+                }
+            }
+            ShapeObject::Ole(ole) => {
+                visit_drawing(&mut ole.drawing, f);
+                if let Some(caption) = ole.caption.as_mut() {
+                    visit_paragraphs(&mut caption.paragraphs, f);
+                }
+                // OLE 의 참조는 `u32` 다. `u16` 범위 밖이면 순번 의미가 아니므로
+                // 손대지 않는다 — 모으는 쪽도 같은 조건으로 건너뛴다.
+                if let Ok(mut id) = u16::try_from(ole.bin_data_id) {
+                    f(&mut id);
+                    ole.bin_data_id = u32::from(id);
+                }
+            }
+            _ => {
+                if let Some(drawing) = shape.drawing_mut() {
+                    visit_drawing(drawing, f);
+                }
+            }
+        }
+    }
+
+    fn visit_controls(controls: &mut [Control], f: &mut dyn FnMut(&mut u16)) {
+        for control in controls {
+            match control {
+                Control::Picture(pic) => {
+                    f(&mut pic.image_attr.bin_data_id);
+                    if let Some(caption) = pic.caption.as_mut() {
+                        visit_paragraphs(&mut caption.paragraphs, f);
+                    }
+                }
+                Control::Shape(shape) => visit_shape(shape, f),
+                Control::Table(table) => {
+                    for cell in &mut table.cells {
+                        visit_paragraphs(&mut cell.paragraphs, f);
+                    }
+                    if let Some(caption) = table.caption.as_mut() {
+                        visit_paragraphs(&mut caption.paragraphs, f);
+                    }
+                }
+                Control::Header(h) => visit_paragraphs(&mut h.paragraphs, f),
+                Control::Footer(h) => visit_paragraphs(&mut h.paragraphs, f),
+                Control::Footnote(n) => visit_paragraphs(&mut n.paragraphs, f),
+                Control::Endnote(n) => visit_paragraphs(&mut n.paragraphs, f),
+                Control::HiddenComment(c) => visit_paragraphs(&mut c.paragraphs, f),
+                Control::Field(field) => visit_paragraphs(&mut field.memo_paragraphs, f),
+                Control::SectionDef(section_def) => {
+                    for master_page in &mut section_def.master_pages {
+                        visit_paragraphs(&mut master_page.paragraphs, f);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn visit_paragraphs(
+        paragraphs: &mut [crate::model::paragraph::Paragraph],
+        f: &mut dyn FnMut(&mut u16),
+    ) {
+        for para in paragraphs {
+            visit_controls(&mut para.controls, f);
+        }
+    }
+
+    for section in &mut doc.sections {
+        visit_paragraphs(&mut section.paragraphs, f);
+    }
+    // DocInfo 의 테두리/배경 이미지 채우기는 문단과 무관하게 살아 있는 참조다.
+    for border_fill in &mut doc.doc_info.border_fills {
+        if let Some(image) = border_fill.fill.image.as_mut() {
+            f(&mut image.bin_data_id);
+        }
+    }
+}
+
+/// 산출 문서가 참조하지 않는 `BinData` 를 버리고 남은 참조를 옮긴다.
+///
+/// 참조가 없거나 버릴 것이 없으면 문서를 건드리지 않는다.
+pub(crate) fn prune_unreferenced_bin_data(doc: &mut Document) -> BinDataPruneReport {
+    let before = doc.bin_data_content.len();
+    if before == 0 {
+        return BinDataPruneReport::default();
+    }
+
+    // 1. 살아 있는 1 기준 순번을 모은다. 범위 밖 값(HWPX 차트 sparse id 등)은
+    //    인덱스 의미가 아니므로 건드리지 않고 그대로 둔다.
+    let mut referenced: BTreeSet<usize> = BTreeSet::new();
+    visit_bin_data_refs(doc, &mut |id| {
+        if *id > 0 && (*id as usize) <= before {
+            referenced.insert(*id as usize - 1);
+        }
+    });
+
+    // 1b. 내장 글꼴이 쓰는 storage id 를 가진 항목도 남긴다 — 순번 축이 아니므로
+    //     참조값은 건드리지 않고 보존 대상에만 더한다.
+    let font_storage: BTreeSet<u16> = doc
+        .doc_info
+        .font_faces
+        .iter()
+        .flatten()
+        .flat_map(|font| {
+            [
+                font.is_embedded
+                    .then_some(font.resolved_bin_data_id)
+                    .flatten(),
+                font.subst_font
+                    .as_ref()
+                    .and_then(|sf| sf.is_embedded.then_some(sf.resolved_bin_data_id).flatten()),
+            ]
+        })
+        .flatten()
+        .collect();
+    if !font_storage.is_empty() {
+        for (index, content) in doc.bin_data_content.iter().enumerate() {
+            if font_storage.contains(&content.id) {
+                referenced.insert(index);
+            }
+        }
+    }
+
+    if referenced.len() == before {
+        return BinDataPruneReport {
+            before,
+            after: before,
+        };
+    }
+
+    // 2. 옛 인덱스 → 새 인덱스. 남는 항목의 상대 순서는 유지한다.
+    let mut new_index = vec![None; before];
+    for (next, old) in referenced.iter().enumerate() {
+        new_index[*old] = Some(next);
+    }
+
+    // 3. 참조를 옮긴다. 살아 있는 참조는 반드시 새 자리를 갖는다.
+    visit_bin_data_refs(doc, &mut |id| {
+        if *id == 0 || (*id as usize) > before {
+            return;
+        }
+        if let Some(next) = new_index[*id as usize - 1] {
+            *id = (next + 1) as u16;
+        }
+    });
+
+    // 4. 두 목록을 같은 규칙으로 거른다 — 인덱스 정합이 깨지면 그림이 뒤바뀐다.
+    let dropped_storage: BTreeSet<u16> = doc
+        .bin_data_content
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| new_index[*i].is_none())
+        .map(|(_, c)| c.id)
+        .collect();
+
+    let mut i = 0usize;
+    doc.bin_data_content.retain(|_| {
+        let keep = new_index[i].is_some();
+        i += 1;
+        keep
+    });
+
+    // `bin_data_list` 는 storage id 로 짝지어져 있다 — 남은 content 가 쓰지 않는
+    // storage id 의 레코드만 버린다.
+    let live_storage: BTreeSet<u16> = doc.bin_data_content.iter().map(|c| c.id).collect();
+    doc.doc_info.bin_data_list.retain(|bd| {
+        !dropped_storage.contains(&bd.storage_id) || live_storage.contains(&bd.storage_id)
+    });
+
+    BinDataPruneReport {
+        before,
+        after: doc.bin_data_content.len(),
+    }
+}

--- a/src/document_core/commands/mod.rs
+++ b/src/document_core/commands/mod.rs
@@ -1,3 +1,5 @@
+// [#6840] 발췌 산출물에서 참조 없는 BinData 를 버린다 — 쪽을 잘라도 파일이 줄지 않던 문제.
+pub(crate) mod bin_data_prune;
 mod clipboard;
 // [#5769] 삭제의 참 역연산 — 조각 저장소. DeleteFragment 타입이 DocumentCore
 // 필드로 쓰이므로 pub(crate).

--- a/src/document_core/commands/page_extract.rs
+++ b/src/document_core/commands/page_extract.rs
@@ -22,6 +22,10 @@ pub struct PageExtractReport {
     pub kept: usize,
     /// 지운 문단 수
     pub removed: usize,
+    /// [#6840] 정리 전 `BinData` 항목 수
+    pub bin_data_before: usize,
+    /// [#6840] 정리 후 `BinData` 항목 수
+    pub bin_data_after: usize,
 }
 
 impl DocumentCore {
@@ -74,6 +78,11 @@ impl DocumentCore {
             }
         }
 
+        // [#6840] 남은 문단이 참조하지 않는 그림은 버린다. 이 정리가 없으면 쪽을 한
+        // 장만 남겨도 `BinData` 가 그대로 따라가 파일이 거의 줄지 않고(6.5MB → 5.2MB),
+        // 지운 쪽에 있던 그림 원본이 산출물 안에 남는다 — 부분 제출에서는 유출이다.
+        let bin_data = super::bin_data_prune::prune_unreferenced_bin_data(&mut self.document);
+
         self.invalidate_page_tree_cache();
         self.paginate_if_needed();
         Ok(PageExtractReport {
@@ -81,6 +90,8 @@ impl DocumentCore {
             pages_after: self.page_count(),
             kept,
             removed,
+            bin_data_before: bin_data.before,
+            bin_data_after: bin_data.after,
         })
     }
 

--- a/tests/cases/issue_6840_extract_pages_prunes_bin_data.rs
+++ b/tests/cases/issue_6840_extract_pages_prunes_bin_data.rs
@@ -1,0 +1,131 @@
+//! [Issue #6840] `extract-pages` 가 참조 없는 `BinData` 를 하나도 버리지 않아, 쪽을 한
+//! 장만 남겨도 파일이 거의 줄지 않던 결함의 가드.
+//!
+//! ## 왜 중요한가
+//!
+//! 이 명령이 내건 용도는 **발췌·부분 제출**과 결함 이분법이다. 그림이 많은 문서는 본문을
+//! 88% 걷어내도 파일이 20% 밖에 줄지 않았고, **버리려던 쪽의 그림 원본이 산출물에 그대로
+//! 남았다** — 부분 제출에서는 유출 경로다.
+//!
+//! ```text
+//!   104쪽 6.5MB 문서 → --from 77 --to 77
+//!     수정 전   BinData 204개 그대로   파일 5,225,984
+//!     수정 후   BinData  36개          파일 1,364,992
+//! ```
+//!
+//! ## 무엇을 잠그나 — 뒤바뀜이 진짜 위험이다
+//!
+//! `ImageAttr.bin_data_id` 는 **1 기준 순번(위치)** 이라 항목을 지우면 뒤 참조가 한 칸씩
+//! 밀려 **그림이 조용히 뒤바뀐다.** 개수만 보는 시험은 그걸 못 잡으므로, 남은 그림의
+//! **좌표와 이미지 바이트**를 정리 전후로 대조한다(`render_page_svg_native` 의 data URI).
+//!
+//! ⚠ 내장 글꼴은 순번이 아니라 **storage id** 로 참조한다
+//! (`load_bounded_embedded_font_bytes` 가 `content.id == font_id` 로 찾는다). 그 축을
+//! 빠뜨리면 발췌본에서 글꼴이 통째로 사라지므로 음성 통제군으로 함께 잠근다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use rhwp::DocumentCore;
+
+/// 43개 중 7개만 실제로 쓰는 문서 — 칸 안 다문단 float 그림.
+const PICTURES: &str = "samples/issue5833/cell_multi_para_float_pics.hwp";
+/// 그림은 없고 `BinData` 가 **내장 글꼴 하나**뿐인 문서.
+const EMBEDDED_FONT: &str = "samples/render-p35-font-native-bitmap.hwpx";
+/// 34개를 모두 쓰는 문서 — 버릴 것이 없으면 건드리지 않아야 한다.
+const ALL_REFERENCED: &str = "samples/basic/Worldcup_FIFA2010_32.hwp";
+
+fn load(rel: &str) -> DocumentCore {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = std::fs::read(&path)
+        .unwrap_or_else(|error| panic!("#6840 공개 fixture 읽기 {}: {error}", path.display()));
+    DocumentCore::from_bytes(&bytes).unwrap_or_else(|error| panic!("{rel} 파싱: {error:?}"))
+}
+
+/// 1쪽 SVG 의 `<image>` 를 `(x, y, 바이트 해시)` 로 모은다.
+///
+/// data URI 를 통째로 비교하지 않고 해시로 줄인다 — 실패 메시지에 수십 KB 가 실리면
+/// 무엇이 달라졌는지 오히려 안 보인다.
+fn page_images(core: &DocumentCore) -> Vec<(String, String, u64)> {
+    let svg = core.render_page_svg_native(0).expect("1쪽 SVG");
+    let mut out = Vec::new();
+    for chunk in svg.split("<image ").skip(1) {
+        let attr = |name: &str| -> String {
+            chunk
+                .split_once(&format!("{name}=\""))
+                .and_then(|(_, rest)| rest.split_once('"'))
+                .map(|(v, _)| v.to_string())
+                .unwrap_or_default()
+        };
+        let href = attr("href");
+        let mut hasher = DefaultHasher::new();
+        href.hash(&mut hasher);
+        out.push((attr("x"), attr("y"), hasher.finish()));
+    }
+    out.sort();
+    out
+}
+
+/// 양성 계약 — 참조 없는 항목은 버리고, 남은 그림은 **한 장도 바뀌지 않는다.**
+#[test]
+fn unreferenced_bin_data_is_dropped_without_swapping_pictures() {
+    let mut core = load(PICTURES);
+    let before = page_images(&core);
+    assert_eq!(
+        before.len(),
+        7,
+        "표본이 어긋났다 — 1쪽에 그림 7장이 있어야 한다"
+    );
+
+    let report = core.extract_page_range(1, 1).expect("1쪽 추출");
+
+    assert_eq!(
+        (report.bin_data_before, report.bin_data_after),
+        (43, 7),
+        "참조 없는 36개가 버려져야 한다 — 회귀 시 43개가 그대로 남아 파일이 줄지 않는다"
+    );
+    assert_eq!(
+        page_images(&core),
+        before,
+        "정리 뒤 그림의 좌표 또는 바이트가 달라졌다 — 순번 재번호매김이 어긋나면 \
+         그림이 조용히 뒤바뀐다"
+    );
+}
+
+/// 음성 통제군 ① — 내장 글꼴은 **순번 참조가 없어도** 남아야 한다.
+///
+/// 이 문서는 그림이 0장이고 `BinData` 가 글꼴 하나(`font-native-smoke.ttf`)뿐이다.
+/// 순번만 보고 버리면 여기서 `1 → 0` 이 되어 발췌본의 글꼴이 사라진다.
+#[test]
+fn embedded_font_bin_data_survives_even_with_no_picture_reference() {
+    let mut core = load(EMBEDDED_FONT);
+    assert!(
+        page_images(&core).is_empty(),
+        "표본이 어긋났다 — 이 문서에는 그림이 없어야 글꼴 축만 남는다"
+    );
+
+    let report = core.extract_page_range(1, 1).expect("1쪽 추출");
+
+    assert_eq!(
+        (report.bin_data_before, report.bin_data_after),
+        (1, 1),
+        "내장 글꼴이 쓰는 항목을 버렸다 — storage id 축을 빠뜨리면 글꼴이 사라진다"
+    );
+}
+
+/// 음성 통제군 ② — 모두 참조되는 문서는 건드리지 않는다.
+#[test]
+fn fully_referenced_bin_data_is_left_alone() {
+    let mut core = load(ALL_REFERENCED);
+    let before = page_images(&core);
+
+    let report = core.extract_page_range(1, 1).expect("1쪽 추출");
+
+    assert_eq!(
+        (report.bin_data_before, report.bin_data_after),
+        (34, 34),
+        "버릴 것이 없는데 항목이 줄었다"
+    );
+    assert_eq!(page_images(&core), before, "그림이 바뀌었다");
+}


### PR DESCRIPTION
`#6840` 을 닫는다.

## 근인

`extract-pages` 는 본문·서식은 제대로 걷어내는데 `BinData`(그림) 스트림은 **한 개도**
버리지 않았다.

```text
  104쪽 6.5MB 문서 → --from 77 --to 77
                     파일        BinData             그 외
    원본          6,521,856   204개 6,177,814      209,205
    수정 전       5,225,984   204개 5,078,167       24,184   ← 스트림 0개 삭제
    수정 후       1,364,992    36개                          ← 실제 참조 36개
```

본문은 88% 줄었는데 파일은 20% 밖에 줄지 않았다. 남은 1.1MB 감소분도 스트림 삭제가
아니라 CFB 섹터 재배치에서 나온 것이다.

이 명령이 내건 용도가 **발췌·부분 제출**과 결함 이분법이라 두 가지가 걸린다.

- 한 쪽만 떼어 보내려 해도 원본 크기가 거의 그대로 나간다
- **버리려던 쪽의 그림 원본이 산출물에 그대로 남는다** — 본문은 지워졌는데 그 쪽에 있던
  그림은 파일 안에 있으므로, 부분 제출에서는 유출 경로다

## 재번호매김을 안전하게

`ImageAttr.bin_data_id` 는 **1 기준 순번(위치)** 이라(`find_bin_data_index`) 항목을 지우면
뒤 참조가 한 칸씩 밀려 **그림이 조용히 뒤바뀐다.** 그래서

- 모으기와 옮기기를 **같은 순회 함수**로 돌린다 — 두 단계가 서로 다른 자리를 볼 수 없다
- 순회 구조는 발명하지 않고 `converters::hwpx_to_hwp` 의 `walk_controls` 를 따랐다.
  프로덕션에서 `OleShape` 를 실제로 갈아끼우는 워커라 담는 그릇 목록이 이미 신뢰된다
- `storage_id`(= `BIN%04X` 스트림 이름)는 건드리지 않는다. 이름이 바뀌면 스트림과 레코드가
  어긋나고, 구멍 있는 문서에서 기존 id 와 충돌한다

### ⚠ 내장 글꼴은 순번이 아니라 storage id 로 참조한다

참조처를 감사하다 잡은 축이다. `Font::resolved_bin_data_id` 와
`SubstFont::resolved_bin_data_id` 는 `BinDataContent.id` 이고
`load_bounded_embedded_font_bytes` 가 `content.id == font_id` 로 찾는다. 그림의 순번과
**다른 축**이라, 순번만 보고 버렸으면 발췌본에서 내장 글꼴이 통째로 사라졌을 것이다 —
렌더는 폴백 글꼴로 조용히 계속되니 눈치채기 어려운 종류다.

그 storage id 를 가진 항목은 참조가 없어도 남기고, 그 참조값은 옮기지 않는다.

`BorderFill` 은 DocInfo 에 있어 문단과 무관하므로 항상 살아 있는 참조로 센다. 그쪽까지
걷어내려면 문단·셀·글자 모양의 `border_fill_id` 를 전수로 다시 세야 하는데, 이 명령의
목적에 비해 위험이 크다.

## 실측

| 문서 | BinData | 그림 | 판정 |
| --- | --- | --- | --- |
| `#6782` 원본 6.5MB | 204 → 36 | 36개 · **12쪽 좌표·바이트 일치** | 5.2MB → 1.36MB · 한/글 정상 개방(11쪽, 정리 전과 동일) |
| `samples/issue5833/...` | 43 → 7 | 7개 좌표·바이트 일치 | 뒤바뀜 없음 |
| `samples/issue5802/hf_cross_section...` | 54 → 0 | 0개 → 0개 | 잃은 것 없음 |
| `samples/render-p35-font-native-bitmap.hwpx` | 1 → 1 | 0개 | **글꼴 가드로만 보존** |

## 시험

기존 공개 fixture 만 쓴다 — 새 파일이 없다.

- `unreferenced_bin_data_is_dropped_without_swapping_pictures`
  43→7 이면서 남은 그림의 **좌표와 이미지 바이트가 불변**(`render_page_svg_native` 의
  data URI 로 대조). 개수만 보는 시험은 뒤바뀜을 못 잡는다.
- `embedded_font_bin_data_survives_even_with_no_picture_reference` — **음성 통제군**.
  그림 0장 · `BinData` 가 `.ttf` 하나뿐인 문서가 `1 → 1` 이어야 한다. 순번만 보는 판이면
  여기서 `1 → 0` 이 된다.
- `fully_referenced_bin_data_is_left_alone` — 음성 통제군. 34개를 다 쓰는 문서는 불변.

## 게이트

저장 경로를 건드리므로 왕복 3종을 먼저 돌렸다.

```text
  issue_6840 신규 3건                          3 passed
  hwp5_roundtrip_baseline                     21 passed
  hwpx_roundtrip + visual_roundtrip            7 passed
  text_overlap + off_canvas                   32 passed
  ir_field_sweep_does_not_regress              4 passed
  oracle_page_count                           16 passed
  cargo fmt --all -- --check                  통과
  cargo clippy --lib                          경고 0
```

⚠ `clipping_gate.py` 는 exit 0 · 회귀 0 이지만 **실질 미검증**이다 —
`render_page_controlset.tsv` 의 92개 문서가 전부 저장소 밖이라 한 건도 검사되지 않는다
("검사 대상 0"이지 "이상 없음"이 아니다). 이 사실은 [#6843](https://github.com/edwardkim/rhwp/pull/6843)
에서 §4.3.1 에 명시하는 중이다.

## 호환성

`extract-pages` 의 **산출물이 달라진다.** 다만 지금까지 그 산출물은 원본과 거의 같은
크기였고 참조 없는 그림이 전부 따라갔으므로, 달라지는 방향은 이 명령이 원래 하려던 쪽이다.
`--json` 봉투에 `binDataBefore` · `binDataAfter` 를 더해 무엇이 정리됐는지 보이게 했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FrNUEuhgCgRHTwuM6yybM
