### PR TITLE
수정(renderer): 문단 기준 왼쪽 정렬 어울림 표에 outMargin.left 를 싣는다 (#6887)

### DIFF
--- a/mydocs/working/issue_6887_para_float_table_outmargin_left.md
+++ b/mydocs/working/issue_6887_para_float_table_outmargin_left.md
@@ -1,0 +1,108 @@
+---
+kind: working
+status: active
+issue: 6887
+---
+
+# 문단 기준 어울림 표가 outMargin.left 를 안 실어 그림이 왼쪽으로 치우친다 (#6887)
+
+작업 브랜치: `fix/6887-para-float-table-outmargin-left`
+대상: `src/renderer/layout.rs` · `src/renderer/float_placement.rs`
+
+## 한 줄
+
+`horzRelTo="PARA"` + `horzAlign="LEFT"` 인 **어울림(Square) 표**가 저장 `horzOffset` 을
+표 자신의 왼끝으로 읽어, 바깥 왼쪽 여백(`outMargin.left`)만큼 왼쪽으로 치우친다.
+그 결과 표 안 그림이 호스트 본문 글자 위로 올라와 겹친다.
+
+## 이슈가 요구한 것
+
+- 그림 x 를 정본과 맞춘다(모든 쪽 상수 −18.6px 해소).
+- 폭·본문 글줄은 이미 정본과 맞으므로 건드리지 않는다.
+- `#6378`·`#1133` 의 이중 가산 금지 계약을 깨지 않는다.
+
+## 원인 — 이슈가 지목한 자리가 아니었다
+
+이슈 본문은 `table_layout.rs` `compute_table_x_position` 의 `HorzRelTo::Para` 분기를
+지목했다. 그 자리에 `outMargin.left` 를 실어 빌드했더니 **좌표가 전혀 변하지 않았다**
+(Image x=431.7 그대로). 이 형상은 그 분기에 도달하지 않는다.
+
+실제 산출 지점은 `layout.rs` 의 `tbl_inline_x` 오버라이드다.
+
+```rust
+} else if !is_tac
+    && tbl_is_square
+    && matches!(t.common.horz_rel_to, HorzRelTo::Para)
+{
+    // [Issue #480 / #590]
+    let area_x = col_area.x + effective_margin;
+    …
+    _ => area_x,          // ← outMargin.left 가 없다
+};
+Some(x)
+```
+
+여기서 확정된 `x` 가 `inline_x_override` 로 `compute_table_x_position` 에 들어가고,
+비-TAC 경로에서 `h_offset` 만 더해져 끝난다 — `HorzRelTo::Para` 분기는 지나가지 않는다.
+
+```text
+  col.x 75.6 + effective_margin 0 + horzOffset 26319HU(350.9px) = 426.5   ← rhwp 실측 426.5
+  여기에 outMargin.left 1417HU(18.89px)                          = 445.4   ← 정본
+```
+
+**같은 파일 바로 위 TAC 분기**(`base_x = col_area.x + effective_margin + leading + om_l`)와
+**개체 경로**(`shape_layout::form_object_origin` 의 `ref_x + m_left + h_offset`)는 이미
+이 여백을 싣고 있다. 어울림 표 경로만 빠져 있었다.
+
+## 수정
+
+`float_placement.rs` 에 `#6378` 헬퍼와 같은 결로 게이트 헬퍼를 두고,
+`layout.rs` 의 왼쪽 정렬 갈래에서만 그 값을 싣는다.
+
+```rust
+pub(crate) fn para_relative_left_aligned_outer_margin_left_hu(table: &Table) -> Option<i32>
+// 비-TAC · horzRelTo=PARA · horzAlign=LEFT|INSIDE · outMargin.left > 0
+```
+
+오른쪽·가운데 정렬은 기준 폭(`area_w`) 산식이 달라 실측 근거가 나올 때까지 두었다.
+`#6378` 이 연 `HorzRelTo::Column` 형상과는 기준이 달라 겹치지 않는다.
+
+## 검증 실측
+
+문서: `156492236_220119_(보도참고자료)_규제샌드박스_시행_3주년(규제자유툭구단).hwpx`
+명령: `rhwp export-render-tree <문서> -p {4,6,8}`
+
+| 쪽 | before | 정본 | after | 잔차 |
+|---|---|---|---|---|
+| 5 | 431.7 | 450.3 | 450.6 | +0.3 |
+| 5 | 433.3 | 451.9 | 452.2 | +0.3 |
+| 7 | 462.4 | 481.0 | 481.3 | +0.3 |
+| 7 | 464.5 | 483.1 | 483.4 | +0.3 |
+| 9 | 470.3 | 488.9 | 489.2 | +0.3 |
+| 9 | 462.3 | 480.9 | 481.2 | +0.3 |
+
+잔차 +0.3px 는 이슈가 예고한 반올림(1417HU = 18.89px ↔ 관측 Δ 18.6px)이다.
+폭은 전후 동일하고, `LAYOUT_OVERFLOW` 진단도 전후 동일하다(p4 pi=59 24.8px,
+p8 pi=91 82.5px — 둘 다 이 축과 무관한 기존 값).
+
+시각 근거(5쪽 SVG 전후): 종전에는 그림이 호스트 본문 글자
+(「보완」「서비스는」「및」「가능」)를 덮었고, 수정 뒤 글자와 그림이 분리된다.
+
+## 게이트
+
+| 게이트 | 결과 |
+|---|---|
+| `cargo fmt --all -- --check` | OK (수정 없음) |
+| `cargo clippy --locked -- -D warnings` | OK |
+| `cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown -- -D warnings` | OK |
+| `cargo build --locked --workspace` | OK |
+| `cargo clippy --locked --workspace --all-targets -- -D warnings` | OK |
+| `node scripts/rust-test-suite-manifest.mjs --check` | 48/48 targets |
+| `cargo test --release --workspace` | **9421 passed / 0 failed / 49 ignored** (94 suites, `convert_verify_corpus_ratchet` 전 파티션 포함) |
+
+## 남긴 것
+
+- `horzAlign=Right/Center` 인 같은 형상은 손대지 않았다 — 기준 폭 산식이 달라
+  별도 실측이 필요하다.
+- `compute_table_x_position` 의 `HorzRelTo::Para` 분기(어울림이 아닌 문단 기준 float)도
+  같은 여백이 빠져 있을 수 있으나, 이 문서의 증거로는 닿지 않아 열지 않았다.

--- a/src/renderer/float_placement.rs
+++ b/src/renderer/float_placement.rs
@@ -778,6 +778,29 @@ pub(crate) fn native_empty_host_cellbreak_fragment_repeats_outer_margin(
         && !has_non_whitespace_text(para)
 }
 
+/// [#6887] 문단 기준 왼쪽 정렬 어울림 표가 원점에 싣는 바깥 왼쪽 여백 (HU).
+///
+/// 한글은 `horzRelTo="PARA"` + `horzAlign="LEFT"` 인 float 의 저장 `horzOffset` 을
+/// **바깥 여백 상자의 왼끝** 기준으로 읽는다 — 표 자신의 왼끝은 거기서
+/// `outMargin.left` 만큼 더 안쪽이다. 같은 좌표를 다루는 개체 경로
+/// (`shape_layout::form_object_origin`)는 이미 `ref_x + m_left + h_offset` 로
+/// 이 여백을 싣고 있고, 표 경로만 빠져 있었다 (156492236: 선언 outMargin.left
+/// 1417HU=18.89px 만큼 그림이 17쪽 전부에서 왼쪽으로 치우침).
+///
+/// `#6378` 이 연 `HorzRelTo::Column` 형상과 겹치지 않게 `Para` 기준으로만 열고,
+/// 오른쪽·가운데 정렬은 `ref_w` 산식이 달라 건드리지 않는다. 여백이 0 이면
+/// 더해질 값이 없어 no-op 다.
+pub(crate) fn para_relative_left_aligned_outer_margin_left_hu(table: &Table) -> Option<i32> {
+    if table.common.treat_as_char
+        || !matches!(table.common.horz_rel_to, HorzRelTo::Para)
+        || !matches!(table.common.horz_align, HorzAlign::Left | HorzAlign::Inside)
+        || table.outer_margin_left <= 0
+    {
+        return None;
+    }
+    Some(i32::from(table.outer_margin_left))
+}
+
 /// [#6378] 원본 HWPX 단 기준 RowBreak 자리차지 표의 사방 균등 outMargin (HU).
 ///
 /// `hwp5_stored_pagination_layout` 이 꺼진 원본 HWPX 는 native HWP5 빈-host

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -10,7 +10,8 @@ use super::float_placement::{
     empty_host_physical_ladder_extras_hu, empty_offset_float_deferred_text_ladder_hu,
     horizontal_range, is_para_topbottom_float, native_empty_host_physical_outer_box_paint_inset,
     native_empty_host_rowbreak_line_advance_hu,
-    original_hwpx_column_rowbreak_equal_outer_margin_hu, signed_hwpunit,
+    original_hwpx_column_rowbreak_equal_outer_margin_hu,
+    para_relative_left_aligned_outer_margin_left_hu, signed_hwpunit,
     stored_empty_anchor_band_host_line_advance_hu, stored_visible_anchor_band_host_line_advance_hu,
     FloatLaneSet, FloatPlacementContext,
 };
@@ -9533,13 +9534,22 @@ impl LayoutEngine {
                 let tbl_w = hwpunit_to_px(t.common.width as i32, self.dpi);
                 let area_x = col_area.x + effective_margin;
                 let area_w = (col_area.width - effective_margin - margin_right).max(0.0);
+                // [#6887] 왼쪽 정렬 어울림 표의 저장 `horzOffset` 은 **바깥 여백
+                // 상자**의 왼끝을 가리킨다 — 표 자신의 왼끝은 거기서
+                // `outMargin.left` 만큼 안쪽이다. 바로 위 TAC 분기(`base_x`)와
+                // 개체 경로(`shape_layout::form_object_origin`)는 이미 이 여백을
+                // 싣고 있고 어울림 표 경로만 빠져 있었다. 오른쪽·가운데 정렬은
+                // 기준 폭 산식이 달라(`area_w`) 실측 근거가 나올 때까지 둔다.
+                let om_l = para_relative_left_aligned_outer_margin_left_hu(t)
+                    .map(|hu| hwpunit_to_px(hu, self.dpi))
+                    .unwrap_or(0.0);
                 let x = match t.common.horz_align {
                     crate::model::shape::HorzAlign::Right
                     | crate::model::shape::HorzAlign::Outside => area_x + (area_w - tbl_w).max(0.0),
                     crate::model::shape::HorzAlign::Center => {
                         area_x + (area_w - tbl_w).max(0.0) / 2.0
                     }
-                    _ => area_x,
+                    _ => area_x + om_l,
                 };
                 Some(x)
             } else if is_tac {


### PR DESCRIPTION
## 변경 요약

`horzRelTo="PARA"` + `horzAlign="LEFT"` 인 **어울림(Square) 표**가 저장 `horzOffset` 을
표 자신의 왼끝으로 읽어, 바깥 왼쪽 여백(`outMargin.left`)만큼 왼쪽으로 치우쳤습니다.
`156492236` 은 17쪽 전부에서 상수 −18.6px 였고, 그 결과 표 안 그림이 호스트 본문
글자를 덮었습니다.

**이슈가 지목한 자리는 이 형상이 지나가지 않습니다.** 이슈 본문은
`table_layout.rs` `compute_table_x_position` 의 `HorzRelTo::Para` 분기를 지목했는데,
그 자리에 `outMargin.left` 를 실어 빌드해도 좌표가 불변이었습니다(Image x=431.7 그대로).
실제 산출 지점은 `layout.rs` 의 `tbl_inline_x` 오버라이드이고, 거기서 확정된 x 가
`inline_x_override` 로 들어가 `h_offset` 만 더해집니다.

```text
col.x 75.6 + effective_margin 0 + horzOffset 26319HU(350.9px) = 426.5   ← 종전 실측
+ outMargin.left 1417HU(18.89px)                             = 445.4   ← 정본
```

같은 파일 **바로 위 TAC 분기**(`base_x = col_area.x + effective_margin + leading + om_l`)와
**개체 경로**(`shape_layout::form_object_origin` 의 `ref_x + m_left + h_offset`)는 이미 이
여백을 싣고 있습니다 — 어울림 표 경로만 빠져 있었습니다.

게이트는 `float_placement.rs` 에 `#6378` 헬퍼와 같은 결로 두고
**비-TAC · PARA · LEFT|INSIDE · outMargin.left > 0** 으로 좁혔습니다. `#6378` 은
`HorzRelTo::Column` 기준이라 겹치지 않고, `#1133` 연속 block 표도 닿지 않습니다.
오른쪽·가운데 정렬은 기준 폭(`area_w`) 산식이 달라 실측 근거가 나올 때까지 두었습니다.

## 관련 이슈

closes #6887

## 테스트

- 변경 범위: Rust (renderer/layout)
- 검증한 commit SHA: `137edf196b5c62bda9bf01a2bd4b6ef3d57fef64`
- 실행 명령·결과:

```
node scripts/rust-test-suite-manifest.mjs --prepare
cargo fmt --all -- --check                                    # OK (수정 없음)
cargo clippy --locked --target-dir target/pr-review -- -D warnings                    # OK
cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown \
  --target-dir target/pr-review -- -D warnings                                        # OK
cargo build --locked --workspace --target-dir target/pr-review                        # OK
cargo clippy --locked --workspace --all-targets --target-dir target/pr-review -- -D warnings  # OK
node scripts/rust-test-suite-manifest.mjs --check             # 48/48 integration targets
cargo test --release --workspace                              # 9421 passed / 0 failed / 49 ignored
```

전체 회귀 94 suites 를 돌렸고 `convert_verify_corpus_ratchet` 전 파티션이 포함됩니다.
같은 문서를 쓰는 `tests/issue_4090_square_table_left_wrap.rs` 는 표 bbox 상대 판정이라
좌표 이동 후에도 통과합니다.

**시각 검증 실측** — `rhwp export-render-tree <문서> -p {4,6,8}` 의 그림 x:

| 쪽 | before | 정본 | after | 잔차 |
|---|---|---|---|---|
| 5 | 431.7 | 450.3 | 450.6 | +0.3 |
| 5 | 433.3 | 451.9 | 452.2 | +0.3 |
| 7 | 462.4 | 481.0 | 481.3 | +0.3 |
| 7 | 464.5 | 483.1 | 483.4 | +0.3 |
| 9 | 470.3 | 488.9 | 489.2 | +0.3 |
| 9 | 462.3 | 480.9 | 481.2 | +0.3 |

잔차 +0.3px 는 이슈가 예고한 반올림(1417HU = 18.89px ↔ 관측 Δ 18.6px)입니다.
폭은 전후 동일하고, `LAYOUT_OVERFLOW` 진단도 전후 동일합니다
(p4 pi=59 24.8px · p8 pi=91 82.5px — 둘 다 이 축과 무관한 기존 값).

- [x] [변경 범위별 필수 검증](https://github.com/edwardkim/rhwp/blob/devel/CONTRIBUTING.md#pr-전-체크리스트)을 수행하고, 제출 HEAD가 검증한 commit과 같음을 확인
- [x] Rust source·test/baseline helper·Rust 검증 입력 변경 시: 별도 worktree 준비 후 `cargo fmt --all -- --check`, native·WASM32·workspace all-target Clippy 통과
- [x] Rust 변경 시: 범위에 해당하는 focused·전체 integration 회귀 및 시각 검증 수행
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json` 을 포함하지 않음 (이 PR은 새 integration test 없음 — 파생 파일 미포함 확인)
- [x] `src/**`의 `#[cfg(test)]` 변경 없음 — 해당 없음
- [x] (에이전트 보조 작업 권장) 작업 증빙 첨부 — 문서 편집이 아닌 Rust source 변경이라 `replay --capsule` 영수증은 해당 없음. 대신 `render-diff --json` 봉투 원문과 17쪽 전수 render tree SHA-256 대조를 [아래 코멘트](https://github.com/edwardkim/rhwp/pull/6926#issuecomment-5594848573)에 첨부

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 — 좌표 산식에 상수 1개를 더하는 변경이고, 게이트 미충족 경로는 `om_l = 0.0` 으로 종전과 동일한 no-op 입니다.
- 재현·측정: 전체 회귀 스위트 수행 시간에 유의한 변화 없음.

## 스크린샷

5쪽 전후 비교(좌: 종전, 우: 수정 후). 종전에는 그림이 호스트 본문 글자
(「보완」「서비스는」「및」「가능」)를 덮었고, 수정 뒤 글자와 그림이 분리됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Atxwm3i6Nkqfar45X9TSzz