### PR TITLE
ci: Rust CodeQL PR 내부 통계 쿼리 계산 축소

### DIFF
--- a/.github/codeql/rust-pr.yml
+++ b/.github/codeql/rust-pr.yml
@@ -5,3 +5,20 @@ paths:
   - crates/**
   - rhwp-desk/src/**
   - build.rs
+
+# #6876: PR에서는 경고를 생성하지 않는 내부 통계 3개만 제외한다.
+# CodeQL 2.26.4 / rust-queries 0.1.41에서는 이 쿼리들에
+# exclude-from-incremental 태그가 없으므로 정확한 ID로 제한한다.
+# metric 조건도 함께 적용하여 향후 경고 쿼리로 바뀌면 제외하지 않는다.
+# 보안 탐지와 추출 오류/경고, 파일 수/커버리지 진단은 그대로 유지한다.
+# devel push와 schedule의 full scan에는 이 설정을 적용하지 않는다.
+query-filters:
+  - exclude:
+      id: rust/summary/summary-statistics
+      kind: metric
+  - exclude:
+      id: rust/summary/reduced-summary-statistics
+      kind: metric
+  - exclude:
+      id: rust/summary/query-sink-counts
+      kind: metric


### PR DESCRIPTION
## 변경 요약

Refs #6876

Rust CodeQL PR 분석에만 내부 통계 쿼리 3개를 제외하는 필터를 추가합니다. 보안 쿼리와 추출 오류/경고 및 커버리지 진단은 유지하며, devel push/schedule의 full scan은 변경하지 않습니다.

- `rust/summary/summary-statistics`
- `rust/summary/reduced-summary-statistics`
- `rust/summary/query-sink-counts`

정확한 ID와 `kind: metric`을 함께 제한합니다. `exclude-from-incremental` 태그만 추가하는 방식은 확인한 Rust 쿼리에 해당 태그가 없어 사용하지 않았습니다.

## 완료한 로컬 검증

- `python3 -m unittest scripts.tests.test_codeql_workflow`: 16개 통과.
- YAML 파싱 및 제외 필터 3개/기존 product paths/default-query override 부재 정적 검사: 통과.
- `git diff --check`: 통과.
- Rust source/test 변경이 없어 Cargo 전체 회귀 및 렌더링 시각 검증은 수행하지 않았습니다.

## 이번 PR에서 검증할 사항

- 최신 head의 실제 CodeQL query selection에서 위 3개 metric이 제외되는지 확인합니다.
- 기존 보안 쿼리 ID 집합과 추출 품질 진단이 유지되는지 확인합니다.
- CI 성공과 성능 실측을 구분합니다. 비교 기준 job은 14분 43초였지만 소스/runner/CLI가 다른 단일 실행만으로 정량 개선을 확정하지 않습니다.
- 비교 기준: https://github.com/edwardkim/rhwp/actions/runs/34131388576/job/101772210665

로컬 CodeQL CLI가 없어 실제 query resolution과 분석 시간은 아직 검증하지 못했습니다. 현재는 검증용 PR이며, #6876을 자동 종료하지 않습니다. CI 결과 확인 뒤 같은 PR에 self-review 기록을 추가합니다. merge는 별도 승인 후 진행합니다.
