### PR TITLE
ci: 검증된 fork PR의 post-merge CI 재사용 지원 (#6901)

### DIFF
--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -71,16 +71,29 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           CALLER_SHA: ${{ inputs.caller_sha }}
+          CALLER_REF: ${{ inputs.caller_ref }}
           WORKFLOW_FILE: ${{ inputs.workflow_file }}
         with:
           script: |
             const fs = require('node:fs');
             const mergeSha = process.env.CALLER_SHA;
             const pullRequest = context.payload.pull_request;
+            const repositoryId = Number(process.env.GITHUB_REPOSITORY_ID);
+            const runAttempt = Number(process.env.GITHUB_RUN_ATTEMPT);
+            const isFork = pullRequest?.head?.repo?.full_name !== process.env.GITHUB_REPOSITORY;
             if (
               !/^[0-9a-f]{40}$/.test(mergeSha || '')
               || !pullRequest
-              || pullRequest.head?.repo?.full_name !== process.env.GITHUB_REPOSITORY
+              || pullRequest.base?.repo?.full_name !== process.env.GITHUB_REPOSITORY
+              || !Number.isSafeInteger(repositoryId) || repositoryId <= 0
+              || pullRequest.base.repo.id !== repositoryId
+              || pullRequest.base.ref !== 'devel'
+              || !Number.isSafeInteger(pullRequest.number) || pullRequest.number <= 0
+              || process.env.CALLER_REF !== `refs/pull/${pullRequest.number}/merge`
+              || !Number.isSafeInteger(runAttempt) || runAttempt <= 0
+              || !Number.isSafeInteger(pullRequest.head?.repo?.id) || pullRequest.head.repo.id <= 0
+              || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(pullRequest.head.repo.full_name || '')
+              || (isFork && (pullRequest.head.repo.fork !== true || pullRequest.head.repo.id === repositoryId))
               || !/^[0-9a-f]{40}$/.test(pullRequest.base?.sha || '')
               || !/^[0-9a-f]{40}$/.test(pullRequest.head?.sha || '')
             ) {
@@ -104,10 +117,16 @@ jobs:
                 core.warning('PR merge ref does not match the event base/head pair; no evidence will be published.');
                 return;
               }
-              const artifactName = `trusted-postmerge-merge-tree-v1-${mergeSha}-${treeSha}`;
+              const artifactName = isFork
+                ? `trusted-postmerge-fork-merge-tree-v1-${pullRequest.number}-${repositoryId}-${pullRequest.head.repo.id}-${runAttempt}-${mergeSha}-${treeSha}`
+                : `trusted-postmerge-merge-tree-v1-${mergeSha}-${treeSha}`;
               fs.writeFileSync('trusted-postmerge-merge-tree.json', `${JSON.stringify({
-                schema: 1,
+                schema: isFork ? 2 : 1,
                 repository: process.env.GITHUB_REPOSITORY,
+                repository_id: repositoryId,
+                pull_number: pullRequest.number,
+                head_repository_id: pullRequest.head.repo.id,
+                run_attempt: runAttempt,
                 workflow_file: process.env.WORKFLOW_FILE,
                 run_id: String(context.runId),
                 merge_sha: mergeSha,
@@ -224,15 +243,21 @@ jobs:
             let currentBaseReviewBridgeSource;
             let selectTrustedPostMergeCandidate;
             let verifyPostMergeReviewBridgeTree;
+            let verifyForkPostMergeTree;
+            let trustedPullRequestSource;
+            let trustedPullRequestWorkflowRun;
+            const repositoryId = Number(process.env.GITHUB_REPOSITORY_ID);
             try {
               ({ classifyReviewOnlyCommit, evaluateTrustedPostMergeReuse, frontendOnlyCiRunIsReusable,
                 currentBaseReviewBridgeSource, selectTrustedPostMergeCandidate,
-                verifyPostMergeReviewBridgeTree } = await import(pathToFileURL(path.join(
+                verifyPostMergeReviewBridgeTree, verifyForkPostMergeTree,
+                trustedPullRequestSource, trustedPullRequestWorkflowRun } = await import(pathToFileURL(path.join(
                 process.env.GITHUB_WORKSPACE,
                 'scripts/verify-trusted-postmerge-ci-reuse.mjs',
               )).href));
               if ([currentBaseReviewBridgeSource, selectTrustedPostMergeCandidate,
-                verifyPostMergeReviewBridgeTree].some((fn) => typeof fn !== 'function')) {
+                verifyPostMergeReviewBridgeTree, verifyForkPostMergeTree,
+                trustedPullRequestSource, trustedPullRequestWorkflowRun].some((fn) => typeof fn !== 'function')) {
                 throw new Error('trusted base has no review-bridge verifier');
               }
               if (process.env.WORKFLOW_FILE === 'ci.yml') {
@@ -264,7 +289,7 @@ jobs:
                 && candidate.merged_at
                 && candidate.merge_commit_sha === mergeSha
                 && candidate.base?.ref === 'devel'
-                && candidate.head?.repo?.full_name === process.env.GITHUB_REPOSITORY
+                && trustedPullRequestSource(candidate, process.env.GITHUB_REPOSITORY, repositoryId)
               ));
               if (pullRequest.length !== 1) {
                 return { mergeCommit, pullRequests, pullFiles: [], workflowRuns: [] };
@@ -276,9 +301,12 @@ jobs:
               if (pr.number !== summary.number || pr.head?.sha !== summary.head.sha
                 || pr.merge_commit_sha !== mergeSha || pr.state !== 'closed' || !pr.merged_at
                 || pr.base?.ref !== 'devel'
-                || pr.head?.repo?.full_name !== process.env.GITHUB_REPOSITORY) {
+                || !trustedPullRequestSource(pr, process.env.GITHUB_REPOSITORY, repositoryId)
+                || pr.head.repo.id !== summary.head.repo.id
+                || pr.head.repo.full_name !== summary.head.repo.full_name) {
                 throw new Error('PR detail identity mismatch');
               }
+              const isFork = pr.head.repo.full_name !== process.env.GITHUB_REPOSITORY;
               const mergeParents = (mergeCommit.parents || []).map((parent) => parent.sha);
               const baseParent = mergeParents.length === 1
                 ? mergeParents[0]
@@ -332,14 +360,15 @@ jobs:
                 }
               }
               const sourceSelection = selectTrustedPostMergeCandidate(pr, prCommits, baseParent);
+              const matchesRun = (run) => trustedPullRequestWorkflowRun(
+                run, pr, process.env.GITHUB_REPOSITORY, repositoryId, process.env.WORKFLOW_FILE,
+              );
               const mergeTreeEvidenceByRunId = {};
               const createdAt = Date.parse(pr.created_at || '');
               const mergedAt = Date.parse(pr.merged_at || '');
               const finalHeadRuns = workflowRuns.filter((run) => (
-                run.event === 'pull_request'
+                matchesRun(run)
                 && run.head_sha === pr.head.sha
-                && run.head_branch === pr.head.ref
-                && run.head_repository?.full_name === process.env.GITHUB_REPOSITORY
                 && Number.isFinite(createdAt)
                 && Number.isFinite(mergedAt)
                 && Date.parse(run.created_at || '') >= createdAt
@@ -352,20 +381,28 @@ jobs:
               const finalHeadRun = finalHeadRuns[0];
               async function recordMergeTreeEvidence(workflowRun, artifacts) {
                 if (
-                  workflowRun?.event !== 'pull_request'
-                  || workflowRun?.head_branch !== pr.head.ref
-                  || workflowRun?.head_repository?.full_name !== process.env.GITHUB_REPOSITORY
-                  || !/^[0-9a-f]{40}$/.test(workflowRun?.head_sha || '')
+                  !matchesRun(workflowRun)
                 ) {
                   return;
                 }
                 const evidenceArtifacts = artifacts
                   .filter((artifact) => artifact.expired !== true)
-                  .map((artifact) => ({
-                    artifact,
-                    match: /^trusted-postmerge-merge-tree-v1-([0-9a-f]{40})-([0-9a-f]{40})$/
-                      .exec(artifact.name || ''),
-                  }))
+                  .map((artifact) => {
+                    if (isFork) {
+                      const identity = /^trusted-postmerge-fork-merge-tree-v1-([1-9][0-9]*)-([1-9][0-9]*)-([1-9][0-9]*)-([1-9][0-9]*)-([0-9a-f]{40})-([0-9a-f]{40})$/
+                        .exec(artifact.name || '');
+                      const matchesIdentity = identity
+                        && identity[1] === String(pr.number)
+                        && identity[2] === String(repositoryId)
+                        && identity[3] === String(pr.head.repo.id)
+                        && identity[4] === String(workflowRun.run_attempt);
+                      return { artifact, match: matchesIdentity
+                        ? [identity[0], identity[5], identity[6]] : null };
+                    }
+                    return { artifact,
+                      match: /^trusted-postmerge-merge-tree-v1-([0-9a-f]{40})-([0-9a-f]{40})$/
+                        .exec(artifact.name || '') };
+                  })
                   .filter(({ match }) => match !== null);
                 if (evidenceArtifacts.length === 1) {
                   const [, testedMergeSha, encodedTreeSha] = evidenceArtifacts[0].match;
@@ -386,6 +423,8 @@ jobs:
                       sha: testedMergeSha,
                       parents: testedParents,
                       treeSha: testedTreeSha,
+                      ...(isFork ? { pullNumber: pr.number, repositoryId,
+                        headRepositoryId: pr.head.repo.id, runAttempt: workflowRun.run_attempt } : {}),
                     };
                   }
                 }
@@ -424,7 +463,7 @@ jobs:
                 }
               }
               const requireFullLaneEvidence = ["ci.yml", "codeql.yml"]
-                .includes(process.env.WORKFLOW_FILE);
+                .includes(process.env.WORKFLOW_FILE) || isFork;
               const reviewOnlyWorker = {
                 "proptest-roundtrip.yml": {
                   preflight: "Proptest preflight",
@@ -438,7 +477,7 @@ jobs:
               const fullLaneRunIds = [];
               if (requireFullLaneEvidence) {
                 for (const workflowRun of workflowRuns) {
-                  if (workflowRun.status !== "completed" || workflowRun.conclusion !== "success") {
+                  if (!matchesRun(workflowRun) || workflowRun.status !== "completed" || workflowRun.conclusion !== "success") {
                     continue;
                   }
                   if (process.env.WORKFLOW_FILE === "ci.yml") {
@@ -462,11 +501,16 @@ jobs:
                     github.rest.actions.listJobsForWorkflowRun,
                     { owner, repo, run_id: workflowRun.id, per_page: 100 },
                   );
-                  if (jobs.some((job) => (
+                  const executed = reviewOnlyWorker
+                    ? [reviewOnlyWorker.preflight, reviewOnlyWorker.worker].every((name) => jobs.some((job) => (
+                      job.name === name && job.status === 'completed' && job.conclusion === 'success'
+                    )))
+                    : jobs.some((job) => (
                     /^Analyze \(.+\)$/.test(job.name || "")
                     && job.status === "completed"
                     && job.conclusion === "success"
-                  ))) {
+                  ));
+                  if (executed) {
                     fullLaneRunIds.push(String(workflowRun.id));
                     const artifacts = await github.paginate(
                       github.rest.actions.listWorkflowRunArtifacts,
@@ -479,7 +523,7 @@ jobs:
               const reviewOnlyFastPassRunIds = [];
               if (reviewOnlyWorker) {
                 for (const workflowRun of workflowRuns) {
-                  if (workflowRun.status !== "completed" || workflowRun.conclusion !== "success") {
+                  if (!matchesRun(workflowRun) || workflowRun.status !== "completed" || workflowRun.conclusion !== "success") {
                     continue;
                   }
                   const jobs = await github.paginate(
@@ -502,6 +546,37 @@ jobs:
                 }
               }
               const reviewBridgeTreeEvidenceByRunId = {};
+              const forkMergeTreeEvidenceByRunId = {};
+              if (isFork && sourceSelection) {
+                for (const run of workflowRuns) {
+                  const tested = mergeTreeEvidenceByRunId[String(run.id)];
+                  if (!matchesRun(run) || !fullLaneRunIds.includes(String(run.id)) || !tested
+                    || tested.parents[0] !== baseParent
+                    || !sourceSelection.fullLaneCandidates.some((candidate) => candidate.sha === run.head_sha)) {
+                    continue;
+                  }
+                  try {
+                    // Compare immutable trees with trusted code; never execute fork code here.
+                    const refs = [mergeSha, tested.sha];
+                    if (!refs.every((sha) => /^[0-9a-f]{40}$/.test(sha))) {
+                      throw new Error('invalid fork merge-tree identity');
+                    }
+                    const gitOptions = { cwd: process.env.GITHUB_WORKSPACE,
+                      timeout: 120000, maxBuffer: 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'] };
+                    execFileSync('git', ['fetch', '--no-tags', '--filter=blob:none', '--depth=1',
+                      '--no-write-fetch-head', 'origin', ...refs], gitOptions);
+                    const proof = verifyForkPostMergeTree(process.env.GITHUB_WORKSPACE, {
+                      baseSha: baseParent, mergeSha, candidateSha: run.head_sha, testedMergeSha: tested.sha,
+                    });
+                    if (proof.testedTreeSha !== tested.treeSha) {
+                      throw new Error('fork artifact tree mismatch');
+                    }
+                    forkMergeTreeEvidenceByRunId[String(run.id)] = proof;
+                  } catch (error) {
+                    core.warning(`Fork tree proof unavailable for run ${run.id}; running full. ${error.message}`);
+                  }
+                }
+              }
               if (sourceSelection?.bridgeSha && requireFullLaneEvidence) {
                 for (const run of workflowRuns) {
                   const tested = mergeTreeEvidenceByRunId[String(run.id)];
@@ -551,6 +626,7 @@ jobs:
                 workflowRuns,
                 mergeTreeEvidenceByRunId,
                 reviewBridgeTreeEvidenceByRunId,
+                forkMergeTreeEvidenceByRunId,
                 frontendOnlyRunIds,
               };
               if (requireFullLaneEvidence) {
@@ -569,6 +645,8 @@ jobs:
                 eventName: process.env.CALLER_EVENT_NAME,
                 ref: process.env.CALLER_REF,
                 repository: process.env.GITHUB_REPOSITORY,
+                repositoryId,
+                workflowFile: process.env.WORKFLOW_FILE,
                 mergeSha: process.env.CALLER_SHA,
                 ...evidence,
               });

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import re
+import shutil
+import subprocess
+import textwrap
 import unittest
 from pathlib import Path
 
@@ -19,6 +22,51 @@ WORKFLOWS = {
 
 
 class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
+    def test_fork_artifact_binds_upstream_pr_head_repository_and_attempt(self) -> None:
+        workflow = REUSABLE.read_text(encoding="utf-8")
+        capture = workflow.split("- name: Capture PR merge-tree evidence", 1)[1].split(
+            "- name: Upload PR merge-tree evidence", 1
+        )[0]
+        self.assertIn("pullRequest.base.repo.id !== repositoryId", capture)
+        self.assertIn("refs/pull/${pullRequest.number}/merge", capture)
+        self.assertIn("trusted-postmerge-fork-merge-tree-v1-${pullRequest.number}", capture)
+        self.assertIn("${repositoryId}-${pullRequest.head.repo.id}-${runAttempt}", capture)
+        self.assertNotIn("|| pullRequest.head?.repo?.full_name !==", capture)
+        self.assertIn("identity[1] === String(pr.number)", workflow)
+        self.assertIn("identity[2] === String(repositoryId)", workflow)
+        self.assertIn("identity[3] === String(pr.head.repo.id)", workflow)
+        self.assertIn("identity[4] === String(workflowRun.run_attempt)", workflow)
+        self.assertIn("artifact.expired !== true", workflow)
+
+    def test_fork_collection_requires_trusted_run_and_independent_tree_proof(self) -> None:
+        workflow = REUSABLE.read_text(encoding="utf-8")
+        collect = workflow.split("async function collectEvidence()", 1)[1]
+        self.assertIn("trustedPullRequestSource(candidate, process.env.GITHUB_REPOSITORY, repositoryId)", collect)
+        self.assertIn("trustedPullRequestWorkflowRun(", collect)
+        self.assertIn("pr.head.repo.id !== summary.head.repo.id", collect)
+        self.assertIn('.includes(process.env.WORKFLOW_FILE) || isFork', collect)
+        self.assertIn("[reviewOnlyWorker.preflight, reviewOnlyWorker.worker].every", collect)
+        self.assertIn("verifyForkPostMergeTree(process.env.GITHUB_WORKSPACE", collect)
+        self.assertIn("tested.parents[0] !== baseParent", collect)
+        self.assertIn("forkMergeTreeEvidenceByRunId", collect)
+        self.assertIn("fork artifact tree mismatch", collect)
+        self.assertNotIn("execFileSync('git', ['checkout'", collect)
+
+    def test_inline_github_scripts_parse_as_async_javascript(self) -> None:
+        workflow = REUSABLE.read_text(encoding="utf-8")
+        scripts = re.findall(r"(?m)^          script: \|\n((?:            .*\n|\n)+)", workflow)
+        self.assertGreaterEqual(len(scripts), 3)
+        node = shutil.which("node")
+        self.assertIsNotNone(node)
+        for index, script in enumerate(scripts):
+            with self.subTest(script=index):
+                result = subprocess.run(
+                    [node, "--check", "--input-type=commonjs"],
+                    input="async function workflowStep() {\n" + textwrap.dedent(script) + "\n}\n",
+                    text=True, capture_output=True, check=False,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+
     def test_reusable_workflow_actions_are_pinned_to_full_commit_shas(self) -> None:
         workflow = REUSABLE.read_text(encoding="utf-8")
         pins = re.findall(

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs
@@ -83,7 +83,7 @@ test("fails closed when a squash merge tree differs from the reviewed PR head", 
 test("fails closed when a squash merge has no unique associated PR", () => {
   const result = evaluateTrustedPostMergeReuse(input({ pullRequests: [] }));
   assert.equal(result.reuse, false);
-  assert.equal(result.reason, "merge-commit-must-map-to-one-merged-same-repository-pr");
+  assert.equal(result.reason, "merge-commit-must-map-to-one-trusted-merged-pr");
 });
 
 test("does not apply two-parent merge-ref evidence to a stale squash merge", () => {

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { evaluateTrustedPostMergeReuse } from "../verify-trusted-postmerge-ci-reuse.mjs";
+import { evaluateTrustedPostMergeReuse, verifyForkPostMergeTree } from "../verify-trusted-postmerge-ci-reuse.mjs";
 
 const base = "1".repeat(40);
 const head = "2".repeat(40);
@@ -492,4 +496,152 @@ frontendTest('does not reuse an earlier frontend run through an untested final r
   const data = frontendReuseInput(true);
   data.workflowRuns[0].head_sha = 'b'.repeat(40);
   frontendAssert.equal(evaluateFrontendReuse(data).reuse, false);
+});
+
+function forkInput() {
+  const data = input({ repositoryId: 10, workflowFile: "ci.yml", fullLaneRunIds: ["123"] });
+  data.pullRequests[0].base.repo = { id: 10, full_name: data.repository };
+  data.pullRequests[0].head.repo = { id: 20, full_name: "contributor/rhwp", fork: true };
+  Object.assign(data.workflowRuns[0], {
+    repository: { id: 10, full_name: data.repository },
+    head_repository: { id: 20, full_name: "contributor/rhwp" },
+    run_attempt: 1, path: ".github/workflows/ci.yml", pull_requests: [],
+  });
+  data.mergeTreeEvidenceByRunId = {
+    123: { sha: testedMerge, parents: [base, head], treeSha: tree,
+      pullNumber: 42, repositoryId: 10, headRepositoryId: 20, runAttempt: 1 },
+  };
+  return data;
+}
+
+function forkTailInput() {
+  const data = forkInput();
+  data.prCommits = [
+    { sha: code, parents: [{ sha: base }], files: [{ filename: "src/renderer/layout.rs", status: "modified" }] },
+    { sha: head, parents: [{ sha: code }], files: [{ filename: "mydocs/pr/archives/review.md", status: "added" }] },
+  ];
+  data.workflowRuns.push({ ...data.workflowRuns[0], id: 456, head_sha: code });
+  data.fullLaneRunIds = ["456"];
+  data.mergeTreeEvidenceByRunId[456] = {
+    ...data.mergeTreeEvidenceByRunId[123], sha: "a".repeat(40), parents: [base, code], treeSha: "b".repeat(40),
+  };
+  data.forkMergeTreeEvidenceByRunId = {
+    456: { baseSha: base, mergeSha: merge, candidateSha: code,
+      testedMergeSha: "a".repeat(40), testedTreeSha: "b".repeat(40), finalTreeSha: tree },
+  };
+  return data;
+}
+
+test("fork PR은 upstream run과 PR 신원이 결합된 정확한 merge-tree 증거로 재사용한다", () => {
+  const result = evaluateTrustedPostMergeReuse(forkInput());
+  assert.equal(result.reuse, true);
+  assert.equal(result.sourceRunId, "123");
+});
+
+test("fork 문서 trailing head는 코드 CI의 동일 base 및 최종 tree 대조 증명을 요구한다", () => {
+  const result = evaluateTrustedPostMergeReuse(forkTailInput());
+  assert.equal(result.reuse, true);
+  assert.equal(result.sourceRunId, "456");
+});
+
+const forkRejections = {
+  "fork 자체 Actions 실행": d => { d.workflowRuns[0].repository = { id: 20, full_name: "contributor/rhwp" }; },
+  "다른 upstream 저장소 ID": d => { d.workflowRuns[0].repository.id = 11; },
+  "다른 fork 저장소 ID": d => { d.workflowRuns[0].head_repository.id = 21; },
+  "다른 fork 이름": d => { d.workflowRuns[0].head_repository.full_name = "other/rhwp"; },
+  "다른 branch": d => { d.workflowRuns[0].head_branch = "other"; },
+  "다른 head": d => { d.workflowRuns[0].head_sha = code; },
+  "다른 workflow": d => { d.workflowRuns[0].path = ".github/workflows/untrusted.yml"; },
+  "PR base 저장소 불일치": d => { d.pullRequests[0].base.repo.id = 11; },
+  "fork 표시 누락": d => { delete d.pullRequests[0].head.repo.fork; },
+  "다른 PR 연결": d => { d.workflowRuns[0].pull_requests = [{ number: 43 }]; },
+  "다른 PR artifact": d => { d.mergeTreeEvidenceByRunId[123].pullNumber = 43; },
+  "다른 base 저장소 artifact": d => { d.mergeTreeEvidenceByRunId[123].repositoryId = 11; },
+  "다른 fork artifact": d => { d.mergeTreeEvidenceByRunId[123].headRepositoryId = 21; },
+  "이전 attempt artifact": d => { d.workflowRuns[0].run_attempt = 2; },
+  "run attempt 누락": d => { delete d.workflowRuns[0].run_attempt; },
+  "신원 없는 기존 v1 artifact": d => { delete d.mergeTreeEvidenceByRunId[123].pullNumber; },
+  "merge-tree 증거 누락": d => { d.mergeTreeEvidenceByRunId = {}; },
+  "tree 불일치": d => { d.mergeTreeEvidenceByRunId[123].treeSha = code; },
+  "base 불일치": d => { d.mergeTreeEvidenceByRunId[123].parents[0] = oldBase; },
+  "worker 실행 증거 누락": d => { delete d.fullLaneRunIds; },
+  "실행 worker 없음": d => { d.fullLaneRunIds = []; },
+  "실패한 run": d => { d.workflowRuns[0].conclusion = "failure"; },
+  "취소한 run": d => { d.workflowRuns[0].conclusion = "cancelled"; },
+  "미완료 run": d => { d.workflowRuns[0].status = "in_progress"; d.workflowRuns[0].conclusion = null; },
+  "머지 이후 실행": d => { d.workflowRuns[0].updated_at = "2026-08-27T10:04:00Z"; },
+  "enforcement 수정": d => { d.pullFiles.push({ filename: ".github/workflows/ci.yml" }); },
+  "증거 없는 squash": d => { d.mergeCommit.parents = [{ sha: base }]; },
+};
+for (const [name, mutate] of Object.entries(forkRejections)) {
+  test(`fork 재사용 거부: ${name}`, () => {
+    const data = forkInput();
+    mutate(data);
+    assert.equal(evaluateTrustedPostMergeReuse(data).reuse, false);
+  });
+}
+
+test("fork 최신 rerun 실패를 이전 green run으로 대체하지 않는다", () => {
+  const data = forkInput();
+  data.workflowRuns.push({ ...data.workflowRuns[0], id: 124, run_attempt: 2,
+    conclusion: "failure", updated_at: "2026-08-27T10:02:30Z" });
+  assert.equal(evaluateTrustedPostMergeReuse(data).reuse, false);
+});
+
+for (const mutate of [
+  d => { d.forkMergeTreeEvidenceByRunId = {}; },
+  d => { d.forkMergeTreeEvidenceByRunId[456].baseSha = oldBase; },
+  d => { d.forkMergeTreeEvidenceByRunId[456].finalTreeSha = code; },
+  d => { d.forkMergeTreeEvidenceByRunId[456].testedTreeSha = tree; },
+  d => { d.mergeTreeEvidenceByRunId[456].parents[0] = oldBase; },
+  d => { d.mergeTreeEvidenceByRunId[456].runAttempt = 2; },
+]) {
+  test("fork 코드 후보의 tree 또는 identity 증명이 없거나 변조되면 거부한다", () => {
+    const data = forkTailInput();
+    mutate(data);
+    assert.equal(evaluateTrustedPostMergeReuse(data).reuse, false);
+  });
+}
+
+test("실제 Git tree 대조는 fork의 문서 trailing만 허용하고 source 변경과 base 이동은 거부한다", () => {
+  const root = mkdtempSync(join(tmpdir(), "rhwp-fork-reuse-"));
+  const git = (...args) => execFileSync("git", ["-C", root, ...args], {
+    encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+  try {
+    git("init");
+    git("config", "user.name", "CI contract");
+    git("config", "user.email", "ci-contract@example.invalid");
+    git("config", "commit.gpgsign", "false");
+    writeFileSync(join(root, "source.txt"), "base\n");
+    git("add", "."); git("commit", "-m", "base");
+    const baseSha = git("rev-parse", "HEAD");
+    git("switch", "-c", "feature");
+    writeFileSync(join(root, "source.txt"), "candidate\n");
+    git("commit", "-am", "candidate");
+    const candidateSha = git("rev-parse", "HEAD");
+    git("switch", "--detach", baseSha);
+    git("merge", "--no-ff", "feature", "-m", "tested merge");
+    const testedMergeSha = git("rev-parse", "HEAD");
+    git("switch", "feature");
+    mkdirSync(join(root, "mydocs"));
+    writeFileSync(join(root, "mydocs/review.md"), "review\n");
+    git("add", "."); git("commit", "-m", "review");
+    git("switch", "--detach", baseSha);
+    git("merge", "--no-ff", "feature", "-m", "final merge");
+    const mergeSha = git("rev-parse", "HEAD");
+    const identity = { baseSha, candidateSha, testedMergeSha, mergeSha };
+    assert.equal(verifyForkPostMergeTree(root, identity).finalTreeSha, git("rev-parse", "HEAD^{tree}"));
+    assert.throws(() => verifyForkPostMergeTree(root, { ...identity, baseSha: oldBase }));
+    git("switch", "feature");
+    writeFileSync(join(root, "source.txt"), "untested source\n");
+    git("commit", "-am", "source changed");
+    git("switch", "--detach", baseSha);
+    git("merge", "--no-ff", "feature", "-m", "different final merge");
+    assert.throws(() => verifyForkPostMergeTree(root, {
+      ...identity, mergeSha: git("rev-parse", "HEAD"),
+    }), /non-review-tree-change/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/scripts/verify-trusted-postmerge-ci-reuse.mjs
+++ b/scripts/verify-trusted-postmerge-ci-reuse.mjs
@@ -17,6 +17,48 @@ function timestamp(value) {
   return Number.isFinite(parsed) ? parsed : Number.NaN;
 }
 
+function positiveId(value) {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+export function trustedPullRequestSource(pullRequest, repository, repositoryId) {
+  const head = pullRequest?.head?.repo;
+  if (head?.full_name === repository) {
+    return true;
+  }
+  return positiveId(repositoryId)
+    && pullRequest?.base?.repo?.full_name === repository
+    && pullRequest.base.repo.id === repositoryId
+    && positiveId(pullRequest.number)
+    && head?.fork === true && positiveId(head.id) && head.id !== repositoryId
+    && /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(head.full_name || "");
+}
+
+// Fork runs belong to upstream Actions, not the fork's Actions installation.
+// An empty pull_requests array is normal for forks; the artifact binds the PR.
+export function trustedPullRequestWorkflowRun(run, pullRequest, repository, repositoryId, workflowFile) {
+  if (run?.event !== "pull_request" || !validSha(run.head_sha)
+    || run.head_branch !== pullRequest?.head?.ref
+    || run.head_repository?.full_name !== pullRequest?.head?.repo?.full_name) {
+    return false;
+  }
+  if (pullRequest.head.repo.full_name === repository) {
+    return true;
+  }
+  return trustedPullRequestSource(pullRequest, repository, repositoryId)
+    && run.repository?.full_name === repository && run.repository.id === repositoryId
+    && run.head_repository.id === pullRequest.head.repo.id
+    && positiveId(run.id) && positiveId(run.run_attempt)
+    && /^[A-Za-z0-9_-]+\.yml$/.test(workflowFile || "")
+    && run.path === `.github/workflows/${workflowFile}`
+    && Array.isArray(run.pull_requests)
+    && (run.pull_requests.length === 0 || run.pull_requests.some((pr) => (
+      pr.number === pullRequest.number && pr.head?.sha === run.head_sha
+      && pr.head?.repo?.id === pullRequest.head.repo.id
+      && pr.base?.repo?.id === repositoryId
+    )));
+}
+
 function enforcementPathChanged(files) {
   const paths = (Array.isArray(files) ? files : [])
     .flatMap((file) => [file?.filename, file?.previous_filename])
@@ -133,9 +175,10 @@ export function selectTrustedPostMergeCandidate(pullRequest, prCommits, baseSha)
 }
 
 // Run only from the trusted base checkout; the inspected commits are data, never code.
-export function verifyPostMergeReviewBridgeTree(repository, identity) {
+function verifyPostMergeTree(repository, identity, requireBridge) {
   const { baseSha, bridgeSha, mergeSha, candidateSha, testedMergeSha } = identity;
-  if (![baseSha, bridgeSha, mergeSha, candidateSha, testedMergeSha].every(validSha)) {
+  if (![baseSha, mergeSha, candidateSha, testedMergeSha].every(validSha)
+    || (requireBridge && !validSha(bridgeSha))) {
     throw new Error("invalid-review-bridge-identity");
   }
   const git = (...args) => execFileSync("git", ["-C", repository, "--no-replace-objects", ...args], {
@@ -155,13 +198,13 @@ export function verifyPostMergeReviewBridgeTree(repository, identity) {
     }
     return { sha, treeSha: trees[0], parents: parents.map(sha => ({ sha })) };
   };
-  const bridge = readCommit(bridgeSha);
+  const bridge = requireBridge ? readCommit(bridgeSha) : null;
   const tested = readCommit(testedMergeSha);
   const final = readCommit(mergeSha);
-  if (!currentBaseReviewBridgeSource(bridge, baseSha)
+  if ((requireBridge && !currentBaseReviewBridgeSource(bridge, baseSha))
     || tested.parents.length !== 2 || tested.parents[0].sha !== baseSha
     || tested.parents[1].sha !== candidateSha || candidateSha === baseSha
-    || final.parents.length < 1 || final.parents.length > 2
+    || final.parents.length < (requireBridge ? 1 : 2) || final.parents.length > 2
     || final.parents[0].sha !== baseSha) {
     throw new Error("review-bridge-base-mismatch");
   }
@@ -173,8 +216,16 @@ export function verifyPostMergeReviewBridgeTree(repository, identity) {
     && path !== "mydocs/tech/canvaskit-parity-implementation.md")) {
     throw new Error("review-bridge-non-review-tree-change");
   }
-  return { baseSha, bridgeSha, mergeSha, candidateSha, testedMergeSha,
+  return { baseSha, ...(requireBridge ? { bridgeSha } : {}), mergeSha, candidateSha, testedMergeSha,
     testedTreeSha: tested.treeSha, finalTreeSha: final.treeSha };
+}
+
+export function verifyPostMergeReviewBridgeTree(repository, identity) {
+  return verifyPostMergeTree(repository, identity, true);
+}
+
+export function verifyForkPostMergeTree(repository, identity) {
+  return verifyPostMergeTree(repository, identity, false);
 }
 
 function hasReviewBridgeTreeEvidence(input, run, baseSha, bridgeSha, finalTreeSha) {
@@ -216,7 +267,7 @@ function isDirectReviewOnlyPullRequest(pullRequest, pullFiles, prCommits) {
   return true;
 }
 
-function latestCandidateRun(runs, pullRequest, repository, candidateSha) {
+function latestCandidateRun(runs, pullRequest, repository, candidateSha, repositoryId, workflowFile) {
   const createdAt = timestamp(pullRequest.created_at);
   const mergedAt = timestamp(pullRequest.merged_at);
   if (
@@ -229,10 +280,8 @@ function latestCandidateRun(runs, pullRequest, repository, candidateSha) {
   }
 
   const matches = (Array.isArray(runs) ? runs : []).filter((run) => (
-    run?.event === "pull_request"
+    trustedPullRequestWorkflowRun(run, pullRequest, repository, repositoryId, workflowFile)
     && run?.head_sha === candidateSha
-    && run?.head_branch === pullRequest.head?.ref
-    && run?.head_repository?.full_name === repository
     && timestamp(run.created_at) >= createdAt
     && timestamp(run.updated_at) <= mergedAt
   ));
@@ -348,6 +397,25 @@ function hasIntermediateCandidateMergeTreeEvidence(input, run) {
   );
 }
 
+function hasForkRunBinding(input, run, pullRequest) {
+  const evidence = input.mergeTreeEvidenceByRunId?.[String(run?.id)];
+  return hasIntermediateCandidateMergeTreeEvidence(input, run)
+    && evidence.pullNumber === pullRequest.number
+    && evidence.repositoryId === input.repositoryId
+    && evidence.headRepositoryId === pullRequest.head.repo.id
+    && evidence.runAttempt === run.run_attempt;
+}
+
+function hasForkCandidateTreeEvidence(input, run, pullRequest, baseSha, finalTreeSha) {
+  const tested = input.mergeTreeEvidenceByRunId?.[String(run?.id)];
+  const proof = input.forkMergeTreeEvidenceByRunId?.[String(run?.id)];
+  return hasForkRunBinding(input, run, pullRequest)
+    && tested.parents[0] === baseSha
+    && proof?.baseSha === baseSha && proof.mergeSha === input.mergeSha
+    && proof.candidateSha === run.head_sha && proof.testedMergeSha === tested.sha
+    && proof.testedTreeSha === tested.treeSha && proof.finalTreeSha === finalTreeSha;
+}
+
 export function evaluateTrustedPostMergeReuse(input) {
   if (input?.eventName !== "push" || input?.ref !== "refs/heads/devel") {
     return denied("not-a-devel-push");
@@ -370,13 +438,20 @@ export function evaluateTrustedPostMergeReuse(input) {
     && typeof pullRequest.merged_at === "string"
     && pullRequest.merge_commit_sha === input.mergeSha
     && pullRequest.base?.ref === "devel"
-    && pullRequest.head?.repo?.full_name === input.repository
+    && trustedPullRequestSource(pullRequest, input.repository, input.repositoryId)
     && validSha(pullRequest.head?.sha)
   ));
   if (pullRequests.length !== 1) {
-    return denied("merge-commit-must-map-to-one-merged-same-repository-pr");
+    return denied("merge-commit-must-map-to-one-trusted-merged-pr");
   }
   const pullRequest = pullRequests[0];
+  const isFork = pullRequest.head.repo.full_name !== input.repository;
+  if (isFork && parents.length !== 2) {
+    return denied("fork-reuse-requires-two-parent-merge");
+  }
+  if (isFork && !Array.isArray(input.fullLaneRunIds)) {
+    return denied("fork-worker-execution-evidence-unavailable");
+  }
   if (parents.length === 2 && !parents.includes(pullRequest.head.sha)) {
     return denied("merge-parent-does-not-match-pr-head");
   }
@@ -402,6 +477,8 @@ export function evaluateTrustedPostMergeReuse(input) {
     pullRequest,
     input.repository,
     pullRequest.head.sha,
+    input.repositoryId,
+    input.workflowFile,
   );
   const exactMergeTreeEvidence = hasExactMergeTreeEvidence(
     input,
@@ -410,6 +487,9 @@ export function evaluateTrustedPostMergeReuse(input) {
     parents,
     mergeTreeSha,
   );
+  if (isFork && (!exactMergeTreeEvidence || !hasForkRunBinding(input, finalHeadCandidate, pullRequest))) {
+    return denied("fork-pr-merge-tree-evidence-unavailable");
+  }
   if (
     headContainsBase
     && mergeTreeSha !== input.sourceCommit?.commit?.tree?.sha
@@ -492,6 +572,8 @@ export function evaluateTrustedPostMergeReuse(input) {
       pullRequest,
       input.repository,
       candidateSourceEntry.sha,
+      input.repositoryId,
+      input.workflowFile,
     );
     if (!candidate) {
       continue;
@@ -503,6 +585,10 @@ export function evaluateTrustedPostMergeReuse(input) {
     foundFullLaneCandidate = true;
     if (candidate.status !== "completed" || candidate.conclusion !== "success") {
       unsuccessfulCandidate = true;
+      continue;
+    }
+    if (isFork && !hasForkCandidateTreeEvidence(input, candidate, pullRequest, baseParent, mergeTreeSha)) {
+      missingIntermediateCandidateEvidence = true;
       continue;
     }
     if (candidateSource.bridgeSha && !hasReviewBridgeTreeEvidence(


### PR DESCRIPTION
## 요약

Refs #6901

검증된 fork PR을 직접 merge할 때 동일 저장소 head 제한 때문에 post-merge CI/CodeQL이 다시 Full lane을 실행하던 경로를 보완합니다. PR #6881의 `merge-commit-must-map-to-one-merged-same-repository-pr` 사례에서 출발했습니다.

- upstream Actions 실행 저장소 및 ID는 고정하고, PR의 fork 저장소 이름/ID, branch/head, workflow, run attempt를 검증합니다.
- fork의 빈 `workflow_run.pull_requests`를 무조건 실패로 처리하는 대신, PR 번호·base/head 저장소 ID·attempt를 결합한 새 merge-tree artifact를 요구합니다. fork 자체 Actions run이나 다른 PR의 증거는 허용하지 않습니다.
- 최종 PR merge의 parent/head/tree를 실제 merge와 대조합니다. 문서 trailing head 뒤의 코드 CI를 사용할 때는 trusted base의 Git 객체 비교로 동일 base와 문서-only tree 차이를 별도로 증명합니다.
- fork의 Adapter/Proptest도 실제 worker 실행 증거를 요구합니다. 증거 누락, base 이동, 잘못된 identity, 실패/취소/pending, enforcement 변경은 계속 Full lane입니다.
- 기존 same-repository 경로와 review bridge 검증을 유지하며, fork squash 재사용은 이번 범위에서 허용하지 않습니다.

## 신뢰 경계와 적용 순서

fork 코드나 수정된 verifier를 privileged 검증 경로에서 checkout/실행하지 않습니다. verifier는 머지 이전 devel 부모에서 읽고 immutable commit/tree만 비교합니다. 허용하는 trailing tree 차이는 기존 review bridge와 같은 제한된 mydocs 범위입니다.

이번 PR 자체는 CI enforcement 변경이므로 Full lane이 예상됩니다. devel에 반영한 다음 새 신원 artifact를 생성한 후속 fork PR로 실제 재사용을 검증해야 합니다. 과거 #6881에는 새 증거가 없으므로 이번 변경만으로 과거 run을 소급 재사용한다고 주장하지 않습니다.

기본 브랜치 main에서 실행되는 CI Impact Policy Controller와 실패 진단 reporter는 변경하지 않습니다. PR #6903 / #6899의 진단 보고 개선과는 별도 범위입니다.

## 검증

- `node --test scripts/tests/verify-trusted-postmerge*.test.mjs`: **120 PASS**.
- `python3 -m unittest discover -s scripts/tests -p 'test_*workflow*.py'`: **228 PASS**.
- 변경 workflow의 actionlint: **PASS**.
- verifier JS 구문 검사, `git diff --check`: **PASS**.
- 실제 임시 Git 저장소에서 문서 trailing tree 허용, source 변경/base 불일치 거부 검증 포함.
- 잘못된 저장소/PR/head/branch/workflow/attempt/artifact 및 실패/취소/pending 거부 계약 포함.
- 넓은 actionlint 실행은 변경하지 않은 `ci.yml:787`의 기존 ShellCheck SC2016 경고로 실패했습니다. 보정 전 HEAD의 동일 파일에서도 같은 경고를 재현했고 이 PR에 범위 밖 수정을 넣지 않았습니다. 전체 actionlint 무경고로 보고하지 않습니다.
- Rust/제품 코드 변경이 없어 Cargo/WASM/시각 검증은 실행하지 않았습니다. 임시 로그는 커밋하지 않습니다.

## 남은 확인

최신 PR head CI와 devel 반영 후 실제 후속 fork PR/devel의 재사용·duration refresh를 확인해야 합니다. 이 런타임 검증 전에는 #6901을 닫지 않습니다. 별도 PR review 및 오늘할일 기록은 CI 결과와 구분합니다.
