### PR TITLE
feat(renderer): P44 native exact glyph replay and atomic fallback

### DIFF
--- a/mydocs/orders/20260908.md
+++ b/mydocs/orders/20260908.md
@@ -1,5 +1,15 @@
 # 오늘 할일 - 2026년 9월 8일
 
+## PR #6881 Native 글리프 재생 메인터너 보정 및 검토
+
+- 원 기여 head `95d7081dca1f2c2500b365b80a14990321bb37ff` 위에 보정 `a2b83a4eedb954250f962f8cfacae38dab15e078`만 추가하여 원 PR `seo-rii/rhwp:render-p44`에 push했다.
+- 준비 전 자원 예산 검사, 중첩 SVG viewport 보존, 공통/Native 글꼴 크기 상한 일치를 보정했다. 봇 지적 3건은 오탐이 아닌 실제 결함이며, 보정 결과와 검증 한계를 답글로 기록하고 resolve했다.
+- 포맷·Native/WASM/workspace Clippy·workspace build, 최종 Native Skia Clippy·manifest·공백 검사를 통과했다. 로컬 전체 회귀 테스트를 다시 실행했다고 기록하지 않는다.
+- 코드 head의 CI(archive A~D/Native Skia 포함), 언어별 CodeQL, Render Diff, Adapter, Proptest 및 CI Impact Policy 성공을 확인했다. 별도 CodeQL check는 `NEUTRAL`이며 코드 head는 `MERGEABLE / CLEAN`이었다.
+- [PR 검토 기록](../pr/archives/pr_6881_review.md)의 판정은 **메인터너 보정 후 수용 가능: 보정 완료**다. #536 전체 해결 또는 전체 문서 시각 동등성으로 확대하지 않는다.
+- 로컬 devel은 upstream/devel `54f4a0237e5aa8c9270dd767d5d9a21b9df56bd8`까지 fast-forward했다. 원 PR에 devel 이력을 섞거나 원 기여 커밋을 재작성하지 않았다.
+- 사용자 승인에 따라 CI 성공 후 이 오늘할일과 검토 문서만 같은 원 PR의 trailing commit으로 push한다. 새 문서 head의 CI와 병합·후속 처리는 아직 완료한 것으로 기록하지 않는다.
+
 ## #6852 일반 사각형 실선 복원 — PR #6858
 
 - 메인테이너가 최종 보고 및 이슈 본문 정정·push·PR 생성을 승인했다.

--- a/mydocs/pr/archives/pr_6881_review.md
+++ b/mydocs/pr/archives/pr_6881_review.md
@@ -1,0 +1,94 @@
+# PR #6881 검토 기록
+
+## 판정: 메인터너 보정 후 수용 가능
+
+**메인터너 보정 완료.** 아래 코드 head에서 실제 결함 3건의 보정과 CI 성공을 확인했다.
+이 판정은 P44의 Native exact glyph replay 및 atomic fallback 범위에 한정한다.
+이 문서를 추가하는 trailing commit의 최신 CI는 별도로 확인해야 하며, 병합 완료를 의미하지 않는다.
+
+## 검토 대상과 출처
+
+- 원 PR: [#6881](https://github.com/edwardkim/rhwp/pull/6881)
+- 기여자: `seo-rii`, 원격 source branch: `seo-rii/rhwp:render-p44`, 대상: `edwardkim/rhwp:devel`.
+- 원 기여 head: `95d7081dca1f2c2500b365b80a14990321bb37ff`.
+- 최종 코드 head 및 메인터너 보정: [a2b83a4eedb954250f962f8cfacae38dab15e078](https://github.com/edwardkim/rhwp/pull/6881/commits/a2b83a4eedb954250f962f8cfacae38dab15e078).
+- 검토일: 2026-09-08. 로컬 검토에서 원 커밋 9개를 출처 보존 체리픽했지만, 원격 push는 원 기여 head 위의 보정 커밋 하나만 수행했다. 통합 이력이나 devel 변경을 fork에 밀어 넣지 않았다.
+- 로컬 `devel`은 `upstream/devel`의 `54f4a0237e5aa8c9270dd767d5d9a21b9df56bd8`까지 fast-forward했다. 원 PR의 커밋을 rebase하거나 force push하지 않았다.
+- 추적 이슈 [#536](https://github.com/edwardkim/rhwp/issues/536)은 이 PR의 종료 대상으로 간주하지 않는다. 후속 P45~P47이나 전체 렌더링 동등성까지 수용한 것으로 확대하지 않는다.
+
+## 코드 검토 및 메인터너 보정
+
+### 1. 글리프 준비 예산의 적용 시점
+
+- 원 구현은 준비 결과를 보관할 때 예산을 검사하여, 이미 예산을 초과했어도 글꼴 파싱·복사 등 준비 비용을 반복 지불할 수 있었다. 실제 결함으로 판정했다.
+- 보정은 leaf별 entry/byte 예산을 준비 전에 검사·예약한다. font blob과 알려진 배치 버퍼의 최소 비용을 반영하며 준비 실패 시 예약분을 반환하지 않는다.
+- 준비 후 계산되는 outline 추가 비용이 남은 예산을 초과하면 이후 준비를 중단한다. 준비 실패 후보의 atomic TextRun fallback 경로는 유지한다.
+- 모든 입력에 대한 CPU 시간의 엄격한 상한이나 부하 개선 수치는 측정하지 않았다. 봇의 표현을 근거로 무한 작업량 또는 특정 메모리 사용량이 실측됐다고 기록하지 않는다.
+- [보정 결과 답글 및 resolve](https://github.com/edwardkim/rhwp/pull/6881#discussion_r3957654458).
+
+### 2. 중첩 SVG viewport 보존
+
+- 원 구현은 중첩 요소까지 모든 `svg`를 `g`로 바꾸어 x/y/width/height/viewBox의 viewport 의미를 잃었다. 실제 결함으로 판정했다.
+- XML 깊이를 추적하여 payload viewBox로 대체하는 최상위 컨테이너만 변환하고, 중첩 SVG는 그대로 유지하도록 보정했다. 불일치하는 요소 깊이는 준비 실패로 처리한다.
+- Chrome 축소 재현에서 중첩 viewport를 유지한 사각형 경계는 x=40, y=30, width=20, height=20이었고, 모든 SVG를 g로 바꾸면 x=0, y=0, width=10, height=10이었다.
+- 이 실험은 원인 확인이다. 수정 후 Native Skia 출력의 픽셀 비교나 실제 문서 전체의 시각 동등성을 검증한 것으로 해석하지 않는다.
+- [보정 결과 답글 및 resolve](https://github.com/edwardkim/rhwp/pull/6881#discussion_r3957654752).
+
+### 3. 공통 선택기와 Native 글꼴 크기 상한
+
+- 공통 선택기는 4096px 초과를 거부하지만 실제 Native 준비 경로에는 같은 상한이 없어 진단과 렌더 선택이 달라질 수 있었다. 실제 결함으로 판정했다.
+- `MAX_GLYPH_FONT_SIZE_PX = 4096.0`을 공통 상수로 두고 선택기 및 Native 준비가 함께 사용하도록 보정했다.
+- Native 경로의 `font_instance.size_px`와 `paint_style.font_size` 모두 상한을 적용한다. 기존 finite/양수 조건은 유지한다.
+- [보정 결과 답글 및 resolve](https://github.com/edwardkim/rhwp/pull/6881#discussion_r3957655096).
+
+세 스레드 모두 오탐이 아니라 **실제 결함 보정 완료**로 답글을 남기고 resolve했다. API로 게시 본문과 resolve 결과를 확인했다.
+
+## 로컬 검증
+
+검토 전용 `CARGO_TARGET_DIR=target/pr6881-maintainer`를 사용했다. 기존 공유 target은 삭제하지 않았다.
+
+| 검사 | 실제 결과 |
+| --- | --- |
+| `cargo fmt --all -- --check` | 최종 보정 후 통과 |
+| `cargo clippy --locked -- -D warnings` | 보정 후보에서 통과 |
+| `cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown -- -D warnings` | 보정 후보에서 통과 |
+| `cargo build --locked --workspace` | 보정 후보에서 통과 |
+| `cargo clippy --locked --workspace --all-targets -- -D warnings` | 보정 후보에서 통과 |
+| `cargo clippy --locked --lib --features native-skia -- -D warnings` | 문자열 비교 타입 오류를 수정한 최종 보정에서 통과 |
+| `node scripts/rust-test-suite-manifest.mjs --check` | 최종 보정 후 통과 |
+| `git diff --check` | 최종 보정 후 통과 |
+
+중간 Native Skia 컴파일 실패는 새 SVG 이름 비교에서 `str`을 byte string과 비교한 메인터너 수정 오류였다. `"svg"` 비교로 바로잡은 뒤 재검증을 통과하고 push했다.
+이번 로컬 작업에서 전체 회귀 테스트를 다시 실행하거나 세 지적 각각의 신규 회귀 테스트를 추가하지 않았다. 아래 원격 CI 성공과 로컬 실행 범위를 구분한다.
+
+## 코드 head의 실제 CI 결과
+
+다음 결과는 모두 `a2b83a4eedb954250f962f8cfacae38dab15e078` 기준이다. 원 기여 head의 과거 성공을 재사용해 성공으로 기록한 것이 아니다.
+
+| 워크플로/검사 | 결과와 근거 |
+| --- | --- |
+| CI | [34223039334](https://github.com/edwardkim/rhwp/actions/runs/34223039334) 성공. Build & Test, Lint, Native Skia, archive A~D 빌드 및 실행 worker 모두 성공 |
+| Native Skia tests | [실행 job](https://github.com/edwardkim/rhwp/actions/runs/34223039334/job/102050540270) 성공 |
+| CodeQL | [34223039380](https://github.com/edwardkim/rhwp/actions/runs/34223039380) 성공. Rust/JavaScript-TypeScript/Python 분석 worker 모두 성공 |
+| 별도 CodeQL check | [check](https://github.com/edwardkim/rhwp/runs/102054863011)는 `NEUTRAL`. 워크플로/언어별 worker 성공과 구분 |
+| Render Diff | [34223039020](https://github.com/edwardkim/rhwp/actions/runs/34223039020) 및 Canvas visual diff 성공 |
+| Adapter inter-diff | [34223039319](https://github.com/edwardkim/rhwp/actions/runs/34223039319) preflight/worker 성공 |
+| Proptest | [34223039116](https://github.com/edwardkim/rhwp/actions/runs/34223039116) preflight/worker 성공 |
+| CI Impact Policy | 최종 status `SUCCESS` |
+
+`gh pr checks --required`의 Build & Test는 `SUCCESS`였다. 독립 WASM Build, Frontend gates, Workflow promotion, PR의 duration refresh는 `SKIPPED`이며 실행된 검사로 세지 않는다. 실제 WASM check는 성공한 Lint job과 로컬 WASM Clippy 결과를 근거로 삼는다.
+코드 head의 최종 상태는 `MERGEABLE / CLEAN`, 실패·취소·pending 없음이었다.
+
+## 시각 증적과 한계
+
+- 기존 CI Native Skia 및 Render Diff job을 증거로 연결한다. 개별 봇 지적을 새 테스트가 직접 검출한다고 주장하지 않는다.
+- 이번 보정에서는 새 한컴 PDF·Native 픽셀 비교 PNG를 생성하지 않았다. Chrome 축소 재현 결과를 실제 HWP/HWPX 문서의 Native 렌더 결과로 대체하지 않는다.
+- 임시 로그, SVG, JSON, 중간 PNG는 커밋하지 않는다. 이 trailing commit은 검토 문서와 오늘할일만 포함한다.
+- 4096 경계의 신규 Native 실행 테스트, 대형 글꼴 반복 입력의 부하 측정, 모든 언어·RTL·세로쓰기의 시각 동등성은 검증 완료 범위가 아니다.
+
+## 후속 처리 및 코멘트 계획
+
+- 보정 결과는 위 원 리뷰 스레드 3곳에 이미 한 번씩 기록했다. 동일 보정 내용을 중복 댓글로 게시하지 않는다.
+- 원 PR의 문서-only trailing head를 push한 뒤 그 최신 head의 checks를 확인한다. 코드 head의 CI 성공을 아직 실행되지 않은 문서 head의 성공으로 기록하지 않는다.
+- 병합 승인 시 `post_merge.md`에 따라 merge SHA 및 실제 PR/devel CI를 확인하고 원 PR의 기존 후속 기록과 중복되지 않게 남긴다. 새 시각 자료가 없으므로 존재하지 않는 이미지나 첨부를 만들어 근거처럼 제시하지 않는다.
+- #536 종료, 기여자 fork branch 삭제, 별도 통합 PR 생성, owner reviewer 자동 지정은 이번 작업에 포함하지 않는다.

--- a/src/paint/mod.rs
+++ b/src/paint/mod.rs
@@ -4,6 +4,7 @@
 
 pub(crate) const MAX_POSITIONED_CONTROL_MARKS_PER_RUN: usize = 4096;
 pub(crate) const MAX_PORTABLE_FONT_BLOB_BYTES: usize = 32 * 1024 * 1024;
+pub(crate) const MAX_GLYPH_FONT_SIZE_PX: f64 = 4096.0;
 pub(crate) const MAX_PORTABLE_GLYPHS_PER_RUN: usize = 4096;
 
 pub mod builder;

--- a/src/paint/paint_op.rs
+++ b/src/paint/paint_op.rs
@@ -1708,15 +1708,24 @@ impl PaintTextStyle {
     /// Returns whether a backend may replay this text as a simple fill-only
     /// positioned glyph run without losing HWP text effects.
     pub fn is_fill_only_glyph_replay(&self) -> bool {
+        self.is_simple_glyph_run_replay()
+            && self.outline_type == 0
+            && self.shadow_type == 0
+            && !self.emboss
+            && !self.engrave
+    }
+
+    /// Geometry-compatible glyph replay for backends that explicitly reproduce
+    /// outline, shadow, emboss and engrave. This does not enable those effects
+    /// for fill-only consumers or change the default text variant policy.
+    pub fn is_simple_glyph_run_replay(&self) -> bool {
         let ratio = if self.ratio > 0.0 { self.ratio } else { 1.0 };
         (ratio - 1.0).abs() <= 0.001
             && self.tab_leaders.is_empty()
             && self.underline == UnderlineType::None
             && !self.strikethrough
-            && self.outline_type == 0
-            && self.shadow_type == 0
-            && !self.emboss
-            && !self.engrave
+            && (self.shadow_type == 0
+                || (self.shadow_offset_x.is_finite() && self.shadow_offset_y.is_finite()))
             && !self.superscript
             && !self.subscript
             && self.emphasis_dot == 0

--- a/src/renderer/layer_renderer.rs
+++ b/src/renderer/layer_renderer.rs
@@ -721,7 +721,10 @@ fn collect_glyph_run_reject_reasons(
         reasons.insert(VariantRejectReason::AdvanceNotFinite);
     }
     let font_size = run.shape_key.font_instance.size_px;
-    if !font_size.is_finite() || font_size <= 0.0 || font_size > 4096.0 {
+    if !font_size.is_finite()
+        || font_size <= 0.0
+        || font_size > crate::paint::MAX_GLYPH_FONT_SIZE_PX
+    {
         reasons.insert(VariantRejectReason::FontInstanceInvalid);
     }
 }

--- a/src/renderer/layer_renderer.rs
+++ b/src/renderer/layer_renderer.rs
@@ -489,6 +489,7 @@ impl TextVariantCandidate {
                             options.backend,
                             VariantSelectionBackend::CanvasKit
                                 | VariantSelectionBackend::CanvasKitBrowser
+                                | VariantSelectionBackend::NativeSkia
                         ))
                 {
                     reasons.insert(VariantRejectReason::BackendDoesNotSupportVariant);

--- a/src/renderer/layer_renderer.rs
+++ b/src/renderer/layer_renderer.rs
@@ -627,7 +627,9 @@ fn collect_glyph_run_reject_reasons(
     if !run.paint_style.is_fill_only_glyph_replay() {
         reasons.insert(VariantRejectReason::UnsupportedPaintEffect);
     }
-    if run.shape_key.font_instance.synthetic_bold || run.shape_key.font_instance.synthetic_italic {
+    if (run.shape_key.font_instance.synthetic_bold || run.shape_key.font_instance.synthetic_italic)
+        && options.backend != VariantSelectionBackend::NativeSkia
+    {
         reasons.insert(VariantRejectReason::SyntheticStyleAuthorityPending);
     }
     if !matches!(run.direction, TextDirection::Ltr)
@@ -663,7 +665,9 @@ fn collect_glyph_run_reject_reasons(
             | VariantSelectionBackend::CanvasKitBrowser
             | VariantSelectionBackend::NativeSkia
     ) {
-        if !run.shape_key.font_instance.variations.is_empty() {
+        if !run.shape_key.font_instance.variations.is_empty()
+            && options.backend != VariantSelectionBackend::NativeSkia
+        {
             reasons.insert(VariantRejectReason::VariationUnsupported);
         }
         if matches!(
@@ -808,11 +812,48 @@ fn collect_glyph_run_font_resource_reject_reasons(
             {
                 reasons.insert(VariantRejectReason::FontBlobDigestMismatch);
             }
+            let parsed_face = ttf_parser::Face::parse(bytes, face.face_index);
             if (face.face_index != 0
-                && options.backend != VariantSelectionBackend::CanvasKitBrowser)
-                || ttf_parser::Face::parse(bytes, face.face_index).is_err()
+                && !matches!(
+                    options.backend,
+                    VariantSelectionBackend::CanvasKitBrowser | VariantSelectionBackend::NativeSkia
+                ))
+                || parsed_face.is_err()
             {
                 reasons.insert(VariantRejectReason::FaceIndexUnsupported);
+            }
+            if options.backend == VariantSelectionBackend::NativeSkia
+                && !run.shape_key.font_instance.variations.is_empty()
+            {
+                // This proves the portable instance contract, not Skia construction.
+                // Native replay must still prepare the exact Typeface before selecting
+                // any part of the strict variant or suppressing its TextRun fallback.
+                let variations = &run.shape_key.font_instance.variations;
+                let mut seen = BTreeSet::new();
+                let valid = variations.len()
+                    <= crate::renderer::shaping::MAX_SHAPING_VARIATION_AXES
+                    && parsed_face.as_ref().is_ok_and(|parsed| {
+                        variations.iter().all(|variation| {
+                            let Ok(tag_bytes) = <&[u8; 4]>::try_from(variation.tag.as_bytes())
+                            else {
+                                return false;
+                            };
+                            if !tag_bytes.iter().all(|byte| (0x20..=0x7e).contains(byte))
+                                || !variation.value.is_finite()
+                                || !seen.insert(variation.tag.as_str())
+                            {
+                                return false;
+                            }
+                            parsed.variation_axes().into_iter().any(|axis| {
+                                axis.tag == ttf_parser::Tag::from_bytes(tag_bytes)
+                                    && variation.value >= axis.min_value
+                                    && variation.value <= axis.max_value
+                            })
+                        })
+                    });
+                if !valid {
+                    reasons.insert(VariantRejectReason::VariationUnsupported);
+                }
             }
         }
         None => {
@@ -2016,7 +2057,7 @@ mod tests {
     }
 
     #[test]
-    fn native_skia_rejects_variation_instances_until_exact_construction_is_proven() {
+    fn native_skia_rejects_variation_axes_missing_from_the_exact_face() {
         let mut op = glyph_run(diagnostics(), 42);
         if let PaintOp::GlyphRun { run, .. } = &mut op {
             run.shape_key.font_instance.variations = vec![VariationAxisValue {
@@ -2034,18 +2075,19 @@ mod tests {
     }
 
     #[test]
-    fn native_skia_rejects_non_default_collection_face_until_exact_construction_is_proven() {
+    fn native_skia_accepts_a_parseable_non_default_collection_face_contract() {
         let report = first_report_with_resource_setup(
             vec![text_op(), glyph_run(diagnostics(), 42)],
             native_skia_options(),
             |resources| add_portable_font_bytes(resources, FIXTURE_TTC, 1),
         );
 
-        assert_eq!(report.selected_variant_kind, Some(TextVariantKind::TextRun));
-        assert!(report.fallback_required);
-        assert!(report.rejected_variants[0]
-            .reasons
-            .contains(&VariantRejectReason::FaceIndexUnsupported));
+        assert_eq!(
+            report.selected_variant_kind,
+            Some(TextVariantKind::GlyphRun)
+        );
+        assert!(!report.fallback_required);
+        assert!(report.rejected_variants.is_empty());
     }
 
     #[test]

--- a/src/renderer/layer_renderer.rs
+++ b/src/renderer/layer_renderer.rs
@@ -624,7 +624,12 @@ fn collect_glyph_run_reject_reasons(
     {
         reasons.insert(VariantRejectReason::GlyphAdvanceCountMismatch);
     }
-    if !run.paint_style.is_fill_only_glyph_replay() {
+    let paint_supported = if options.backend == VariantSelectionBackend::NativeSkia {
+        run.paint_style.is_simple_glyph_run_replay()
+    } else {
+        run.paint_style.is_fill_only_glyph_replay()
+    };
+    if !paint_supported {
         reasons.insert(VariantRejectReason::UnsupportedPaintEffect);
     }
     if (run.shape_key.font_instance.synthetic_bold || run.shape_key.font_instance.synthetic_italic)

--- a/src/renderer/skia/glyph_replay.rs
+++ b/src/renderer/skia/glyph_replay.rs
@@ -33,6 +33,68 @@ pub(super) struct PreparedGlyph {
     pub byte_cost: usize,
 }
 
+pub(super) struct GlyphPreparationBudget {
+    remaining_entries: usize,
+    remaining_bytes: usize,
+}
+
+impl GlyphPreparationBudget {
+    pub fn new() -> Self {
+        Self {
+            remaining_entries: 4096,
+            remaining_bytes: MAX_PREPARED_GLYPH_BYTES,
+        }
+    }
+
+    pub fn prepare(
+        &mut self,
+        minimum_bytes: usize,
+        prepare: impl FnOnce() -> Option<PreparedGlyph>,
+    ) -> Option<PreparedGlyph> {
+        if self.remaining_entries == 0
+            || self.remaining_bytes == 0
+            || minimum_bytes > self.remaining_bytes
+        {
+            return None;
+        }
+        // Charge before parsing/copying. A failed candidate must not restore
+        // the work allowance and repeatedly prepare the same large resource.
+        self.remaining_entries -= 1;
+        self.remaining_bytes -= minimum_bytes;
+        let prepared = prepare()?;
+        let additional_bytes = prepared.byte_cost.saturating_sub(minimum_bytes);
+        let Some(remaining) = self.remaining_bytes.checked_sub(additional_bytes) else {
+            // Outline costs are known only after preparation. Stop further
+            // preparation if this candidate exhausted the remaining allowance.
+            self.remaining_bytes = 0;
+            return None;
+        };
+        self.remaining_bytes = remaining;
+        Some(prepared)
+    }
+}
+
+pub(super) fn glyph_run_minimum_byte_cost(
+    run: &LayerGlyphRunPaint,
+    resources: &ResourceArena,
+) -> Option<usize> {
+    let fonts = resources.font_resources();
+    let face = fonts
+        .faces
+        .iter()
+        .find(|face| face.id == run.shape_key.font_instance.face_key)?;
+    let blob = fonts.blobs.iter().find(|blob| blob.id == face.blob_key)?;
+    let bytes = resources.font_blob_bytes_for_ref(blob.data_ref.as_ref()?)?;
+    let placement_bytes = if run.paint_style.is_fill_only_glyph_replay() {
+        run.glyph_ids
+            .len()
+            .checked_mul(std::mem::size_of::<Point>() + std::mem::size_of::<u16>())?
+    } else {
+        0
+    };
+    bytes.len().checked_add(placement_bytes)
+}
+
 struct PreparedDraw {
     transforms: Vec<Matrix>,
     paint: Paint,
@@ -798,18 +860,34 @@ fn svg_glyph_image(
     {
         return None;
     }
-    // The payload viewBox is authoritative. SVG containers act as groups in
-    // the static path contract, preserving their paint/transform attributes.
+    // The payload viewBox replaces only the outer container's viewport.
+    // Nested SVG elements retain their own viewport, scaling and clipping.
     let mut reader = Reader::from_str(fragment);
     let mut writer = Writer::new(Vec::new());
+    let mut depth = 0usize;
     loop {
         let event = reader.read_event().ok()?;
         let empty = matches!(&event, Event::Empty(_));
+        let rewrite_container = match &event {
+            Event::Start(element) | Event::Empty(element) => {
+                depth == 0 && element.name().as_ref() == "svg"
+            }
+            Event::End(element) => depth == 1 && element.name().as_ref() == "svg",
+            _ => false,
+        };
+        match &event {
+            Event::Start(_) => depth = depth.checked_add(1)?,
+            Event::End(_) => depth = depth.checked_sub(1)?,
+            _ => {}
+        }
         match event {
-            Event::Eof => break,
-            Event::Start(mut element) | Event::Empty(mut element)
-                if element.name().as_ref() == "svg" =>
-            {
+            Event::Eof => {
+                if depth != 0 {
+                    return None;
+                }
+                break;
+            }
+            Event::Start(mut element) | Event::Empty(mut element) if rewrite_container => {
                 element.set_name("g");
                 writer
                     .write_event(if empty {
@@ -819,7 +897,7 @@ fn svg_glyph_image(
                     })
                     .ok()?;
             }
-            Event::End(element) if element.name().as_ref() == "svg" => {
+            Event::End(_) if rewrite_container => {
                 writer.write_event(Event::End(BytesEnd::new("g"))).ok()?;
             }
             event => {

--- a/src/renderer/skia/glyph_replay.rs
+++ b/src/renderer/skia/glyph_replay.rs
@@ -697,8 +697,16 @@ pub(super) fn prepare_glyph_outline(
             if pixels == 0 || pixels > MAX_IMAGE_PIXELS {
                 return None;
             }
-            // Image construction alone only reads a header. Eagerly decode before
-            // replacing the text fallback so a truncated strike cannot drop ink.
+            // Skia's lazy image and raster copy can accept incomplete encoded
+            // data. Require a bounded, successful full decode before replacing
+            // text, then retain Skia's own color-managed raster for replay.
+            let mut decoder = image::ImageReader::new(std::io::Cursor::new(bytes))
+                .with_guessed_format()
+                .ok()?;
+            let mut limits = image::Limits::default();
+            limits.max_alloc = Some(MAX_PREPARED_GLYPH_BYTES as u64);
+            decoder.limits(limits);
+            decoder.decode().ok()?;
             let image = encoded.make_raster_image(None, None)?;
             let transforms = optional_matrix(payload.transform_to_run)?;
             result.byte_cost = pixels as usize * 4;

--- a/src/renderer/skia/glyph_replay.rs
+++ b/src/renderer/skia/glyph_replay.rs
@@ -234,6 +234,9 @@ pub(super) fn construct_glyph_font(
     let transforms =
         vec![matrix(run.placement.run_to_page)
             .ok_or_else(|| vec![FontFailure::PlacementNotFinite])?];
+    if !run.paint_style.is_fill_only_glyph_replay() {
+        return prepare_glyph_effects(run, &font, transforms, bytes.len());
+    }
     Ok(PreparedGlyph {
         byte_cost: bytes.len() + run.glyph_ids.len() * (std::mem::size_of::<Point>() + 2),
         draws: vec![PreparedDraw {
@@ -250,6 +253,91 @@ pub(super) fn construct_glyph_font(
             },
         }],
     })
+}
+
+fn prepare_glyph_effects(
+    run: &LayerGlyphRunPaint,
+    font: &Font,
+    transforms: Vec<Matrix>,
+    font_byte_cost: usize,
+) -> Result<PreparedGlyph, Vec<FontFailure>> {
+    let unsupported = || vec![FontFailure::UnsupportedPaintEffect];
+    let mut paths = Vec::with_capacity(run.glyph_ids.len());
+    let mut byte_cost = font_byte_cost;
+    // Resolve every outline before suppressing the TextRun. A missing outline
+    // is safe only for an actually empty glyph, such as a space.
+    for (&glyph, position) in run.glyph_ids.iter().zip(&run.positions) {
+        let Some(path) = font.get_path(glyph as u16) else {
+            let mut bounds = [Rect::default()];
+            font.get_bounds(&[glyph as u16], &mut bounds, None);
+            if !bounds[0].is_empty() {
+                return Err(unsupported());
+            }
+            continue;
+        };
+        let path = path.with_offset((position.x as f32, position.y as f32));
+        if !path.is_finite() || path.count_verbs() > MAX_PATH_COMMANDS {
+            return Err(unsupported());
+        }
+        byte_cost = byte_cost
+            .checked_add(path.approximate_bytes_used())
+            .filter(|cost| *cost <= MAX_PREPARED_GLYPH_BYTES)
+            .ok_or_else(unsupported)?;
+        paths.push(path);
+    }
+    let style = &run.paint_style;
+    let fill = fill_paint(colorref_to_skia(style.color, 1.0));
+    let highlight = fill_paint(Color::WHITE);
+    let mut passes = Vec::with_capacity(3);
+    if style.emboss || style.engrave {
+        let offset = (style.font_size as f32 / 20.0).max(1.0);
+        let relief_shadow = fill_paint(Color::from_rgb(0x80, 0x80, 0x80));
+        let (upper, lower) = if style.emboss {
+            (highlight, relief_shadow)
+        } else {
+            (relief_shadow, highlight)
+        };
+        passes.push((upper, (-offset, -offset)));
+        passes.push((lower, (offset, offset)));
+        passes.push((fill, (0.0, 0.0)));
+    } else {
+        if style.shadow_type > 0 {
+            passes.push((
+                fill_paint(colorref_to_skia(style.shadow_color, 1.0)),
+                (style.shadow_offset_x as f32, style.shadow_offset_y as f32),
+            ));
+        }
+        if style.outline_type > 0 {
+            let mut stroke = fill;
+            stroke.set_style(skia_safe::paint::Style::Stroke);
+            stroke.set_stroke_width((style.font_size as f32 / 25.0).max(0.5));
+            passes.push((highlight, (0.0, 0.0)));
+            passes.push((stroke, (0.0, 0.0)));
+        } else {
+            passes.push((fill, (0.0, 0.0)));
+        }
+    }
+    let mut draws = Vec::with_capacity(paths.len() * passes.len());
+    // Preserve the branch's effect precedence and complete pass ordering:
+    // relief overrides shadow/outline; shadow precedes white fill and stroke.
+    for (paint, offset) in passes {
+        for path in &paths {
+            let shifted = path.with_offset(offset);
+            if !shifted.is_finite() {
+                return Err(unsupported());
+            }
+            byte_cost = byte_cost
+                .checked_add(shifted.approximate_bytes_used())
+                .filter(|cost| *cost <= MAX_PREPARED_GLYPH_BYTES)
+                .ok_or_else(unsupported)?;
+            draws.push(PreparedDraw {
+                transforms: transforms.clone(),
+                paint: paint.clone(),
+                content: DrawContent::Path(shifted),
+            });
+        }
+    }
+    Ok(PreparedGlyph { draws, byte_cost })
 }
 
 fn path(commands: &[PathCommand], fill_rule: GlyphOutlineFillRule) -> Option<Path> {

--- a/src/renderer/skia/glyph_replay.rs
+++ b/src/renderer/skia/glyph_replay.rs
@@ -1,0 +1,758 @@
+//! Prepare strict glyph resources before selecting a text alternative.
+//!
+//! Preparation is atomic: a failed font, path, shader or image never suppresses
+//! the anchored TextRun. Prepared Skia objects are reused by the actual draw.
+
+use std::collections::HashSet;
+
+use skia_safe::{
+    font_arguments::{variation_position, VariationPosition},
+    gradient::{shaders, Colors, Gradient, Interpolation},
+    Canvas, Color, Color4f, Data, FilterMode, Font, FontArguments, FontMgr, FourByteTag, Image,
+    Matrix, MipmapMode, Paint, Path, PathBuilder, Point, Rect, SamplingOptions, TileMode,
+};
+
+use crate::paint::{
+    BitmapGlyphFiltering, ColorGlyphFormat, ColorPaintGraphNodeKind, GlyphOutlineFillRule,
+    GlyphOutlinePaintOrder, GlyphOutlinePayloadKind, GlyphRunReplayEligibility,
+    LayerAffineTransform, LayerGlyphOutlinePaint, LayerGlyphRunPaint, ResolvedColor, ResourceArena,
+    TextVariantQuality,
+};
+use crate::renderer::render_tree::BoundingBox;
+use crate::renderer::{svg_arc_to_beziers, PathCommand};
+
+use super::renderer::{colorref_to_skia, NativeGlyphRunReplayProofReason as FontFailure};
+
+pub(super) const MAX_PREPARED_GLYPH_BYTES: usize = 64 * 1024 * 1024;
+const MAX_PATH_COMMANDS: usize = 100_000;
+const MAX_IMAGE_BYTES: usize = 4 * 1024 * 1024;
+const MAX_IMAGE_PIXELS: u64 = 4096 * 4096;
+
+pub(super) struct PreparedGlyph {
+    draws: Vec<PreparedDraw>,
+    pub byte_cost: usize,
+}
+
+struct PreparedDraw {
+    transforms: Vec<Matrix>,
+    paint: Paint,
+    content: DrawContent,
+}
+
+enum DrawContent {
+    Glyphs {
+        font: Font,
+        glyphs: Vec<u16>,
+        positions: Vec<Point>,
+    },
+    Path(Path),
+    Image {
+        image: Image,
+        destination: Rect,
+        sampling: SamplingOptions,
+    },
+}
+
+impl PreparedGlyph {
+    pub fn draw(&self, canvas: &Canvas) {
+        for draw in &self.draws {
+            canvas.save();
+            for transform in &draw.transforms {
+                canvas.concat(transform);
+            }
+            match &draw.content {
+                DrawContent::Glyphs {
+                    font,
+                    glyphs,
+                    positions,
+                } => {
+                    canvas.draw_glyphs_at(
+                        glyphs,
+                        positions.as_slice(),
+                        (0.0, 0.0),
+                        font,
+                        &draw.paint,
+                    );
+                }
+                DrawContent::Path(path) => {
+                    canvas.draw_path(path, &draw.paint);
+                }
+                DrawContent::Image {
+                    image,
+                    destination,
+                    sampling,
+                } => {
+                    canvas.draw_image_rect_with_sampling_options(
+                        image,
+                        None,
+                        destination,
+                        *sampling,
+                        &draw.paint,
+                    );
+                }
+            }
+            canvas.restore();
+        }
+    }
+}
+
+pub(super) fn finite_scalar(value: f64) -> bool {
+    value.is_finite() && value.abs() <= f64::from(f32::MAX)
+}
+
+fn matrix(transform: LayerAffineTransform) -> Option<Matrix> {
+    let values = [
+        transform.a,
+        transform.b,
+        transform.c,
+        transform.d,
+        transform.e,
+        transform.f,
+    ];
+    values
+        .into_iter()
+        .all(finite_scalar)
+        .then(|| Matrix::from_affine(&values.map(|value| value as f32)))
+}
+
+fn fill_paint(color: Color) -> Paint {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(color);
+    paint
+}
+
+pub(super) fn construct_glyph_font(
+    run: &LayerGlyphRunPaint,
+    resources: &ResourceArena,
+    font_mgr: &FontMgr,
+) -> Result<PreparedGlyph, Vec<FontFailure>> {
+    let instance = &run.shape_key.font_instance;
+    let face = resources
+        .font_resources()
+        .faces
+        .iter()
+        .find(|face| face.id == instance.face_key)
+        .ok_or_else(|| vec![FontFailure::FontFaceMissing])?;
+    let blob = resources
+        .font_resources()
+        .blobs
+        .iter()
+        .find(|blob| blob.id == face.blob_key)
+        .ok_or_else(|| vec![FontFailure::FontBlobMissing])?;
+    let bytes = blob
+        .data_ref
+        .as_ref()
+        .and_then(|data_ref| resources.font_blob_bytes_for_ref(data_ref))
+        .ok_or_else(|| vec![FontFailure::FontBlobBytesMissing])?;
+    let unavailable = || {
+        let mut reasons = vec![FontFailure::ExactFaceUnavailable];
+        if face.face_index != 0 {
+            reasons.push(FontFailure::FaceIndexUnsupported);
+        }
+        if !instance.variations.is_empty() {
+            reasons.push(FontFailure::FontVariationUnsupported);
+        }
+        reasons
+    };
+    // Parse the requested collection face first. Font backends must never turn
+    // an out-of-range face into a successful face-zero family fallback.
+    let parsed = ttf_parser::Face::parse(bytes, face.face_index).map_err(|_| unavailable())?;
+    if run
+        .glyph_ids
+        .iter()
+        .any(|glyph| *glyph >= u32::from(parsed.number_of_glyphs()))
+    {
+        return Err(vec![FontFailure::GlyphIdOutOfRange]);
+    }
+    let mut typeface = font_mgr
+        .new_from_data(bytes, Some(face.face_index as usize))
+        .ok_or_else(unavailable)?;
+    if !instance.variations.is_empty() {
+        if instance.variations.len() > 16 {
+            return Err(vec![FontFailure::FontVariationUnsupported]);
+        }
+        let parameters = typeface
+            .variation_design_parameters()
+            .ok_or_else(|| vec![FontFailure::FontVariationUnsupported])?;
+        let mut seen = HashSet::new();
+        let mut coordinates = Vec::with_capacity(instance.variations.len());
+        for variation in &instance.variations {
+            let tag: [u8; 4] = variation
+                .tag
+                .as_bytes()
+                .try_into()
+                .map_err(|_| vec![FontFailure::FontVariationUnsupported])?;
+            let axis = FourByteTag::from_chars(
+                tag[0] as char,
+                tag[1] as char,
+                tag[2] as char,
+                tag[3] as char,
+            );
+            let parameter = parameters
+                .iter()
+                .find(|parameter| parameter.tag == axis)
+                .ok_or_else(|| vec![FontFailure::FontVariationUnsupported])?;
+            if !seen.insert(tag)
+                || !variation.value.is_finite()
+                || variation.value < parameter.min
+                || variation.value > parameter.max
+            {
+                return Err(vec![FontFailure::FontVariationUnsupported]);
+            }
+            coordinates.push(variation_position::Coordinate {
+                axis,
+                value: variation.value,
+            });
+        }
+        let mut arguments = FontArguments::new().set_variation_design_position(VariationPosition {
+            coordinates: &coordinates,
+        });
+        arguments.set_collection_index(face.face_index as usize);
+        typeface = typeface
+            .clone_with_arguments(&arguments)
+            .ok_or_else(|| vec![FontFailure::FontVariationUnsupported])?;
+        let actual = typeface
+            .variation_design_position()
+            .ok_or_else(|| vec![FontFailure::FontVariationUnsupported])?;
+        if coordinates.iter().any(|expected| {
+            !actual.iter().any(|value| {
+                value.axis == expected.axis && (value.value - expected.value).abs() <= 0.001
+            })
+        }) {
+            return Err(vec![FontFailure::FontVariationUnsupported]);
+        }
+    }
+    let mut font = Font::from_typeface(typeface, instance.size_px as f32);
+    font.set_embolden(instance.synthetic_bold);
+    font.set_skew_x(if instance.synthetic_italic {
+        -0.25
+    } else {
+        0.0
+    });
+    font.set_edging(skia_safe::font::Edging::AntiAlias);
+    let transforms =
+        vec![matrix(run.placement.run_to_page)
+            .ok_or_else(|| vec![FontFailure::PlacementNotFinite])?];
+    Ok(PreparedGlyph {
+        byte_cost: bytes.len() + run.glyph_ids.len() * (std::mem::size_of::<Point>() + 2),
+        draws: vec![PreparedDraw {
+            transforms,
+            paint: fill_paint(colorref_to_skia(run.paint_style.color, 1.0)),
+            content: DrawContent::Glyphs {
+                font,
+                glyphs: run.glyph_ids.iter().map(|glyph| *glyph as u16).collect(),
+                positions: run
+                    .positions
+                    .iter()
+                    .map(|position| Point::new(position.x as f32, position.y as f32))
+                    .collect(),
+            },
+        }],
+    })
+}
+
+fn path(commands: &[PathCommand], fill_rule: GlyphOutlineFillRule) -> Option<Path> {
+    if commands.is_empty() || commands.len() > MAX_PATH_COMMANDS {
+        return None;
+    }
+    let mut builder = PathBuilder::new();
+    let mut current = (0.0, 0.0);
+    let mut origin = current;
+    for command in commands {
+        match *command {
+            PathCommand::MoveTo(x, y) | PathCommand::LineTo(x, y) => {
+                if !finite_scalar(x) || !finite_scalar(y) {
+                    return None;
+                }
+                if matches!(command, PathCommand::MoveTo(..)) {
+                    builder.move_to((x as f32, y as f32));
+                    origin = (x, y);
+                } else {
+                    builder.line_to((x as f32, y as f32));
+                }
+                current = (x, y);
+            }
+            PathCommand::CurveTo(x1, y1, x2, y2, x, y) => {
+                if ![x1, y1, x2, y2, x, y].into_iter().all(finite_scalar) {
+                    return None;
+                }
+                builder.cubic_to(
+                    (x1 as f32, y1 as f32),
+                    (x2 as f32, y2 as f32),
+                    (x as f32, y as f32),
+                );
+                current = (x, y);
+            }
+            PathCommand::ArcTo(rx, ry, rotation, large, sweep, x, y) => {
+                if ![rx, ry, rotation, x, y].into_iter().all(finite_scalar) {
+                    return None;
+                }
+                if rx == 0.0 || ry == 0.0 {
+                    builder.line_to((x as f32, y as f32));
+                } else {
+                    for segment in svg_arc_to_beziers(
+                        current.0, current.1, rx, ry, rotation, large, sweep, x, y,
+                    ) {
+                        if let PathCommand::CurveTo(x1, y1, x2, y2, ex, ey) = segment {
+                            if ![x1, y1, x2, y2, ex, ey].into_iter().all(finite_scalar) {
+                                return None;
+                            }
+                            builder.cubic_to(
+                                (x1 as f32, y1 as f32),
+                                (x2 as f32, y2 as f32),
+                                (ex as f32, ey as f32),
+                            );
+                        }
+                    }
+                }
+                current = (x, y);
+            }
+            PathCommand::ClosePath => {
+                builder.close();
+                current = origin;
+            }
+        }
+    }
+    builder.set_fill_type(match fill_rule {
+        GlyphOutlineFillRule::NonZero => skia_safe::PathFillType::Winding,
+        GlyphOutlineFillRule::EvenOdd => skia_safe::PathFillType::EvenOdd,
+    });
+    Some(builder.detach())
+}
+
+fn resolved_color(color: &ResolvedColor, opacity: f64) -> Option<Color> {
+    if !color
+        .rgba
+        .into_iter()
+        .all(|value| value.is_finite() && (0.0..=1.0).contains(&value))
+        || !opacity.is_finite()
+        || !(0.0..=1.0).contains(&opacity)
+        || color
+            .color_space
+            .as_deref()
+            .is_some_and(|space| !space.eq_ignore_ascii_case("srgb"))
+    {
+        return None;
+    }
+    let channel = |value: f32| (value * 255.0).round() as u8;
+    Some(Color::from_argb(
+        channel(color.rgba[3] * opacity as f32),
+        channel(color.rgba[0]),
+        channel(color.rgba[1]),
+        channel(color.rgba[2]),
+    ))
+}
+
+fn gradient_stops(stops: &[crate::paint::ColorGradientStop]) -> Option<(Vec<Color4f>, Vec<f32>)> {
+    if stops.len() < 2 || stops.len() > MAX_PATH_COMMANDS {
+        return None;
+    }
+    let mut colors = Vec::with_capacity(stops.len());
+    let mut positions = Vec::with_capacity(stops.len());
+    let mut last = 0.0;
+    for stop in stops {
+        if !stop.offset.is_finite() || stop.offset < last || stop.offset > 1.0 {
+            return None;
+        }
+        colors.push(Color4f::from(resolved_color(&stop.color, 1.0)?));
+        positions.push(stop.offset as f32);
+        last = stop.offset;
+    }
+    Some((colors, positions))
+}
+
+pub(super) fn prepare_glyph_outline(
+    outline: &LayerGlyphOutlinePaint,
+    bbox: BoundingBox,
+    resources: &ResourceArena,
+    raster_scale: f32,
+) -> Option<PreparedGlyph> {
+    let diagnostics = &outline.diagnostics;
+    if !diagnostics.strict_visual_eligible
+        || diagnostics.replay_eligibility != GlyphRunReplayEligibility::Portable
+        || !matches!(
+            diagnostics.quality,
+            TextVariantQuality::Exact | TextVariantQuality::PositionAdjusted
+        )
+        || diagnostics.missing_glyph_count != 0
+        || diagnostics.cluster_mismatch_count != 0
+        || diagnostics.used_fallback_font_count != 0
+        || (diagnostics.quality == TextVariantQuality::PositionAdjusted
+            && (!diagnostics.max_residual_after_adjustment_px.is_finite()
+                || diagnostics.max_residual_after_adjustment_px > 0.25))
+        || !outline.paint_style.is_fill_only_glyph_replay()
+        || !outline.has_exclusive_payload_family()
+        || !finite_scalar(outline.placement.baseline_y)
+    {
+        return None;
+    }
+    let placement = matrix(outline.placement.run_to_page)?;
+    let mut result = PreparedGlyph {
+        draws: Vec::new(),
+        byte_cost: 0,
+    };
+    match outline.payload_kind {
+        GlyphOutlinePayloadKind::MonochromeFill | GlyphOutlinePayloadKind::MonochromeFillStroke => {
+            if outline.paths.is_empty() || outline.paths.len() > 4096 {
+                return None;
+            }
+            let fill = fill_paint(colorref_to_skia(outline.paint_style.color, 1.0));
+            let stroke = if outline.payload_kind == GlyphOutlinePayloadKind::MonochromeFillStroke {
+                let style = outline.stroke.as_ref()?;
+                if !style.is_strict_subset()
+                    || !finite_scalar(style.width)
+                    || !finite_scalar(style.miter_limit)
+                {
+                    return None;
+                }
+                let mut paint = fill_paint(colorref_to_skia(style.color, 1.0));
+                paint.set_style(skia_safe::paint::Style::Stroke);
+                paint.set_stroke_width(style.width as f32);
+                paint.set_stroke_miter(style.miter_limit as f32);
+                paint.set_stroke_join(skia_safe::paint::Join::Miter);
+                paint.set_stroke_cap(skia_safe::paint::Cap::Butt);
+                Some((paint, style.paint_order))
+            } else {
+                None
+            };
+            for outline_path in &outline.paths {
+                let path = path(&outline_path.commands, outline_path.fill_rule)?;
+                result.byte_cost = result.byte_cost.checked_add(
+                    outline_path.commands.len() * std::mem::size_of::<PathCommand>(),
+                )?;
+                if result.byte_cost > MAX_PREPARED_GLYPH_BYTES {
+                    return None;
+                }
+                let paints = match &stroke {
+                    Some((stroke, GlyphOutlinePaintOrder::StrokeThenFill)) => {
+                        vec![stroke.clone(), fill.clone()]
+                    }
+                    Some((stroke, GlyphOutlinePaintOrder::FillThenStroke)) => {
+                        vec![fill.clone(), stroke.clone()]
+                    }
+                    None => vec![fill.clone()],
+                    _ => return None,
+                };
+                for paint in paints {
+                    result.draws.push(PreparedDraw {
+                        transforms: vec![placement],
+                        paint,
+                        content: DrawContent::Path(path.clone()),
+                    });
+                }
+            }
+        }
+        GlyphOutlinePayloadKind::ColorLayers => {
+            let payload = outline.color_layers.as_ref()?;
+            if payload.color_format == ColorGlyphFormat::ColrV0
+                && payload.has_colrv0_resolved_layer_contract()
+            {
+                if payload.layers.len() > 4096 {
+                    return None;
+                }
+                for layer in &payload.layers {
+                    let commands = layer.commands.as_deref()?;
+                    let path = path(commands, layer.fill_rule?)?;
+                    let mut transforms = vec![placement];
+                    if let Some(transform) = layer.transform_to_run {
+                        transforms.push(matrix(transform)?);
+                    }
+                    result.byte_cost = result
+                        .byte_cost
+                        .checked_add(commands.len() * std::mem::size_of::<PathCommand>())?;
+                    if result.byte_cost > MAX_PREPARED_GLYPH_BYTES {
+                        return None;
+                    }
+                    result.draws.push(PreparedDraw {
+                        transforms,
+                        paint: fill_paint(resolved_color(
+                            layer.fill.as_ref()?,
+                            layer.opacity.unwrap_or(1.0),
+                        )?),
+                        content: DrawContent::Path(path),
+                    });
+                }
+            } else if payload.has_colrv1_supported_graph_contract() {
+                let graph = payload.paint_graph.as_ref()?;
+                let mut transforms = vec![placement];
+                let mut node_id = graph.root_node_id;
+                for _ in 0..64 {
+                    let node = graph.nodes.iter().find(|node| node.node_id == node_id)?;
+                    let (commands, fill_rule, paint) = match node.kind {
+                        ColorPaintGraphNodeKind::Transform => {
+                            let transform = node.transform.as_ref()?;
+                            transforms.push(matrix(transform.transform)?);
+                            node_id = transform.child_node_id;
+                            continue;
+                        }
+                        ColorPaintGraphNodeKind::SolidPath => {
+                            let leaf = node.solid_path.as_ref()?;
+                            (
+                                &leaf.commands,
+                                leaf.fill_rule,
+                                fill_paint(resolved_color(&leaf.fill, 1.0)?),
+                            )
+                        }
+                        ColorPaintGraphNodeKind::LinearGradientPath => {
+                            let leaf = node.linear_gradient_path.as_ref()?;
+                            let gradient = &leaf.gradient;
+                            if ![gradient.x0, gradient.y0, gradient.x1, gradient.y1]
+                                .into_iter()
+                                .all(finite_scalar)
+                            {
+                                return None;
+                            }
+                            let (colors, stops) = gradient_stops(&gradient.stops)?;
+                            let specification = Gradient::new(
+                                Colors::new(&colors, Some(&stops), TileMode::Clamp, None),
+                                Interpolation::default(),
+                            );
+                            let shader = shaders::linear_gradient(
+                                (
+                                    (gradient.x0 as f32, gradient.y0 as f32),
+                                    (gradient.x1 as f32, gradient.y1 as f32),
+                                ),
+                                &specification,
+                                None,
+                            )?;
+                            let mut paint = fill_paint(Color::WHITE);
+                            paint.set_shader(shader);
+                            (&leaf.commands, leaf.fill_rule, paint)
+                        }
+                        ColorPaintGraphNodeKind::RadialGradientPath => {
+                            let leaf = node.radial_gradient_path.as_ref()?;
+                            let gradient = &leaf.gradient;
+                            if ![gradient.cx, gradient.cy, gradient.radius]
+                                .into_iter()
+                                .all(finite_scalar)
+                                || gradient.radius <= 0.0
+                            {
+                                return None;
+                            }
+                            let (colors, stops) = gradient_stops(&gradient.stops)?;
+                            let specification = Gradient::new(
+                                Colors::new(&colors, Some(&stops), TileMode::Clamp, None),
+                                Interpolation::default(),
+                            );
+                            let shader = shaders::radial_gradient(
+                                (
+                                    (gradient.cx as f32, gradient.cy as f32),
+                                    gradient.radius as f32,
+                                ),
+                                &specification,
+                                None,
+                            )?;
+                            let mut paint = fill_paint(Color::WHITE);
+                            paint.set_shader(shader);
+                            (&leaf.commands, leaf.fill_rule, paint)
+                        }
+                        ColorPaintGraphNodeKind::SweepGradientPath => {
+                            let leaf = node.sweep_gradient_path.as_ref()?;
+                            let gradient = &leaf.gradient;
+                            if ![
+                                gradient.cx,
+                                gradient.cy,
+                                gradient.start_angle_degrees,
+                                gradient.end_angle_degrees,
+                            ]
+                            .into_iter()
+                            .all(finite_scalar)
+                            {
+                                return None;
+                            }
+                            let (colors, stops) = gradient_stops(&gradient.stops)?;
+                            let specification = Gradient::new(
+                                Colors::new(&colors, Some(&stops), TileMode::Clamp, None),
+                                Interpolation::default(),
+                            );
+                            let shader = shaders::sweep_gradient(
+                                (gradient.cx as f32, gradient.cy as f32),
+                                (
+                                    gradient.start_angle_degrees as f32,
+                                    gradient.end_angle_degrees as f32,
+                                ),
+                                &specification,
+                                None,
+                            )?;
+                            let mut paint = fill_paint(Color::WHITE);
+                            paint.set_shader(shader);
+                            (&leaf.commands, leaf.fill_rule, paint)
+                        }
+                        _ => return None,
+                    };
+                    result.byte_cost = commands.len() * std::mem::size_of::<PathCommand>();
+                    result.draws.push(PreparedDraw {
+                        transforms,
+                        paint,
+                        content: DrawContent::Path(path(commands, fill_rule)?),
+                    });
+                    break;
+                }
+            } else {
+                return None;
+            }
+        }
+        GlyphOutlinePayloadKind::BitmapGlyph => {
+            let payload = outline.bitmap_glyph.as_ref()?;
+            if !payload.has_strict_visual_contract() {
+                return None;
+            }
+            let bytes = resources.image_bytes(payload.image_ref)?;
+            if bytes.len() > MAX_IMAGE_BYTES {
+                return None;
+            }
+            let encoded = Image::from_encoded(Data::new_copy(bytes))?;
+            let pixels = u64::try_from(encoded.width())
+                .ok()?
+                .checked_mul(u64::try_from(encoded.height()).ok()?)?;
+            if pixels == 0 || pixels > MAX_IMAGE_PIXELS {
+                return None;
+            }
+            // Image construction alone only reads a header. Eagerly decode before
+            // replacing the text fallback so a truncated strike cannot drop ink.
+            let image = encoded.make_raster_image(None, None)?;
+            let transforms = optional_matrix(payload.transform_to_run)?;
+            result.byte_cost = pixels as usize * 4;
+            result.draws.push(PreparedDraw {
+                transforms: transforms.into_iter().collect(),
+                paint: fill_paint(Color::WHITE),
+                content: DrawContent::Image {
+                    image,
+                    destination: drawable_rect(payload.placement)?,
+                    sampling: SamplingOptions::new(
+                        match payload.filtering {
+                            BitmapGlyphFiltering::Nearest => FilterMode::Nearest,
+                            BitmapGlyphFiltering::Linear => FilterMode::Linear,
+                        },
+                        MipmapMode::None,
+                    ),
+                },
+            });
+        }
+        GlyphOutlinePayloadKind::SvgGlyph => {
+            let payload = outline.svg_glyph.as_ref()?;
+            if !payload.has_static_sanitized_contract() {
+                return None;
+            }
+            let fragment = resources.svg_fragment(payload.svg_ref)?;
+            let (image, bytes) = svg_glyph_image(fragment, payload.view_box, bbox, raster_scale)?;
+            let transforms = optional_matrix(payload.transform_to_run)?;
+            result.byte_cost = bytes;
+            result.draws.push(PreparedDraw {
+                transforms: transforms.into_iter().collect(),
+                paint: fill_paint(Color::WHITE),
+                content: DrawContent::Image {
+                    image,
+                    destination: drawable_rect(bbox)?,
+                    sampling: SamplingOptions::new(FilterMode::Linear, MipmapMode::None),
+                },
+            });
+        }
+    }
+    (!result.draws.is_empty()).then_some(result)
+}
+
+fn drawable_rect(bbox: BoundingBox) -> Option<Rect> {
+    ([
+        bbox.x,
+        bbox.y,
+        bbox.width,
+        bbox.height,
+        bbox.x + bbox.width,
+        bbox.y + bbox.height,
+    ]
+    .into_iter()
+    .all(finite_scalar)
+        && bbox.width > 0.0
+        && bbox.height > 0.0)
+        .then(|| {
+            Rect::from_xywh(
+                bbox.x as f32,
+                bbox.y as f32,
+                bbox.width as f32,
+                bbox.height as f32,
+            )
+        })
+}
+
+fn svg_glyph_image(
+    fragment: &str,
+    view_box: BoundingBox,
+    bbox: BoundingBox,
+    scale: f32,
+) -> Option<(Image, usize)> {
+    use quick_xml::{
+        events::{BytesEnd, Event},
+        Reader, Writer,
+    };
+    use resvg::{tiny_skia, usvg};
+    if !crate::renderer::static_svg::static_svg_fragment_has_path_layer(fragment) {
+        return None;
+    }
+    drawable_rect(bbox)?;
+    drawable_rect(view_box)?;
+    let width = (bbox.width * f64::from(scale)).ceil();
+    let height = (bbox.height * f64::from(scale)).ceil();
+    if !width.is_finite()
+        || !height.is_finite()
+        || width < 1.0
+        || height < 1.0
+        || width * height > MAX_IMAGE_PIXELS as f64
+    {
+        return None;
+    }
+    // The payload viewBox is authoritative. SVG containers act as groups in
+    // the static path contract, preserving their paint/transform attributes.
+    let mut reader = Reader::from_str(fragment);
+    let mut writer = Writer::new(Vec::new());
+    loop {
+        let event = reader.read_event().ok()?;
+        let empty = matches!(&event, Event::Empty(_));
+        match event {
+            Event::Eof => break,
+            Event::Start(mut element) | Event::Empty(mut element)
+                if element.name().as_ref() == "svg" =>
+            {
+                element.set_name("g");
+                writer
+                    .write_event(if empty {
+                        Event::Empty(element)
+                    } else {
+                        Event::Start(element)
+                    })
+                    .ok()?;
+            }
+            Event::End(element) if element.name().as_ref() == "svg" => {
+                writer.write_event(Event::End(BytesEnd::new("g"))).ok()?;
+            }
+            event => {
+                writer.write_event(event).ok()?;
+            }
+        }
+    }
+    let inner = String::from_utf8(writer.into_inner()).ok()?;
+    let svg = format!("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{width}\" height=\"{height}\" viewBox=\"{} {} {} {}\" preserveAspectRatio=\"none\">{inner}</svg>", view_box.x,view_box.y,view_box.width,view_box.height);
+    let mut options = usvg::Options::default();
+    options.image_href_resolver = usvg::ImageHrefResolver {
+        resolve_data: Box::new(|_, _, _| None),
+        resolve_string: Box::new(|_, _| None),
+    };
+    let tree = usvg::Tree::from_str(&svg, &options).ok()?;
+    if tree.root().children().is_empty() {
+        return None;
+    }
+    let mut pixels = tiny_skia::Pixmap::new(width as u32, height as u32)?;
+    resvg::render(&tree, tiny_skia::Transform::default(), &mut pixels.as_mut());
+    let byte_cost = pixels.data().len();
+    let encoded = pixels.encode_png().ok()?;
+    let image = Image::from_encoded(Data::new_copy(&encoded))?.make_raster_image(None, None)?;
+    Some((image, byte_cost))
+}
+
+fn optional_matrix(transform: Option<LayerAffineTransform>) -> Option<Option<Matrix>> {
+    match transform {
+        Some(transform) => matrix(transform).map(Some),
+        None => Some(None),
+    }
+}

--- a/src/renderer/skia/glyph_replay.rs
+++ b/src/renderer/skia/glyph_replay.rs
@@ -166,7 +166,7 @@ pub(super) fn construct_glyph_font(
         return Err(vec![FontFailure::GlyphIdOutOfRange]);
     }
     let mut typeface = font_mgr
-        .new_from_data(bytes, Some(face.face_index as usize))
+        .new_from_data(skia_safe::Data::new_copy(bytes), Some(face.face_index))
         .ok_or_else(unavailable)?;
     if !instance.variations.is_empty() {
         if instance.variations.len() > 16 {

--- a/src/renderer/skia/glyph_replay.rs
+++ b/src/renderer/skia/glyph_replay.rs
@@ -548,7 +548,7 @@ pub(super) fn prepare_glyph_outline(
                     }
                     result.byte_cost = result
                         .byte_cost
-                        .checked_add(commands.len() * std::mem::size_of::<PathCommand>())?;
+                        .checked_add(std::mem::size_of_val(commands))?;
                     if result.byte_cost > MAX_PREPARED_GLYPH_BYTES {
                         return None;
                     }

--- a/src/renderer/skia/mod.rs
+++ b/src/renderer/skia/mod.rs
@@ -4,8 +4,12 @@
 
 mod equation_conv;
 mod font_lookup;
+mod glyph_replay;
 mod image_conv;
 mod renderer;
 mod text_replay;
 
-pub use renderer::SkiaLayerRenderer;
+pub use renderer::{
+    native_skia_glyph_run_replay_proof, NativeGlyphRunReplayProof, NativeGlyphRunReplayProofReason,
+    SkiaLayerRenderer,
+};

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -212,7 +212,13 @@ fn prepare_native_glyph_run(
     if run.diagnostics.replay_eligibility != GlyphRunReplayEligibility::Portable {
         contract_reasons.insert(NativeGlyphRunReplayProofReason::ReplayEligibilityNotPortable);
     }
-    if !run.paint_style.is_fill_only_glyph_replay() {
+    if !run.paint_style.is_simple_glyph_run_replay()
+        || !finite_scalar(run.paint_style.font_size)
+        || run.paint_style.font_size <= 0.0
+        || (run.paint_style.shadow_type != 0
+            && (!finite_scalar(run.paint_style.shadow_offset_x)
+                || !finite_scalar(run.paint_style.shadow_offset_y)))
+    {
         contract_reasons.insert(NativeGlyphRunReplayProofReason::UnsupportedPaintEffect);
     }
     if run

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -29,6 +29,10 @@ use super::font_lookup::{
     collect_system_families, legacy_typeface_for_style, match_system_family_style,
     SystemFontFamilies,
 };
+use super::glyph_replay::{
+    construct_glyph_font, finite_scalar, prepare_glyph_outline, PreparedGlyph,
+    MAX_PREPARED_GLYPH_BYTES,
+};
 use super::image_conv::{draw_image_bytes, draw_svg_fragment, ImageSampling};
 use super::text_replay::SkiaTextReplay;
 
@@ -58,6 +62,12 @@ pub enum NativeGlyphRunReplayProofReason {
     FaceIndexUnsupported,
     FontVariationUnsupported,
     TypefaceConstructionNotImplemented,
+    ExactFaceUnavailable,
+    FontInstanceInvalid,
+    GlyphRunTooLarge,
+    FontResourceTooLarge,
+    FontResourceAmbiguous,
+    DirectionUnsupported,
 }
 
 impl NativeGlyphRunReplayProofReason {
@@ -87,6 +97,12 @@ impl NativeGlyphRunReplayProofReason {
             Self::FaceIndexUnsupported => "faceIndexUnsupported",
             Self::FontVariationUnsupported => "fontVariationUnsupported",
             Self::TypefaceConstructionNotImplemented => "typefaceConstructionNotImplemented",
+            Self::ExactFaceUnavailable => "exactFaceUnavailable",
+            Self::FontInstanceInvalid => "fontInstanceInvalid",
+            Self::GlyphRunTooLarge => "glyphRunTooLarge",
+            Self::FontResourceTooLarge => "fontResourceTooLarge",
+            Self::FontResourceAmbiguous => "fontResourceAmbiguous",
+            Self::DirectionUnsupported => "directionUnsupported",
         }
     }
 }
@@ -113,11 +129,42 @@ pub fn native_skia_glyph_run_replay_proof(
     run: &LayerGlyphRunPaint,
     resources: &ResourceArena,
 ) -> NativeGlyphRunReplayProof {
+    prepare_native_glyph_run(run, resources, &FontMgr::default()).0
+}
+
+fn prepare_native_glyph_run(
+    run: &LayerGlyphRunPaint,
+    resources: &ResourceArena,
+    font_mgr: &FontMgr,
+) -> (NativeGlyphRunReplayProof, Option<PreparedGlyph>) {
     let mut contract_reasons = BTreeSet::new();
     let mut construction_reasons = BTreeSet::new();
 
     if run.glyph_ids.is_empty() {
         contract_reasons.insert(NativeGlyphRunReplayProofReason::EmptyGlyphIds);
+    }
+    if run.glyph_ids.len() > crate::paint::MAX_PORTABLE_GLYPHS_PER_RUN
+        || run.positions.len() > crate::paint::MAX_PORTABLE_GLYPHS_PER_RUN
+        || run.clusters.len() > crate::paint::MAX_PORTABLE_GLYPHS_PER_RUN
+        || run
+            .advances
+            .as_ref()
+            .is_some_and(|values| values.len() > crate::paint::MAX_PORTABLE_GLYPHS_PER_RUN)
+    {
+        contract_reasons.insert(NativeGlyphRunReplayProofReason::GlyphRunTooLarge);
+    }
+    if run.direction != crate::paint::TextDirection::Ltr
+        || run.shape_key.direction != crate::paint::TextDirection::Ltr
+        || run.bidi_level != Some(0)
+        || run.writing_mode != crate::paint::WritingMode::HorizontalTb
+        || run.shape_key.writing_mode != crate::paint::WritingMode::HorizontalTb
+    {
+        contract_reasons.insert(NativeGlyphRunReplayProofReason::DirectionUnsupported);
+    }
+    if !finite_scalar(run.shape_key.font_instance.size_px)
+        || run.shape_key.font_instance.size_px <= 0.0
+    {
+        contract_reasons.insert(NativeGlyphRunReplayProofReason::FontInstanceInvalid);
     }
     if run.glyph_ids.len() != run.positions.len() {
         contract_reasons.insert(NativeGlyphRunReplayProofReason::GlyphPositionCountMismatch);
@@ -140,6 +187,9 @@ pub fn native_skia_glyph_run_replay_proof(
     }
     if run.diagnostics.missing_glyph_count != 0 {
         contract_reasons.insert(NativeGlyphRunReplayProofReason::MissingGlyph);
+    }
+    if run.diagnostics.used_fallback_font_count != 0 {
+        contract_reasons.insert(NativeGlyphRunReplayProofReason::FontBlobNotPortable);
     }
     if run.diagnostics.cluster_mismatch_count != 0 {
         contract_reasons.insert(NativeGlyphRunReplayProofReason::ClusterMismatch);
@@ -168,7 +218,7 @@ pub fn native_skia_glyph_run_replay_proof(
     if run
         .glyph_ids
         .iter()
-        .any(|glyph_id| *glyph_id > u16::MAX as u32)
+        .any(|glyph_id| *glyph_id == 0 || *glyph_id > u16::MAX as u32)
     {
         contract_reasons.insert(NativeGlyphRunReplayProofReason::GlyphIdOutOfRange);
     }
@@ -178,14 +228,29 @@ pub fn native_skia_glyph_run_replay_proof(
         .iter()
         .find(|face| face.id == run.shape_key.font_instance.face_key);
     if let Some(face) = face {
-        if face.face_index != 0 {
-            construction_reasons.insert(NativeGlyphRunReplayProofReason::FaceIndexUnsupported);
+        if font_resources
+            .faces
+            .iter()
+            .filter(|item| item.id == face.id)
+            .count()
+            != 1
+        {
+            contract_reasons.insert(NativeGlyphRunReplayProofReason::FontResourceAmbiguous);
         }
         let blob = font_resources
             .blobs
             .iter()
             .find(|blob| blob.id == face.blob_key);
         if let Some(blob) = blob {
+            if font_resources
+                .blobs
+                .iter()
+                .filter(|item| item.id == blob.id)
+                .count()
+                != 1
+            {
+                contract_reasons.insert(NativeGlyphRunReplayProofReason::FontResourceAmbiguous);
+            }
             if !blob.portability.is_self_contained_replayable() {
                 contract_reasons.insert(NativeGlyphRunReplayProofReason::FontBlobNotPortable);
             } else if let crate::paint::FontPortability::PortableBlob { data_ref, .. } =
@@ -196,6 +261,10 @@ pub fn native_skia_glyph_run_replay_proof(
                         .insert(NativeGlyphRunReplayProofReason::FontBlobDataRefMismatch);
                 }
                 match resources.font_blob_bytes_for_ref(data_ref) {
+                    Some(bytes) if bytes.len() > crate::paint::MAX_PORTABLE_FONT_BLOB_BYTES => {
+                        contract_reasons
+                            .insert(NativeGlyphRunReplayProofReason::FontResourceTooLarge);
+                    }
                     Some(bytes) if font_blob_digest_matches(bytes, blob) => {}
                     Some(_) => {
                         contract_reasons
@@ -213,9 +282,6 @@ pub fn native_skia_glyph_run_replay_proof(
     } else {
         contract_reasons.insert(NativeGlyphRunReplayProofReason::FontFaceMissing);
     }
-    if !run.shape_key.font_instance.variations.is_empty() {
-        construction_reasons.insert(NativeGlyphRunReplayProofReason::FontVariationUnsupported);
-    }
     let transform = run.placement.run_to_page;
     if ![
         transform.a,
@@ -227,35 +293,50 @@ pub fn native_skia_glyph_run_replay_proof(
         run.placement.baseline_y,
     ]
     .into_iter()
-    .all(f64::is_finite)
+    .all(finite_scalar)
     {
         contract_reasons.insert(NativeGlyphRunReplayProofReason::PlacementNotFinite);
     }
     if !run
         .positions
         .iter()
-        .all(|position| position.x.is_finite() && position.y.is_finite())
+        .all(|position| finite_scalar(position.x) && finite_scalar(position.y))
+        || run.advances.as_ref().is_some_and(|values| {
+            values
+                .iter()
+                .any(|advance| !finite_scalar(advance.dx) || !finite_scalar(advance.dy))
+        })
     {
         contract_reasons.insert(NativeGlyphRunReplayProofReason::PositionNotFinite);
     }
 
     let contract_replayable = contract_reasons.is_empty();
-    if contract_replayable && construction_reasons.is_empty() {
-        construction_reasons
-            .insert(NativeGlyphRunReplayProofReason::TypefaceConstructionNotImplemented);
-    }
-    let typeface_constructible = contract_replayable && construction_reasons.is_empty();
+    let prepared = if contract_replayable {
+        match construct_glyph_font(run, resources, font_mgr) {
+            Ok(prepared) => Some(prepared),
+            Err(reasons) => {
+                construction_reasons.extend(reasons);
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let typeface_constructible = prepared.is_some();
     let mut reasons = contract_reasons
         .into_iter()
         .chain(construction_reasons)
         .collect::<Vec<_>>();
     reasons.sort();
 
-    NativeGlyphRunReplayProof {
-        contract_replayable,
-        typeface_constructible,
-        reasons,
-    }
+    (
+        NativeGlyphRunReplayProof {
+            contract_replayable,
+            typeface_constructible,
+            reasons,
+        },
+        prepared,
+    )
 }
 
 fn font_blob_digest_matches(bytes: &[u8], blob: &crate::paint::FontBlobResource) -> bool {
@@ -799,35 +880,57 @@ impl SkiaLayerRenderer {
             }
             LayerNodeKind::Leaf { ops } => {
                 let mut variant_order = 0usize;
+                let mut prepared_glyphs = HashMap::<usize, PreparedGlyph>::new();
+                let mut prepared_bytes = 0usize;
                 let mut glyph_variants =
                     HashMap::<String, HashMap<String, (usize, u32, HashSet<u32>, bool)>>::new();
                 let mut glyph_variant_sources = HashMap::<String, u32>::new();
-                for op in ops {
+                for (op_index, op) in ops.iter().enumerate() {
                     if paint_op_replay_plane_with_layer(op, active_layer) != replay_plane {
                         continue;
                     }
-                    if let PaintOp::GlyphRun { run, .. } = op {
+                    let candidate = match op {
+                        PaintOp::GlyphRun { run, .. } => Some((
+                            &run.variant,
+                            run.source.id.0,
+                            prepare_native_glyph_run(run, resources, &self.font_mgr).1,
+                        )),
+                        PaintOp::GlyphOutline { outline, bbox } => Some((
+                            &outline.variant,
+                            outline.source.id.0,
+                            prepare_glyph_outline(outline, *bbox, resources, fallback_raster_scale),
+                        )),
+                        _ => None,
+                    };
+                    if let Some((variant, source_id, prepared)) = candidate {
                         glyph_variant_sources
-                            .entry(run.variant.equivalence_group.clone())
-                            .or_insert(run.source.id.0);
+                            .entry(variant.equivalence_group.clone())
+                            .or_insert(source_id);
                         let group = glyph_variants
-                            .entry(run.variant.equivalence_group.clone())
+                            .entry(variant.equivalence_group.clone())
                             .or_default();
-                        let state =
-                            group
-                                .entry(run.variant.variant_id.clone())
-                                .or_insert_with(|| {
-                                    let order = variant_order;
-                                    variant_order = variant_order.saturating_add(1);
-                                    (order, run.variant.part_count, HashSet::new(), true)
-                                });
-                        if state.1 != run.variant.part_count || run.variant.part_count == 0 {
+                        let state = group.entry(variant.variant_id.clone()).or_insert_with(|| {
+                            let order = variant_order;
+                            variant_order = variant_order.saturating_add(1);
+                            (order, variant.part_count, HashSet::new(), true)
+                        });
+                        if state.1 != variant.part_count || variant.part_count == 0 {
                             state.3 = false;
                         }
-                        if !state.2.insert(run.variant.part_index) {
+                        if !state.2.insert(variant.part_index) {
                             state.3 = false;
                         }
-                        state.3 &= native_skia_can_replay_glyph_run(run, resources);
+                        let prepared = prepared.filter(|prepared| {
+                            prepared_glyphs.len() < 4096
+                                && prepared_bytes
+                                    .checked_add(prepared.byte_cost)
+                                    .is_some_and(|bytes| bytes <= MAX_PREPARED_GLYPH_BYTES)
+                        });
+                        state.3 &= prepared.is_some();
+                        if let Some(prepared) = prepared {
+                            prepared_bytes += prepared.byte_cost;
+                            prepared_glyphs.insert(op_index, prepared);
+                        }
                     }
                 }
                 let mut selected_text_variants = HashMap::new();
@@ -847,7 +950,7 @@ impl SkiaLayerRenderer {
                     .keys()
                     .filter_map(|group| glyph_variant_sources.get(group).copied())
                     .collect::<HashSet<_>>();
-                for op in ops {
+                for (op_index, op) in ops.iter().enumerate() {
                     if paint_op_replay_plane_with_layer(op, active_layer) != replay_plane {
                         continue;
                     }
@@ -866,7 +969,12 @@ impl SkiaLayerRenderer {
                                 None => true,
                             }
                         }
-                        PaintOp::GlyphOutline { .. } => true,
+                        PaintOp::GlyphOutline { outline, .. } => {
+                            match selected_text_variants.get(&outline.variant.equivalence_group) {
+                                Some(selected) => selected != &outline.variant.variant_id,
+                                None => true,
+                            }
+                        }
                         _ => false,
                     };
                     if skip_unselected_text_variant {
@@ -1033,14 +1141,14 @@ impl SkiaLayerRenderer {
                                 render_marks,
                             );
                         }
-                        PaintOp::GlyphRun { run, .. } => {
-                            if !native_skia_can_replay_glyph_run(run, resources) {
-                                continue;
+                        PaintOp::GlyphRun { .. } | PaintOp::GlyphOutline { .. } => {
+                            // Every selected part was prepared before its TextRun
+                            // fallback was suppressed. Drawing cannot re-resolve
+                            // a different face or re-decode a failed resource.
+                            if let Some(prepared) = prepared_glyphs.get(&op_index) {
+                                prepared.draw(canvas);
                             }
-                            // Unreachable until native_skia_can_replay_glyph_run can verify
-                            // blob-backed typeface construction. Keep the TextRun fallback.
                         }
-                        PaintOp::GlyphOutline { .. } => {}
                         PaintOp::FootnoteMarker { bbox, marker } => {
                             let style = crate::renderer::TextStyle {
                                 font_family: marker.font_family.clone(),
@@ -1834,7 +1942,7 @@ mod tests {
                 flags: Vec::new(),
             }],
             direction: TextDirection::Ltr,
-            bidi_level: None,
+            bidi_level: Some(0),
             writing_mode: WritingMode::HorizontalTb,
             orientation,
             glyph_transforms: None,
@@ -1890,7 +1998,7 @@ mod tests {
     }
 
     #[test]
-    fn native_skia_keeps_glyph_run_disabled_until_blob_typeface_replay_exists() {
+    fn native_skia_keeps_glyph_run_fallback_when_exact_blob_cannot_instantiate() {
         let resources = portable_font_resources();
         let run = portable_glyph_run(GlyphRunOrientation::Horizontal);
         let proof = native_skia_glyph_run_replay_proof(&run, &resources);
@@ -1899,12 +2007,9 @@ mod tests {
         assert!(!proof.typeface_constructible);
         assert_eq!(
             proof.reasons,
-            vec![NativeGlyphRunReplayProofReason::TypefaceConstructionNotImplemented]
+            vec![NativeGlyphRunReplayProofReason::ExactFaceUnavailable]
         );
-        assert_eq!(
-            proof.reasons[0].as_str(),
-            "typefaceConstructionNotImplemented"
-        );
+        assert_eq!(proof.reasons[0].as_str(), "exactFaceUnavailable");
         assert!(native_skia_glyph_run_contract_is_replayable(
             &run, &resources
         ));

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -30,8 +30,8 @@ use super::font_lookup::{
     SystemFontFamilies,
 };
 use super::glyph_replay::{
-    construct_glyph_font, finite_scalar, prepare_glyph_outline, PreparedGlyph,
-    MAX_PREPARED_GLYPH_BYTES,
+    construct_glyph_font, finite_scalar, glyph_run_minimum_byte_cost, prepare_glyph_outline,
+    GlyphPreparationBudget, PreparedGlyph,
 };
 use super::image_conv::{draw_image_bytes, draw_svg_fragment, ImageSampling};
 use super::text_replay::SkiaTextReplay;
@@ -163,6 +163,7 @@ fn prepare_native_glyph_run(
     }
     if !finite_scalar(run.shape_key.font_instance.size_px)
         || run.shape_key.font_instance.size_px <= 0.0
+        || run.shape_key.font_instance.size_px > crate::paint::MAX_GLYPH_FONT_SIZE_PX
     {
         contract_reasons.insert(NativeGlyphRunReplayProofReason::FontInstanceInvalid);
     }
@@ -215,6 +216,7 @@ fn prepare_native_glyph_run(
     if !run.paint_style.is_simple_glyph_run_replay()
         || !finite_scalar(run.paint_style.font_size)
         || run.paint_style.font_size <= 0.0
+        || run.paint_style.font_size > crate::paint::MAX_GLYPH_FONT_SIZE_PX
         || (run.paint_style.shadow_type != 0
             && (!finite_scalar(run.paint_style.shadow_offset_x)
                 || !finite_scalar(run.paint_style.shadow_offset_y)))
@@ -887,7 +889,7 @@ impl SkiaLayerRenderer {
             LayerNodeKind::Leaf { ops } => {
                 let mut variant_order = 0usize;
                 let mut prepared_glyphs = HashMap::<usize, PreparedGlyph>::new();
-                let mut prepared_bytes = 0usize;
+                let mut preparation_budget = GlyphPreparationBudget::new();
                 let mut glyph_variants =
                     HashMap::<String, HashMap<String, (usize, u32, HashSet<u32>, bool)>>::new();
                 let mut glyph_variant_sources = HashMap::<String, u32>::new();
@@ -899,12 +901,23 @@ impl SkiaLayerRenderer {
                         PaintOp::GlyphRun { run, .. } => Some((
                             &run.variant,
                             run.source.id.0,
-                            prepare_native_glyph_run(run, resources, &self.font_mgr).1,
+                            glyph_run_minimum_byte_cost(run, resources).and_then(|minimum_bytes| {
+                                preparation_budget.prepare(minimum_bytes, || {
+                                    prepare_native_glyph_run(run, resources, &self.font_mgr).1
+                                })
+                            }),
                         )),
                         PaintOp::GlyphOutline { outline, bbox } => Some((
                             &outline.variant,
                             outline.source.id.0,
-                            prepare_glyph_outline(outline, *bbox, resources, fallback_raster_scale),
+                            preparation_budget.prepare(0, || {
+                                prepare_glyph_outline(
+                                    outline,
+                                    *bbox,
+                                    resources,
+                                    fallback_raster_scale,
+                                )
+                            }),
                         )),
                         _ => None,
                     };
@@ -926,15 +939,8 @@ impl SkiaLayerRenderer {
                         if !state.2.insert(variant.part_index) {
                             state.3 = false;
                         }
-                        let prepared = prepared.filter(|prepared| {
-                            prepared_glyphs.len() < 4096
-                                && prepared_bytes
-                                    .checked_add(prepared.byte_cost)
-                                    .is_some_and(|bytes| bytes <= MAX_PREPARED_GLYPH_BYTES)
-                        });
                         state.3 &= prepared.is_some();
                         if let Some(prepared) = prepared {
-                            prepared_bytes += prepared.byte_cost;
                             prepared_glyphs.insert(op_index, prepared);
                         }
                     }

--- a/tests/cases/issue_4969_shaping_atomic_activation.rs
+++ b/tests/cases/issue_4969_shaping_atomic_activation.rs
@@ -1247,8 +1247,8 @@ fn issue_4969_q3_e4_native_instance_publishes_atomic_portable_outline() {
         ),
         (
             VariantSelectionBackend::NativeSkia,
-            TextVariantKind::TextRun,
-            true,
+            TextVariantKind::GlyphOutline,
+            false,
         ),
         (VariantSelectionBackend::Svg, TextVariantKind::TextRun, true),
         (

--- a/tests/cases/issue_4969_shaping_glyph_lowering.rs
+++ b/tests/cases/issue_4969_shaping_glyph_lowering.rs
@@ -513,8 +513,22 @@ fn issue_4969_q3_c_variable_outline_is_selected_only_on_proven_shadow_backends()
         assert!(!reports[0].fallback_required);
     }
 
+    let native = analyze_text_variant_selection(
+        &tree,
+        TextVariantSelectionOptions {
+            backend: VariantSelectionBackend::NativeSkia,
+            prefer_strict_outline: true,
+            ..TextVariantSelectionOptions::canvaskit()
+        },
+    );
+    assert_eq!(native.len(), 1);
+    assert_eq!(
+        native[0].selected_variant_kind,
+        Some(TextVariantKind::GlyphOutline)
+    );
+    assert!(!native[0].fallback_required);
+
     for backend in [
-        VariantSelectionBackend::NativeSkia,
         VariantSelectionBackend::Svg,
         VariantSelectionBackend::Canvas2D,
     ] {

--- a/tests/cases/issue_536_glyph_effect_contract.rs
+++ b/tests/cases/issue_536_glyph_effect_contract.rs
@@ -1,0 +1,20 @@
+//! Skia migration: effects must be implemented explicitly by glyph consumers.
+
+use rhwp::paint::PaintTextStyle;
+use rhwp::renderer::TextStyle;
+
+#[test]
+fn effects_require_explicit_replay_but_preserve_simple_glyph_geometry() {
+    let mut style = PaintTextStyle::from(&TextStyle::default());
+    assert!(style.is_fill_only_glyph_replay());
+    style.outline_type = 1;
+    style.shadow_type = 1;
+    style.emboss = true;
+    assert!(style.is_simple_glyph_run_replay());
+    assert!(!style.is_fill_only_glyph_replay());
+    style.shadow_offset_x = f64::INFINITY;
+    assert!(!style.is_simple_glyph_run_replay());
+    style.shadow_offset_x = 1.0;
+    style.shade_color = 0x112233;
+    assert!(!style.is_simple_glyph_run_replay());
+}

--- a/tests/cases/issue_536_native_font_selection.rs
+++ b/tests/cases/issue_536_native_font_selection.rs
@@ -1,0 +1,184 @@
+//! Portable Native Skia instance selection; actual Typeface construction is tested
+//! separately by the native renderer. Browser authority must not widen with it.
+
+use rhwp::paint::{
+    lower_font_native_glyph_sidecars, EmbeddedFontFace, LayerGlyphRunPaint, LayerNode,
+    LayerNodeKind, PageLayerTree, PaintOp, TextVariantKind, VariationAxisValue,
+};
+use rhwp::renderer::layer_renderer::{
+    analyze_text_variant_selection, TextVariantSelectionOptions, TextVariantSelectionReport,
+    VariantRejectReason, VariantSelectionBackend,
+};
+use rhwp::renderer::render_tree::{BoundingBox, TextRunNode};
+use rhwp::renderer::TextStyle;
+
+const COLLECTION: &[u8] = include_bytes!("../fixtures/fonts/RHWPExactFaceSmoke.ttc");
+const VARIABLE: &[u8] =
+    include_bytes!("../../ttfs/redistributable/happiness-sans/HappinessSansVF.ttf");
+
+fn tree(bytes: &[u8], face_index: u32, text: &str) -> PageLayerTree {
+    let bbox = BoundingBox::new(0.0, 0.0, 32.0, 32.0);
+    let run = TextRunNode {
+        text: text.to_owned(),
+        style: TextStyle {
+            font_family: "exact fixture".into(),
+            font_size: 16.0,
+            ..Default::default()
+        },
+        char_shape_id: Some(536),
+        para_shape_id: None,
+        section_index: Some(0),
+        para_index: Some(0),
+        char_start: Some(0),
+        cell_context: None,
+        is_para_end: false,
+        is_line_break_end: false,
+        rotation: 0.0,
+        is_vertical: false,
+        char_overlap: None,
+        border_fill_id: 0,
+        baseline: 16.0,
+        field_marker: Default::default(),
+        layout_positions: Some(vec![0.0, 16.0]),
+        display_text: None,
+    };
+    let mut tree = PageLayerTree::new(
+        64.0,
+        64.0,
+        LayerNode::leaf(bbox, None, vec![PaintOp::text_run(bbox, run)]),
+    );
+    let report = lower_font_native_glyph_sidecars(
+        &mut tree.root,
+        &mut tree.resources,
+        &[EmbeddedFontFace {
+            char_shape_id: 536,
+            language_index: 0,
+            family: "exact fixture",
+            alternate_family: None,
+            bytes,
+            face_index,
+        }],
+    );
+    assert_eq!(report.emitted_glyph_runs, 1, "{report:?}");
+    // Only the GlyphRun contract is under test, not bitmap/SVG alternatives.
+    let LayerNodeKind::Leaf { ops } = &mut tree.root.kind else {
+        panic!("expected a leaf");
+    };
+    ops.retain(|op| !matches!(op, PaintOp::GlyphOutline { .. }));
+    tree
+}
+
+fn glyph(tree: &mut PageLayerTree) -> &mut LayerGlyphRunPaint {
+    let LayerNodeKind::Leaf { ops } = &mut tree.root.kind else {
+        panic!("expected a leaf");
+    };
+    ops.iter_mut()
+        .find_map(|op| match op {
+            PaintOp::GlyphRun { run, .. } => Some(run.as_mut()),
+            _ => None,
+        })
+        .expect("nominal producer GlyphRun")
+}
+
+fn selection(tree: &PageLayerTree, backend: VariantSelectionBackend) -> TextVariantSelectionReport {
+    analyze_text_variant_selection(
+        tree,
+        TextVariantSelectionOptions {
+            backend,
+            ..TextVariantSelectionOptions::canvaskit()
+        },
+    )
+    .into_iter()
+    .next()
+    .expect("one source-bound variant group")
+}
+
+#[test]
+fn native_collection_contract_keeps_the_exact_face_and_rejects_invalid_indexes() {
+    let mut tree = tree(COLLECTION, 1, "\u{e104}");
+    let report = selection(&tree, VariantSelectionBackend::NativeSkia);
+    assert_eq!(
+        report.selected_variant_kind,
+        Some(TextVariantKind::GlyphRun)
+    );
+    assert!(!report.fallback_required);
+    tree.resources.font_resources_mut().faces[0].face_index = 999;
+    let report = selection(&tree, VariantSelectionBackend::NativeSkia);
+    assert!(report.fallback_required);
+    assert!(report.rejected_variants[0]
+        .reasons
+        .contains(&VariantRejectReason::FaceIndexUnsupported));
+}
+
+#[test]
+fn native_synthetic_instances_do_not_grant_browser_authority_or_bypass_digest_proof() {
+    let mut tree = tree(COLLECTION, 1, "\u{e104}");
+    glyph(&mut tree).shape_key.font_instance.synthetic_bold = true;
+    glyph(&mut tree).shape_key.font_instance.synthetic_italic = true;
+    assert!(!selection(&tree, VariantSelectionBackend::NativeSkia).fallback_required);
+    let browser = selection(&tree, VariantSelectionBackend::CanvasKitBrowser);
+    assert!(browser.fallback_required);
+    assert!(browser.rejected_variants[0]
+        .reasons
+        .contains(&VariantRejectReason::SyntheticStyleAuthorityPending));
+    tree.resources.font_resources_mut().blobs[0]
+        .digest
+        .as_mut()
+        .unwrap()
+        .value = "not-the-embedded-font".into();
+    let report = selection(&tree, VariantSelectionBackend::NativeSkia);
+    assert!(report.fallback_required);
+    assert!(report.rejected_variants[0]
+        .reasons
+        .contains(&VariantRejectReason::FontBlobDigestMismatch));
+}
+
+#[test]
+fn native_variation_contract_checks_exact_axes_ranges_duplicates_and_budget() {
+    let mut tree = tree(VARIABLE, 0, "한");
+    glyph(&mut tree).shape_key.font_instance.variations = vec![VariationAxisValue {
+        tag: "wght".into(),
+        value: 900.0,
+    }];
+    assert!(!selection(&tree, VariantSelectionBackend::NativeSkia).fallback_required);
+    assert!(selection(&tree, VariantSelectionBackend::CanvasKitBrowser).fallback_required);
+    for axes in [
+        vec![VariationAxisValue {
+            tag: "nope".into(),
+            value: 900.0,
+        }],
+        vec![VariationAxisValue {
+            tag: "wght".into(),
+            value: f32::NAN,
+        }],
+        vec![VariationAxisValue {
+            tag: "wght".into(),
+            value: 1_000_000.0,
+        }],
+        vec![
+            VariationAxisValue {
+                tag: "wght".into(),
+                value: 900.0
+            };
+            2
+        ],
+        vec![
+            VariationAxisValue {
+                tag: "wght".into(),
+                value: 900.0
+            };
+            17
+        ],
+        vec![VariationAxisValue {
+            tag: "wgt".into(),
+            value: 900.0,
+        }],
+    ] {
+        glyph(&mut tree).shape_key.font_instance.variations = axes;
+        let report = selection(&tree, VariantSelectionBackend::NativeSkia);
+        assert!(report.fallback_required);
+        assert!(report.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::VariationUnsupported));
+    }
+}

--- a/tests/cases/skia_native_glyph_replay.rs
+++ b/tests/cases/skia_native_glyph_replay.rs
@@ -267,6 +267,60 @@ fn native_glyph_replay_changes_ink_for_exact_synthetic_instances() {
 }
 
 #[test]
+fn native_glyph_replay_preserves_shadow_outline_and_relief_passes() {
+    let normal = glyph_tree(TTF, 0, 'A');
+    let normal_pixels = assert_selected(&normal);
+    let mut images = Vec::new();
+    for effect in 0..5 {
+        let mut tree = normal.clone();
+        let style = &mut glyph_mut(&mut tree).paint_style;
+        match effect {
+            0 | 4 => {
+                style.shadow_type = 1;
+                style.shadow_color = 0xff0000;
+                style.shadow_offset_x = 8.0;
+                style.shadow_offset_y = 5.0;
+                if effect == 4 {
+                    style.outline_type = 1;
+                }
+            }
+            1 => style.outline_type = 1,
+            2 => style.emboss = true,
+            _ => style.engrave = true,
+        }
+        assert!(proof(&tree).typeface_constructible, "effect {effect}");
+        let image = assert_selected(&tree);
+        assert_ne!(normal_pixels, image, "effect {effect}");
+        if effect == 0 || effect == 4 {
+            assert!(image.pixels().any(|pixel| pixel[2] > 200 && pixel[0] < 30));
+        }
+        images.push(image);
+    }
+    assert_ne!(images[1], images[4], "outline must retain its shadow");
+    assert_ne!(images[2], images[3], "relief direction must change");
+    let mut relief = normal.clone();
+    glyph_mut(&mut relief).paint_style.emboss = true;
+    let expected = assert_selected(&relief);
+    let style = &mut glyph_mut(&mut relief).paint_style;
+    style.engrave = true;
+    style.outline_type = 1;
+    style.shadow_type = 1;
+    style.shadow_offset_x = 8.0;
+    style.shadow_offset_y = 5.0;
+    assert_eq!(expected, assert_selected(&relief));
+    for offset in [f64::NAN, f64::INFINITY, f64::MAX] {
+        let mut tree = normal.clone();
+        let style = &mut glyph_mut(&mut tree).paint_style;
+        style.shadow_type = 1;
+        style.shadow_offset_x = offset;
+        assert!(proof(&tree)
+            .reasons
+            .contains(&NativeGlyphRunReplayProofReason::UnsupportedPaintEffect));
+        assert_eq!(render(&tree), render(&fallback_tree()));
+    }
+}
+
+#[test]
 fn native_glyph_replay_constructs_requested_variable_axis_and_rejects_invalid_tuples() {
     let normal = glyph_tree(VARIABLE, 0, '가');
     let axis = ttf_parser::Face::parse(VARIABLE, 0)

--- a/tests/cases/skia_native_glyph_replay.rs
+++ b/tests/cases/skia_native_glyph_replay.rs
@@ -227,6 +227,17 @@ fn render(tree: &PageLayerTree) -> image::RgbaImage {
     image::load_from_memory(&png).unwrap().to_rgba8()
 }
 
+fn assert_same_pixels(actual: image::RgbaImage, expected: image::RgbaImage) {
+    assert_eq!(actual.dimensions(), expected.dimensions());
+    if let Some(((x, y, actual), expected)) = actual
+        .enumerate_pixels()
+        .zip(expected.pixels())
+        .find(|((_, _, actual), expected)| *actual != *expected)
+    {
+        panic!("first differing pixel ({x}, {y}): {actual:?}, expected {expected:?}");
+    }
+}
+
 fn assert_selected(tree: &PageLayerTree) -> image::RgbaImage {
     let image = render(tree);
     assert!(
@@ -262,7 +273,7 @@ fn native_glyph_replay_changes_ink_for_exact_synthetic_instances() {
         instance.synthetic_bold = bold;
         instance.synthetic_italic = italic;
         assert!(proof(&tree).typeface_constructible);
-        assert_ne!(normal_pixels, assert_selected(&tree));
+        assert!(normal_pixels != assert_selected(&tree));
     }
 }
 
@@ -290,14 +301,14 @@ fn native_glyph_replay_preserves_shadow_outline_and_relief_passes() {
         }
         assert!(proof(&tree).typeface_constructible, "effect {effect}");
         let image = assert_selected(&tree);
-        assert_ne!(normal_pixels, image, "effect {effect}");
+        assert!(normal_pixels != image, "effect {effect}");
         if effect == 0 || effect == 4 {
             assert!(image.pixels().any(|pixel| pixel[2] > 200 && pixel[0] < 30));
         }
         images.push(image);
     }
-    assert_ne!(images[1], images[4], "outline must retain its shadow");
-    assert_ne!(images[2], images[3], "relief direction must change");
+    assert!(images[1] != images[4], "outline must retain its shadow");
+    assert!(images[2] != images[3], "relief direction must change");
     let mut relief = normal.clone();
     glyph_mut(&mut relief).paint_style.emboss = true;
     let expected = assert_selected(&relief);
@@ -307,7 +318,7 @@ fn native_glyph_replay_preserves_shadow_outline_and_relief_passes() {
     style.shadow_type = 1;
     style.shadow_offset_x = 8.0;
     style.shadow_offset_y = 5.0;
-    assert_eq!(expected, assert_selected(&relief));
+    assert_same_pixels(assert_selected(&relief), expected);
     for offset in [f64::NAN, f64::INFINITY, f64::MAX] {
         let mut tree = normal.clone();
         let style = &mut glyph_mut(&mut tree).paint_style;
@@ -316,7 +327,7 @@ fn native_glyph_replay_preserves_shadow_outline_and_relief_passes() {
         assert!(proof(&tree)
             .reasons
             .contains(&NativeGlyphRunReplayProofReason::UnsupportedPaintEffect));
-        assert_eq!(render(&tree), render(&fallback_tree()));
+        assert_same_pixels(render(&tree), render(&fallback_tree()));
     }
 }
 
@@ -339,7 +350,7 @@ fn native_glyph_replay_constructs_requested_variable_axis_and_rejects_invalid_tu
         assert!(proof(&tree).typeface_constructible);
         images.push(assert_selected(&tree));
     }
-    assert_ne!(images.first(), images.last());
+    assert!(images.first() != images.last());
     for axes in [
         vec![VariationAxisValue {
             tag: "wght".into(),
@@ -366,7 +377,7 @@ fn native_glyph_replay_constructs_requested_variable_axis_and_rejects_invalid_tu
         assert!(proof(&tree)
             .reasons
             .contains(&NativeGlyphRunReplayProofReason::FontVariationUnsupported));
-        assert_eq!(render(&tree), render(&fallback_tree()));
+        assert_same_pixels(render(&tree), render(&fallback_tree()));
     }
 }
 
@@ -395,7 +406,7 @@ fn native_glyph_replay_rejects_invalid_bytes_digest_face_and_geometry_without_fo
             }
         }
         assert!(!proof(&tree).typeface_constructible, "case {case}");
-        assert_eq!(render(&tree), fallback, "case {case}");
+        assert_same_pixels(render(&tree), fallback.clone());
     }
 }
 
@@ -496,9 +507,10 @@ fn native_glyph_replay_requires_every_variant_part_and_every_path() {
         BoundingBox::new(10.0, 10.0, 30.0, 30.0),
         second,
     ));
-    assert_eq!(render(&tree), render(&fallback_tree()));
+    assert_same_pixels(render(&tree), render(&fallback_tree()));
     ops_mut(&mut tree).pop();
-    assert_eq!(render(&tree), render(&fallback_tree()));
+    let error = SkiaLayerRenderer::new().render_png(&tree).unwrap_err();
+    assert!(error.to_string().contains("has 1 parts, expected 2"));
 }
 
 fn bitmap_tree(bytes: &[u8]) -> PageLayerTree {
@@ -531,7 +543,7 @@ fn native_glyph_replay_decodes_bitmap_before_selection_and_preserves_payload_pla
     assert_eq!(image.get_pixel(30, 20).0, [0, 0, 255, 255]);
     assert_eq!(image.get_pixel(12, 12)[3], 0);
     let corrupt = &encoded.get_ref()[..encoded.get_ref().len() / 2];
-    assert_eq!(render(&bitmap_tree(corrupt)), render(&fallback_tree()));
+    assert_same_pixels(render(&bitmap_tree(corrupt)), render(&fallback_tree()));
 }
 
 fn svg_tree(fragment: &str) -> PageLayerTree {
@@ -566,7 +578,7 @@ fn native_glyph_replay_uses_static_svg_viewbox_and_rejects_unsafe_resources() {
         "<svg><image href=\"file:///private/missing.png\"/><path d=\"M10 20H40V50Z\"/></svg>",
         "<svg><path d=\"Mbroken\"/></svg>",
     ] {
-        assert_eq!(render(&svg_tree(fragment)), render(&fallback_tree()));
+        assert_same_pixels(render(&svg_tree(fragment)), render(&fallback_tree()));
     }
 }
 
@@ -610,5 +622,5 @@ fn native_glyph_replay_renders_resolved_colrv0_layers_in_order() {
         .as_mut()
         .unwrap()
         .rgba[0] = f32::NAN;
-    assert_eq!(render(&tree), render(&fallback_tree()));
+    assert_same_pixels(render(&tree), render(&fallback_tree()));
 }

--- a/tests/cases/skia_native_glyph_replay.rs
+++ b/tests/cases/skia_native_glyph_replay.rs
@@ -1,0 +1,560 @@
+//! Strict Native Skia alternatives must paint exact resources or retain TextRun.
+
+#![cfg(all(feature = "native-skia", not(target_arch = "wasm32")))]
+
+use std::io::Cursor;
+
+use rhwp::paint::*;
+use rhwp::renderer::layer_renderer::LayerRasterRenderer;
+use rhwp::renderer::render_tree::{BoundingBox, FieldMarkerType, TextRunNode};
+use rhwp::renderer::skia::{
+    native_skia_glyph_run_replay_proof, NativeGlyphRunReplayProofReason, SkiaLayerRenderer,
+};
+use rhwp::renderer::{PathCommand, TextStyle};
+
+const TTF: &[u8] = include_bytes!("../fixtures/fonts/RHWPExactKerningSmoke.ttf");
+const TTC: &[u8] = include_bytes!("../fixtures/fonts/RHWPExactFaceSmoke.ttc");
+const VARIABLE: &[u8] =
+    include_bytes!("../../ttfs/redistributable/happiness-sans/HappinessSansVF.ttf");
+
+fn fallback_tree() -> PageLayerTree {
+    let run = TextRunNode {
+        text: "A".into(),
+        style: TextStyle {
+            font_family: "sans-serif".into(),
+            font_size: 32.0,
+            color: 0x0000ff,
+            ..Default::default()
+        },
+        char_shape_id: None,
+        para_shape_id: None,
+        section_index: None,
+        para_index: None,
+        char_start: None,
+        cell_context: None,
+        is_para_end: false,
+        is_line_break_end: false,
+        rotation: 0.0,
+        is_vertical: false,
+        char_overlap: None,
+        border_fill_id: 0,
+        baseline: 32.0,
+        field_marker: FieldMarkerType::None,
+        layout_positions: None,
+        display_text: None,
+    };
+    PageLayerTree::new(
+        180.0,
+        80.0,
+        LayerNode::leaf(
+            BoundingBox::new(0.0, 0.0, 180.0, 80.0),
+            None,
+            vec![PaintOp::text_run(
+                BoundingBox::new(120.0, 5.0, 40.0, 40.0),
+                run,
+            )],
+        ),
+    )
+}
+
+fn source(tree: &PageLayerTree) -> TextSourceSpan {
+    let LayerNodeKind::Leaf { ops } = &tree.root.kind else {
+        unreachable!()
+    };
+    let PaintOp::TextRun {
+        source: Some(source),
+        ..
+    } = &ops[0]
+    else {
+        unreachable!()
+    };
+    source.clone()
+}
+
+fn ops_mut(tree: &mut PageLayerTree) -> &mut Vec<PaintOp> {
+    let LayerNodeKind::Leaf { ops } = &mut tree.root.kind else {
+        unreachable!()
+    };
+    ops
+}
+
+fn variant(kind: TextVariantKind) -> PaintVariantMeta {
+    let mut variant = PaintVariantMeta::text_run_default("text-0");
+    variant.variant_id = match kind {
+        TextVariantKind::GlyphRun => "glyphRun",
+        _ => "glyphOutline",
+    }
+    .into();
+    variant.variant_kind = kind;
+    variant.is_default_fallback = false;
+    variant.quality = Some(TextVariantQuality::Exact);
+    variant.anchor_op_id = Some("text-0".into());
+    variant
+}
+
+fn diagnostics() -> GlyphRunDiagnostics {
+    GlyphRunDiagnostics {
+        quality: TextVariantQuality::Exact,
+        replay_eligibility: GlyphRunReplayEligibility::Portable,
+        strict_visual_eligible: true,
+        max_origin_delta_px: 0.0,
+        max_advance_delta_px: 0.0,
+        max_residual_after_adjustment_px: 0.0,
+        cluster_mismatch_count: 0,
+        missing_glyph_count: 0,
+        used_fallback_font_count: 0,
+        reason: None,
+    }
+}
+
+fn glyph_tree(bytes: &[u8], face_index: u32, character: char) -> PageLayerTree {
+    let mut tree = fallback_tree();
+    let digest = FontDigest {
+        algorithm: "blake3".into(),
+        value: resource_digest_hex(bytes),
+    };
+    let data_ref = BinaryResourceRef {
+        kind: BinaryResourceKind::FontBlob,
+        id: font_blob_resource_key(bytes.len(), &digest.value),
+    };
+    tree.resources.intern_font_blob_bytes(bytes);
+    tree.resources
+        .font_resources_mut()
+        .blobs
+        .push(FontBlobResource {
+            id: FontBlobKey("blob".into()),
+            digest: Some(digest.clone()),
+            source: FontResourceSource::Embedded,
+            data_ref: Some(data_ref.clone()),
+            portability: FontPortability::PortableBlob { digest, data_ref },
+        });
+    tree.resources
+        .font_resources_mut()
+        .faces
+        .push(FontFaceResource {
+            id: FontFaceKey("face".into()),
+            blob_key: FontBlobKey("blob".into()),
+            face_index,
+            postscript_name: None,
+            family_names: Vec::new(),
+            style_names: Vec::new(),
+            weight_class: None,
+            width_class: None,
+            italic: None,
+        });
+    let glyph = ttf_parser::Face::parse(bytes, face_index)
+        .unwrap()
+        .glyph_index(character)
+        .unwrap()
+        .0;
+    let run = LayerGlyphRunPaint {
+        source: source(&tree),
+        variant: variant(TextVariantKind::GlyphRun),
+        paint_style: PaintTextStyle::from(&TextStyle {
+            font_size: 32.0,
+            ..Default::default()
+        }),
+        shape_key: ShapeKey {
+            font_instance: FontInstanceKey {
+                face_key: FontFaceKey("face".into()),
+                size_px: 32.0,
+                variations: Vec::new(),
+                synthetic_bold: false,
+                synthetic_italic: false,
+            },
+            direction: TextDirection::Ltr,
+            writing_mode: WritingMode::HorizontalTb,
+            script: None,
+            language: None,
+            features: Vec::new(),
+            shaping_engine: ShapingEngineId("fixture".into()),
+            fallback_policy: FontFallbackPolicyId("none".into()),
+        },
+        placement: TextRunPlacement {
+            run_to_page: LayerAffineTransform {
+                a: 1.0,
+                b: 0.0,
+                c: 0.0,
+                d: 1.0,
+                e: 10.0,
+                f: 42.0,
+            },
+            baseline_y: 42.0,
+        },
+        glyph_ids: vec![u32::from(glyph)],
+        positions: vec![LayerPoint { x: 0.0, y: 0.0 }],
+        advances: None,
+        clusters: vec![GlyphCluster {
+            source_range_utf8: TextSourceRange::new(0, 1),
+            source_range_utf16: Some(TextSourceRange::new(0, 1)),
+            text_range_utf8: Some(TextSourceRange::new(0, 1)),
+            glyph_range: GlyphRange::new(0, 1),
+            flags: Vec::new(),
+        }],
+        direction: TextDirection::Ltr,
+        bidi_level: Some(0),
+        writing_mode: WritingMode::HorizontalTb,
+        orientation: GlyphRunOrientation::Horizontal,
+        glyph_transforms: None,
+        diagnostics: diagnostics(),
+    };
+    ops_mut(&mut tree).push(PaintOp::glyph_run(
+        BoundingBox::new(10.0, 10.0, 40.0, 40.0),
+        run,
+    ));
+    tree
+}
+
+fn glyph_mut(tree: &mut PageLayerTree) -> &mut LayerGlyphRunPaint {
+    let PaintOp::GlyphRun { run, .. } = &mut ops_mut(tree)[1] else {
+        unreachable!()
+    };
+    run
+}
+
+fn proof(tree: &PageLayerTree) -> rhwp::renderer::skia::NativeGlyphRunReplayProof {
+    let LayerNodeKind::Leaf { ops } = &tree.root.kind else {
+        unreachable!()
+    };
+    let PaintOp::GlyphRun { run, .. } = &ops[1] else {
+        unreachable!()
+    };
+    native_skia_glyph_run_replay_proof(run, &tree.resources)
+}
+
+fn render(tree: &PageLayerTree) -> image::RgbaImage {
+    let png = SkiaLayerRenderer::new().render_png(tree).unwrap();
+    image::load_from_memory(&png).unwrap().to_rgba8()
+}
+
+fn assert_selected(tree: &PageLayerTree) -> image::RgbaImage {
+    let image = render(tree);
+    assert!(
+        image
+            .enumerate_pixels()
+            .any(|(x, _, pixel)| x < 100 && pixel[3] > 64),
+        "exact resource must paint visible left-side ink"
+    );
+    assert!(
+        !image
+            .enumerate_pixels()
+            .any(|(x, _, pixel)| x >= 100 && pixel[3] > 64),
+        "anchored right-side fallback must be suppressed"
+    );
+    image
+}
+
+#[test]
+fn native_glyph_replay_constructs_ttf_and_exact_nonzero_ttc_face() {
+    for tree in [glyph_tree(TTF, 0, 'A'), glyph_tree(TTC, 1, '\u{e104}')] {
+        assert!(proof(&tree).typeface_constructible);
+        assert_selected(&tree);
+    }
+}
+
+#[test]
+fn native_glyph_replay_changes_ink_for_exact_synthetic_instances() {
+    let normal = glyph_tree(TTF, 0, 'A');
+    let normal_pixels = assert_selected(&normal);
+    for (bold, italic) in [(true, false), (false, true), (true, true)] {
+        let mut tree = normal.clone();
+        let instance = &mut glyph_mut(&mut tree).shape_key.font_instance;
+        instance.synthetic_bold = bold;
+        instance.synthetic_italic = italic;
+        assert!(proof(&tree).typeface_constructible);
+        assert_ne!(normal_pixels, assert_selected(&tree));
+    }
+}
+
+#[test]
+fn native_glyph_replay_constructs_requested_variable_axis_and_rejects_invalid_tuples() {
+    let normal = glyph_tree(VARIABLE, 0, '가');
+    let axis = ttf_parser::Face::parse(VARIABLE, 0)
+        .unwrap()
+        .variation_axes()
+        .into_iter()
+        .find(|axis| axis.tag == ttf_parser::Tag::from_bytes(b"wght"))
+        .unwrap();
+    let mut images = Vec::new();
+    for value in [axis.min_value, axis.def_value, axis.max_value] {
+        let mut tree = normal.clone();
+        glyph_mut(&mut tree).shape_key.font_instance.variations = vec![VariationAxisValue {
+            tag: "wght".into(),
+            value,
+        }];
+        assert!(proof(&tree).typeface_constructible);
+        images.push(assert_selected(&tree));
+    }
+    assert_ne!(images.first(), images.last());
+    for axes in [
+        vec![VariationAxisValue {
+            tag: "wght".into(),
+            value: axis.max_value + 1.0,
+        }],
+        vec![VariationAxisValue {
+            tag: "nope".into(),
+            value: 0.0,
+        }],
+        vec![VariationAxisValue {
+            tag: "wght".into(),
+            value: f32::NAN,
+        }],
+        vec![
+            VariationAxisValue {
+                tag: "wght".into(),
+                value: axis.def_value
+            };
+            2
+        ],
+    ] {
+        let mut tree = normal.clone();
+        glyph_mut(&mut tree).shape_key.font_instance.variations = axes;
+        assert!(proof(&tree)
+            .reasons
+            .contains(&NativeGlyphRunReplayProofReason::FontVariationUnsupported));
+        assert_eq!(render(&tree), render(&fallback_tree()));
+    }
+}
+
+#[test]
+fn native_glyph_replay_rejects_invalid_bytes_digest_face_and_geometry_without_font_lookup() {
+    let base = glyph_tree(TTF, 0, 'A');
+    let fallback = render(&fallback_tree());
+    for case in 0..7 {
+        let mut tree = base.clone();
+        match case {
+            0 => {
+                tree.resources.font_resources_mut().blobs[0]
+                    .digest
+                    .as_mut()
+                    .unwrap()
+                    .value = "wrong".into()
+            }
+            1 => tree.resources.font_resources_mut().faces[0].face_index = 99,
+            2 => glyph_mut(&mut tree).glyph_ids[0] = u32::from(u16::MAX) + 1,
+            3 => glyph_mut(&mut tree).positions[0].x = f64::MAX,
+            4 => glyph_mut(&mut tree).shape_key.font_instance.size_px = f64::NAN,
+            5 => glyph_mut(&mut tree).direction = TextDirection::Rtl,
+            _ => {
+                let face = tree.resources.font_resources().faces[0].clone();
+                tree.resources.font_resources_mut().faces.push(face);
+            }
+        }
+        assert!(!proof(&tree).typeface_constructible, "case {case}");
+        assert_eq!(render(&tree), fallback, "case {case}");
+    }
+}
+
+fn rectangle_path() -> LayerGlyphOutlinePath {
+    LayerGlyphOutlinePath {
+        glyph_id: 1,
+        source_range_utf8: TextSourceRange::new(0, 1),
+        glyph_range: GlyphRange::new(0, 1),
+        fill_rule: GlyphOutlineFillRule::NonZero,
+        commands: vec![
+            PathCommand::MoveTo(10.0, 10.0),
+            PathCommand::LineTo(40.0, 10.0),
+            PathCommand::LineTo(40.0, 40.0),
+            PathCommand::LineTo(10.0, 40.0),
+            PathCommand::ClosePath,
+        ],
+    }
+}
+
+fn outline_tree() -> PageLayerTree {
+    let mut tree = fallback_tree();
+    let outline = LayerGlyphOutlinePaint {
+        source: source(&tree),
+        variant: variant(TextVariantKind::GlyphOutline),
+        payload_kind: GlyphOutlinePayloadKind::MonochromeFill,
+        color_layers: None,
+        bitmap_glyph: None,
+        svg_glyph: None,
+        paint_style: PaintTextStyle::from(&TextStyle::default()),
+        placement: TextRunPlacement {
+            run_to_page: LayerAffineTransform {
+                a: 1.0,
+                b: 0.0,
+                c: 0.0,
+                d: 1.0,
+                e: 0.0,
+                f: 0.0,
+            },
+            baseline_y: 0.0,
+        },
+        paths: vec![rectangle_path()],
+        stroke: None,
+        diagnostics: diagnostics(),
+    };
+    ops_mut(&mut tree).push(PaintOp::glyph_outline(
+        BoundingBox::new(10.0, 10.0, 30.0, 30.0),
+        outline,
+    ));
+    tree
+}
+
+fn outline_mut(tree: &mut PageLayerTree) -> &mut LayerGlyphOutlinePaint {
+    let PaintOp::GlyphOutline { outline, .. } = &mut ops_mut(tree)[1] else {
+        unreachable!()
+    };
+    outline
+}
+
+#[test]
+fn native_glyph_replay_renders_outline_fill_rule_transform_and_stroke_order() {
+    let mut tree = outline_tree();
+    outline_mut(&mut tree).placement.run_to_page.e = 5.0;
+    let image = assert_selected(&tree);
+    assert_eq!(image.get_pixel(20, 20).0, [0, 0, 0, 255]);
+    assert_eq!(image.get_pixel(12, 20)[3], 0);
+    for order in [
+        GlyphOutlinePaintOrder::FillThenStroke,
+        GlyphOutlinePaintOrder::StrokeThenFill,
+    ] {
+        let outline = outline_mut(&mut tree);
+        outline.payload_kind = GlyphOutlinePayloadKind::MonochromeFillStroke;
+        outline.stroke = Some(GlyphOutlineStrokeStyle {
+            color: 0x0000ff,
+            width: 8.0,
+            join: GlyphOutlineStrokeJoin::Miter,
+            cap: GlyphOutlineStrokeCap::Butt,
+            miter_limit: 4.0,
+            paint_order: order,
+        });
+        let image = assert_selected(&tree);
+        let inside_edge = image.get_pixel(17, 20);
+        assert_eq!(
+            inside_edge[0] > 200,
+            order == GlyphOutlinePaintOrder::FillThenStroke
+        );
+    }
+}
+
+#[test]
+fn native_glyph_replay_requires_every_variant_part_and_every_path() {
+    let mut tree = outline_tree();
+    let outline = outline_mut(&mut tree);
+    outline.variant.part_count = 2;
+    let mut second = outline.clone();
+    second.variant.part_index = 1;
+    second.paths[0].commands[0] = PathCommand::MoveTo(f64::NAN, 0.0);
+    ops_mut(&mut tree).push(PaintOp::glyph_outline(
+        BoundingBox::new(10.0, 10.0, 30.0, 30.0),
+        second,
+    ));
+    assert_eq!(render(&tree), render(&fallback_tree()));
+    ops_mut(&mut tree).pop();
+    assert_eq!(render(&tree), render(&fallback_tree()));
+}
+
+fn bitmap_tree(bytes: &[u8]) -> PageLayerTree {
+    let mut tree = outline_tree();
+    let image_ref = tree.resources.intern_image_bytes(bytes);
+    let outline = outline_mut(&mut tree);
+    outline.payload_kind = GlyphOutlinePayloadKind::BitmapGlyph;
+    outline.paths.clear();
+    outline.bitmap_glyph = Some(BitmapGlyphPayload {
+        image_ref,
+        source_range_utf8: TextSourceRange::new(0, 1),
+        glyph_range: GlyphRange::new(0, 1),
+        placement: BoundingBox::new(25.0, 15.0, 20.0, 20.0),
+        alpha_premultiplied: true,
+        scaling_policy: BitmapGlyphScalingPolicy::SourceExact,
+        filtering: BitmapGlyphFiltering::Nearest,
+        transform_to_run: None,
+    });
+    tree
+}
+
+#[test]
+fn native_glyph_replay_decodes_bitmap_before_selection_and_preserves_payload_placement() {
+    let mut encoded = Cursor::new(Vec::new());
+    image::RgbaImage::from_pixel(2, 2, image::Rgba([0, 0, 255, 255]))
+        .write_to(&mut encoded, image::ImageFormat::Png)
+        .unwrap();
+    let tree = bitmap_tree(encoded.get_ref());
+    let image = assert_selected(&tree);
+    assert_eq!(image.get_pixel(30, 20).0, [0, 0, 255, 255]);
+    assert_eq!(image.get_pixel(12, 12)[3], 0);
+    let corrupt = &encoded.get_ref()[..encoded.get_ref().len() / 2];
+    assert_eq!(render(&bitmap_tree(corrupt)), render(&fallback_tree()));
+}
+
+fn svg_tree(fragment: &str) -> PageLayerTree {
+    let mut tree = outline_tree();
+    let svg_ref = tree.resources.intern_svg_fragment(fragment);
+    let outline = outline_mut(&mut tree);
+    outline.payload_kind = GlyphOutlinePayloadKind::SvgGlyph;
+    outline.paths.clear();
+    outline.svg_glyph = Some(SvgGlyphPayload {
+        svg_ref,
+        source_range_utf8: TextSourceRange::new(0, 1),
+        glyph_range: GlyphRange::new(0, 1),
+        view_box: BoundingBox::new(10.0, 20.0, 30.0, 30.0),
+        intrinsic_size: None,
+        static_sanitized: true,
+        script_allowed: false,
+        animation_allowed: false,
+        external_resources_allowed: false,
+        interactivity_allowed: false,
+        transform_to_run: None,
+    });
+    tree
+}
+
+#[test]
+fn native_glyph_replay_uses_static_svg_viewbox_and_rejects_unsafe_resources() {
+    let tree = svg_tree("<svg xmlns=\"http://www.w3.org/2000/svg\"><path fill=\"#0000ff\" d=\"M10 20H40V50H10Z\"/></svg>");
+    let image = assert_selected(&tree);
+    assert_eq!(image.get_pixel(20, 20).0, [0, 0, 255, 255]);
+    for fragment in [
+        "<svg><script>alert(1)</script><path d=\"M10 20H40V50Z\"/></svg>",
+        "<svg><image href=\"file:///private/missing.png\"/><path d=\"M10 20H40V50Z\"/></svg>",
+        "<svg><path d=\"Mbroken\"/></svg>",
+    ] {
+        assert_eq!(render(&svg_tree(fragment)), render(&fallback_tree()));
+    }
+}
+
+#[test]
+fn native_glyph_replay_renders_resolved_colrv0_layers_in_order() {
+    let mut tree = outline_tree();
+    let outline = outline_mut(&mut tree);
+    outline.payload_kind = GlyphOutlinePayloadKind::ColorLayers;
+    outline.paths.clear();
+    let layer = |rgba| ColorLayerNode {
+        layer_index: Some(0),
+        glyph_id: Some(1),
+        glyph_range: Some(GlyphRange::new(0, 1)),
+        source_range_utf8: Some(TextSourceRange::new(0, 1)),
+        source_font_ref: None,
+        commands: Some(rectangle_path().commands),
+        fill: Some(ResolvedColor {
+            color_space: Some("sRGB".into()),
+            rgba,
+        }),
+        fill_rule: Some(GlyphOutlineFillRule::NonZero),
+        palette_index: None,
+        color: None,
+        opacity: None,
+        transform_to_run: None,
+    };
+    outline.color_layers = Some(ColorLayersPayload {
+        color_format: ColorGlyphFormat::ColrV0,
+        source_font_ref: None,
+        palette_ref: None,
+        layers: vec![layer([1.0, 0.0, 0.0, 1.0]), layer([0.0, 0.0, 1.0, 0.5])],
+        paint_graph: None,
+        source_range_utf8: None,
+        glyph_range: None,
+    });
+    let image = assert_selected(&tree);
+    let pixel = image.get_pixel(20, 20);
+    assert!((120..=135).contains(&pixel[0]) && (120..=135).contains(&pixel[2]));
+    outline_mut(&mut tree).color_layers.as_mut().unwrap().layers[1]
+        .fill
+        .as_mut()
+        .unwrap()
+        .rgba[0] = f32::NAN;
+    assert_eq!(render(&tree), render(&fallback_tree()));
+}


### PR DESCRIPTION
## 변경 요약

#536 committed Skia 잔여 이관 스택의 P44(첫 번째 묶음)입니다. 기준 `skia`는
`8ffd556ee1d632c21eed1a662e7b1fb081a962f0`이며 원본 dirty worktree는 포함하지 않습니다.

Native Skia가 실제 exact typeface와 전체 glyph payload를 준비한 경우에만
해당 variant를 재생하고 같은 source의 TextRun fallback을 생략하도록 합니다.
font instance, 실제 준비/그리기, paint effects와 회귀를 같은 PR에 묶었습니다.

- digest와 face index가 증명된 TTF/TTC, 유효한 variable axes 및 synthetic instance
- 기존 monochrome/stroke/color/bitmap/SVG outline subset의 atomic 준비와 재생
- 수평 exact GlyphRun의 shadow/outline/emboss/engrave
- malformed font, decode 실패, 효과/자원/좌표 제한 초과 시 전체 variant fallback
- 실제 Native variable outline 지원에 맞춘 shared selector 및 이전 잠정 기대값 정정

구형 font-name 기반 glyph 선택은 복원하지 않습니다. SVG/Canvas2D, 기본 PDF 경로,
browser 기본 renderer 및 layout authority는 바꾸지 않습니다. #6775의 기본 PDF
italic 수정과 별개이며 그 이슈를 다시 열거나 일반 synthetic authority를 주장하지 않습니다.

## 스택과 관련 이슈

Tracking: https://github.com/edwardkim/rhwp/issues/536

`devel → render-p44 → render-p45 → render-p46 → render-p47` 순서입니다.
P45는 공통 glyph/Text IR v2/WASM, P46은 browser parity/cache/transport,
P47은 native 나머지 replay/diagnostics와 공통 visual bounds/corpus입니다.
후속 PR 링크와 증분 비교 링크는 제출 후 연결합니다. 이 PR로 #536을 닫지 않습니다.

fork의 브랜치는 위와 같이 실제 의존 관계로 쌓습니다. 업스트림에 중간 base branch를
만들 권한이 없어 GitHub PR은 모두 upstream `devel` 대상으로 제출하며 누적 diff로
보입니다. 각 후속 PR에는 바로 전 phase와의 증분 비교 링크와 병합 순서를 명시합니다.

## 검증

검증 기준은 `devel@b5eee9c50d95edca43431a7590e59d6101a30a67`, candidate는
`95d7081dca1f2c2500b365b80a14990321bb37ff`입니다. #6838에서 바뀐 Skia 0.153.2의
owned Data/u32 collection index API에 맞춰 exact font 로딩을 보정했습니다.

- 전체 nextest: **9,228 passed / 46 skipped**, 0 failed (748.803초)
- Native feature 전체 lib: rhwp **3,930 passed / 13 ignored**, workspace lib 182 passed
- Native exact glyph 실제 PNG/pixel 회귀 **10 passed**: exact TTF/TTC, variable/synthetic,
  effects, path fill/stroke 순서, bitmap/SVG 배치와 atomic fallback
- 누락 이미지 **2 passed**, direct PDF **4 passed**, Native CLI/background/chart 회귀 **5 passed**
- 전체 fmt, default·WASM32·workspace all-target·native-skia Clippy, workspace build 통과
- source unit tier **4,205 tests / 298 modules**, manifest 계약 **21 passed**, manifest check 통과
- 같은 SHA의 fresh Docker WASM **optimized build 통과** (`wasm-opt` 포함, 11분 18초)

시각 증거는 위 Native 실제 raster의 픽셀/잉크 비교입니다. 예를 들어 잘못된 face/digest와
부분 variant는 TextRun fallback과 동일 픽셀이어야 하고, variable axis/synthetic/effects는
실제 잉크가 달라져야 합니다. mock 또는 렌더 계획만으로 출력 성공을 판정하지 않습니다.
이전 기준 커밋의 테스트 결과는 위 숫자에 재사용하지 않았습니다.

재현 명령(review 전용 worktree, Cargo 순차 실행):

```sh
node scripts/rust-test-suite-manifest.mjs --prepare
cargo fmt --all -- --check
node scripts/rust-unit-test-tiers.mjs --check
cargo clippy --locked -- -D warnings
cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown -- -D warnings
cargo build --locked --workspace
cargo clippy --locked --workspace --all-targets -- -D warnings
node scripts/rust-test-suite-manifest.mjs --check
node --test scripts/tests/rust-test-suite-manifest.test.mjs
cargo nextest run --locked --cargo-profile release-test --tests --test-threads 4 --no-fail-fast
cargo clippy --locked --lib --features native-skia -- -D warnings
cargo test --locked --profile release-test --features native-skia --lib
node scripts/run-rust-test.mjs --cargo-test skia_native_glyph_replay -- --profile release-test --features native-skia
node scripts/run-rust-test.mjs --cargo-test issue_2225_missing_picture_placeholder -- --profile release-test --features native-skia
node scripts/run-rust-test.mjs --cargo-test render_p37_direct_pdf_export -- --profile release-test --features native-skia
docker compose -p rhwp-render-p43 --env-file .env.docker run --rm -e CARGO_BUILD_JOBS=4 wasm
```

새 integration 원본만 `tests/cases/`에 두며 generated suite/manifest, Cargo registry,
maintainer 운영 기록은 PR에 포함하지 않습니다. Linux x86_64에서 검증합니다.
Codex 보조로 구현·검증했습니다. Studio/package/배포 설정은 이 PR에서 변경하지 않습니다.
따라서 Studio package/E2E 및 npm/editor 검사는 이 PR의 변경 범위에 해당하지 않습니다.

- [x] 필수 검증 완료, 제출 HEAD와 검증 SHA 일치
- [x] 원본만 제출하고 generated suite/manifest/WASM/운영 기록 제외
- [x] frozen devel 기준 commit 범위 공백 검사 및 clean source tree 확인

## 성능과 한계

font construction/whole-variant preparation 비용이 추가됩니다. 캐시 최적화는 P47에서
같은 producer/resource identity를 보존하며 이관합니다. 이 PR의 전후 성능은 미측정이며,
한컴/macOS와의 pixel-perfect parity 또는 일반 RTL/mixed-vertical 지원을 주장하지 않습니다.
