### PR TITLE
fix(parser): LenientCfbReader 가 CFB 스트림을 경로로 찾도록 (BodyText/ViewText 이름 충돌)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 # SVG 골든 스냅샷 — 렌더러 생성물(LF)과 바이트 비교하므로 CRLF 변환 금지 (#1786)
 tests/golden_svg/**/*.svg text eol=lf
 
+# Cargo의 generated test target 블록은 플랫폼과 무관하게 LF로 체크아웃한다.
+/Cargo.toml text eol=lf
+
 # Lawful HML corpus — preserve provenance bytes (BOM/CRLF/trailing spaces) and verify by SHA
 samples/hml/*.hml -text -diff
 

--- a/mydocs/orders/20260908.md
+++ b/mydocs/orders/20260908.md
@@ -30,6 +30,23 @@
 - 최종 기록은 로컬 문서 commit으로 남긴다. 남은 순서는 승인된 문서 push → 최신 head
   checks 확인 → 별도 승인된 merge commit 병합·#6812 close다. 병합·이슈 종료는 미실행이다.
 
+## #6884 CFB 경로 조회 및 Windows CRLF 보정 — PR #6885
+
+- [PR #6885](https://github.com/edwardkim/rhwp/pull/6885)의 원 head `ce6bca037`를 검토하고,
+  삭제 슬롯을 정상 스트림으로 오인해 기존 복구에 도달하지 못하는 회귀를 확인했다.
+- 원 contributor 이력을 유지한 채 `4b1f1179b`로 경로 부모·항목 타입 검증과 회귀 4개를 추가했다.
+  집중 6개, Windows 전체 nextest **9,222개**(실패 0, skip 46), native/WASM/workspace Clippy,
+  workspace build와 manifest 검사가 모두 통과했다.
+- 작성자 댓글의 CRLF 지적도 같은 PR에서 `3fadf9524`로 보완했다. 루트 Cargo manifest의 LF
+  checkout을 고정하고 기존 CRLF 블록 비교를 정규화하되 실제 target drift 검사는 유지했다.
+  실제 `core.autocrlf=true` checkout을 포함한 Node 테스트 **23개**와 manifest 검사가 통과했다.
+- 보정 코드 및 [PR review](../pr/archives/pr_6885_review.md)를 별도 commit으로 원 fork branch에
+  push했으며, 원격 head `d23876d51` 일치를 확인했다. force-push하지 않았다.
+- 로컬 `devel`은 `upstream/devel` `e7e978589`로 fast-forward 동기화했다. source branch에
+  관련 없는 devel 이력을 병합하거나 최신 오늘할일 전체를 복사하지 않고 현재 항목만 추가한다.
+- 새 CI는 외부 fork 실행 승인 대기(`action_required`)이며 성공·병합 완료로 기록하지 않는다.
+  GitHub 댓글은 사용자 승인 전 초안 상태이고, CI 실행 승인·댓글 게시·merge는 수행하지 않았다.
+
 ## #6876 Rust CodeQL PR 통계 쿼리 축소 - PR #6877
 
 - [PR #6877](https://github.com/edwardkim/rhwp/pull/6877)의 코드 후보 `04c71852c`에서 Full CI,

--- a/mydocs/orders/20260908.md
+++ b/mydocs/orders/20260908.md
@@ -44,8 +44,11 @@
   push했으며, 원격 head `d23876d51` 일치를 확인했다. force-push하지 않았다.
 - 로컬 `devel`은 `upstream/devel` `e7e978589`로 fast-forward 동기화했다. source branch에
   관련 없는 devel 이력을 병합하거나 최신 오늘할일 전체를 복사하지 않고 현재 항목만 추가한다.
-- 새 CI는 외부 fork 실행 승인 대기(`action_required`)이며 성공·병합 완료로 기록하지 않는다.
-  GitHub 댓글은 사용자 승인 전 초안 상태이고, CI 실행 승인·댓글 게시·merge는 수행하지 않았다.
+- head `182a6cdbf`의 CI(archive A~D, lint, Native Skia 포함), 언어별·종합 CodeQL, Adapter,
+  Proptest, CI Impact Policy 성공 및 `MERGEABLE / CLEAN`을 확인했다. 실행 승인 대기는 해소됐다.
+- 사용자가 CI 완료 후 merge·후속 처리를 승인했다. 이 최종 기록의 trailing head checks 확인 후
+  병합·devel 동기화·첫 기여 감사 및 이슈 후속 기록·작업 소유 브랜치 정리를 진행한다.
+  contributor fork는 보존한다. 승인 전 별도 CRLF 답변 초안은 게시하지 않는다.
 
 ## #6876 Rust CodeQL PR 통계 쿼리 축소 - PR #6877
 

--- a/mydocs/pr/archives/pr_6885_review.md
+++ b/mydocs/pr/archives/pr_6885_review.md
@@ -1,0 +1,188 @@
+# PR #6885 검토
+
+## 대상과 판정
+
+- 현재 판정: **머지 보류 — 원 코드 P2는 보정·로컬 검증 완료, 새 PR head CI 대기**
+- PR: [#6885](https://github.com/edwardkim/rhwp/pull/6885)
+- 이슈: [#6884](https://github.com/edwardkim/rhwp/issues/6884)
+- 작성자: `zunstudio` (저장소 PR 이력 조회상 첫 외부 PR)
+- 원 PR head: `ce6bca037b8e971a6818fef01a30acf495c28ff8`
+- 동기화한 `upstream/devel` 및 로컬 `devel`: `5111c24c745863fde1f6a7db4b61ed48d2269195`
+- 최초 통합 검토 이력 보존 브랜치: `codex/review-pr6885-integration-20260908`
+- 최신 devel 위 cherry-pick 결과: `d73aa5d42` (원 commit 1개, 충돌 없음)
+- current-base merge tree: `4e29614bc7ac270d427041660afce52fdae42051`; 검토 HEAD tree와 일치
+- 규모: 3개 파일, +154/-75
+- 조회 시점 상태: OPEN, non-draft, base `devel`, MERGEABLE/CLEAN
+- 최초 검토에서는 원격 조치를 수행하지 않았다. 후속 사용자 승인에 따라 원 PR에 code·review를
+  push하며, GitHub 댓글은 초안 승인 전 게시하지 않는다. merge는 이번 요청 범위 밖이다.
+
+라우팅은 `collaborator_external_pr`이며 `intake_and_review`, `local_validation`,
+`first_time_contributor`를 함께 읽었다. 아래 발견·전후 비교는 최초 검토 기록이며,
+후속 직접 보정과 검증은 문서 마지막 절에 구분한다.
+
+## 변경 이해와 댓글 검토
+
+기존 lenient CFB reader는 마지막 이름만 비교해 `/BodyText/Section0` 요청에도 앞에 있는
+`/ViewText/Section0`을 반환했다. PR은 directory ID를 보존한 트리 탐색을 사용하고, 트리 탐색에
+실패하면 같은 이름이 유일한 경우만 복구한다. BodyText와 BinData 호출부에도 명시적 경로를 전달한다.
+스트림 크기 제한과 복호화 알고리즘은 유지하며 #5169의 정상 ViewText 우선 규칙도 바꾸지 않는다.
+
+[작성자 댓글](https://github.com/edwardkim/rhwp/pull/6885#issuecomment-5582151638)은 Node 설치 후
+manifest 준비와 해당 suite 169건 통과를 추가 보고했다. 이 댓글을 참조했으며 작성자의 169건과
+아래 로컬 검증 수를 혼동하지 않았다. inline review comment와 review event는 조회 당시 없었다.
+
+댓글의 CRLF 문제는 이 PR의 코드 결함과 별개다. 현재 checkout은 `core.autocrlf=false`,
+`Cargo.toml` LF이며 manifest 준비·검사가 통과했다. `.gitattributes`에서 `Cargo.toml`의 eol은
+명시되지 않았다. 작성자의 CRLF checkout 재현은 별도로 수행하지 않았다.
+
+## 발견 사항
+
+### [P2] 트리에서 찾은 삭제 슬롯을 검증하지 않아 기존 복구가 실패한다
+
+위치: `src/parser/cfb_reader.rs:822-823`의 즉시 반환.
+
+`find_child_entry_by_name`은 이름만 일치하면 `obj_type=0`인 미사용/삭제 슬롯도 반환한다.
+새 `find_entry_id`는 그 결과를 유효성 검사 없이 반환하므로, 손상된 child/sibling 링크가
+이름이 남은 삭제 슬롯을 가리키면 아래의 유일 이름 fallback에 도달하지 않는다.
+
+재현 CFB에는 다음 조건을 만들었다.
+
+1. `/FileHeader`에 12바이트 `valid header`를 기록한 CFB v3를 만든다.
+2. 미사용 directory slot에 해당 entry를 복사하고 `obj_type`만 0으로 설정한다.
+3. root child pointer를 이 미사용 슬롯으로 바꾼다. 기존 유효 스트림과 데이터는 유지한다.
+
+동일한 바이트에 최신 devel의 원본 reader와 PR reader를 각각 실행한 결과:
+
+| 구현 | 유효한 FileHeader entry 수 | 읽기 결과 | 검증 exit |
+| --- | ---: | --- | ---: |
+| devel의 기존 reader | 1 | `Ok("valid header")` | 0 |
+| PR reader | 1 | `StreamError("FileHeader: 스트림이 아님 (type=0)")` | 101 |
+
+이는 reader 경계의 합성 CFB 재현이며 실제 사용자 HWP에서 발생했다고 주장하지 않는다. 다만
+손상된 디렉터리를 복구하는 lenient 경로에서 기존에 복구하던 유효 스트림을 새 코드가 거절하는
+회귀다. 실제 문서 파서도 `parse_hwp_with_lenient` 시작 시 `read_file_header()` 실패를 반환한다.
+
+보완 방향은 트리 탐색에서 부모가 storage이고 최종 entry가 유효한 종류인지 확인하고, 무효 항목을
+발견하면 안전한 유일 이름 fallback으로 진행하는 것이다. 미사용 슬롯, 끊긴 링크, 중복 이름의
+모호성 거절을 함께 회귀로 고정해야 한다. 현재 PR의 정상 실물 fixture 테스트 2건은 이 경계를
+포함하지 않는다.
+
+### 재현 핵심 코드
+
+아래는 진단 executable이 구성한 입력과 같은 내용이다. 원본 문서는 수정하지 않았다.
+
+```rust
+use std::io::{Cursor, Write};
+use rhwp::parser::cfb_reader::LenientCfbReader;
+
+let mut c = cfb::CompoundFile::create_with_version(
+    cfb::Version::V3, Cursor::new(Vec::new()),
+).unwrap();
+c.create_stream("/FileHeader").unwrap().write_all(b"valid header").unwrap();
+let mut bytes = c.into_inner().into_inner();
+let sector = 1usize << u16::from_le_bytes(bytes[30..32].try_into().unwrap());
+let sid = u32::from_le_bytes(bytes[48..52].try_into().unwrap()) as usize;
+let dir = 512 + sid * sector;
+let valid_id = u32::from_le_bytes(bytes[dir + 76..dir + 80].try_into().unwrap()) as usize;
+let invalid_id = if valid_id == 2 { 3 } else { 2 };
+let entry = bytes[dir + valid_id * 128..dir + (valid_id + 1) * 128].to_vec();
+bytes[dir + invalid_id * 128..dir + (invalid_id + 1) * 128].copy_from_slice(&entry);
+bytes[dir + invalid_id * 128 + 66] = 0;
+bytes[dir + 76..dir + 80].copy_from_slice(&(invalid_id as u32).to_le_bytes());
+let r = LenientCfbReader::open(&bytes).unwrap();
+assert_eq!(r.read_file_header().unwrap(), b"valid header");
+```
+
+진단 소스와 실행 파일은 ignored `target/pr-review/pr6885-probe*`에 보존했다. standalone rustc가
+실제 `cfb_reader.rs`를 모듈로 포함했고, 비교본은 `git show upstream/devel:src/parser/cfb_reader.rs`를
+그대로 사용했다. 동일한 `cfb`/`flate2` rlib을 링크해 알고리즘 재작성 없이 전후 비교했다.
+
+## 검증 결과
+
+환경: Windows native PowerShell, Rust 1.93.1, Node 24.19.0, cargo-nextest 0.9.143,
+검토 target `target/pr-review`. 기존 target과 다른 작업의 산출물은 삭제하지 않았다.
+
+- `node scripts/rust-test-suite-manifest.mjs --prepare`: 통과.
+- `cargo fmt --all -- --check`: exit 0.
+- `node scripts/rust-test-suite-manifest.mjs --check`: 통과. 1,208 sources,
+  28 suites + 20 exceptions = 48 integration targets.
+- `node scripts/run-rust-test.mjs lenient_cfb_path_lookup -- --cargo-profile release-test --target-dir target/pr-review`:
+  새 회귀 **2/2 통과**. 첫 compile 7분, test 0.061초.
+- `node scripts/run-rust-test.mjs issue_5169_prefer_viewtext -- --cargo-profile release-test --target-dir target/pr-review`:
+  기존 ViewText 우선 회귀 **1/1 통과**.
+- current-base merge simulation 및 `git diff --check upstream/devel...HEAD`: 통과.
+- 추가 합성 CFB 전후 비교: 위 P2 회귀를 재현했다.
+
+원 code head `ce6bca0`의 [Full CI run 34204676159](https://github.com/edwardkim/rhwp/actions/runs/34204676159)는
+success이며 lint, archive A-D test, Build & Test가 성공했다. CodeQL 및 proptest도 조회 시점에
+성공했다. 제품 보정 없이 clean한 current-base merge와 focused 검증을 수행했으므로 전체 회귀와
+Clippy 묶음은 기존 code head의 CI 증적을 참조했다. 해당 GitHub CI를 로컬 통합 head에서 실행한
+결과로 표시하지 않는다.
+
+이번 PR은 CFB 경로 조회 변경이고 renderer/layout/pagination 및 신규 sample을 바꾸지 않는다.
+새 테스트는 원시 스트림 선택을 검사하며 한컴 PDF나 특정 시각 개선을 주장하지 않으므로 PDF
+변환·visual sweep은 수행하지 않았다. 위 reader 회귀만으로 보류 사유가 성립한다.
+
+## 최초 보류 해제 조건
+
+무효 directory entry를 즉시 채택하지 않도록 보완하고, 위 실패 입력 및 유일/중복 fallback 테스트와
+기존 경로·ViewText 회귀를 통과해야 한다. 수정된 code head의 CI도 다시 확인해야 한다. 현재 GitHub
+CI가 녹색이라는 사실만으로 이 회귀를 승인하지 않는다.
+
+## 2026-09-08 직접 보정 및 push 준비
+
+사용자가 보류 조건의 코드 보정과 **원 PR source branch 직접 push**를 승인했다. 이에 따라
+최초 devel 기반 통합 이력은 위 보존 브랜치에 남기고, 가시성 브랜치
+`codex/review-pr6885-20260908`을 원 head `ce6bca037b8e971a6818fef01a30acf495c28ff8`
+위에서 시작했다. contributor history를 rewrite하지 않고 별도 보정 commit을 추가했다.
+
+- 보정 code SHA: `4b1f1179bd4c42e0a87e88f9accb063a34943a88`.
+- 원 contributor 변경: 경로 기반 CFB 조회와 실물 fixture 회귀 2개.
+- collaborator 보정: 경로 부모는 storage(type 1)만 허용하며, 최종 무효 entry(type 0/255 등)는
+  즉시 반환하지 않고 기존의 유일 이름 fallback으로 진행한다.
+- 합성 CFB 회귀 4개 추가: 무효 이름 슬롯 복구, 끊긴 링크의 유일 이름 복구/중복 이름 거절,
+  stream의 부모 storage 오인 거절, 순환 sibling 링크의 종료와 복구.
+- 변경 sample·fixture·baseline 없음. 파생 harness와 manifest는 stage하지 않는다.
+- push 직전 조회에서 PR head와 contributor remote SHA가 모두 원 head와 같고
+  `maintainerCanModify=true`임을 확인했다.
+- 재조회한 `upstream/devel`: `e7e9785893e7dffdaa600859cb1f28cca18621cb`.
+  `git merge-tree --write-tree upstream/devel HEAD`는 충돌 없이
+  `4673109d63abe5caf0964cb453141b99e18a38b2`를 생성했다. 로컬 검증은 이 merge tree가
+  아닌 원 source 위 보정 code SHA에서 수행했으며, 새 current-base 검증은 push 후 CI로 확인한다.
+
+### 보정 코드 로컬 검증
+
+모든 명령은 Windows native PowerShell에서 `target/pr-review`를 사용해 순차 실행했다.
+
+| 검증 | 결과 |
+| --- | --- |
+| `cargo fmt --all -- --check` | exit 0 |
+| native root Clippy (`-D warnings`) | exit 0 |
+| WASM32 lib Clippy (`-D warnings`) | exit 0 |
+| `cargo build --locked --workspace --target-dir target/pr-review` | exit 0 |
+| workspace all-target Clippy (`-D warnings`) | exit 0 |
+| manifest `--prepare`, `--check` | 통과; 1,197 sources, 48/48 integration targets |
+| `lenient_cfb_path_lookup` focused nextest | **6/6 통과**, exit 0 |
+| `cargo nextest run --locked --cargo-profile release-test --target-dir target/pr-review --tests --no-fail-fast` | **9,222/9,222 통과**, 46 skipped, exit 0 |
+| `git diff --check` | 통과 |
+
+전체 nextest 실행 시간은 665.848초(별도 compile 8분 30초), run ID는
+`63aded46-580e-4d7e-ada5-0c294bffad59`다. 원 PR의 이전 녹색 CI를 이번 로컬 검증의 대체로
+사용하지 않았다. focused 첫 시도는 fmt 이후 source 크기 변화로 harness 배정이 달라져 0개 실행으로
+실패했으며 성공으로 집계하지 않았다. fmt 후 `--prepare`를 다시 실행해 6개 모두 실행·통과했다.
+
+### 작성자 댓글의 CRLF 지적 처리
+
+댓글 원문을 재조회했다. 생성기의 `renderCargoTestBlock`은 LF로 조립한 문자열을 반환하고,
+검증 코드는 Cargo marker 블록과 이를 개행 정규화 없이 직접 비교한다. 메모리에서만 기존
+`Cargo.toml`을 CRLF로 변환한 비교 결과는 다음과 같다. 실제 checkout이나 Cargo 파일은 수정하지 않았다.
+
+- 기존 LF 내용에 expected block 포함: `true`.
+- CRLF 변환 내용에 expected block 포함: `false`.
+- CRLF를 LF로 정규화한 내용에 expected block 포함: `true`.
+
+따라서 줄바꿈만으로 drift 판정이 달라질 수 있다는 지적에는 코드·진단 근거가 있다. 다만
+작성자의 clean CRLF checkout 전체 실행과 `49 > 48` 연쇄 오류는 독립 재현하지 않았다.
+`Cargo.toml text eol=lf` 지정, LF/CRLF 회귀와 필요 시 비교 정규화는 parser 수정과 분리한
+후속 검토를 제안한다. 이번 PR에 `.gitattributes`나 생성기 변경을 섞지 않는다.
+답변 초안은 사용자 승인 전이며 GitHub에 게시하지 않는다. 새 head CI 확인 후 최종 판정을 갱신한다.

--- a/mydocs/pr/archives/pr_6885_review.md
+++ b/mydocs/pr/archives/pr_6885_review.md
@@ -183,6 +183,28 @@ CI가 녹색이라는 사실만으로 이 회귀를 승인하지 않는다.
 
 따라서 줄바꿈만으로 drift 판정이 달라질 수 있다는 지적에는 코드·진단 근거가 있다. 다만
 작성자의 clean CRLF checkout 전체 실행과 `49 > 48` 연쇄 오류는 독립 재현하지 않았다.
-`Cargo.toml text eol=lf` 지정, LF/CRLF 회귀와 필요 시 비교 정규화는 parser 수정과 분리한
-후속 검토를 제안한다. 이번 PR에 `.gitattributes`나 생성기 변경을 섞지 않는다.
-답변 초안은 사용자 승인 전이며 GitHub에 게시하지 않는다. 새 head CI 확인 후 최종 판정을 갱신한다.
+처음에는 별도 후속 작업을 제안했으나, 사용자가 이번 PR에서 함께 개선하도록 요청해 아래처럼
+직접 보완했다. 답변 초안은 사용자 승인 전이며 GitHub에 게시하지 않는다.
+새 head CI 확인 후 최종 판정을 갱신한다.
+
+### 같은 PR에서 CRLF 문제 보완
+
+- 보정 SHA: `3fadf95246e4b3dec124525832f815b76ee0de51`.
+- `.gitattributes`에 `/Cargo.toml text eol=lf`를 추가해 루트 Cargo manifest의 checkout을 LF로 고정했다.
+- 기존 CRLF checkout이나 에디터가 기록한 CRLF도 허용하도록 generated Cargo block 비교에서
+  CRLF만 LF로 정규화한다. target 이름·순서·내용 변경과 기타 공백은 그대로 drift로 검사한다.
+- 실제 Git 임시 저장소에서 `core.autocrlf=true`와 `checkout-index`를 사용해 저장소 속성이 LF를
+  유지하는지 검증했다. 사용자 checkout의 Git 설정이나 Cargo 내용은 바꾸지 않았다.
+- LF/CRLF 모두 동일한 target은 통과하고, target 이름 변경은 둘 다 거절하며, 검사가 파일을 쓰지
+  않는지 회귀 테스트로 고정했다. 최초 테스트 작성 시 `derive` 모드가 Cargo 검사를 생략하는 것을
+  음성 대조군이 검출해, 실제 Cargo 검사를 수행하는 기본 validation으로 바로잡은 뒤 재실행했다.
+- `node --test scripts/tests/rust-test-suite-manifest.test.mjs`: **23/23 통과**, exit 0.
+- manifest `--prepare`와 `--check`: **48/48 targets**, exit 0. `git diff --check`: 통과.
+- 이번 추가 commit은 `.gitattributes`와 Node 생성기·테스트만 변경한다. 앞서 9,222개 전체 회귀와
+  Rust lint를 통과한 Rust source/test 및 `Cargo.toml` 내용은 동일해 Cargo 전체 검증은 반복하지 않았다.
+- `49 > 48` 연쇄 오류 전체의 재현·해결까지 확대해서 주장하지 않는다. 개행으로 인한 Cargo drift를
+  해결하고 실제 target 예산 검사와 내용 drift 검사를 유지하는 것이 이번 보완 범위다.
+
+앞선 code·review head `a772883fffd6fbc8c6453458944eca71918eeb85`는 원 PR에 push한 뒤
+GitHub head 일치를 확인했다. 해당 head의 새 CI는 외부 fork 실행 승인 대기(`action_required`)였으며,
+통과로 기록하지 않는다. 이번 보완도 원 contributor 브랜치에 추가 commit으로 push하며 force-push하지 않는다.

--- a/mydocs/pr/archives/pr_6885_review.md
+++ b/mydocs/pr/archives/pr_6885_review.md
@@ -2,7 +2,7 @@
 
 ## 대상과 판정
 
-- 현재 판정: **머지 보류 — 원 코드 P2는 보정·로컬 검증 완료, 새 PR head CI 대기**
+- 현재 판정: **승인 — 원 PR의 보정된 head 검증 완료**. 최종 문서 head의 CI 확인 후 병합한다.
 - PR: [#6885](https://github.com/edwardkim/rhwp/pull/6885)
 - 이슈: [#6884](https://github.com/edwardkim/rhwp/issues/6884)
 - 작성자: `zunstudio` (저장소 PR 이력 조회상 첫 외부 PR)
@@ -208,3 +208,26 @@ CI가 녹색이라는 사실만으로 이 회귀를 승인하지 않는다.
 앞선 code·review head `a772883fffd6fbc8c6453458944eca71918eeb85`는 원 PR에 push한 뒤
 GitHub head 일치를 확인했다. 해당 head의 새 CI는 외부 fork 실행 승인 대기(`action_required`)였으며,
 통과로 기록하지 않는다. 이번 보완도 원 contributor 브랜치에 추가 commit으로 push하며 force-push하지 않는다.
+
+## 최종 CI 및 병합 준비
+
+- 검증 head: `182a6cdbf293c03570e4d720704e3b19e1f81064`.
+- [CI 34226937127](https://github.com/edwardkim/rhwp/actions/runs/34226937127):
+  Build & Test, archive A~D, lint, Native Skia, Frontend package gates 성공.
+- [CodeQL 34226937176](https://github.com/edwardkim/rhwp/actions/runs/34226937176):
+  Rust/JavaScript/Python 분석 성공, 종합 CodeQL도 SUCCESS.
+- [Adapter](https://github.com/edwardkim/rhwp/actions/runs/34226937108),
+  [Proptest](https://github.com/edwardkim/rhwp/actions/runs/34226937021), CI Impact Policy 성공.
+- 조회 시점 `MERGEABLE / CLEAN`. 앞선 실행 승인 대기는 해소됐다.
+- 사용자에게 CI 완료 후 merge·후속 처리 및 작업 소유 원격 브랜치 정리를 승인받았다.
+  이 문서와 오늘할일의 최종 기록만 trailing push한 뒤 최신 head checks를 다시 확인한다.
+  병합과 issue close를 미리 완료한 것으로 기록하지 않는다.
+
+### Merge 후 contributor PR comment 계획
+
+첫 기여 환영과 감사, 실제 merge SHA 및 검증 링크를 남긴다. contributor의 경로 기반 조회와
+회귀 2개, collaborator의 손상 슬롯·부모 타입 보정 및 CRLF 개선을 구분한다.
+로컬 9,222개·focused 6개·Node 23개와 실제 성공한 CI만 기록하며 PDF 시각 동등성은 주장하지 않는다.
+별도 후속 작업을 제안했던 승인 전 CRLF 댓글 초안은 게시하지 않고, 이번 PR에서 완료한 개선 사실을
+merge 후 결과 기록에 포함한다. #6884의 해결 범위를 대조하고 종료·검증 결과를 중복 없이 기록한다.
+contributor fork branch와 shared target/pr-review는 보존하고 작업 소유 local review/fetch ref만 정리한다.

--- a/scripts/rust-test-suite-manifest.mjs
+++ b/scripts/rust-test-suite-manifest.mjs
@@ -906,7 +906,8 @@ function inspectRepository(
     }
     try {
       const bounds = cargoBlockBounds(cargoManifest);
-      const actual = cargoManifest.slice(bounds.start, bounds.end);
+      // 기존 CRLF checkout도 허용하되 target 내용·순서의 drift는 계속 검사한다.
+      const actual = cargoManifest.slice(bounds.start, bounds.end).replaceAll('\r\n', '\n');
       const expected = renderCargoTestBlock(manifest);
       if (actual !== expected) {
         errors.push('Cargo.toml generated test target block drift');

--- a/scripts/tests/rust-test-suite-manifest.test.mjs
+++ b/scripts/tests/rust-test-suite-manifest.test.mjs
@@ -98,6 +98,41 @@ function writeRepositoryFixture(root) {
   return manifest;
 }
 
+test('Cargo CRLF 블록은 허용하지만 실제 target drift는 거절한다', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'rhwp-cargo-crlf-'));
+  try {
+    writeRepositoryFixture(root);
+    const cargoPath = path.join(root, 'Cargo.toml');
+    const original = readFileSync(cargoPath, 'utf8');
+    for (const eol of ['\n', '\r\n']) {
+      const contents = original.replace(/\r?\n/g, eol);
+      writeFileSync(cargoPath, contents);
+      assert.deepEqual(validateRepository(root).errors, []);
+      assert.equal(readFileSync(cargoPath, 'utf8'), contents, '검사는 파일을 쓰지 않는다');
+      writeFileSync(cargoPath, contents.replace('name = "regression_suite_001"', 'name = "wrong_target"'));
+      assert.ok(validateRepository(root).errors.some(
+        (error) => error.includes('Cargo.toml generated test target block drift'),
+      ));
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Cargo checkout은 core.autocrlf=true여도 저장소 속성에 따라 LF를 유지한다', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'rhwp-cargo-checkout-'));
+  try {
+    writeRepositoryFixture(root);
+    writeFileSync(path.join(root, '.gitattributes'), readFileSync(path.join(ROOT, '.gitattributes')));
+    runGit(root, ['add', '.gitattributes']);
+    runGit(root, ['-c', 'core.autocrlf=true', 'checkout-index', '-f', '--', 'Cargo.toml']);
+    assert.ok(!readFileSync(path.join(root, 'Cargo.toml'), 'utf8').includes('\r'));
+    assert.deepEqual(validateRepository(root).errors, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('전체 integration source는 파생 산출물을 쓰지 않고 검증한다', () => {
   const policyPath = path.join(ROOT, 'tests', 'suites', 'suite-policy.json');
   const policyBefore = readFileSync(policyPath, 'utf8');

--- a/src/parser/cfb_reader.rs
+++ b/src/parser/cfb_reader.rs
@@ -817,9 +817,16 @@ impl LenientCfbReader {
         {
             let mut current = Some(root_id);
             for segment in parents {
-                current = current.and_then(|id| self.find_child_entry_by_name(id, segment));
+                current = current
+                    .and_then(|id| self.find_child_entry_by_name(id, segment))
+                    .filter(|&id| self.directory_entries[id].obj_type == 1);
             }
-            if let Some(id) = current.and_then(|id| self.find_child_entry_by_name(id, last)) {
+            // 손상된 링크가 이름만 남은 삭제 슬롯을 가리킬 수 있다.
+            // 무효 entry는 채택하지 않고 아래의 유일 이름 복구를 시도한다.
+            if let Some(id) = current
+                .and_then(|id| self.find_child_entry_by_name(id, last))
+                .filter(|&id| matches!(self.directory_entries[id].obj_type, 1 | 2 | 5))
+            {
                 return Some(id);
             }
         }

--- a/src/parser/cfb_reader.rs
+++ b/src/parser/cfb_reader.rs
@@ -795,30 +795,57 @@ impl LenientCfbReader {
         result
     }
 
-    /// 디렉토리 경로로 스트림 내용을 가져온다.
-    /// 경로 형식: "FileHeader", "DocInfo", "BodyText/Section0" 등
-    fn find_entry_idx(&self, path: &str) -> Option<usize> {
-        // 경로 "/" 제거 및 트리 탐색 단순화: 이름으로 검색
-        let parts: Vec<&str> = path.trim_start_matches('/').split('/').collect();
-        if parts.is_empty() {
-            return None;
+    /// 디렉토리 경로로 엔트리 id(= `directory_entries` 인덱스)를 찾는다.
+    /// 경로 형식: "FileHeader", "/DocInfo", "/BodyText/Section0" 등
+    ///
+    /// 스토리지를 실제로 따라간다. 이름만 비교하면 `BodyText/Section0` 과
+    /// `ViewText/Section0` 처럼 **이름이 같은 스트림**을 가진 문서에서 디렉터리에
+    /// 먼저 나오는 쪽이 잡힌다(변경 추적 문서 등에서 실제로 발생).
+    fn find_entry_id(&self, path: &str) -> Option<usize> {
+        let parts: Vec<&str> = path
+            .trim_start_matches('/')
+            .split('/')
+            .filter(|segment| !segment.is_empty())
+            .collect();
+        let (last, parents) = parts.split_last()?;
+
+        // 1) 정상 CFB: 루트에서 세그먼트마다 자식으로 내려간다.
+        if let Some(root_id) = self
+            .directory_entries
+            .iter()
+            .position(|entry| entry.obj_type == 5)
+        {
+            let mut current = Some(root_id);
+            for segment in parents {
+                current = current.and_then(|id| self.find_child_entry_by_name(id, segment));
+            }
+            if let Some(id) = current.and_then(|id| self.find_child_entry_by_name(id, last)) {
+                return Some(id);
+            }
         }
 
-        // 간단한 DFS - directory entries가 Red-Black 트리이므로
-        // child_id/sibling을 써야 하지만, 이름 기반 단순 매칭으로 충분
-        // (HWP 파일은 스트림이 많지 않음)
-        let target_name = if parts.len() == 1 {
-            parts[0].to_string()
-        } else {
-            // 마지막 세그먼트를 이름으로 사용
-            parts.last().unwrap().to_string()
-        };
+        // 2) lenient 폴백: 디렉터리 트리가 깨진 입력은 이름으로 찾는다.
+        //    단 같은 이름이 둘 이상이면 어느 쪽이 맞는지 알 수 없으므로 고르지 않는다
+        //    (잘못된 스트림을 조용히 읽느니 없다고 답한다).
+        let mut found = None;
+        for (id, entry) in self.directory_entries.iter().enumerate() {
+            if entry.name == *last && matches!(entry.obj_type, 1 | 2 | 5) {
+                if found.is_some() {
+                    return None;
+                }
+                found = Some(id);
+            }
+        }
+        found
+    }
 
-        // 정확한 경로 매칭이 필요하면 트리 탐색해야 하지만,
-        // HWP에서는 이름이 유일하므로 단순 매칭
-        self.entries
-            .iter()
-            .position(|(name, _, _, _)| name == &target_name)
+    /// 본문 섹션 스트림 경로. strict `CfbReader::read_body_text_section_raw` 와 같은 규칙.
+    fn body_text_section_path(&self, index: u32) -> String {
+        let bodytext_path = format!("/BodyText/Section{}", index);
+        if self.has_stream(&bodytext_path) {
+            return bodytext_path;
+        }
+        format!("/Section{}", index)
     }
 
     fn find_child_entry_by_name(&self, parent_id: usize, name: &str) -> Option<usize> {
@@ -907,24 +934,10 @@ impl LenientCfbReader {
     }
 
     pub fn read_stream(&self, path: &str) -> Result<Vec<u8>, CfbError> {
-        let idx = self
-            .find_entry_idx(path)
+        let entry_id = self
+            .find_entry_id(path)
             .ok_or_else(|| CfbError::StreamNotFound(path.to_string()))?;
-        let (_, start, size, obj_type) = &self.entries[idx];
-        if *obj_type != 2 {
-            return Err(CfbError::StreamError(format!(
-                "{}: 스트림이 아님 (type={})",
-                path, obj_type
-            )));
-        }
-
-        if *size < self.mini_stream_cutoff as u64 {
-            Ok(self.read_mini_stream(*start, *size))
-        } else {
-            let mut data = Self::read_chain_static(&self.data, &self.fat, *start, self.sector_size);
-            data.truncate(*size as usize);
-            Ok(data)
-        }
+        self.read_directory_stream(entry_id, path)
     }
 
     /// 원시 스트림을 caller 제공 상한 안에서 읽는다.
@@ -936,35 +949,14 @@ impl LenientCfbReader {
         path: &str,
         max_bytes: usize,
     ) -> Result<Vec<u8>, CfbError> {
-        let idx = self
-            .find_entry_idx(path)
+        let entry_id = self
+            .find_entry_id(path)
             .ok_or_else(|| CfbError::StreamNotFound(path.to_string()))?;
-        let (_, start, declared_size, obj_type) = &self.entries[idx];
-        if *obj_type != 2 {
-            return Err(CfbError::StreamError(format!(
-                "{}: 스트림이 아님 (type={})",
-                path, obj_type
-            )));
-        }
-        if *declared_size > max_bytes as u64 {
-            return Err(CfbError::LimitExceeded(max_bytes));
-        }
-        let size = *declared_size as usize;
-        if *declared_size < self.mini_stream_cutoff as u64 {
-            Ok(self.read_mini_stream_sized(*start, size))
-        } else {
-            Ok(Self::read_chain_static_sized(
-                &self.data,
-                &self.fat,
-                *start,
-                self.sector_size,
-                size,
-            ))
-        }
+        self.read_directory_stream_limited(entry_id, path, max_bytes)
     }
 
     pub fn has_stream(&self, path: &str) -> bool {
-        self.find_entry_idx(path).is_some()
+        self.find_entry_id(path).is_some()
     }
 
     pub fn read_doc_info(&self, compressed: bool) -> Result<Vec<u8>, CfbError> {
@@ -984,8 +976,8 @@ impl LenientCfbReader {
         index: u32,
         compressed: bool,
     ) -> Result<Vec<u8>, CfbError> {
-        let name = format!("Section{}", index);
-        decode_stream(self.read_stream(&name)?, compressed)
+        let path = self.body_text_section_path(index);
+        decode_stream(self.read_stream(&path)?, compressed)
     }
 
     pub fn list_entries(&self) -> &[(String, u32, u64, u8)] {
@@ -1005,15 +997,15 @@ impl LenientCfbReader {
         distribution: bool,
     ) -> Result<Vec<u8>, CfbError> {
         if distribution {
-            let viewtext_name = format!("Section{}", index);
+            let viewtext_path = format!("/ViewText/Section{}", index);
             // ViewText 하위 스트림 탐색
-            if self.has_stream(&viewtext_name) {
-                return self.read_stream(&viewtext_name);
+            if self.has_stream(&viewtext_path) {
+                return self.read_stream(&viewtext_path);
             }
         }
 
-        let name = format!("Section{}", index);
-        decode_stream(self.read_stream(&name)?, compressed)
+        let path = self.body_text_section_path(index);
+        decode_stream(self.read_stream(&path)?, compressed)
     }
 
     /// 배포용 ViewText 섹션의 암호문 원본을 반환한다.
@@ -1069,8 +1061,19 @@ impl LenientCfbReader {
         compressed: bool,
         max_bytes: usize,
     ) -> Result<Vec<u8>, CfbError> {
-        let name = format!("Section{}", index);
-        decode_stream_limited(self.read_stream(&name)?, compressed, max_bytes)
+        let path = self.body_text_section_path(index);
+        decode_stream_limited(self.read_stream(&path)?, compressed, max_bytes)
+    }
+
+    /// 일반 BodyText 섹션의 원본을 caller 제공 상한까지 읽는다.
+    /// strict `CfbReader::read_body_text_section_raw_limited` 와 같은 경로 규칙.
+    pub fn read_body_text_section_raw_limited(
+        &self,
+        index: u32,
+        max_bytes: usize,
+    ) -> Result<Vec<u8>, CfbError> {
+        let path = self.body_text_section_path(index);
+        self.read_stream_raw_limited(&path, max_bytes)
     }
 
     /// 본문 섹션 수 계산

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -922,7 +922,7 @@ fn parse_hwp_with_lenient(
         } else if encrypted {
             // 비밀번호 암호 문서: lenient reader 로 raw 섹션 바이트를 얻어 복호화.
             let raw = lenient
-                .read_stream_raw_limited(&format!("Section{}", i), section_raw_limit)
+                .read_body_text_section_raw_limited(i, section_raw_limit)
                 .map_err(ParseError::CfbError)?;
             crypto::decrypt_password_protected_limited(
                 &raw,
@@ -942,7 +942,7 @@ fn parse_hwp_with_lenient(
                 Some(decoded) => decoded,
                 None => {
                     let raw = lenient
-                        .read_stream_raw_limited(&format!("Section{}", i), section_raw_limit)
+                        .read_body_text_section_raw_limited(i, section_raw_limit)
                         .map_err(ParseError::CfbError)?;
                     cfb_reader::decode_stream_limited(raw, compressed, section_output_limit)
                         .map_err(ParseError::CfbError)?
@@ -1097,7 +1097,7 @@ fn load_bin_data_content_lenient(
         let stream_compressed =
             bin_data_stream_is_compressed(bd.compression, compressed, encrypted);
 
-        match lenient.read_stream(&storage_name) {
+        match lenient.read_stream(&format!("/BinData/{}", storage_name)) {
             Ok(data) => {
                 let mut decompressed = if encrypted {
                     let pwd = password.unwrap();

--- a/tests/cases/lenient_cfb_path_lookup.rs
+++ b/tests/cases/lenient_cfb_path_lookup.rs
@@ -1,0 +1,76 @@
+//! [parser] `LenientCfbReader` 가 CFB 스트림을 **경로가 아니라 이름으로** 찾던 회귀.
+//!
+//! `BodyText/Section0` 과 `ViewText/Section0` 은 **이름이 같다**. 종전 `find_entry_idx` 는
+//! 경로의 마지막 세그먼트만 떼어 전체 엔트리에서 첫 일치를 돌려주었으므로, 명시적으로
+//! `/BodyText/Section0` 을 물어도 디렉터리에 먼저 나오는 `ViewText/Section0` 이 왔다.
+//! (주석의 근거 "HWP에서는 이름이 유일하므로 단순 매칭" 이라는 전제가 성립하지 않는다.)
+//!
+//! 표본 `samples/issue5169_viewtext_changetracking.hwp` 의 두 스트림:
+//!   `ViewText/Section0` = 30,738 B (디렉터리에서 **먼저** 나온다)
+//!   `BodyText/Section0` =  6,974 B
+//!
+//! 계약: 두 경로는 서로 **다른** 스트림으로 풀려야 하고, 각각 제 스토리지 아래의 것이어야 한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::parser::cfb_reader::LenientCfbReader;
+
+const SAMPLE: &str = "samples/issue5169_viewtext_changetracking.hwp";
+const CAP: usize = 64 * 1024 * 1024;
+const BODY_LEN: usize = 6_974;
+const VIEW_LEN: usize = 30_738;
+
+fn sample() -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"))
+}
+
+#[test]
+fn lenient_cfb_resolves_same_named_streams_by_path() {
+    let data = sample();
+    let lenient = LenientCfbReader::open(&data).expect("lenient open");
+
+    // 표본이 이 회귀를 실제로 태우는지 먼저 확인한다 — 이름이 같은 스트림이 둘이어야 한다.
+    let same_named = lenient
+        .list_entries()
+        .iter()
+        .filter(|(name, _, _, _)| name == "Section0")
+        .count();
+    assert_eq!(
+        same_named, 2,
+        "표본에 이름이 Section0 인 스트림이 둘이어야 이 테스트가 의미가 있다"
+    );
+
+    let body = lenient
+        .read_stream_raw_limited("/BodyText/Section0", CAP)
+        .expect("/BodyText/Section0 를 읽을 수 있어야 한다");
+    let view = lenient
+        .read_stream_raw_limited("/ViewText/Section0", CAP)
+        .expect("/ViewText/Section0 를 읽을 수 있어야 한다");
+
+    assert_ne!(
+        body.len(),
+        view.len(),
+        "두 경로가 같은 스트림으로 풀렸다 — 이름만 비교하고 있다"
+    );
+    assert_eq!(
+        body.len(),
+        BODY_LEN,
+        "/BodyText/Section0 가 ViewText 쪽으로 풀렸다"
+    );
+    assert_eq!(view.len(), VIEW_LEN, "/ViewText/Section0 크기가 다르다");
+}
+
+#[test]
+fn lenient_body_text_section_reads_bodytext_storage() {
+    let data = sample();
+    let lenient = LenientCfbReader::open(&data).expect("lenient open");
+
+    let raw = lenient
+        .read_body_text_section_raw_limited(0, CAP)
+        .expect("BodyText Section0 raw");
+    assert_eq!(
+        raw.len(),
+        BODY_LEN,
+        "본문 섹션 읽기가 ViewText 스트림을 집었다"
+    );
+}

--- a/tests/cases/lenient_cfb_path_lookup.rs
+++ b/tests/cases/lenient_cfb_path_lookup.rs
@@ -13,6 +13,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use rhwp::parser::cfb_reader::LenientCfbReader;
+use std::io::{Cursor, Write};
 
 const SAMPLE: &str = "samples/issue5169_viewtext_changetracking.hwp";
 const CAP: usize = 64 * 1024 * 1024;
@@ -73,4 +74,96 @@ fn lenient_body_text_section_reads_bodytext_storage() {
         BODY_LEN,
         "본문 섹션 읽기가 ViewText 스트림을 집었다"
     );
+}
+
+// 아래 합성 CFB는 directory entry가 root 포함 4개 이하인 v3 문서다.
+// 실제 문서나 암호화 내용을 바꾸지 않고 디렉터리 링크 손상만 재현한다.
+fn small_cfb(streams: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut cfb =
+        cfb::CompoundFile::create_with_version(cfb::Version::V3, Cursor::new(Vec::new())).unwrap();
+    for &(path, contents) in streams {
+        let parent = std::path::Path::new(path).parent().unwrap();
+        cfb.create_storage_all(parent).unwrap();
+        cfb.create_stream(path)
+            .unwrap()
+            .write_all(contents)
+            .unwrap();
+    }
+    cfb.into_inner().into_inner()
+}
+
+fn directory_offset(bytes: &[u8]) -> usize {
+    assert_eq!(u16::from_le_bytes(bytes[30..32].try_into().unwrap()), 9);
+    let sid = u32::from_le_bytes(bytes[48..52].try_into().unwrap()) as usize;
+    (sid + 1) * 512
+}
+
+fn set_u32(bytes: &mut [u8], offset: usize, value: u32) {
+    bytes[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+}
+
+#[test]
+fn lenient_cfb_invalid_named_slot_falls_back_to_valid_stream() {
+    for invalid_type in [0, 255] {
+        let mut bytes = small_cfb(&[("/FileHeader", b"valid header")]);
+        let dir = directory_offset(&bytes);
+        let valid_id = u32::from_le_bytes(bytes[dir + 76..dir + 80].try_into().unwrap());
+        assert_eq!(valid_id, 1);
+        let entry = bytes[dir + 128..dir + 256].to_vec();
+        bytes[dir + 256..dir + 384].copy_from_slice(&entry);
+        bytes[dir + 256 + 66] = invalid_type;
+        set_u32(&mut bytes, dir + 76, 2);
+
+        let reader = LenientCfbReader::open(&bytes).unwrap();
+        assert_eq!(reader.read_file_header().unwrap(), b"valid header");
+    }
+}
+
+#[test]
+fn lenient_cfb_broken_child_link_recovers_only_unique_names() {
+    let mut bytes = small_cfb(&[("/FileHeader", b"valid header")]);
+    let dir = directory_offset(&bytes);
+    set_u32(&mut bytes, dir + 76, 10_000);
+    let reader = LenientCfbReader::open(&bytes).unwrap();
+    assert_eq!(reader.read_file_header().unwrap(), b"valid header");
+
+    let mut bytes = sample();
+    let dir = directory_offset(&bytes);
+    set_u32(&mut bytes, dir + 76, 10_000);
+    let reader = LenientCfbReader::open(&bytes).unwrap();
+    // 트리 밖에 Section0이 둘이면 임의의 것을 선택하면 안 된다.
+    assert!(!reader.has_stream("/BodyText/Section0"));
+    assert!(reader
+        .read_stream_raw_limited("/BodyText/Section0", CAP)
+        .is_err());
+}
+
+#[test]
+fn lenient_cfb_stream_cannot_be_used_as_parent_storage() {
+    let mut bytes = small_cfb(&[("/BodyText/Section0", b"body"), ("/Section0", b"other")]);
+    let dir = directory_offset(&bytes);
+    // create 순서상 entry 1은 BodyText storage다. child pointer를 유지한 채
+    // stream으로 손상시켜도 이를 부모 storage로 통과시켜서는 안 된다.
+    assert_eq!(bytes[dir + 128 + 66], 1);
+    bytes[dir + 128 + 66] = 2;
+    let reader = LenientCfbReader::open(&bytes).unwrap();
+    assert!(reader
+        .read_stream_raw_limited("/BodyText/Section0", CAP)
+        .is_err());
+}
+
+#[test]
+fn lenient_cfb_cyclic_sibling_link_terminates_and_recovers_unique_name() {
+    let mut bytes = small_cfb(&[("/FileHeader", b"valid header")]);
+    let dir = directory_offset(&bytes);
+    let entry = bytes[dir + 128..dir + 256].to_vec();
+    bytes[dir + 256..dir + 384].copy_from_slice(&entry);
+    bytes[dir + 256 + 66] = 0;
+    // 다른 이름의 삭제 슬롯만 순환하도록 만들어 유일 이름 fallback을 검사한다.
+    bytes[dir + 256] = b'X';
+    set_u32(&mut bytes, dir + 256 + 68, 2);
+    set_u32(&mut bytes, dir + 256 + 72, 2);
+    set_u32(&mut bytes, dir + 76, 2);
+    let reader = LenientCfbReader::open(&bytes).unwrap();
+    assert_eq!(reader.read_file_header().unwrap(), b"valid header");
 }


### PR DESCRIPTION
Fixes #6884

## 문제

`LenientCfbReader::find_entry_idx` 가 경로의 **마지막 세그먼트만** 떼어 전체 엔트리에서 첫 일치를
돌려준다. `BodyText/Section0` 과 `ViewText/Section0` 은 **이름이 같으므로**, 경로를 명시해서
`/BodyText/Section0` 을 요청해도 디렉터리에 먼저 나오는 `ViewText/Section0` 이 돌아온다.

```
수정 전   /BodyText/Section0 = 30738 B   ← ViewText 가 왔다
          /ViewText/Section0 = 30738 B
수정 후   /BodyText/Section0 =  6974 B
          /ViewText/Section0 = 30738 B
```

(표본 = 저장소에 이미 있는 `samples/issue5169_viewtext_changetracking.hwp`)

주석이 근거로 든 "HWP에서는 이름이 유일" 이라는 전제가 성립하지 않는다.

## 고친 것

- **`find_entry_id`**(옛 `find_entry_idx`): 루트에서 세그먼트마다 `find_child_entry_by_name` 으로
  내려간다 — 같은 파일에 이미 있던, 배포용 `ViewText` 경로가 쓰던 그 탐색이다.
  `LenientCfbReader` 는 **디렉터리 트리가 깨진 입력을 살리는 것**이 존재 이유라 이름 폴백은
  남겼지만, **같은 이름이 둘 이상이면 고르지 않는다**(잘못된 스트림을 조용히 읽느니 없다고 답한다).
- `entries`(= `obj_type` 1/2/5 만 걸러 담은 벡터)의 인덱스와 `directory_entries` 의 id 는
  **인덱스 공간이 다르다**. 그래서 `read_stream` · `read_stream_raw_limited` · `has_stream` 을
  이미 있는 `read_directory_stream{,_limited}` 위로 옮겨 변환 자체를 없앴다(읽기 로직은 그대로).
- 이름으로 `Section{i}` 를 읽던 호출부를 strict 쪽과 같은 규칙으로 바꿨다
  (`/BodyText/Section{i}` → 없으면 `/Section{i}`). 경로 조회가 맞아진 뒤에는 바로 이 자리가
  아니면 결함이 드러나지 않는다:
  - `parse_hwp_with_lenient` 의 **BodyText 폴백** · **비밀번호 문서 섹션 복호화**
  - `read_body_text_section{,_full,_limited}`
  - lenient `BinData` → `/BinData/{name}`
- 새 헬퍼 `LenientCfbReader::read_body_text_section_raw_limited`(strict 쪽과 같은 경로 규칙).

## #5169 와의 관계

이 PR 은 **#5169 의 "비배포 문서라도 정상 복호되는 `ViewText` 를 우선한다" 규칙을 건드리지 않는다.**
그 규칙은 strict 경로에서 의도대로 동작하고, `tests/cases/issue_5169_prefer_viewtext.rs` 는
그대로 통과한다. 여기서 고치는 것은 **경로를 명시해도 다른 스트림이 돌아오는** CFB 조회 자체다.

표본을 `issue5169_…` 로 쓴 이유는 그 문서가 이름이 같은 두 스트림을 가진, 저장소에 이미 있는
표본이기 때문이다.

## 회귀 테스트

`tests/cases/lenient_cfb_path_lookup.rs` — 원본만 `tests/cases/` 에 두었다(README 규약대로
`tests/generated/` 와 `Cargo.toml` 의 generated 블록은 손대지 않았다).

- `/BodyText/Section0` 과 `/ViewText/Section0` 이 **서로 다른** 스트림으로 풀리는지
- `read_body_text_section_raw_limited(0)` 이 `BodyText` 스트림을 주는지

두 테스트 모두 **수정 전에는 실패하고 수정 후 통과**하는 것을 확인했다.

## 검증

| | 결과 |
|---|---|
| `node scripts/rust-test-suite-manifest.mjs --prepare` (CI 스텝) | **통과** — `48/48 integration targets`, 새 테스트가 generated suite 에 자동 배정 |
| 배정된 generated suite 실행 | **169 통과 · 0 실패** (새 테스트 2건 포함) |
| `cargo test --release --lib` (rhwp) | **3,873 통과 · 0 실패 · 13 ignored** |
| 워크스페이스 크레이트 | `rhwp-contracts` 15 · `rhwp-ooxml-chart` 165 · `rhwp-password-crypto` 2 — 전부 통과 |
| `tests/cases/issue_5169_prefer_viewtext.rs` | 통과 (#5169 동작 불변) |
| 새 회귀 2건 | 통과 — **수정 전에는 실패**하는 것도 확인 |

`tests/generated/` 와 `tests/suites/manifest.json` 은 `.gitignore` 대상이라 이 PR 에는 들어 있지 않습니다
(원본만 `tests/cases/` 에 두었고, 배정은 `--prepare` 가 합니다).

플랫폼: Windows 11 · Rust 1.93.1 · Node 24.19.0 · `devel` @ `91147ae` 기준.

<sub>참고: Windows 에서 `core.autocrlf=true` 로 체크아웃하면 `Cargo.toml` 이 CRLF 가 되어
`--prepare` 가 `Cargo.toml generated test target block drift` 로 떨어집니다(생성기는 LF 로 렌더). 
`core.autocrlf=false` 로 다시 체크아웃하니 통과했습니다. `.gitattributes` 가 `.claude/skills/**/*.md` 등에
`eol=lf` 를 박아 둔 것과 같은 계열이라, 필요하시면 `Cargo.toml` 에도 같은 처리를 고려해 보실 만합니다.</sub>
