### PR TITLE
ci: 문서 base 전진 재사용 및 post-merge CodeQL 통계 축소 (#6947)

### DIFF
--- a/.github/codeql/rust-postmerge.yml
+++ b/.github/codeql/rust-postmerge.yml
@@ -1,0 +1,14 @@
+# #6947: devel push keeps the full Rust source scope and default security suite.
+# Unlike rust-pr.yml, do not add paths or paths-ignore here.
+# Exclude only the three non-alert metrics already excluded for PRs by #6877.
+# Matching kind as well as ID retains a query if it becomes an alert query.
+query-filters:
+  - exclude:
+      id: rust/summary/summary-statistics
+      kind: metric
+  - exclude:
+      id: rust/summary/reduced-summary-statistics
+      kind: metric
+  - exclude:
+      id: rust/summary/query-sink-counts
+      kind: metric

--- a/.github/codeql/rust-pr.yml
+++ b/.github/codeql/rust-pr.yml
@@ -11,7 +11,8 @@ paths:
 # exclude-from-incremental 태그가 없으므로 정확한 ID로 제한한다.
 # metric 조건도 함께 적용하여 향후 경고 쿼리로 바뀌면 제외하지 않는다.
 # 보안 탐지와 추출 오류/경고, 파일 수/커버리지 진단은 그대로 유지한다.
-# devel push와 schedule의 full scan에는 이 설정을 적용하지 않는다.
+# devel push는 경로 축소가 없는 rust-postmerge.yml에서 같은 metric만 제외한다.
+# main push, schedule, workflow_dispatch에는 metric 제외를 적용하지 않는다.
 query-filters:
   - exclude:
       id: rust/summary/summary-statistics

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -814,10 +814,19 @@ jobs:
           build-mode: none
           config-file: .github/codeql/rust-pr.yml
 
-      # PR은 제품 Rust만 빠르게 검사하고, devel push·schedule은 아래 기존 전체
-      # 경로 분석을 유지한다. PR 축소가 기준선 보안 탐지를 대신하지 않게 한다.
+      # #6947: devel push도 전체 Rust 경로와 보안 쿼리를 유지하되,
+      # #6877에서 제외한 내부 metric 3개만 생략한다. PR의 paths는 가져오지 않는다.
+      - name: Initialize CodeQL (Rust post-merge)
+        if: ${{ matrix.language == 'rust' && contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) && github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
+        uses: github/codeql-action/init@v4
+        with:
+          languages: rust
+          build-mode: none
+          config-file: .github/codeql/rust-postmerge.yml
+
+      # main push, schedule, workflow_dispatch retain all paths and all queries.
       - name: Initialize CodeQL (Rust full scan)
-        if: ${{ matrix.language == 'rust' && contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) && github.event_name != 'pull_request' }}
+        if: ${{ matrix.language == 'rust' && contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) && github.event_name != 'pull_request' && !(github.event_name == 'push' && github.ref == 'refs/heads/devel') }}
         uses: github/codeql-action/init@v4
         with:
           languages: rust

--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -244,13 +244,14 @@ jobs:
             let selectTrustedPostMergeCandidate;
             let verifyPostMergeReviewBridgeTree;
             let verifyForkPostMergeTree;
+            let verifyReviewOnlyBaseAdvance;
             let trustedPullRequestSource;
             let trustedPullRequestWorkflowRun;
             const repositoryId = Number(process.env.GITHUB_REPOSITORY_ID);
             try {
               ({ classifyReviewOnlyCommit, evaluateTrustedPostMergeReuse, frontendOnlyCiRunIsReusable,
                 currentBaseReviewBridgeSource, selectTrustedPostMergeCandidate,
-                verifyPostMergeReviewBridgeTree, verifyForkPostMergeTree,
+                verifyPostMergeReviewBridgeTree, verifyForkPostMergeTree, verifyReviewOnlyBaseAdvance,
                 trustedPullRequestSource, trustedPullRequestWorkflowRun } = await import(pathToFileURL(path.join(
                 process.env.GITHUB_WORKSPACE,
                 'scripts/verify-trusted-postmerge-ci-reuse.mjs',
@@ -438,6 +439,46 @@ jobs:
               }
               // Only the trusted pre-merge classifier sees API metadata here;
               // no candidate code or candidate-provided lane marker is executed.
+              const reviewOnlyBaseAdvanceByRunId = {};
+              const testedFinalHead = mergeTreeEvidenceByRunId[String(finalHeadRun?.id)];
+              if (isFork && testedFinalHead && testedFinalHead.parents[0] !== baseParent
+                && typeof verifyReviewOnlyBaseAdvance === 'function'
+                && finalHeadRun?.status === 'completed' && finalHeadRun.conclusion === 'success') {
+                try {
+                  // Bound API/object inventory; prove ancestry and path/mode safety using raw Git.
+                  const testedBase = testedFinalHead.parents[0];
+                  const refs = new Set([mergeSha, testedFinalHead.sha, testedBase]);
+                  let cursor = baseParent;
+                  for (let count = 0; cursor !== testedBase && count < 64; count += 1) {
+                    if (!/^[0-9a-f]{40}$/.test(cursor || '')) throw new Error('invalid base identity');
+                    refs.add(cursor);
+                    const commit = (await github.rest.repos.getCommit({ owner, repo, ref: cursor })).data;
+                    if (commit.sha !== cursor || !Array.isArray(commit.parents)
+                      || commit.parents.length < 1 || commit.parents.length > 2) {
+                      throw new Error('incomplete base history');
+                    }
+                    cursor = commit.parents[0].sha;
+                  }
+                  if (cursor !== testedBase || ![...refs].every((sha) => /^[0-9a-f]{40}$/.test(sha))) {
+                    throw new Error('base history limit or identity mismatch');
+                  }
+                  execFileSync('git', ['fetch', '--no-tags', '--filter=blob:none', '--depth=1',
+                    '--no-write-fetch-head', 'origin', ...refs], {
+                    cwd: process.env.GITHUB_WORKSPACE, timeout: 120000, maxBuffer: 1024 * 1024,
+                    stdio: ['ignore', 'pipe', 'pipe'],
+                  });
+                  const proof = verifyReviewOnlyBaseAdvance(process.env.GITHUB_WORKSPACE, {
+                    baseSha: baseParent, mergeSha, candidateSha: pr.head.sha,
+                    testedMergeSha: testedFinalHead.sha,
+                  });
+                  if (proof.testedBaseSha !== testedBase || proof.testedTreeSha !== testedFinalHead.treeSha) {
+                    throw new Error('base advance artifact mismatch');
+                  }
+                  reviewOnlyBaseAdvanceByRunId[String(finalHeadRun.id)] = proof;
+                } catch (error) {
+                  core.warning(`Review-only base advance proof unavailable; running full. ${error.message}`);
+                }
+              }
               const frontendOnlyRunIds = [];
               if (
                 process.env.WORKFLOW_FILE === 'ci.yml'
@@ -627,6 +668,7 @@ jobs:
                 mergeTreeEvidenceByRunId,
                 reviewBridgeTreeEvidenceByRunId,
                 forkMergeTreeEvidenceByRunId,
+                reviewOnlyBaseAdvanceByRunId,
                 frontendOnlyRunIds,
               };
               if (requireFullLaneEvidence) {

--- a/mydocs/orders/20260909.md
+++ b/mydocs/orders/20260909.md
@@ -1,5 +1,13 @@
 # 2026년 9월 9일 오늘할일
 
+## #6947 문서 base 전진 재사용 및 CodeQL post-merge 개선
+
+- [x] #6933 CI 대기 중 문서 PR #6945의 base 전진으로 재사용이 거부된 원인을 확인하고 [이슈 #6947](https://github.com/edwardkim/rhwp/issues/6947)을 등록했다.
+- [x] 신뢰된 verifier에 제한된 Markdown base 전진 증명을 추가하고, devel push CodeQL의 내부 metric 3개만 제외했다. 전체 Rust 경로와 보안 쿼리, main·정기·수동 전체 스캔은 유지했다.
+- [x] JS 134개·Python workflow 233개, 변경 workflow actionlint 및 실제 #6933/#6945 Git 객체 증명을 통과했다. 제품 Cargo/WASM 검증과 실제 CodeQL 시간 측정은 수행하지 않았다.
+- [x] 코드 `93f309230`을 push해 [PR #6948](https://github.com/edwardkim/rhwp/pull/6948)을 생성했다. [자체 검토](../pr/archives/pr_6948_review.md)와 오늘할일은 같은 PR의 문서 trailing commit으로 포함한다.
+- [ ] 최신 trailing head CI, 병합 승인, 후속 fork의 실제 재사용·CodeQL 쿼리 선택 검증. duration artifact 등 #6901의 별도 잔여 요건은 완화하지 않았다.
+
 ## planet6897 #6914·#6918·#6934·#6937 통합 검토
 
 - [x] 원 PR 4개의 최신 head를 확인하고 출처 보존 체리픽 6개를 통합했다. #6914의 표 아래 간격 생략 조건은 메인터너 보정 `ae89a7b9d72dabce1a1a705b5fcd6d53d6baa953`으로 제한했다.
@@ -46,7 +54,7 @@
 - [x] 원 head `227c8a75270c8fb0586af6644ac19e6828eaf832`에서 집중 테스트 2개를 실행해 모두 통과했다. 이미지 순서·중복 방지·기존 평문·CLI 이미지 바이트를 확인했다. 전체 회귀는 사용자 지시에 따라 반복하지 않았다.
 - [x] [최종 리뷰](../pr/archives/pr_6933_review.md)의 판정은 승인이다. 메인터너 제품 코드 보정은 없으며, 별도 CodeQL check의 NEUTRAL은 JS/Python 비교 구성 누락으로 구분했다.
 - [x] 로컬 devel을 `74d0a68b74919761cc30343f7511dbc5d0fe32d3`까지 동기화했다. 원 contributor branch에는 devel 전체를 merge/rebase하지 않고 이 오늘할일과 review 문서만 trailing commit으로 추가한다.
-- [ ] trailing head의 최신 CI·required checks를 확인한 뒤 병합 및 첫 기여자 post_merge 절차를 진행한다. 원격 CI 성공·병합·후속 댓글 완료를 미리 기록하지 않는다.
+- [x] 최종 head `dfb208e8516da920d172872fbd16e9dd3771db26` CI 후 `b6d2d39f9fd9012012ac69e4c70d223241b8cd56`으로 병합했다. devel CI·CodeQL·Adapter·Proptest·Close Issues 성공 후 [첫 기여자 환영 및 검증 댓글](https://github.com/edwardkim/rhwp/pull/6933#issuecomment-5599720565)을 게시하고 API로 확인했다. 로컬 검토 브랜치는 정리했으며 contributor fork는 보존했다.
 ## #6916 제품과 선택적 Gym 의존 경계
 
 - [x] 승인된 Stage 1 조사·Stage 2 최소 분리 구현과 focused 계약 검증을 완료했다.

--- a/mydocs/pr/archives/pr_6948_review.md
+++ b/mydocs/pr/archives/pr_6948_review.md
@@ -1,0 +1,76 @@
+---
+kind: report
+status: active
+canonical: mydocs/pr/archives/pr_6948_review.md
+last_verified: 2026-09-09
+---
+
+# PR #6948 자체 검토
+
+## 판정: 승인
+
+로컬 검증 범위에서 수용 가능하다. 최신 PR head의 원격 CI와 병합 승인, 후속 fork PR의
+실제 재사용 및 CodeQL 시간 단축은 별도 조건이며 아직 완료하지 않았다.
+
+- PR: https://github.com/edwardkim/rhwp/pull/6948
+- Issue: [#6947](https://github.com/edwardkim/rhwp/issues/6947), 상위 잔여 추적 [#6901](https://github.com/edwardkim/rhwp/issues/6901)
+- 코드 후보: `93f309230`
+- 기준 devel: `b6d2d39f9fd9012012ac69e4c70d223241b8cd56`
+- 브랜치: `fix/fork-review-only-base-advance-20260909`
+- 경로: collaborator self-merge 후보. owner에게 자동 review를 요청하지 않는다.
+
+## 변경과 신뢰 경계
+
+최종 fork head가 그대로인 상태에서 base에 허용된 Markdown만 추가된 경우를 지원한다.
+신뢰된 pre-merge verifier가 immutable Git 객체의 최대 64개 first-parent 단계 및 최종
+병합 tree 차이를 확인한다. 단순히 API의 파일명이나 PR CI 성공만으로 허용하지 않는다.
+
+- 허용: `mydocs/` 아래 일반 Markdown 파일. rename은 삭제/추가로 양쪽 경로를 확인한다.
+- 거부: source/test/workflow/sample, JSON, symlink/executable, CI 소비 기술 규약 2개,
+  source 변경 후 되돌림, 이력/객체 누락, 한도 초과, 최종 코드 충돌 보정.
+- 유지: upstream/fork 저장소와 PR/head/workflow/attempt 신원, 최종 head 성공, 병합 이전 완료,
+  필수 worker 및 duration artifact 증거. privileged 경로에서 fork 코드를 실행하지 않는다.
+- 기존 같은 저장소 및 과거 trailing candidate의 base 계약은 완화하지 않는다.
+
+CodeQL은 devel push에서 내부 metric 3개만 제외한다. PR의 제품 경로 제한은 복사하지 않으며
+전체 Rust 분석 경로와 기본 보안 쿼리 및 추출 진단은 유지한다. main push, 정기 및 수동 스캔은
+기존 전체 분석을 유지한다. main CI Impact Policy Controller는 변경하지 않는다.
+
+## 완료한 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| JS verifier 및 실제 workflow 하네스 | 134 통과, 실패/skip 0 |
+| Python workflow 계약 | 233 통과 |
+| 변경 workflow 2개의 actionlint | 통과 |
+| 코드 변경 diff 공백 검사 | 통과 |
+| 실제 #6933/#6945 Git 객체의 base 전진 증명 | 통과 |
+
+실제 증명은 검사 base `74d0a68b74919761cc30343f7511dbc5d0fe32d3`, 최종 base
+`9a96eef92458112d5d7998f4b3390261c0e3c811`, tested merge
+`d1bcfa7e833e565cf267507a2ed6dd80c45d5e71`, 최종 merge
+`b6d2d39f9fd9012012ac69e4c70d223241b8cd56`에 적용했다.
+
+새 테스트는 문서 이동/shallow 객체 허용과 비허용 경로, mode, source 되돌림, 이력 한도,
+다른 head, 위조 proof/attempt, 실패/pending 및 worker 증거 누락 거부를 확인했다.
+CodeQL은 event/ref/language/선택 여부별 초기화의 상호 배타성과 필터 3개, 경로 및 기본
+보안 쿼리 override 부재를 검사했다. 실제 CodeQL CLI의 query resolution과 단축 시간은
+측정하지 않았다. Rust/제품 변경이 없어 Cargo/WASM/시각 검증은 수행하지 않았다.
+
+## 잔여와 적용 조건
+
+이 PR은 CI enforcement 변경이므로 자체 CI는 full 검증이 예상된다. 변경된 verifier는
+이 PR 자체의 검증을 생략하는 근거로 사용하지 않는다. 원격 적용 후 후속 fork PR에서
+실제 재사용 사유 및 CodeQL 선택 쿼리를 확인해야 한다.
+
+#6933의 PR CI에는 duration artifact가 없었다. 따라서 base 전진 증명을 통과하더라도
+CI 전체 재사용은 별도 duration 요건 때문에 거부될 수 있다. 이를 허위 성공으로 처리하지 않으며
+duration publisher 및 Adapter/Proptest 등 #6901 잔여 전체를 해결했다고 주장하지 않는다.
+
+## 병합 후 이슈 코멘트 계획
+
+최신 head 및 병합 SHA의 실제 CI 결과를 확인한 뒤, #6947에 merge SHA, 실제 CI URL,
+이 리뷰의 merge-SHA 고정 링크와 적용 범위를 UTF-8 body-file로 기록한다. 기존 동일 merge
+댓글이 있으면 수정하고 중복 게시하지 않으며 API로 본문을 확인한다. 시각 변경이 아니므로
+존재하지 않는 PNG/PDF를 게시하지 않는다. 실제 후속 fork 검증이 남으면 미완료로 명시하고,
+#6901의 잔여를 임의로 닫지 않는다. 로컬/원격 변경 정리는 사용자 승인 및 post_merge 절차를 따른다.

--- a/scripts/tests/test_codeql_workflow.py
+++ b/scripts/tests/test_codeql_workflow.py
@@ -193,7 +193,7 @@ class CodeQLWorkflowTests(unittest.TestCase):
         self.assertIn(
             "if: ${{ matrix.language == 'rust' && "
             + selected
-            + " && github.event_name != 'pull_request' }}",
+            + " && github.event_name != 'pull_request' && !(github.event_name == 'push' && github.ref == 'refs/heads/devel') }}",
             analyze,
         )
         job_if = next(
@@ -284,6 +284,43 @@ class CodeQLWorkflowTests(unittest.TestCase):
         self.assertIn("paths:\n", config)
         for path in ("src/**", "crates/**", "rhwp-desk/src/**", "build.rs"):
             self.assertIn(f"  - {path}\n", config)
+
+    def test_postmerge_metrics_keep_full_source_scope_and_security_defaults(self) -> None:
+        config = (REPO_ROOT / ".github/codeql/rust-postmerge.yml").read_text(encoding="utf-8")
+        active = "\n".join(line for line in config.splitlines() if not line.lstrip().startswith("#"))
+        self.assertNotRegex(active, r"(?m)^\s*(paths|paths-ignore|queries|packs|disable-default-queries):")
+        self.assertEqual(re.findall(r"id: (\S+)", active), [
+            "rust/summary/summary-statistics",
+            "rust/summary/reduced-summary-statistics",
+            "rust/summary/query-sink-counts",
+        ])
+        self.assertEqual(active.count("kind: metric"), 3)
+        self.assertEqual(active.count("- exclude:"), 3)
+
+    def test_rust_initializers_are_exclusive_for_every_event_and_language(self) -> None:
+        analyze = job_body(self.workflow, "analyze")
+        blocks = re.findall(r"(?ms)^      - name: Initialize CodeQL \(Rust[^\n]*\n.*?(?=^      - name:|\Z)", analyze)
+        self.assertEqual(len(blocks), 3)
+        conditions = [re.search(r"if: \$\{\{ (.*?) \}\}", block).group(1) for block in blocks]
+        selection = "contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language))"
+        for event in ("pull_request", "push", "schedule", "workflow_dispatch"):
+            for ref in ("refs/heads/devel", "refs/heads/main"):
+                for language in ("rust", "python"):
+                    for selected in (True, False):
+                        values = []
+                        for condition in conditions:
+                            expression = condition.replace(selection, str(selected))
+                            expression = expression.replace("matrix.language", repr(language))
+                            expression = expression.replace("github.event_name", repr(event))
+                            expression = expression.replace("github.ref", repr(ref))
+                            expression = expression.replace("&&", " and ").replace("||", " or ")
+                            expression = re.sub(r"!(?!=)", "not ", expression)
+                            values.append(eval(expression, {"__builtins__": {}}, {}))
+                        expected = (0 if event == "pull_request" else
+                                    1 if event == "push" and ref == "refs/heads/devel" else 2)
+                        self.assertEqual(values, [language == "rust" and selected and i == expected for i in range(3)])
+        self.assertIn("config-file: .github/codeql/rust-postmerge.yml", blocks[1])
+        self.assertNotIn("config-file:", blocks[2])
 
     def test_temporary_measurement_jobs_and_artifacts_are_absent(self) -> None:
         workflow = self.workflow

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -22,6 +22,22 @@ WORKFLOWS = {
 
 
 class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
+    def test_base_advance_uses_bounded_trusted_object_proof_for_final_head(self) -> None:
+        workflow = REUSABLE.read_text(encoding="utf-8")
+        block = workflow.split("const reviewOnlyBaseAdvanceByRunId = {};", 1)[1].split("const frontendOnlyRunIds", 1)[0]
+        for guard in (
+            "isFork && testedFinalHead", "count < 64", "cursor !== testedBase",
+            "commit.sha !== cursor", "typeof verifyReviewOnlyBaseAdvance === 'function'",
+            "finalHeadRun?.status === 'completed'", "finalHeadRun.conclusion === 'success'",
+            "verifyReviewOnlyBaseAdvance(process.env.GITHUB_WORKSPACE",
+            "candidateSha: pr.head.sha", "proof.testedTreeSha !== testedFinalHead.treeSha",
+            "reviewOnlyBaseAdvanceByRunId[String(finalHeadRun.id)] = proof",
+        ):
+            self.assertIn(guard, block)
+        self.assertNotIn("checkout", block)
+        self.assertIn("reviewOnlyBaseAdvanceByRunId,", workflow)
+        self.assertIn("candidate-duration-artifacts-unavailable", workflow)
+
     def test_fork_artifact_binds_upstream_pr_head_repository_and_attempt(self) -> None:
         workflow = REUSABLE.read_text(encoding="utf-8")
         capture = workflow.split("- name: Capture PR merge-tree evidence", 1)[1].split(

--- a/scripts/tests/verify-trusted-postmerge-base-advance.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-base-advance.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { evaluateTrustedPostMergeReuse, verifyReviewOnlyBaseAdvance } from "../verify-trusted-postmerge-ci-reuse.mjs";
+
+function fixture(t, advances = [{ "mydocs/pr/new.md": "review" }], finalChanges = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "rhwp-base-advance-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const git = (args, input) => execFileSync("git", ["-C", dir, ...args], {
+    encoding: "utf8", input, stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, GIT_AUTHOR_NAME: "Fixture", GIT_AUTHOR_EMAIL: "fixture@example.invalid",
+      GIT_COMMITTER_NAME: "Fixture", GIT_COMMITTER_EMAIL: "fixture@example.invalid" },
+  }).trim();
+  git(["init", "--quiet"]);
+  const tree = (parent, changes) => {
+    git(parent ? ["read-tree", `${parent}^{tree}`] : ["read-tree", "--empty"]);
+    for (const [path, value] of Object.entries(changes)) {
+      if (value === null) git(["update-index", "--force-remove", "--", path]);
+      else {
+        const blob = git(["hash-object", "-w", "--stdin"], typeof value === "string" ? value : value.text);
+        git(["update-index", "--add", "--cacheinfo", `${value.mode || "100644"},${blob},${path}`]);
+      }
+    }
+    return git(["write-tree"]);
+  };
+  const commit = (sha, parents) => git(["commit-tree", sha, ...parents.flatMap(p => ["-p", p]), "-m", "fixture"]);
+  const old = commit(tree(null, { "src/lib.rs": "before", "mydocs/pr/old.md": "old" }), []);
+  const headTree = tree(old, { "src/lib.rs": "after" });
+  const head = commit(headTree, [old]);
+  const tested = commit(headTree, [old, head]);
+  let base = old;
+  for (const changes of advances) base = commit(tree(base, changes), [base]);
+  const finalTree = tree(base, { "src/lib.rs": "after", ...finalChanges });
+  const merge = commit(finalTree, [base, head]);
+  const identity = { baseSha: base, mergeSha: merge, candidateSha: head, testedMergeSha: tested };
+  return { dir, git, tree, commit, old, head, headTree, tested, base, merge, finalTree, identity };
+}
+
+test("문서 base 전진과 문서 rename은 shallow raw 객체에서도 허용한다", t => {
+  const f = fixture(t, [{ "mydocs/pr/old.md": null, "mydocs/pr/archive.md": "old" }]);
+  const proof = verifyReviewOnlyBaseAdvance(f.dir, f.identity);
+  assert.equal(proof.testedBaseSha, f.old);
+  assert.equal(proof.finalTreeSha, f.finalTree);
+  const shallow = mkdtempSync(join(tmpdir(), "rhwp-base-shallow-"));
+  t.after(() => rmSync(shallow, { recursive: true, force: true }));
+  execFileSync("git", ["-C", shallow, "init", "--quiet"]);
+  execFileSync("git", ["-C", shallow, "fetch", "--quiet", "--depth=1", f.dir,
+    f.merge, f.tested, f.base, f.old]);
+  assert.deepEqual(verifyReviewOnlyBaseAdvance(shallow, f.identity), proof);
+});
+
+for (const path of ["src/lib.rs", ".github/workflows/ci.yml", "tests/case.rs", "samples/sample.hwp",
+  "mydocs/state.json", "mydocs/tech/text-ir-v2.md", "mydocs/tech/canvaskit-parity-implementation.md"]) {
+  test(`base의 비허용 변경은 거부한다: ${path}`, t => {
+    const f = fixture(t, [{ [path]: "changed" }]);
+    assert.throws(() => verifyReviewOnlyBaseAdvance(f.dir, f.identity), /non-review-change/);
+  });
+}
+
+test("source 변경을 되돌려 최종 diff에서 숨겨도 거부한다", t => {
+  const f = fixture(t, [{ "src/lib.rs": "unsafe" }, { "src/lib.rs": "before" }]);
+  assert.throws(() => verifyReviewOnlyBaseAdvance(f.dir, f.identity), /non-review-change/);
+});
+
+test("rename의 원래 비문서 경로와 Markdown symlink 및 executable을 거부한다", t => {
+  for (const changes of [
+    { "src/lib.rs": null, "mydocs/source.md": "before" },
+    { "mydocs/link.md": { mode: "120000", text: "../../src/lib.rs" } },
+    { "mydocs/executable.md": { mode: "100755", text: "script" } },
+  ]) {
+    const f = fixture(t, [changes]);
+    assert.throws(() => verifyReviewOnlyBaseAdvance(f.dir, f.identity), /non-review-change/);
+  }
+});
+
+test("base는 문서뿐이어도 최종 병합의 코드 충돌 보정은 거부한다", t => {
+  const f = fixture(t, undefined, { "src/lib.rs": "unreviewed resolution" });
+  assert.throws(() => verifyReviewOnlyBaseAdvance(f.dir, f.identity), /non-review-change/);
+});
+
+test("다른 head와 누락 객체 및 전진하지 않은 base를 거부한다", t => {
+  const f = fixture(t);
+  assert.throws(() => verifyReviewOnlyBaseAdvance(f.dir, { ...f.identity, candidateSha: f.old }), /parent-mismatch/);
+  assert.throws(() => verifyReviewOnlyBaseAdvance(f.dir, { ...f.identity, testedMergeSha: "f".repeat(40) }));
+  const same = fixture(t, []);
+  assert.throws(() => verifyReviewOnlyBaseAdvance(same.dir, same.identity), /parent-mismatch/);
+});
+
+test("first-parent 조상이 아닌 base와 64단계 초과 이력을 거부한다", t => {
+  const f = fixture(t);
+  const unrelated = f.commit(f.tree(null, { "mydocs/other.md": "other" }), []);
+  const badBase = f.commit(f.tree(unrelated, { "mydocs/new.md": "new" }), [unrelated]);
+  const badMerge = f.commit(f.finalTree, [badBase, f.head]);
+  assert.throws(() => verifyReviewOnlyBaseAdvance(f.dir, {
+    ...f.identity, baseSha: badBase, mergeSha: badMerge,
+  }), /history-unavailable/);
+  const long = fixture(t, Array.from({ length: 65 }, (_, i) => ({ "mydocs/count.md": String(i) })));
+  assert.throws(() => verifyReviewOnlyBaseAdvance(long.dir, long.identity), /history-limit/);
+});
+
+test("최종 head 성공 및 신원과 tree 증거가 모두 맞을 때만 재사용한다", t => {
+  const f = fixture(t);
+  const proof = verifyReviewOnlyBaseAdvance(f.dir, f.identity);
+  const repository = { id: 1, full_name: "edwardkim/rhwp" };
+  const fork = { id: 2, full_name: "contributor/rhwp", fork: true };
+  const run = { id: 10, run_attempt: 2, event: "pull_request", status: "completed", conclusion: "success",
+    repository, head_repository: fork, head_branch: "feature", head_sha: f.head,
+    path: ".github/workflows/codeql.yml", pull_requests: [],
+    created_at: "2026-09-09T00:01:00Z", updated_at: "2026-09-09T00:02:00Z" };
+  const input = { eventName: "push", ref: "refs/heads/devel", repository: repository.full_name,
+    repositoryId: 1, workflowFile: "codeql.yml", mergeSha: f.merge,
+    mergeCommit: { sha: f.merge, parents: [{ sha: f.base }, { sha: f.head }], commit: { tree: { sha: f.finalTree } } },
+    sourceCommit: { sha: f.head, commit: { tree: { sha: f.headTree } } }, mergeBaseSha: f.old,
+    pullRequests: [{ number: 42, state: "closed", merged_at: "2026-09-09T00:03:00Z",
+      created_at: "2026-09-09T00:00:00Z", merge_commit_sha: f.merge,
+      base: { ref: "devel", repo: repository }, head: { sha: f.head, ref: "feature", repo: fork } }],
+    pullFiles: [{ filename: "src/lib.rs", status: "modified" }],
+    prCommits: [{ sha: f.head, parents: [{ sha: f.old }], files: [{ filename: "src/lib.rs", status: "modified" }] }],
+    workflowRuns: [run], fullLaneRunIds: ["10"],
+    mergeTreeEvidenceByRunId: { 10: { sha: f.tested, parents: [f.old, f.head], treeSha: f.headTree,
+      pullNumber: 42, repositoryId: 1, headRepositoryId: 2, runAttempt: 2 } },
+    reviewOnlyBaseAdvanceByRunId: { 10: proof } };
+  assert.equal(evaluateTrustedPostMergeReuse(input).reason, "review-only-base-advance-final-head-green-pr-workflow-reused");
+  const reject = modify => { const copy = structuredClone(input); modify(copy); assert.equal(evaluateTrustedPostMergeReuse(copy).reuse, false); };
+  reject(x => { x.reviewOnlyBaseAdvanceByRunId = {}; });
+  for (const field of Object.keys(proof)) reject(x => { x.reviewOnlyBaseAdvanceByRunId[10][field] = "f".repeat(40); });
+  for (const field of ["pullNumber", "repositoryId", "headRepositoryId", "runAttempt"]) reject(x => { x.mergeTreeEvidenceByRunId[10][field] = 99; });
+  for (const conclusion of ["failure", "cancelled", "skipped"]) reject(x => { x.workflowRuns[0].conclusion = conclusion; });
+  reject(x => { x.workflowRuns[0].status = "in_progress"; });
+  reject(x => { x.workflowRuns[0].updated_at = "2026-09-09T00:04:00Z"; });
+  reject(x => { x.fullLaneRunIds = []; });
+  reject(x => { x.pullFiles = [{ filename: ".github/workflows/ci.yml" }]; });
+});

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import "./verify-trusted-postmerge-base-advance.test.mjs";
 import test from "node:test";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";

--- a/scripts/verify-trusted-postmerge-ci-reuse.mjs
+++ b/scripts/verify-trusted-postmerge-ci-reuse.mjs
@@ -228,6 +228,69 @@ export function verifyForkPostMergeTree(repository, identity) {
   return verifyPostMergeTree(repository, identity, false);
 }
 
+// Only the exact final fork head may reuse a run across a Markdown-only base advance.
+// Inspect raw immutable objects, including every first-parent step, never PR code.
+export function verifyReviewOnlyBaseAdvance(repository, identity) {
+  const { baseSha, mergeSha, candidateSha, testedMergeSha } = identity;
+  if (![baseSha, mergeSha, candidateSha, testedMergeSha].every(validSha)) {
+    throw new Error("invalid-review-base-advance-identity");
+  }
+  const git = (...args) => execFileSync("git", ["-C", repository, "--no-replace-objects", ...args], {
+    encoding: "utf8", timeout: 30000, maxBuffer: 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const commit = (sha) => {
+    const headers = git("cat-file", "commit", sha).split("\n\n", 1)[0].split("\n");
+    const trees = headers.filter(line => line.startsWith("tree ")).map(line => line.slice(5));
+    const parents = headers.filter(line => line.startsWith("parent ")).map(line => line.slice(7));
+    if (trees.length !== 1 || !validSha(trees[0]) || !parents.every(validSha)
+      || new Set(parents).size !== parents.length) {
+      throw new Error("review-base-advance-commit-unavailable");
+    }
+    return { tree: trees[0], parents };
+  };
+  const assertReviewDiff = (before, after) => {
+    const fields = git("diff", "--raw", "--no-abbrev", "-z", "--no-renames", "--no-ext-diff",
+      "--no-textconv", "--ignore-submodules=none", before, after, "--").split("\0");
+    if (fields.pop() !== "" || fields.length % 2 !== 0) {
+      throw new Error("review-base-advance-incomplete-diff");
+    }
+    for (let index = 0; index < fields.length; index += 2) {
+      const path = fields[index + 1];
+      if (!/^:(000000|100644) (000000|100644) [0-9a-f]{40} [0-9a-f]{40} [AMD]$/.test(fields[index])
+        || !path.startsWith("mydocs/") || !path.endsWith(".md")
+        || path === "mydocs/tech/text-ir-v2.md"
+        || path === "mydocs/tech/canvaskit-parity-implementation.md") {
+        throw new Error("review-base-advance-non-review-change");
+      }
+    }
+  };
+  const tested = commit(testedMergeSha);
+  const final = commit(mergeSha);
+  if (tested.parents.length !== 2 || final.parents.length !== 2
+    || tested.parents[1] !== candidateSha || final.parents[1] !== candidateSha
+    || final.parents[0] !== baseSha || tested.parents[0] === baseSha) {
+    throw new Error("review-base-advance-parent-mismatch");
+  }
+  const testedBaseSha = tested.parents[0];
+  let cursor = baseSha;
+  for (let count = 0; cursor !== testedBaseSha && count < 64; count += 1) {
+    const current = commit(cursor);
+    if (current.parents.length < 1 || current.parents.length > 2) {
+      throw new Error("review-base-advance-history-unavailable");
+    }
+    const parent = commit(current.parents[0]);
+    assertReviewDiff(parent.tree, current.tree);
+    cursor = current.parents[0];
+  }
+  if (cursor !== testedBaseSha) {
+    throw new Error("review-base-advance-history-limit");
+  }
+  assertReviewDiff(tested.tree, final.tree);
+  return { baseSha, testedBaseSha, mergeSha, candidateSha, testedMergeSha,
+    testedTreeSha: tested.tree, finalTreeSha: final.tree };
+}
+
 function hasReviewBridgeTreeEvidence(input, run, baseSha, bridgeSha, finalTreeSha) {
   const tested = input.mergeTreeEvidenceByRunId?.[String(run.id)];
   const proof = input.reviewBridgeTreeEvidenceByRunId?.[String(run.id)];
@@ -487,17 +550,32 @@ export function evaluateTrustedPostMergeReuse(input) {
     parents,
     mergeTreeSha,
   );
-  if (isFork && (!exactMergeTreeEvidence || !hasForkRunBinding(input, finalHeadCandidate, pullRequest))) {
+  const advanceProof = input.reviewOnlyBaseAdvanceByRunId?.[String(finalHeadCandidate?.id)];
+  const testedFinalHead = input.mergeTreeEvidenceByRunId?.[String(finalHeadCandidate?.id)];
+  const reviewOnlyBaseAdvance = isFork
+    && finalHeadCandidate?.status === "completed" && finalHeadCandidate.conclusion === "success"
+    && hasForkRunBinding(input, finalHeadCandidate, pullRequest)
+    && advanceProof?.baseSha === baseParent
+    && advanceProof.testedBaseSha === testedFinalHead.parents[0]
+    && advanceProof.testedBaseSha !== baseParent
+    && advanceProof.mergeSha === input.mergeSha
+    && advanceProof.candidateSha === pullRequest.head.sha
+    && advanceProof.testedMergeSha === testedFinalHead.sha
+    && advanceProof.testedTreeSha === testedFinalHead.treeSha
+    && advanceProof.finalTreeSha === mergeTreeSha;
+  if (isFork && ((!exactMergeTreeEvidence && !reviewOnlyBaseAdvance)
+    || !hasForkRunBinding(input, finalHeadCandidate, pullRequest))) {
     return denied("fork-pr-merge-tree-evidence-unavailable");
   }
   if (
     headContainsBase
     && mergeTreeSha !== input.sourceCommit?.commit?.tree?.sha
     && !exactMergeTreeEvidence
+    && !reviewOnlyBaseAdvance
   ) {
     return denied("merge-tree-does-not-match-pr-head");
   }
-  if (!headContainsBase && !exactMergeTreeEvidence) {
+  if (!headContainsBase && !exactMergeTreeEvidence && !reviewOnlyBaseAdvance) {
     return denied("pr-merge-tree-evidence-unavailable");
   }
 
@@ -540,7 +618,9 @@ export function evaluateTrustedPostMergeReuse(input) {
   ) {
     return {
       reuse: true,
-      reason: frontendOnly
+      reason: reviewOnlyBaseAdvance
+        ? "review-only-base-advance-final-head-green-pr-workflow-reused"
+        : frontendOnly
         ? (candidateSource.hasReviewOnlyTail
           ? "review-tail-final-head-green-frontend-ci-reused"
           : "exact-green-frontend-ci-reused")


### PR DESCRIPTION
## 요약

Refs #6947, #6901. PR #6904의 fork post-merge 재사용 계약과 #6877의 Rust CodeQL 내부 통계 최적화를 보완합니다.

- 정확한 최종 fork head의 CI가 성공했으나 대기 중 devel에 Markdown 기록만 추가된 경우, 신뢰된 verifier가 base 이력과 최종 tree 차이를 증명하면 재사용합니다.
- 최대 64개 first-parent 단계 각각을 확인합니다. 허용 범위는 `mydocs/**/*.md` 일반 파일이며 CI 소비 기술 규약 2개, source/test/workflow/sample, symlink/executable, 비문서 rename, 누락 객체/이력 초과는 거부합니다. source 변경 후 되돌림도 거부합니다.
- PR 번호, upstream/fork repository ID, head, workflow, run attempt, 성공 및 병합 이전 완료 조건을 유지합니다. fork 코드를 privileged 경로에서 checkout/실행하지 않습니다.
- devel push Rust CodeQL에서도 내부 metric 3개만 제외합니다. 전체 Rust 분석 경로와 기본 보안 쿼리는 유지하고 PR의 paths는 복사하지 않습니다. main push/schedule/workflow_dispatch는 기존 전체 분석입니다.

## 실제 근거

#6933 head `dfb208e8516da920d172872fbd16e9dd3771db26`의 CI 실행 후 문서 PR #6945가 먼저 병합되어 base가 `74d0a68b7`에서 `9a96eef92`로 전진했습니다. merge `b6d2d39f9fd9012012ac69e4c70d223241b8cd56`에서 CI/CodeQL이 `fork-pr-merge-tree-evidence-unavailable`로 재실행했습니다. fork artifact는 존재했고 attempt도 일치했습니다.

[기존 devel CI](https://github.com/edwardkim/rhwp/actions/runs/34333630877), [기존 devel CodeQL](https://github.com/edwardkim/rhwp/actions/runs/34333630971).

## 로컬 검증

- JS verifier/실제 workflow harness: **134 PASS**, 실패/skip 0.
- Python workflow 계약: **233 PASS**.
- 변경된 CodeQL/reusable workflow actionlint: **PASS**.
- `git diff --check`: **PASS**.
- 실제 #6933/#6945 immutable Git 객체에 새 base 전진 검증기 적용: **PASS**.
- 허용/거부 fixture, shallow raw 객체, source 되돌림, rename, symlink/executable, 다른 head, 이력 한도, 위조 proof/attempt, 실패/pending 및 duration 증거 부재를 검증했습니다.
- CodeQL 초기화의 event/ref/language/선택 조합별 상호 배타성과 post-merge 설정의 경로 제한·기본 쿼리 override 부재를 검증했습니다.
- Rust/제품 변경이 없어 Cargo/WASM/시각 검증은 반복하지 않았습니다. 임시 로그는 커밋하지 않습니다.

## 남은 검증과 범위 제한

이 PR 자체는 CI enforcement 변경이므로 full 검증이 예상됩니다. devel 반영 후 후속 fork PR에서 실제 재사용과 CodeQL 쿼리 선택/시간을 확인해야 합니다. 아직 성능 단축을 실측한 것으로 주장하지 않습니다.

#6933 PR CI에는 duration artifact가 없었습니다. 이 요건은 유지하므로 이 변경만으로 모든 fork CI가 skip되는 것은 아닙니다. duration publisher, older trailing candidate 및 Adapter/Proptest의 기존 제약은 #6901의 별도 범위입니다. main CI Impact Policy Controller는 변경하지 않습니다.

[자체 검토](https://github.com/edwardkim/rhwp/blob/fix/fork-review-only-base-advance-20260909/mydocs/pr/archives/pr_6948_review.md)와 [오늘할일](https://github.com/edwardkim/rhwp/blob/fix/fork-review-only-base-advance-20260909/mydocs/orders/20260909.md)을 문서 trailing commit `d7677c43d`으로 포함했습니다. 병합 및 이슈 종료는 최신 head CI와 실제 적용 결과를 확인한 뒤 별도 승인 범위에서 수행합니다.

