### PR TITLE
수정(studio): 문서 교체가 부른 리사이즈에는 스크롤 앵커를 걸지 않는다 (#6902)

### DIFF
--- a/rhwp-studio/src/view/canvas-view.ts
+++ b/rhwp-studio/src/view/canvas-view.ts
@@ -147,6 +147,16 @@ export class CanvasView {
   private documentLoadPrepared = false;
   private layoutViewportSize = { width: 0, height: 0 };
   private blankPagePlaceholder: HTMLElement | null = null;
+  /**
+   * [#6902] 문서 교체가 만든 리사이즈 한 번은 스크롤 앵커를 걸지 않는다.
+   *
+   * 쪽맞춤에서 빈 쪽 자리표시자는 한 쪽 크기라 스크롤바 없이 딱 맞는데, 문서가 실려
+   * 여러 쪽이 되면 세로 스크롤바가 생기며 컨테이너 폭이 줄고(1380→1365) ResizeObserver
+   * 가 뜬다. `onViewportResize` 의 중심 앵커는 **이전 문서/이전 기하** 기준이라 갓 연
+   * 문서에는 보존할 읽던 자리가 없는데도 `setScrollTop(7)` 을 걸고, 다음 프레임에
+   * 0 으로 되돌려져 한 프레임짜리 7px 왕복(=화면 흔들림)이 된다.
+   */
+  private suppressResizeScrollAnchor = false;
   private lastPageSize: { width: number; height: number } | null = null;
   private disposed = false;
 
@@ -182,6 +192,9 @@ export class CanvasView {
 
     this.unsubscribers.push(
       eventBus.on('viewport-scroll', () => {
+        // [#6902] 사용자가 한 번이라도 스크롤했으면 보존할 읽던 자리가 생긴다 —
+        // 문서 교체용 앵커 억제를 그때 거둔다(억제가 다음 리사이즈까지 남지 않게).
+        this.suppressResizeScrollAnchor = false;
         if (!this.viewportManager.isZoomAnimating()) this.updateVisiblePages('scroll');
       }),
       eventBus.on('viewport-resize', () => this.onViewportResize()),
@@ -273,6 +286,8 @@ export class CanvasView {
     );
 
     this.container.scrollTop = 0;
+    // [#6902] 이 대입 직후 스크롤바 출현이 리사이즈를 부른다 — 그 한 번은 앵커를 끈다.
+    this.suppressResizeScrollAnchor = true;
     this.lastPageSize = { width: this.pages[0].width, height: this.pages[0].height };
     this.updateVisiblePages('initial');
     this.clearBlankPagePlaceholder();
@@ -311,6 +326,7 @@ export class CanvasView {
     this.pageRenderer.beginDocument();
     this.activeRendererDecisionKey = null;
     this.reset();
+    this.suppressResizeScrollAnchor = true;
     this.showBlankPagePlaceholder();
   }
 
@@ -321,6 +337,8 @@ export class CanvasView {
   showBlankPage(): void {
     if (this.disposed) return;
     this.reset();
+    // [#6902] 자리표시자로 갈아타는 전이도 스크롤바 유무를 뒤집을 수 있다.
+    this.suppressResizeScrollAnchor = true;
     this.showBlankPagePlaceholder();
   }
 
@@ -1616,8 +1634,14 @@ export class CanvasView {
       return;
     }
 
+    // [#6902] 문서 교체가 부른 리사이즈에는 앵커를 걸지 않는다 — 보존할 읽던 자리가
+    // 없는데도 이전 기하 기준으로 스크롤을 옮겨 한 프레임 튄다.
+    const suppressAnchor = this.suppressResizeScrollAnchor;
+    this.suppressResizeScrollAnchor = false;
+
     const previousViewport = this.layoutViewportSize;
-    const canPreserveCenter = previousViewport.width > 0 && previousViewport.height > 0;
+    const canPreserveCenter =
+      !suppressAnchor && previousViewport.width > 0 && previousViewport.height > 0;
     const scrollLeft = this.viewportManager.getScrollX();
     const scrollTop = this.viewportManager.getScrollY();
     const focusPage = canPreserveCenter

--- a/rhwp-studio/tests/canvas-view-load-scroll-anchor.test.ts
+++ b/rhwp-studio/tests/canvas-view-load-scroll-anchor.test.ts
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [#6902] 쪽맞춤에서 문서를 열면 화면이 한 프레임 위아래로 튀었다.
+//
+// 빈 쪽 자리표시자는 한 쪽 크기라 쪽맞춤에서 세로 스크롤바 없이 딱 맞는데, 문서가 실려
+// 여러 쪽이 되면 스크롤바가 생기며 컨테이너 폭이 줄고(1380→1365) ResizeObserver 가 뜬다.
+// `onViewportResize` 의 중심 앵커는 **이전 문서/이전 기하** 기준이라 갓 연 문서에는 보존할
+// 읽던 자리가 없는데도 스크롤을 옮겼다.
+//
+//   dev 서버 · 쪽맞춤 · 1400×1000 실측 (rAF 표본)
+//     수정 전   firstTop {140, 147}   scrollTop {0, 7}   ← i=24 에서 7px 튀고 i=25 에 복귀
+//     수정 후   firstTop {147}        scrollTop {0}      ← 스크롤바 전이(scW 1380→1365)와
+//                                                          쪽맞춤 재계산(432→429)은 그대로
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+function section(text: string, startMarker: string, endMarker: string): string {
+  const start = text.indexOf(startMarker);
+  const end = text.indexOf(endMarker, start);
+  assert.ok(start >= 0 && end > start, `${startMarker} 범위를 찾을 수 있어야 한다`);
+  return text.slice(start, end);
+}
+
+test('문서를 실은 직후 리사이즈 앵커를 끈다', () => {
+  const view = source('src/view/canvas-view.ts');
+  const load = section(view, '  async loadDocument(): Promise<void> {', '\n  /** WASM 문서 교체');
+
+  const scrollTopIndex = load.indexOf('this.container.scrollTop = 0;');
+  const suppressIndex = load.indexOf('this.suppressResizeScrollAnchor = true;');
+  assert.ok(scrollTopIndex >= 0, '문서 로드는 맨 위로 맞춰야 한다');
+  assert.ok(
+    suppressIndex > scrollTopIndex,
+    '맨 위로 맞춘 뒤 그 값을 지킬 수 있도록 앵커를 꺼야 한다',
+  );
+});
+
+test('자리표시자로 갈아타는 두 진입점도 앵커를 끈다', () => {
+  const view = source('src/view/canvas-view.ts');
+  for (const [head, tail] of [
+    ['  prepareDocumentLoad(): void {', '\n  /**'],
+    ['  showBlankPage(): void {', '\n  /**'],
+  ] as const) {
+    const body = section(view, head, tail);
+    assert.match(
+      body,
+      /this\.suppressResizeScrollAnchor = true;/,
+      `${head.trim()} 도 앵커를 꺼야 한다 — 자리표시자 전이가 스크롤바 유무를 뒤집는다`,
+    );
+  }
+});
+
+test('리사이즈 앵커는 억제 플래그를 한 번 쓰고 스스로 거둔다', () => {
+  const view = source('src/view/canvas-view.ts');
+  const resize = section(view, '  private onViewportResize(): void {', '\n  /**');
+
+  assert.match(
+    resize,
+    /const suppressAnchor = this\.suppressResizeScrollAnchor;\s*\n\s*this\.suppressResizeScrollAnchor = false;/,
+    '읽은 뒤 곧바로 내려 다음 리사이즈까지 남지 않아야 한다',
+  );
+  assert.match(
+    resize,
+    /const canPreserveCenter =\s*\n?\s*!suppressAnchor &&/,
+    '억제 중에는 중심 앵커를 계산하지 않아야 한다',
+  );
+});
+
+test('사용자가 스크롤하면 억제를 거둔다', () => {
+  const view = source('src/view/canvas-view.ts');
+  const subscription = section(
+    view,
+    "eventBus.on('viewport-scroll', () => {",
+    '}),',
+  );
+
+  assert.match(
+    subscription,
+    /this\.suppressResizeScrollAnchor = false;/,
+    '한 번이라도 스크롤했으면 보존할 읽던 자리가 생기므로 앵커를 되살려야 한다',
+  );
+});


### PR DESCRIPTION
`#6902` 를 닫는다. `npm run dev` + **쪽 맞춤**에서 문서를 열 때 화면이 한 프레임 위아래로
튀는 현상이다.

## 프레임 단위 실측

dev 서버 · 쪽맞춤 · 1400×1000 · headful, `requestAnimationFrame` 마다 기하를 찍었다
(표본 511개, 문서 `156746143_(별첨1) 부총리 모두발언.hwp`).

```text
  i     firstTop  contentH     scW    scrollTop  zoom
  23    147       832.575px    1380   0          432   ← 빈 쪽 자리표시자
  24    140       1627.46px    1365   7          429   ← 튐
  25    147       1627.46px    1365   0          429   ← 되돌아옴
```

## 사슬

1. `loadBytes` 가 파싱 전에 빈 쪽 자리표시자를 놓는다(`showBlankPage`). 쪽맞춤이라 그
   높이 832.575px 가 컨테이너 838px 안에 들어가 **세로 스크롤바가 없다.**
2. 문서가 실려 여러 쪽이 되며 스크롤바가 생기고 컨테이너 폭이 **1380 → 1365** 로 준다.
3. `ResizeObserver` → `viewport-resize` → `onViewportResize()` 가 **이전 문서/이전 기하**
   기준 중심 앵커로 `setScrollTop(7)` 을 건다. 갓 연 문서에는 보존할 읽던 자리가 없다.
4. 다음 프레임에 0 으로 되돌려져 **7px 왕복만** 남는다.

눈금자는 무죄다 — 트랙이 고정 20px(`grid-template-rows: 20px minmax(0,1fr)`)이고 런타임
토글이 없다(인쇄에서만 `display:none`). `viewport-resize` 를 구독해 같은 프레임에 다시
그려질 뿐이라 "줄자를 그리면서 흔들린다"로 보였다.

## 수정

문서 교체가 부른 리사이즈 **한 번**만 세로 앵커를 끈다.

| 자리 | 하는 일 |
| --- | --- |
| `suppressResizeScrollAnchor` 필드 | 억제 플래그 |
| 문서 설치(`scrollTop = 0` 직후) · `prepareDocumentLoad` · `showBlankPage` | 켠다 |
| `onViewportResize` | 읽고 곧바로 내린다 — 다음 리사이즈까지 남지 않는다 |
| `viewport-scroll` 구독 | 사용자가 한 번이라도 스크롤하면 거둔다 |

가로 중앙 정렬과 그리드 재계산은 그대로 돈다 — 끄는 것은 세로 앵커 하나다.

## 검증

```text
  수정 전   firstTop {140, 147}   scrollTop {0, 7}
  수정 후   firstTop {147}        scrollTop {0}
```

스크롤바 전이(`scW` 1380→1365)와 쪽맞춤 재계산(432→429)은 **그대로 일어난다** — 원인만
제거했다. 문서 셋에서 모두 튐 0 이다.

```text
  156746143.hwp    firstTop [147]  scrollTop [0]  scW [1365, 1380]  OK
  156730935.hwpx   firstTop [147]  scrollTop [0]  scW [1380]        OK
  3067979.hwpx     firstTop [147]  scrollTop [0]  scW [1365, 1380]  OK
```

## 시험

`rhwp-studio/tests/canvas-view-load-scroll-anchor.test.ts` 4개 — 문서 설치 직후 억제 ·
자리표시자 두 진입점 · 한 번 쓰고 스스로 거둠 · 스크롤 시 해제. 기존
`canvas-view-blank-page-placeholder.test.ts` 와 같은 소스 구조 검증 방식이다.

`npm test`: 수정 전 1499개 중 **6 실패**(이 PR 의 새 시험 4 + 기존 2) → 수정 후 **2 실패**.
남은 둘은 이 변경과 무관한 기존 것이다(`chrome-mode` 의 CRLF 정규식, 원장 파서).
`tsc --noEmit` 오류 5건도 `wasm-bridge.ts` 의 스테일 `rhwp.d.ts` 탓으로 수정 전후 동일하다.

## 재현 절차

```
cd rhwp-studio && npm run dev          # http://127.0.0.1:7700/
# 쪽 맞춤(p) 후 .hwp 를 창에 드래그
# 계측은 puppeteer 로 #file-input 에 주입하고 rAF 마다 scrollTop·firstTop 을 찍는다
```

⚠ headless(오버레이 스크롤바)나 `dist` 정적 서버에서는 ②의 폭 전이가 안 생기거나
자리표시자가 뷰포트를 넘어 **재현되지 않는다.**
