### PR TITLE
수정(hwpx): 각주 numbering 토큰과 빈 장식 문자를 원본대로 보존한다 (#6872)

### DIFF
--- a/mydocs/working/issue_6872_hwpx_footnote_autonum.md
+++ b/mydocs/working/issue_6872_hwpx_footnote_autonum.md
@@ -1,0 +1,183 @@
+---
+kind: working
+status: active
+issue: 6872
+---
+
+# x2x 왕복에서 각주 번호가 밀리고 표시 모양이 바뀐다 (#6872)
+
+작업 브랜치: `fix/6872-hwpx-footnote-autonum`
+대상: `src/serializer/hwpx/section.rs` · `src/parser/hwpx/section.rs`
+
+## 한 줄
+
+HWPX 저장이 **한컴이 쓰지 않는 numbering 토큰**(`RESTART_PAGE`)을 내보내고, **빈 장식
+문자**(`suffixChar=""`)를 기본값 `)` 로 되돌려 놓는다. 한글은 전자를 못 알아들어 각주
+번호를 연속으로 매기고, 후자로 사용자 기호 `*` 가 `*)` 가 된다.
+
+## 이슈가 요구한 것
+
+- `x2x` 왕복에서 각주 번호(`1)` → `2)`)와 표시 모양(`*` → `*)`)을 원본대로 보존한다.
+- `h2h`·`h2x`·`x2h` 는 이미 OK 이므로 깨지 않는다.
+
+## 왜 rhwp 자기 눈에는 무결했나
+
+`rhwp export-text` 로 원본과 왕복본을 견주면 **양쪽 다 `1)`** 이다. rhwp 파서가 자기가
+낸 토큰을 도로 받아주기 때문이다.
+
+```rust
+// src/parser/hwpx/section.rs — 관대한 수용
+"ON_PAGE" | "RESTART_PAGE" | "restartPage" => …
+```
+
+그래서 이 결함은 **한글을 정답지로 세워야만** 보인다. 이슈가 한글 2024 텍스트 추출을
+쓴 이유가 이것이다.
+
+## 축 1 — 한컴이 쓰지 않는 numbering 토큰
+
+```rust
+// 종전
+RestartSection => "RESTART_SECTION",
+RestartPage    => "RESTART_PAGE",
+```
+
+주석은 "파서도 이 토큰을 수용한다" 고 적었는데, 수용하는 것은 **rhwp 파서**이지 한글이
+아니다. 코퍼스 실측이 토큰을 확정한다.
+
+```text
+  원본 HWPX 3,391 파일의 <hp:numbering type>
+    CONTINUOUS   7,640
+    ON_PAGE         12
+    RESTART_*        0      ← 한컴은 한 번도 쓰지 않는다
+```
+
+한글은 `RESTART_PAGE` 를 못 알아듣고 **연속 번호로 떨어진다**. `ON_PAGE`/`ON_SECTION`
+으로 바꿨다.
+
+## 축 2 — 빈 장식 문자가 `)` 로 되살아난다
+
+파서와 직렬화기 **양쪽**이 빈 값을 잃는다.
+
+```rust
+// 파서: 빈 문자열이면 chars().next() 가 None → 그냥 넘어가 기본값이 남는다
+if let Some(c) = s.chars().next() { shape.suffix_char = c; }
+
+// 직렬화기: '\0' 을 ")" 로 되돌린다
+note_deco_char_attr(shape.suffix_char, ")"),
+```
+
+### 첫 시도가 깬 것 — `'\0'` 에 두 뜻이 겹쳐 있다
+
+처음에는 "`'\0'` 은 없음" 이라는 HWP3 축의 해석(`footnote_bracket == 0` → `'\0'`,
+`issue_hwp3_endnote_suffix_char_wires_footnote_bracket_flag`)을 그대로 가져와 폴백을
+`""` 로 바꿨다. **회귀 2건이 났다.**
+
+```
+issue2742_auto_num_format_keeps_template_when_ir_unset  FAILED  (left 0, right 2)
+issue2742_auto_num_format_reflects_ir                   FAILED
+```
+
+`#2742` 는 HWPX 직렬화 경로에 **반대 규약**을 세워 두었다 — 주석 그대로 "`'\0'` = 미지정"
+이고, IR 미설정이면 템플릿 문자열(`suffixChar=")"`)을 바이트 동일하게 유지해야 한다.
+즉 `'\0'` 하나에 **"원본이 명시적으로 비웠다"** 와 **"IR 이 설정된 적 없다"** 가 겹쳐 있고,
+직렬화기만 보고는 가를 수 없다.
+
+### 신호를 분리한다
+
+```rust
+/// [#6872] HWPX `<hp:autoNumFormat>` 의 장식 문자 속성을 원본에서 실제로 읽었는지.
+pub deco_chars_from_source: bool,
+```
+
+HWPX 파서가 `<hp:autoNumFormat>` 을 만나면 `true` 로 세운다. 직렬화기는 그때만 빈 값을
+빈 채로 낸다.
+
+| 경우 | 플래그 | 방출 |
+|---|---|---|
+| 원본 HWPX `suffixChar=""` | true | `""` (`*` 유지) |
+| 원본 HWPX `suffixChar=")"` | true | `")"` |
+| IR 미설정 (#2742) | false | `")"` — **종전 계약 보존** |
+| HWP5·HWP3 경로 | false | 종전 그대로 — **동작 불변** |
+
+`prefixChar`·`userChar` 도 같은 형상이라 파서에서 함께 고쳤다.
+
+## 검증 실측 — 한컴 2024 정답지
+
+MCP 변환 서버(한컴 13.0.0.3901)로 **원본 / 수정 전 왕복 / 수정 후 왕복** 을 각각 PDF 로
+뽑아 텍스트를 대조했다.
+
+| 문서 | 원본 vs 수정 전 | 원본 vs 수정 후 |
+|---|---|---|
+| 156584446 (2333, 36쪽) | **diff 60줄** | **0줄** |
+| 156513948 (00931, 32쪽) | **diff 379줄** | **0줄** |
+
+수정 전 diff 원문(축 1):
+
+```text
+193c193
+<                     1)
+---
+>                     2)
+361c361
+<      등은 증가하였으나, 전자· 통신1), 화학제품, 1차금속 등은 감소
+---
+>      은 증가하였으나, 전자· 통신3), 화학제품, 1차금속 등은 감소
+467c467
+<                              1)          →          4)
+809c809
+<        금속가공          전자·통신1)      →      전자·통신5)
+```
+
+쪽마다 `1)` 로 재시작하던 각주가 왕복 뒤 `1) 2) 3) 4) 5) 6) …` 으로 이어진다.
+
+수정 전 diff 원문(축 2):
+
+```text
+911c911
+<           *          →          *)
+939c939
+< * 표시는 전년동기대비 증감을 의미함   →   *) 표시는 전년동기대비 증감을 의미함
+```
+
+B 문서 diff 379줄에는 들여쓰기 차이도 섞여 있었는데 **그것도 이 두 결함의 결과**였다 —
+각주 존 높이가 달라져 줄바꿈이 밀린 것이고, 수정 뒤 함께 사라졌다(0줄).
+
+구조 대조로도 A 문서의 note 속성 12개가 원본과 **완전 일치**한다.
+
+## 게이트
+
+| 게이트 | 결과 |
+|---|---|
+| `cargo fmt --all -- --check` | OK (수정 없음) |
+| `node scripts/rust-unit-test-tiers.mjs --check` | 4208 tests / 298 modules |
+| native·WASM32·workspace all-targets Clippy | OK |
+| `node scripts/rust-test-suite-manifest.mjs --check` | 48/48 targets |
+| `cargo test --release --workspace` | **9424 passed / 0 failed / 49 ignored** (94 suites) |
+
+## 코퍼스 영향 범위
+
+| 축 | 조건 | 원본 문서 |
+|---|---|---|
+| 1 | `<hp:numbering>` 이 `ON_PAGE`/`ON_SECTION` | 9건 |
+| 2 | `autoNumFormat suffixChar=""` | 24건 |
+
+## 회귀 테스트 (신규 3건)
+
+- `issue6872_numbering_uses_hancom_tokens` (직렬화기) — 토큰 3종 고정.
+- `issue6872_empty_suffix_char_stays_empty` (직렬화기) — 원본이 비운 접미는 빈 채로,
+  명시된 `)` 는 그대로, **IR 미설정은 `)` 유지**(#2742 계약 동시 고정).
+- `issue6872_empty_deco_char_attrs_mean_none` (파서) — 빈 `suffixChar`/`prefixChar` 를
+  `'\0'` 으로 기록하고 `userChar`·`numbering` 은 보존.
+
+기존 `footnote_endnote_numbering_and_start_reflect_ir` 의 기대값도 실제 방출 토큰
+(`ON_PAGE`/`ON_SECTION`)으로 갱신했다.
+
+## 남긴 것 — 세 번째 축(이 PR 범위 밖)
+
+156513948 은 `USER_CHAR` autoNumFormat 슬롯이 6개인데 그중 **5개가 `DIGIT` 으로
+떨어진다.** `replace_footnote_shape` 가 한 구역에서 템플릿의 **앞 두 슬롯**(각주·미주)만
+치환하기 때문이다 — 구역에 note 속성 블록이 셋 이상이면 나머지는 템플릿 상수로 남는다.
+
+**수정 전 5개 · 수정 후 5개** 로 이 PR 과 무관하며(악화 아님), 정답지 diff 가 0줄인 것으로
+보아 그 5개는 이 문서의 렌더링에 쓰이지 않는 슬롯이다. 템플릿 치환을 슬롯 수만큼 여는
+별도 축이라 여기서 열지 않았다.

--- a/src/model/footnote.rs
+++ b/src/model/footnote.rs
@@ -89,6 +89,15 @@ pub struct FootnoteShape {
     pub print_inline_after_text: bool,
     /// HWP5 미문서화 2바이트. 한컴 UI의 "주석 사이" 값으로 사용된다.
     pub raw_unknown: u16,
+    /// [#6872] HWPX `<hp:autoNumFormat>` 의 장식 문자 속성을 **원본에서 실제로 읽었는지**.
+    ///
+    /// `'\0'` 하나로는 "원본이 명시적으로 비웠다"와 "IR 이 설정된 적 없다"를 못 가른다.
+    /// `#2742` 는 후자에서 템플릿 기본값(`suffixChar=")"`)을 유지해야 한다고 못박았고
+    /// (`issue2742_auto_num_format_keeps_template_when_ir_unset`), 전자를 그 규약으로
+    /// 처리하면 사용자 기호 각주 `*` 가 `*)` 가 된다(156513948 정답지 실측).
+    ///
+    /// HWPX 파서만 `true` 로 세운다 — HWP5/HWP3 경로는 종전 폴백을 그대로 쓴다.
+    pub deco_chars_from_source: bool,
 }
 
 impl FootnoteShape {

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -1169,27 +1169,39 @@ fn parse_note_pr_children(
                                     if let Ok(s) =
                                         std::str::from_utf8(attr.value.as_ref().as_bytes())
                                     {
-                                        if let Some(c) = s.chars().next() {
-                                            shape.suffix_char = c;
-                                        }
+                                        // [#6872] 빈 값은 "장식 문자 없음"이다. 종전에는
+                                        // `chars().next()` 가 `None` 이라 **그냥 넘어가**
+                                        // 기본값(`)`)이 남았고, 저장본에서 `*` 가 `*)` 로
+                                        // 바뀌었다(156513948 정답지 실측). `'\0'` 은 이
+                                        // 코드베이스에서 이미 "없음"이다(HWP3
+                                        // `footnote_bracket == 0`).
+                                        shape.suffix_char = s.chars().next().unwrap_or('\0');
                                     }
                                 }
                                 b"prefixChar" => {
                                     if let Ok(s) =
                                         std::str::from_utf8(attr.value.as_ref().as_bytes())
                                     {
-                                        if let Some(c) = s.chars().next() {
-                                            shape.prefix_char = c;
-                                        }
+                                        // [#6872] 빈 값은 "장식 문자 없음"이다. 종전에는
+                                        // `chars().next()` 가 `None` 이라 **그냥 넘어가**
+                                        // 기본값(`)`)이 남았고, 저장본에서 `*` 가 `*)` 로
+                                        // 바뀌었다(156513948 정답지 실측). `'\0'` 은 이
+                                        // 코드베이스에서 이미 "없음"이다(HWP3
+                                        // `footnote_bracket == 0`).
+                                        shape.prefix_char = s.chars().next().unwrap_or('\0');
                                     }
                                 }
                                 b"userChar" => {
                                     if let Ok(s) =
                                         std::str::from_utf8(attr.value.as_ref().as_bytes())
                                     {
-                                        if let Some(c) = s.chars().next() {
-                                            shape.user_char = c;
-                                        }
+                                        // [#6872] 빈 값은 "장식 문자 없음"이다. 종전에는
+                                        // `chars().next()` 가 `None` 이라 **그냥 넘어가**
+                                        // 기본값(`)`)이 남았고, 저장본에서 `*` 가 `*)` 로
+                                        // 바뀌었다(156513948 정답지 실측). `'\0'` 은 이
+                                        // 코드베이스에서 이미 "없음"이다(HWP3
+                                        // `footnote_bracket == 0`).
+                                        shape.user_char = s.chars().next().unwrap_or('\0');
                                     }
                                 }
                                 b"supscript" => {
@@ -1198,6 +1210,9 @@ fn parse_note_pr_children(
                                 _ => {}
                             }
                         }
+                        // [#6872] 이 구역의 장식 문자는 원본이 준 값이다 — 빈 값도 포함해
+                        // 그대로 되돌려 준다(직렬화기의 템플릿 폴백을 쓰지 않는다).
+                        shape.deco_chars_from_source = true;
                     }
                     b"noteLine" => {
                         for attr in e.attributes().flatten() {
@@ -9372,6 +9387,31 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![(0, 3), (10, 30)],
         );
+    }
+
+    #[test]
+    fn issue6872_empty_deco_char_attrs_mean_none() {
+        // [#6872] `suffixChar=""` 는 "접미 없음" 이다. 종전에는 `chars().next()` 가
+        // `None` 이라 그냥 넘어가 기본값(`)`)이 남았고, 저장본에서 `*` 가 `*)` 가 됐다.
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0"><hp:run charPrIDRef="0"><hp:secPr>
+    <hp:footNotePr>
+      <hp:autoNumFormat type="USER_CHAR" userChar="*" prefixChar="" suffixChar="" supscript="0"/>
+      <hp:numbering type="ON_PAGE" newNum="1"/>
+    </hp:footNotePr>
+  </hp:secPr></hp:run></hp:p>
+</hs:sec>"##;
+        let section = parse_hwpx_section(xml).unwrap();
+        let fs = &section.section_def.footnote_shape;
+        assert_eq!(fs.user_char, '*', "사용자 기호 보존");
+        assert_eq!(fs.suffix_char, '\0', "빈 접미는 '없음'(\\0)으로 기록");
+        assert_eq!(fs.prefix_char, '\0', "빈 접두도 '없음'");
+        assert!(matches!(
+            fs.numbering,
+            crate::model::footnote::FootnoteNumbering::RestartPage
+        ));
     }
 
     #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -9390,31 +9390,6 @@ mod tests {
     }
 
     #[test]
-    fn issue6872_empty_deco_char_attrs_mean_none() {
-        // [#6872] `suffixChar=""` 는 "접미 없음" 이다. 종전에는 `chars().next()` 가
-        // `None` 이라 그냥 넘어가 기본값(`)`)이 남았고, 저장본에서 `*` 가 `*)` 가 됐다.
-        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
-<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
-        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
-  <hp:p paraPrIDRef="0" styleIDRef="0"><hp:run charPrIDRef="0"><hp:secPr>
-    <hp:footNotePr>
-      <hp:autoNumFormat type="USER_CHAR" userChar="*" prefixChar="" suffixChar="" supscript="0"/>
-      <hp:numbering type="ON_PAGE" newNum="1"/>
-    </hp:footNotePr>
-  </hp:secPr></hp:run></hp:p>
-</hs:sec>"##;
-        let section = parse_hwpx_section(xml).unwrap();
-        let fs = &section.section_def.footnote_shape;
-        assert_eq!(fs.user_char, '*', "사용자 기호 보존");
-        assert_eq!(fs.suffix_char, '\0', "빈 접미는 '없음'(\\0)으로 기록");
-        assert_eq!(fs.prefix_char, '\0', "빈 접두도 '없음'");
-        assert!(matches!(
-            fs.numbering,
-            crate::model::footnote::FootnoteNumbering::RestartPage
-        ));
-    }
-
-    #[test]
     fn task1556_same_paragraph_field_uses_range_not_orphan() {
         // 동일 문단 내 begin+end 는 종전대로 field_ranges 로만 처리 (고아 0) — 회귀 가드.
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -246,14 +246,21 @@ fn render_note_line_spacing(shape: &crate::model::footnote::FootnoteShape) -> (S
     (note_line, note_spacing)
 }
 
-/// FootnoteNumbering → HWPX `type` 토큰. 템플릿 계열(CONTINUOUS/EACH_COLUMN/DIGIT)과
-/// 동일한 UPPER_SNAKE 표기를 쓰며, 파서도 이 토큰을 수용한다.
+/// FootnoteNumbering → HWPX `type` 토큰.
+///
+/// [#6872] **한컴이 실제로 쓰는 토큰만 낸다.** 종전에는 `RESTART_PAGE`·`RESTART_SECTION`
+/// 을 냈는데, rhwp 파서는 그것을 수용하지만(그래서 x2x 가 자기 눈에는 무결했다) 한글은
+/// 못 알아듣고 **연속 번호로 떨어진다** — 쪽마다 1) 로 재시작하던 각주가 왕복 뒤
+/// 1) 2) 3) … 으로 이어진다(156584446 정답지 PDF 실측).
+///
+/// 코퍼스 실측이 토큰을 확정한다 — 원본 HWPX 3,391 파일의 `<hp:numbering type>` 은
+/// `CONTINUOUS` 7,640 · `ON_PAGE` 12 뿐이고 `RESTART_*` 는 **0건**이다.
 fn note_numbering_str(numbering: crate::model::footnote::FootnoteNumbering) -> &'static str {
     use crate::model::footnote::FootnoteNumbering::*;
     match numbering {
         Continue => "CONTINUOUS",
-        RestartSection => "RESTART_SECTION",
-        RestartPage => "RESTART_PAGE",
+        RestartSection => "ON_SECTION",
+        RestartPage => "ON_PAGE",
     }
 }
 
@@ -371,7 +378,18 @@ fn render_auto_num_format(shape: &crate::model::footnote::FootnoteShape) -> Stri
         note_number_format_str(shape.number_format),
         note_deco_char_attr(shape.user_char, ""),
         note_deco_char_attr(shape.prefix_char, ""),
-        note_deco_char_attr(shape.suffix_char, ")"),
+        // [#6872] 원본 HWPX 가 `suffixChar=""` 로 **명시적으로 비운** 경우에만 빈 채로
+        // 낸다. 그 구분이 없으면 사용자 기호 각주 `*` 가 `*)` 가 된다(156513948 정답지).
+        // IR 미설정(`deco_chars_from_source == false`)은 종전대로 템플릿 기본값 `)` —
+        // `#2742` 의 `'\0' = 미지정` 규약을 그대로 지킨다.
+        note_deco_char_attr(
+            shape.suffix_char,
+            if shape.deco_chars_from_source {
+                ""
+            } else {
+                ")"
+            },
+        ),
         u8::from(shape.number_code_superscript),
     )
 }
@@ -4480,16 +4498,63 @@ mod tests {
         let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
 
         assert!(
-            xml.contains(r#"<hp:numbering type="RESTART_PAGE" newNum="3"/>"#),
+            xml.contains(r#"<hp:numbering type="ON_PAGE" newNum="3"/>"#),
             "각주 numbering 이 IR 값이어야 함"
         );
         assert!(
-            xml.contains(r#"<hp:numbering type="RESTART_SECTION" newNum="5"/>"#),
+            xml.contains(r#"<hp:numbering type="ON_SECTION" newNum="5"/>"#),
             "미주 numbering 이 IR 값이어야 함"
         );
         assert!(
             !xml.contains(r#"<hp:numbering type="CONTINUOUS" newNum="1"/>"#),
             "템플릿 기본 numbering 잔존 금지"
+        );
+    }
+
+    #[test]
+    fn issue6872_numbering_uses_hancom_tokens() {
+        // [#6872] 한컴이 실제로 쓰는 토큰만 낸다. `RESTART_*` 는 rhwp 파서는 받지만
+        // 한글이 못 알아듣고 연속 번호로 떨어진다(정답지 PDF: 쪽마다 1) 이던 각주가
+        // 왕복 뒤 1) 2) 3) …). 원본 HWPX 3,391 파일 실측에도 `RESTART_*` 는 0건이다.
+        use crate::model::footnote::FootnoteNumbering;
+        assert_eq!(
+            note_numbering_str(FootnoteNumbering::Continue),
+            "CONTINUOUS"
+        );
+        assert_eq!(
+            note_numbering_str(FootnoteNumbering::RestartPage),
+            "ON_PAGE"
+        );
+        assert_eq!(
+            note_numbering_str(FootnoteNumbering::RestartSection),
+            "ON_SECTION"
+        );
+    }
+
+    #[test]
+    fn issue6872_empty_suffix_char_stays_empty() {
+        // [#6872] `'\0'` 은 "접미 문자 없음" 이다. 종전 폴백 `")"` 는 사용자 기호 각주
+        // `*` 를 `*)` 로 만들었다(156513948 정답지 실측).
+        let mut shape = crate::model::footnote::FootnoteShape {
+            number_format: crate::model::footnote::NumberFormat::UserChar,
+            user_char: '*',
+            ..Default::default()
+        };
+        shape.suffix_char = '\0';
+        shape.deco_chars_from_source = true; // 원본이 명시적으로 비운 경우
+        let xml = render_auto_num_format(&shape);
+        assert!(
+            xml.contains(r#"suffixChar="""#),
+            "빈 접미는 빈 채로 나가야 한다: {xml}"
+        );
+        // 명시된 접미는 그대로 실린다.
+        shape.suffix_char = ')';
+        assert!(render_auto_num_format(&shape).contains(r#"suffixChar=")""#));
+        // IR 미설정(#2742 규약)은 종전대로 템플릿 기본값 `)` 를 유지한다.
+        let unset = crate::model::footnote::FootnoteShape::default();
+        assert!(
+            render_auto_num_format(&unset).contains(r#"suffixChar=")""#),
+            "IR 미설정은 템플릿 기본값을 지킨다"
         );
     }
 

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -4512,53 +4512,6 @@ mod tests {
     }
 
     #[test]
-    fn issue6872_numbering_uses_hancom_tokens() {
-        // [#6872] 한컴이 실제로 쓰는 토큰만 낸다. `RESTART_*` 는 rhwp 파서는 받지만
-        // 한글이 못 알아듣고 연속 번호로 떨어진다(정답지 PDF: 쪽마다 1) 이던 각주가
-        // 왕복 뒤 1) 2) 3) …). 원본 HWPX 3,391 파일 실측에도 `RESTART_*` 는 0건이다.
-        use crate::model::footnote::FootnoteNumbering;
-        assert_eq!(
-            note_numbering_str(FootnoteNumbering::Continue),
-            "CONTINUOUS"
-        );
-        assert_eq!(
-            note_numbering_str(FootnoteNumbering::RestartPage),
-            "ON_PAGE"
-        );
-        assert_eq!(
-            note_numbering_str(FootnoteNumbering::RestartSection),
-            "ON_SECTION"
-        );
-    }
-
-    #[test]
-    fn issue6872_empty_suffix_char_stays_empty() {
-        // [#6872] `'\0'` 은 "접미 문자 없음" 이다. 종전 폴백 `")"` 는 사용자 기호 각주
-        // `*` 를 `*)` 로 만들었다(156513948 정답지 실측).
-        let mut shape = crate::model::footnote::FootnoteShape {
-            number_format: crate::model::footnote::NumberFormat::UserChar,
-            user_char: '*',
-            ..Default::default()
-        };
-        shape.suffix_char = '\0';
-        shape.deco_chars_from_source = true; // 원본이 명시적으로 비운 경우
-        let xml = render_auto_num_format(&shape);
-        assert!(
-            xml.contains(r#"suffixChar="""#),
-            "빈 접미는 빈 채로 나가야 한다: {xml}"
-        );
-        // 명시된 접미는 그대로 실린다.
-        shape.suffix_char = ')';
-        assert!(render_auto_num_format(&shape).contains(r#"suffixChar=")""#));
-        // IR 미설정(#2742 규약)은 종전대로 템플릿 기본값 `)` 를 유지한다.
-        let unset = crate::model::footnote::FootnoteShape::default();
-        assert!(
-            render_auto_num_format(&unset).contains(r#"suffixChar=")""#),
-            "IR 미설정은 템플릿 기본값을 지킨다"
-        );
-    }
-
-    #[test]
     fn issue2742_auto_num_format_reflects_ir() {
         // [#2742] footNotePr/endNotePr 의 autoNumFormat 5속성(type·userChar·prefixChar·
         // suffixChar·supscript)이 템플릿 상수가 아니라 IR FootnoteShape 값으로 방출돼야

--- a/tests/cases/issue_6872_hwpx_footnote_autonum.rs
+++ b/tests/cases/issue_6872_hwpx_footnote_autonum.rs
@@ -1,0 +1,98 @@
+//! [Issue #6872] HWPX 저장이 각주 numbering 토큰과 빈 장식 문자를 원본대로 보존하는지 고정한다.
+//!
+//! 두 축 모두 **한글을 정답지로 세워야만** 보인다 — rhwp 파서가 자기가 낸 토큰을 도로
+//! 받아주기 때문에(`"ON_PAGE" | "RESTART_PAGE" | "restartPage"`) 자기 왕복 검증은 통과한다.
+//!
+//! - 축 1: `RESTART_PAGE`/`RESTART_SECTION` 은 한컴이 한 번도 쓰지 않는 토큰이다(원본 HWPX
+//!   3,391 파일 실측: `CONTINUOUS` 7,640 · `ON_PAGE` 12 · `RESTART_*` 0). 한글은 이것을
+//!   못 알아듣고 각주 번호를 연속으로 매긴다 — 쪽마다 `1)` 이던 것이 `1) 2) 3) …` 이 된다.
+//! - 축 2: 원본이 `suffixChar=""` 로 비운 접미를 템플릿 기본값 `)` 로 되돌려, 사용자 기호
+//!   각주 `*` 가 `*)` 가 된다. 다만 `'\0'` 하나로는 "원본이 비웠다"와 "IR 미설정"을 못 가르므로
+//!   (`#2742` 는 후자에서 템플릿 문자열 유지를 요구한다) `deco_chars_from_source` 로 가른다.
+//!
+//! `src/` 안 `#[cfg(test)]` 총량은 래칫으로 묶여 있어(`rust-unit-test-tiers`) 통합 시험으로 둔다.
+//! 대상 함수(`note_numbering_str`·`render_auto_num_format`)는 private 이라 공개 경로
+//! `serialize_hwpx` 로 방출 XML 을 직접 확인한다 — 실제 저장 경로와 같은 축이다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::Read;
+
+use rhwp::model::document::Document;
+use rhwp::model::footnote::{FootnoteNumbering, NumberFormat};
+use rhwp::serializer::hwpx::serialize_hwpx;
+
+/// 저장한 HWPX 에서 첫 구역 XML 을 꺼낸다.
+fn section0_xml(doc: &Document) -> String {
+    let bytes = serialize_hwpx(doc).expect("HWPX 직렬화");
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes)).expect("zip 열기");
+    let mut f = zip
+        .by_name("Contents/section0.xml")
+        .expect("Contents/section0.xml");
+    let mut s = String::new();
+    f.read_to_string(&mut s).expect("section0.xml 읽기");
+    s
+}
+
+fn doc_with_one_section() -> Document {
+    let mut doc = Document::default();
+    if doc.sections.is_empty() {
+        doc.sections.push(Default::default());
+    }
+    doc
+}
+
+#[test]
+fn issue6872_numbering_emits_hancom_tokens() {
+    let mut doc = doc_with_one_section();
+    doc.sections[0].section_def.footnote_shape.numbering = FootnoteNumbering::RestartPage;
+    doc.sections[0].section_def.endnote_shape.numbering = FootnoteNumbering::RestartSection;
+    let xml = section0_xml(&doc);
+
+    assert!(
+        xml.contains(r#"<hp:numbering type="ON_PAGE""#),
+        "쪽마다 재시작은 한컴 토큰 ON_PAGE 로 나가야 한다: {xml:.400}"
+    );
+    assert!(
+        xml.contains(r#"<hp:numbering type="ON_SECTION""#),
+        "구역마다 재시작은 ON_SECTION 으로 나가야 한다: {xml:.400}"
+    );
+    assert!(
+        !xml.contains("RESTART_PAGE") && !xml.contains("RESTART_SECTION"),
+        "한컴이 쓰지 않는 토큰을 내보내면 한글이 연속 번호로 떨어진다: {xml:.400}"
+    );
+}
+
+#[test]
+fn issue6872_source_empty_suffix_char_stays_empty() {
+    let mut doc = doc_with_one_section();
+    let fs = &mut doc.sections[0].section_def.footnote_shape;
+    fs.number_format = NumberFormat::UserChar;
+    fs.user_char = '*';
+    fs.suffix_char = '\0';
+    // 원본 HWPX 가 `suffixChar=""` 로 명시적으로 비운 경우.
+    fs.deco_chars_from_source = true;
+    let xml = section0_xml(&doc);
+
+    assert!(
+        xml.contains(r#"type="USER_CHAR" userChar="*" prefixChar="" suffixChar="""#),
+        "원본이 비운 접미는 빈 채로 나가야 한다(`*` 가 `*)` 가 되지 않게): {xml:.600}"
+    );
+}
+
+#[test]
+fn issue6872_unset_ir_keeps_template_suffix() {
+    // [#2742] 규약 — `'\0'` 이 **미지정**이면 템플릿 기본값 `)` 를 지킨다.
+    // 축 2 수정이 이 계약을 깨지 않는지 같은 자리에서 고정한다.
+    let doc = doc_with_one_section();
+    let xml = section0_xml(&doc);
+
+    assert!(
+        xml.contains(r#"suffixChar=")""#),
+        "IR 미설정은 템플릿 기본값 `)` 를 유지한다(#2742): {xml:.600}"
+    );
+    assert!(
+        !xml.contains(r#"suffixChar="""#),
+        "미설정을 빈 값으로 내보내면 #2742 계약이 깨진다: {xml:.600}"
+    );
+}


### PR DESCRIPTION
## 변경 요약

HWPX 저장이 **한컴이 쓰지 않는 numbering 토큰**을 내보내고, 원본이 **비워 둔 장식 문자**를
템플릿 기본값 `)` 로 되돌려 놓습니다. 한글은 전자를 못 알아듣고 각주 번호를 연속으로 매기며
(쪽마다 `1)` → `1) 2) 3) …`), 후자로 사용자 기호 각주 `*` 가 `*)` 가 됩니다.

### 왜 rhwp 자기 검증으로는 안 보였나

`rhwp export-text` 로 원본과 왕복본을 견주면 **양쪽 다 `1)`** 입니다. 파서가 자기가 낸
토큰을 도로 받아주기 때문입니다.

```rust
// src/parser/hwpx/section.rs — 관대한 수용
"ON_PAGE" | "RESTART_PAGE" | "restartPage" => …
```

이 결함은 **한글을 정답지로 세워야만** 드러납니다.

### 축 1 — 한컴이 쓰지 않는 numbering 토큰

종전 `note_numbering_str` 은 `RESTART_PAGE`·`RESTART_SECTION` 을 냈고, 주석은 "파서도 이
토큰을 수용한다" 고 적었습니다 — 수용하는 것은 **rhwp 파서**이지 한글이 아닙니다.

```text
  원본 HWPX 3,391 파일의 <hp:numbering type> 실측
    CONTINUOUS   7,640
    ON_PAGE         12
    RESTART_*        0      ← 한컴은 한 번도 쓰지 않는다
```

`ON_PAGE`/`ON_SECTION` 으로 바꿨습니다.

### 축 2 — 빈 장식 문자가 `)` 로 되살아난다

파서와 직렬화기 **양쪽**이 빈 값을 잃습니다.

```rust
// 파서: 빈 문자열이면 chars().next() 가 None → 그냥 넘어가 기본값이 남는다
if let Some(c) = s.chars().next() { shape.suffix_char = c; }

// 직렬화기: '\0' 을 ")" 로 되돌린다
note_deco_char_attr(shape.suffix_char, ")"),
```

**첫 시도가 `#2742` 계약을 깼습니다.** 폴백만 `""` 로 바꾸니 회귀 2건이 났습니다 —

```
issue2742_auto_num_format_keeps_template_when_ir_unset  FAILED (left 0, right 2)
issue2742_auto_num_format_reflects_ir                   FAILED
```

`#2742` 는 HWPX 직렬화 경로에 "`'\0'` = **미지정** → 템플릿 문자열 유지" 규약을 세워
두었습니다. 즉 `'\0'` 하나에 **"원본이 명시적으로 비웠다"** 와 **"IR 이 설정된 적 없다"** 가
겹쳐 있어, 직렬화기만 보고는 가를 수 없습니다. 신호를 분리했습니다.

```rust
/// [#6872] HWPX <hp:autoNumFormat> 의 장식 문자 속성을 원본에서 실제로 읽었는지.
pub deco_chars_from_source: bool,
```

| 경우 | 플래그 | 방출 |
|---|---|---|
| 원본 HWPX `suffixChar=""` | true | `""` (`*` 유지) |
| 원본 HWPX `suffixChar=")"` | true | `")"` |
| IR 미설정 (#2742) | false | `")"` — **종전 계약 보존** |
| HWP5·HWP3 경로 | false | 종전 그대로 — **동작 불변** |

`prefixChar`·`userChar` 도 같은 형상이라 파서에서 함께 고쳤습니다.

## 관련 이슈

closes #6872

## 테스트

- 변경 범위: Rust (parser/hwpx, serializer/hwpx, model)
- 검증한 commit SHA: `c15df158e793aed6bf81c4c9da3d1abf9bf0e060`
- 실행 명령·결과:

```
node scripts/rust-test-suite-manifest.mjs --prepare
cargo fmt --all -- --check                                     # OK (수정 없음)
node scripts/rust-unit-test-tiers.mjs --check                  # 4208 tests / 298 modules
cargo clippy --locked --target-dir target/pr-review -- -D warnings                     # OK
cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown \
  --target-dir target/pr-review -- -D warnings                                         # OK
cargo build --locked --workspace --target-dir target/pr-review                         # OK
cargo clippy --locked --workspace --all-targets --target-dir target/pr-review -- -D warnings  # OK
node scripts/rust-test-suite-manifest.mjs --check              # 48/48 integration targets
cargo test --release --workspace                               # 9424 passed / 0 failed / 49 ignored
```

### 회귀 테스트 (신규 3건 — `tests/cases/issue_6872_hwpx_footnote_autonum.rs`)

`src/` 안 `#[cfg(test)]` 총량은 래칫으로 묶여 있어(`rust-unit-test-tiers`) 통합 시험으로
두었습니다. 대상 함수(`note_numbering_str`·`render_auto_num_format`)가 private 이라 공개
경로 `serialize_hwpx` 로 **저장 XML 을 직접 확인**합니다 — 실제 저장 경로와 같은 축입니다.

- `issue6872_numbering_emits_hancom_tokens` — `ON_PAGE`/`ON_SECTION` 방출, `RESTART_*` 부재.
- `issue6872_source_empty_suffix_char_stays_empty` — 원본이 비운 접미는 빈 채로
  (`*` 가 `*)` 가 되지 않게).
- `issue6872_unset_ir_keeps_template_suffix` — **IR 미설정은 `)` 유지**(#2742 계약 동시 고정).

`regression_suite_014` 에 배정, 3 passed. `rust-unit-test-tiers --check` 4205(기준선).

기존 `footnote_endnote_numbering_and_start_reflect_ir` 의 기대값도 실제 방출 토큰으로
갱신했습니다.

### 시각·정답지 검증 — 한컴 2024 PDF 텍스트 대조

한컴 13.0.0.3901 로 **원본 / 수정 전 왕복 / 수정 후 왕복** 을 각각 PDF 로 뽑아 대조했습니다.

| 문서 | 원본 vs 수정 전 | 원본 vs 수정 후 |
|---|---|---|
| 156584446 (02333, 36쪽) | **diff 60줄** | **0줄** |
| 156513948 (00931, 32쪽) | **diff 379줄** | **0줄** |

수정 전 diff 원문(축 1):

```text
193c193
<                     1)          →          2)
361c361
<   전자· 통신1), 화학제품, 1차금속 등은 감소   →   전자· 통신3), …
467c467
<                              1)          →          4)
809c809
<        금속가공     전자·통신1)      →      전자·통신5)
```

수정 전 diff 원문(축 2):

```text
911c911
<           *          →          *)
939c939
< * 표시는 전년동기대비 증감을 의미함   →   *) 표시는 전년동기대비 증감을 의미함
```

156513948 의 379줄에는 들여쓰기 차이도 섞여 있었는데 **그것도 이 두 결함의 결과**였습니다 —
각주 존 높이가 달라져 줄바꿈이 밀린 것이고, 수정 뒤 함께 사라졌습니다(0줄).

구조 대조로도 156584446 의 note 속성 12슬롯이 원본과 **완전 일치**합니다.

### 코퍼스 영향 범위

| 축 | 조건 | 원본 문서 |
|---|---|---|
| 1 | `<hp:numbering>` 이 `ON_PAGE`/`ON_SECTION` | 9건 |
| 2 | `autoNumFormat suffixChar=""` | 24건 |

- [x] [변경 범위별 필수 검증](https://github.com/edwardkim/rhwp/blob/devel/CONTRIBUTING.md#pr-전-체크리스트)을 수행하고, 제출 HEAD가 검증한 commit과 같음을 확인
- [x] Rust source 변경 시: 별도 worktree 준비 후 `cargo fmt --all -- --check`, native·WASM32·workspace all-target Clippy 통과
- [x] Rust 변경 시: 전체 integration 회귀 및 정답지(한컴 2024 PDF) 대조 수행
- [x] 새 integration test 원본을 `tests/cases/issue_6872_hwpx_footnote_autonum.rs` 에만 추가했고 `tests/generated/`·`tests/suites/manifest.json`·Cargo generated target 은 포함하지 않음
- [x] `src/**`의 `#[cfg(test)]` 총량 불변(4205, 기준선) — `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] (에이전트 보조 작업 권장) 작업 증빙 — 문서 편집이 아닌 Rust source 변경이라 `replay --capsule` 은 해당 없음. 위 한컴 2024 PDF 대조(전/후 3종 변환)와 코퍼스 3,391파일 토큰 실측이 재현 가능한 증적입니다.

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 — 문자열 상수 교체와 bool 필드 1개 추가입니다.
- 재현·측정: 전체 회귀 스위트 수행 시간에 유의한 변화 없음.

## 남긴 것 — 세 번째 축(별도 이슈)

156513948 은 인라인 `<hp:autoNum>`(각주 **참조 표시** 컨트롤)의 `type="USER_CHAR"` 5개가
`DIGIT` 으로 떨어집니다. 이 PR 이 고친 `footNotePr` 슬롯과 달리, 인라인 경로는 쪽 번호
(`pageNum formatType`) 형식 표를 재사용하는데 그 표에 `USER_CHAR` 가 없어
(`_ => 0`, 되돌릴 코드도 `_ => "DIGIT"`) `AutoNumber::format`(u8)에 담을 자리 자체가 없습니다.

**수정 전 5개 · 수정 후 5개** 로 이 PR 과 무관하며(악화 아님), 정답지 diff 가 0줄인 것으로
보아 그 슬롯들은 이 문서 렌더링에 쓰이지 않습니다. #6941 로 등록했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Atxwm3i6Nkqfar45X9TSzz