### PR TITLE
Task #6806: 도형 리사이즈가 생성 시 크기(original_*)를 덮지 않게 한다

### DIFF
--- a/src/document_core/commands/object_ops/shape.rs
+++ b/src/document_core/commands/object_ops/shape.rs
@@ -408,37 +408,24 @@ impl DocumentCore {
             .map(super::clamp_degenerate_size);
         Self::apply_common_obj_attr_from_json(c, props_json);
 
-        // Polygon/Curve: original_width/height는 생성 시 값으로 유지해야 렌더러의
-        // 스케일 팩터(sx = current/original)가 올바르게 동작한다.
-        let is_polygon_or_curve = matches!(
-            shape,
-            crate::model::shape::ShapeObject::Polygon(_)
-                | crate::model::shape::ShapeObject::Curve(_)
-        );
-        let saved_orig_w = if is_polygon_or_curve {
-            shape.drawing().map(|d| d.shape_attr.original_width)
-        } else {
-            None
-        };
-        let saved_orig_h = if is_polygon_or_curve {
-            shape.drawing().map(|d| d.shape_attr.original_height)
-        } else {
-            None
-        };
-
         // ShapeComponentAttr 크기/회전/채우기 동기화
         if let Some(d) = shape.drawing_mut() {
-            // [#6806] 값이 실제로 바뀔 때만 `current_*`·`original_*` 를 따라가게 한다.
+            // [#6806] 값이 실제로 바뀔 때만 `current_*` 를 따라가게 한다.
             // 게터가 내보내는 `width` 는 `common.width` 라, 종전에는 같은 봉지를 되먹여도
-            // 한컴이 저장한 생성 시 크기(`original_*`)가 현재 크기로 덮였다. Line·Arc 는
-            // `original_*` 가 렌더 스케일 분모라 그 순간 선이 실제로 움직였다.
+            // 크기가 다시 대입됐다.
+            //
+            // `original_*` 는 **생성 시 크기**(HWP5 SHAPE_COMPONENT offset 20/24)이고
+            // 도형의 로컬 좌표계 크기다 — 렌더러는 끝점·꼭짓점을 `current/original` 로
+            // 스케일한다(`layout/shape_layout.rs` Line 1388·Arc 1684·Rectangle 1156,
+            // 글상자 글꼴 비 2691). 리사이즈는 상자만 바꾸고 로컬 좌표는 그대로 두므로
+            // 여기서 `original_*` 를 다시 쓰면 분모가 분자를 따라가 스케일이 1 로 무너진다.
+            // 묶음(아래)과 Polygon·Curve 는 이미 이 규칙을 지키고 있었고, 같은 렌더러
+            // 의존을 가진 Line·Arc·Rectangle 만 빠져 있었다.
             if let Some(w) = new_w.filter(|&w| w != width_before) {
                 d.shape_attr.current_width = w;
-                d.shape_attr.original_width = w;
             }
             if let Some(h) = new_h.filter(|&h| h != height_before) {
                 d.shape_attr.current_height = h;
-                d.shape_attr.original_height = h;
             }
 
             // 회전/기울임
@@ -614,16 +601,6 @@ impl DocumentCore {
         }
 
         let caption_changed = Self::apply_shape_caption_props(shape, props_json);
-
-        // Polygon/Curve: original_width/height 복원 (생성 시 값 유지 → 렌더러 스케일 팩터 정상화)
-        if let Some(d) = shape.drawing_mut() {
-            if let Some(w) = saved_orig_w {
-                d.shape_attr.original_width = w;
-            }
-            if let Some(h) = saved_orig_h {
-                d.shape_attr.original_height = h;
-            }
-        }
 
         // Group 리사이즈: original_width 유지, current_width만 변경 (렌더러가 스케일 적용)
         // 한컴 방식: 자식은 변경하지 않고, 컨테이너의 current/original 비율로 스케일 결정
@@ -808,34 +785,14 @@ impl DocumentCore {
             .map(super::clamp_degenerate_size);
         Self::apply_common_obj_attr_from_json(c, props_json);
 
-        let is_polygon_or_curve = matches!(
-            shape,
-            crate::model::shape::ShapeObject::Polygon(_)
-                | crate::model::shape::ShapeObject::Curve(_)
-        );
-        let saved_orig_w = if is_polygon_or_curve {
-            shape.drawing().map(|d| d.shape_attr.original_width)
-        } else {
-            None
-        };
-        let saved_orig_h = if is_polygon_or_curve {
-            shape.drawing().map(|d| d.shape_attr.original_height)
-        } else {
-            None
-        };
-
         if let Some(d) = shape.drawing_mut() {
-            // [#6806] 값이 실제로 바뀔 때만 `current_*`·`original_*` 를 따라가게 한다.
-            // 게터가 내보내는 `width` 는 `common.width` 라, 종전에는 같은 봉지를 되먹여도
-            // 한컴이 저장한 생성 시 크기(`original_*`)가 현재 크기로 덮였다. Line·Arc 는
-            // `original_*` 가 렌더 스케일 분모라 그 순간 선이 실제로 움직였다.
+            // [#6806] 본문 경로와 동형 — 값이 바뀔 때만 `current_*` 만 따라간다.
+            // `original_*`(생성 시 크기)는 렌더 스케일 분모라 리사이즈가 다시 쓰지 않는다.
             if let Some(w) = new_w.filter(|&w| w != width_before) {
                 d.shape_attr.current_width = w;
-                d.shape_attr.original_width = w;
             }
             if let Some(h) = new_h.filter(|&h| h != height_before) {
                 d.shape_attr.current_height = h;
-                d.shape_attr.original_height = h;
             }
             if let Some(v) = json_i32(props_json, "rotationAngle") {
                 d.shape_attr.rotation_angle = v as i16;
@@ -995,15 +952,6 @@ impl DocumentCore {
         }
 
         let caption_changed = Self::apply_shape_caption_props(shape, props_json);
-
-        if let Some(d) = shape.drawing_mut() {
-            if let Some(w) = saved_orig_w {
-                d.shape_attr.original_width = w;
-            }
-            if let Some(h) = saved_orig_h {
-                d.shape_attr.original_height = h;
-            }
-        }
 
         if let crate::model::shape::ShapeObject::Group(ref mut group) = shape {
             // [#6806] 본문 경로와 동형 — 값이 바뀔 때만.

--- a/tests/cases/issue_6806_shape_resize_original_scale.rs
+++ b/tests/cases/issue_6806_shape_resize_original_scale.rs
@@ -1,0 +1,134 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! [#6806 잔여] 도형 리사이즈가 `original_*`(생성 시 크기 = 렌더 스케일 분모)를 덮는다.
+//!
+//! 표본 `21_언어_기출_편집가능본.hwp` s0p4c0 — 한컴 저장 가로선 `common 31804×4`,
+//! `original 100×100`. 폭을 절반으로 줄이면 424.05px 선이 1.33px(=100 HWPUNIT)로 붕괴했다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+
+const LINE: &str = "samples/21_언어_기출_편집가능본.hwp";
+const LINE_AT: (usize, usize, usize) = (0, 4, 0);
+
+fn load() -> DocumentCore {
+    let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(LINE);
+    DocumentCore::from_bytes(&std::fs::read(p).expect("표본 로드")).expect("파싱")
+}
+
+/// `(common.w, common.h, original_w, original_h, current_w, current_h)`.
+fn geometry(core: &DocumentCore) -> (u32, u32, u32, u32, u32, u32) {
+    let (si, pi, ci) = LINE_AT;
+    let s = match &core.document().sections[si].paragraphs[pi].controls[ci] {
+        Control::Shape(s) => s.as_ref(),
+        _ => panic!("표본 전제 위반: s{si}p{pi}c{ci} 가 도형이 아니다"),
+    };
+    (
+        s.common().width,
+        s.common().height,
+        s.shape_attr().original_width,
+        s.shape_attr().original_height,
+        s.shape_attr().current_width,
+        s.shape_attr().current_height,
+    )
+}
+
+fn resize_to(core: &mut DocumentCore, w: u32, h: u32) {
+    let (si, pi, ci) = LINE_AT;
+    core.set_shape_properties_native(si, pi, ci, &format!("{{\"width\":{w},\"height\":{h}}}"))
+        .expect("set_shape_properties_native");
+}
+
+/// 0쪽 SVG 에서 그 가로선의 길이(px). 같은 y 대역의 가장 긴 `<line>` 을 고른다.
+fn line_length(core: &DocumentCore) -> f64 {
+    let svg = core.render_page_svg_native(0).expect("0쪽 svg");
+    let attr = |head: &str, name: &str| -> Option<f64> {
+        let key = format!("{name}=\"");
+        let s = head.find(&key)? + key.len();
+        let e = s + head[s..].find('"')?;
+        head[s..e].parse().ok()
+    };
+    svg.split("<line ")
+        .skip(1)
+        .filter_map(|chunk| {
+            let head = &chunk[..chunk.find('>')?];
+            let (x1, x2, y1) = (attr(head, "x1")?, attr(head, "x2")?, attr(head, "y1")?);
+            // 이 도형이 놓인 줄(y≈533)만 본다 — 같은 쪽의 다른 괘선과 섞이지 않게.
+            ((532.0..535.0).contains(&y1)).then_some((x2 - x1).abs())
+        })
+        .fold(0.0f64, f64::max)
+}
+
+fn assert_premise(core: &DocumentCore) -> (u32, u32) {
+    let (w, h, ow, oh, ..) = geometry(core);
+    assert!(h < 200, "표본 전제: 200 미만 높이의 가로선 (h={h})");
+    assert_eq!(
+        (ow, oh),
+        (100, 100),
+        "표본 전제: 한컴이 저장한 생성 시 크기가 100×100 이어야 스케일 판정이 선다"
+    );
+    assert_ne!(ow, w, "표본 전제: original({ow}) ≠ common({w})");
+    (w, h)
+}
+
+#[test]
+fn real_resize_scales_the_drawn_line_proportionally() {
+    let mut core = load();
+    let (w0, h0) = assert_premise(&core);
+    let before = line_length(&core);
+    assert!(
+        (before - 424.05).abs() < 1.0,
+        "표본 전제: 원래 선 길이 424.05px (실측 {before:.2})"
+    );
+
+    resize_to(&mut core, w0 / 2, h0);
+
+    let after = line_length(&core);
+    assert!(
+        (after - before / 2.0).abs() < 1.0,
+        "폭을 절반으로 줄였는데 그려진 선이 {after:.2}px 다 — 절반인 {:.2}px 이어야 한다. \
+         `original_*` 가 덮이면 스케일이 1 이 되어 100 HWPUNIT(=1.33px)로 붕괴한다",
+        before / 2.0
+    );
+    assert_eq!(
+        geometry(&core),
+        (w0 / 2, h0, 100, 100, w0 / 2, h0),
+        "`current_*` 만 새 크기를 따라가고 `original_*` 는 생성 시 값으로 남아야 한다"
+    );
+}
+
+#[test]
+fn real_resize_then_undo_restores_geometry_and_rendering() {
+    // studio 의 `ResizeObjectCommand.undo` 는 게터가 냈던 원래 크기를 다시 넣는다
+    // (`command.ts` `setProps` → `setShapeProperties`).
+    let mut core = load();
+    let (w0, h0) = assert_premise(&core);
+    let before_geometry = geometry(&core);
+    let before_svg = core.render_page_svg_native(0).expect("0쪽 svg");
+
+    resize_to(&mut core, w0 / 2, h0);
+    resize_to(&mut core, w0, h0);
+
+    assert_eq!(
+        geometry(&core),
+        before_geometry,
+        "리사이즈 되돌리기가 개체 기하를 원래대로 돌리지 못했다"
+    );
+    assert_eq!(
+        core.render_page_svg_native(0).expect("0쪽 svg"),
+        before_svg,
+        "리사이즈 되돌리기 뒤 0쪽 렌더링이 원래와 다르다"
+    );
+}
+
+#[test]
+fn resize_still_applies() {
+    // 대조 — 보존을 넣었다고 실제 리사이즈가 막히면 안 된다.
+    let mut core = load();
+    let (w0, h0) = assert_premise(&core);
+
+    resize_to(&mut core, w0 + 4000, h0 + 40);
+
+    let (w, h, ..) = geometry(&core);
+    assert_eq!((w, h), (w0 + 4000, h0 + 40), "실제 변경은 그대로 적용된다");
+}


### PR DESCRIPTION
관련 이슈: #6806

## 문제

직선·호·사각형의 크기를 바꾸면 **그 순간 도형이 무너진다.** 되돌리기도 원래 모습을 돌려주지 못한다.

`samples/21_언어_기출_편집가능본.hwp` s0p4c0(한컴 저장 가로선, `common 31804×4`·`original 100×100`)의 폭을 절반으로 줄이면 0쪽 SVG 의 그 선이 이렇게 된다.

| | 그려진 선 | 길이 |
|---|---|---:|
| 리사이즈 전 | `x1=117.17 … x2=541.23` | 424.05px |
| 리사이즈 후 (devel) | `x1=117.17 … x2=118.51` | **1.33px** |
| 기대 | `x1=117.17 … x2=329.20` | 212.03px |

1.33px 은 `original_width` 에 적힌 100 HWPUNIT 을 스케일 1 로 그린 값이다.

#6806/PR #6808 이 고친 것은 "같은 값을 되먹였을 때" 뿐이라, 값이 실제로 달라지는 리사이즈는 setter 를 그대로 통과해 이 층이 남아 있었다. `fe6d157c0` 의 변환 저널은 대상이 그림일 때만 잡으므로(`picture_transform_target` 이 그 밖을 거절, studio `PictureResizeJournal::capture` 도 `type === 'image'` 만 담음) 도형은 그 보호도 받지 못한다.

## 원인

`object_ops/shape.rs` 의 본문·셀 두 경로가 크기를 적용하며 `original_*` 까지 쓴다.

```rust
if let Some(w) = new_w.filter(|&w| w != width_before) {
    d.shape_attr.current_width = w;
    d.shape_attr.original_width = w;   // ← 생성 시 크기를 덮는다
}
```

`original_*` 는 **생성 시 크기**(HWP5 `SHAPE_COMPONENT` offset 20/24)이자 도형의 **로컬 좌표계 크기**이고, 렌더러는 끝점·꼭짓점을 `current/original` 로 스케일한다. 분모가 분자를 따라가면 스케일이 1 로 무너진다.

| `renderer/layout/shape_layout.rs` | 도형 | 종전 setter 보호 |
|---|---|---|
| 1156 · 1194 | Rectangle(회전 경로)·폴백 | **없음** |
| 1388 | Line | **없음** |
| 1684 | Arc | **없음** |
| 1786 · 1863 · 1967 | Polygon · Curve · Group | 있음 |
| 2691 | 글상자 글꼴 비 `current/original` | — |

저장소는 이미 이 규칙을 알고 있었다 — 같은 파일이 Polygon·Curve 를 저장·복원으로, 묶음을 `current_*` 만 갱신으로 지키고("original_width는 유지 (스케일 기준) / 한컴 방식"), 그림 setter(`picture.rs`)도 `original_*` 를 건드리지 않고 `current_*` 만 비례 조정한다. 같은 렌더러 의존을 가진 **Line·Arc·Rectangle 만 그 목록에서 빠져 있었다.**

## 변경

규칙을 예외 목록이 아니라 **경로 전체**에 건다 — 리사이즈는 `current_*` 만 갱신하고 `original_*` 는 두지 않는다.

```rust
if let Some(w) = new_w.filter(|&w| w != width_before) {
    d.shape_attr.current_width = w;
}
```

- 본문 경로·셀 경로 두 곳 동형.
- 그 결과 Polygon·Curve 전용 저장/복원 블록(`saved_orig_w`/`saved_orig_h`)이 죽은 코드가 되어 **두 곳 모두 제거**했다. 묶음의 `current_*` 만 갱신하는 기존 블록은 그대로다.
- `insert_shape` 의 생성 시 `original = current = width` 와, `scale_group_children` 이 자식 좌표를 실제로 재스케일하며 `original_*` 를 함께 올리는 것은 로컬 좌표계가 진짜로 바뀌는 연산이라 건드리지 않았다.

Rust 1파일, setter 판정만. 렌더러·직렬화기·studio 는 무변경.

회귀 테스트 `tests/cases/issue_6806_shape_resize_original_scale.rs` 3건 — 그려진 선이 상자에 비례하는지(424.05 → 212.03, 같은 시험이 `original_*` 보존도 한 줄로 단언), 되돌리기가 기하와 0쪽 SVG 를 원래대로 돌리는지, 그리고 대조로 실제 변경이 여전히 적용되는지. 퇴화값 0 클램프는 `issue_6806_getset_identity.rs` 의 `zero_size_still_clamps_to_min` 이 같은 표본으로 이미 지킨다.

## 검증

devel `5111c24c7` 기준.
![도형 리사이즈 전/후 비교](https://raw.githubusercontent.com/lpaiu-cs/rhwp/assets/shape-resize-original-scale/shape-resize-line.png)

위에서부터 원본 · devel · 이 PR 이다. 세 장 모두 같은 문서 0쪽을 `render_page_png_native`(native-skia) 로 그린 뒤 그 선 주변(x 105~575, y 518~548)만 잘랐다. devel 은 `src/document_core/commands/object_ops/shape.rs` 만 수정 전으로 되돌려 뽑았다.

픽셀 차이 상자(`ImageChops.difference(...).getbbox()`)가 같은 것을 수치로 말한다.

```
원본 vs devel  : (117, 532, 542, 534)   선 전체가 바뀜 — 사라졌다
원본 vs 이 PR  : (329, 532, 542, 534)   오른쪽 절반만 바뀜 — 절반으로 줄었다
devel vs 이 PR : (117, 532, 330, 534)
```


**수정 전 실패 증명** — 수정 전 devel 에서 🔴 **2건 실패 / 1건 통과**. 실패한 둘이 비례 렌더와 되돌리기이고, 통과한 하나는 "실제 변경은 여전히 적용" 대조다(수정 전에도 통과해야 맞다). 실패 출력은 이렇다.

```
폭을 절반으로 줄였는데 그려진 선이 1.33px 다 — 절반인 212.03px 이어야 한다
left:  (31804, 4, 31804, 100, 31804, 4)
right: (31804, 4,   100, 100, 31804, 4)
```

**수정 후** — 새 3건 통과. 전체 Rust 회귀 **9,304 통과 / 실패 0 / 건너뜀 49**, exit 0.

**게이트** — `cargo fmt --check` 통과, `clippy --locked --lib --tests -D warnings` 무경고, `rust-unit-test-tiers.mjs --check --base-ref origin/devel` 통과(cfg support items 28 무증가), `rust-test-suite-manifest.mjs --prepare` 반영.

## 범위 외

- **한컴 리사이즈 재저장 오라클은 돌리지 않았다.** 근거는 (a) 렌더러의 스케일 식, (b) 한컴 저장본이 담고 있는 `original ≠ current`(이 가로선 100×100 vs 31804×4, `exam_kor` 사각형 2925×975 vs 6518×1983 — `shape_layout.rs:2691` 주석의 실측), (c) 저장소가 이미 Polygon·Curve·묶음·그림에 같은 규칙을 적용한다는 세 가지 정합이다. 한컴에서 도형을 끌어 리사이즈한 뒤 재저장한 바이트는 재지 않았다.
- **`raw_rendering` 은 이 PR 이 다루지 않는다.** 실제로 변환이 바뀌면 지문(#6355·#6740)이 달라져 한컴 원본 행렬이 무효화되고, 되돌리기가 그것을 복원하지는 못한다. 그림은 `fe6d157c0` 의 변환 저널이 복원하지만 도형은 대상이 아니다. 도형에 같은 저널을 붙이는 것은 별도 축이다.
- **studio 배선 무변경** — 이 PR 은 엔진 setter 만 고친다. 세 리사이즈 입구(핸들 드래그·`Shift`+방향키·다중 선택)는 종전 `ResizeObjectCommand` 를 그대로 쓰고, 그 봉지가 이제 무해해진다.
