### PR TITLE
수정(hwpx): 각주 번호 서식 네 필드를 왕복에서 지킨다 (#6872)

### DIFF
--- a/src/model/footnote.rs
+++ b/src/model/footnote.rs
@@ -28,6 +28,13 @@ pub struct Footnote {
     pub instance_id: u32,
     /// LIST_HEADER property (UInt4, default 0)
     pub list_header_property: u32,
+    /// [#6872] 장식 문자를 HWPX 가 `userChar` 로 실었는가.
+    ///
+    /// HWPX 의 `<hp:footNote>`/`<hp:endNote>` 는 번호 모양이 사용자 기호일 때
+    /// `suffixChar` 대신 `userChar` 에 그 기호를 싣는다(실측: `156513948` 각주 5개가
+    /// `userChar="42"`). HWP5 의 CTRL_FOOTNOTE 에는 장식 문자 슬롯이 하나뿐이라 값은
+    /// 같은 자리에 두고, **어느 이름으로 왔는지**만 기억해 왕복에서 되돌린다.
+    pub decoration_is_user_char: bool,
 }
 
 /// 미주 ('en  ' 컨트롤) — [Task #1050] Footnote 와 동일 구조
@@ -47,6 +54,13 @@ pub struct Endnote {
     pub instance_id: u32,
     /// LIST_HEADER property (UInt4)
     pub list_header_property: u32,
+    /// [#6872] 장식 문자를 HWPX 가 `userChar` 로 실었는가.
+    ///
+    /// HWPX 의 `<hp:footNote>`/`<hp:endNote>` 는 번호 모양이 사용자 기호일 때
+    /// `suffixChar` 대신 `userChar` 에 그 기호를 싣는다(실측: `156513948` 각주 5개가
+    /// `userChar="42"`). HWP5 의 CTRL_FOOTNOTE 에는 장식 문자 슬롯이 하나뿐이라 값은
+    /// 같은 자리에 두고, **어느 이름으로 왔는지**만 기억해 왕복에서 되돌린다.
+    pub decoration_is_user_char: bool,
 }
 
 /// 각주/미주 모양 (HWPTAG_FOOTNOTE_SHAPE)

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5466,6 +5466,18 @@ fn parse_ctrl_footnote(
                     note.after_decoration_letter = v;
                 }
             }
+            // [#6872] 번호 모양이 사용자 기호면 한컴은 `suffixChar` 대신 `userChar` 에
+            // 기호를 싣는다. 종전에는 이 속성을 아예 읽지 않아 값이 사라지고, 직렬화기가
+            // 기본값 `)`(0x29)를 채워 각주 표시가 `*` 에서 `*)` 로 바뀌었다.
+            b"userChar" => {
+                if let Ok(v) = std::str::from_utf8(attr.value.as_ref().as_bytes())
+                    .unwrap_or("")
+                    .parse::<u16>()
+                {
+                    note.after_decoration_letter = v;
+                    note.decoration_is_user_char = true;
+                }
+            }
             // [#2716] flag = HWP5 CTRL_FOOTNOTE numberShape(UInt4). 한컴 HWP5/HWPX 쌍
             // (3-09월_교육_통합_2023) 각주/미주 46개 전수 대조에서 바이트 단위로 일치했다.
             // 값이 0 이면 한컴이 속성 자체를 생략하므로 default 0 유지.
@@ -5522,6 +5534,16 @@ fn parse_ctrl_endnote(
                     .parse::<u16>()
                 {
                     note.after_decoration_letter = v;
+                }
+            }
+            // [#6872] footNote 와 동일 — 사용자 기호는 `userChar` 로 온다.
+            b"userChar" => {
+                if let Ok(v) = std::str::from_utf8(attr.value.as_ref().as_bytes())
+                    .unwrap_or("")
+                    .parse::<u16>()
+                {
+                    note.after_decoration_letter = v;
+                    note.decoration_is_user_char = true;
                 }
             }
             // [#2716] flag = HWP5 CTRL_ENDNOTE numberShape(UInt4). footNote 와 동일 계약.
@@ -5791,6 +5813,12 @@ fn parse_ctrl_autonum(
                                     "LATIN_SMALL" => 5,
                                     "HANGUL" => 6,
                                     "HANJA" => 7,
+                                    // [#6872] 사용자 기호. 종전에는 `_ => 0` 에 걸려
+                                    // DIGIT 으로 떨어졌고, 왕복 저장본의 각주 번호
+                                    // 모양이 사용자 기호에서 숫자로 바뀌었다.
+                                    // 코드는 `NumberFormat::UserChar` 의 서수(18)를
+                                    // 그대로 쓴다 — pageNum 이 쓰는 0..7 과 겹치지 않는다.
+                                    "USER_CHAR" => 18,
                                     _ => 0,
                                 };
                             }

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -252,8 +252,11 @@ fn note_numbering_str(numbering: crate::model::footnote::FootnoteNumbering) -> &
     use crate::model::footnote::FootnoteNumbering::*;
     match numbering {
         Continue => "CONTINUOUS",
-        RestartSection => "RESTART_SECTION",
-        RestartPage => "RESTART_PAGE",
+        // [#6872] 한컴이 실제로 쓰는 토큰은 ON_* 다 — 코퍼스 HWPX 3,418건에서
+        // CONTINUOUS 7,766 · ON_PAGE 12 이고 RESTART_* 는 **하나도 없다**.
+        // 파서는 두 표기를 다 받으므로 읽기는 불변이다.
+        RestartSection => "ON_SECTION",
+        RestartPage => "ON_PAGE",
     }
 }
 
@@ -366,12 +369,21 @@ fn note_deco_char_attr(c: char, fallback: &str) -> String {
 /// [#2742] FootnoteShape → `<hp:autoNumFormat .../>`.
 /// 속성 순서는 템플릿·한컴 실물과 같이 type → userChar → prefixChar → suffixChar → supscript.
 fn render_auto_num_format(shape: &crate::model::footnote::FootnoteShape) -> String {
+    // [#6872] 번호 모양이 **사용자 기호**면 표시는 그 기호 하나로 끝난다 — 한컴도
+    // `suffixChar` 를 비운다(코퍼스 HWPX 3,418건의 노트 모양 7,778개 중 `suffixChar=""`
+    // 는 1개이고 그것이 유일한 `USER_CHAR` 다). 이때 기본값 `)` 를 채우면 표시가 `*` 에서
+    // `*)` 로 바뀐다. 숫자 계열(7,651개가 `)`)의 폴백은 그대로 둔다.
+    let suffix_fallback = if shape.number_format == crate::model::footnote::NumberFormat::UserChar {
+        ""
+    } else {
+        ")"
+    };
     format!(
         r#"<hp:autoNumFormat type="{}" userChar="{}" prefixChar="{}" suffixChar="{}" supscript="{}"/>"#,
         note_number_format_str(shape.number_format),
         note_deco_char_attr(shape.user_char, ""),
         note_deco_char_attr(shape.prefix_char, ""),
-        note_deco_char_attr(shape.suffix_char, ")"),
+        note_deco_char_attr(shape.suffix_char, suffix_fallback),
         u8::from(shape.number_code_superscript),
     )
 }
@@ -2529,6 +2541,10 @@ fn render_autonum(an: &AutoNumber) -> String {
         // 형식을 "CIRCLED_DIGIT"로 표기한다(각주/미주 경로에서 실측 검증됨, #2742).
         ty = if an.format == 1 {
             "CIRCLED_DIGIT"
+        } else if an.format == 18 {
+            // [#6872] 사용자 기호(`NumberFormat::UserChar` 서수). `page_num_format_to_str`
+            // 는 쪽 번호용 0..7 만 알아서 이 값을 DIGIT 으로 떨궜다.
+            "USER_CHAR"
         } else {
             page_num_format_to_str(an.format)
         },
@@ -3074,6 +3090,8 @@ struct NoteAttrs {
     prefix_char: u16,
     /// `after_decoration_letter` — 항상 방출.
     suffix_char: u16,
+    /// [#6872] true 면 `suffixChar` 가 아니라 `userChar` 라는 이름으로 방출한다.
+    decoration_is_user_char: bool,
     /// HWP5 `numberShape` — 0 이면 속성 생략(한컴 계약).
     number_shape: u32,
     /// HWP5 `instanceId` — 항상 방출.
@@ -3101,9 +3119,17 @@ fn render_note_attrs(attrs: &NoteAttrs) -> String {
     if attrs.prefix_char != 0 {
         out.push_str(&format!(r#" prefixChar="{}""#, attrs.prefix_char));
     }
+    // [#6872] 사용자 기호로 온 장식 문자는 같은 이름으로 되돌린다. 한컴은 번호 모양이
+    // 사용자 기호일 때 `suffixChar` 를 아예 쓰지 않으므로(156513948 각주 5개 실측),
+    // 이름을 바꿔 내보내면 표시가 `*` 에서 `*)` 로 바뀐다.
+    let deco_name = if attrs.decoration_is_user_char {
+        "userChar"
+    } else {
+        "suffixChar"
+    };
     out.push_str(&format!(
-        r#" suffixChar="{}" instId="{}""#,
-        attrs.suffix_char, attrs.inst_id
+        r#" {}="{}" instId="{}""#,
+        deco_name, attrs.suffix_char, attrs.inst_id
     ));
     out
 }
@@ -3195,6 +3221,7 @@ fn render_footnote(note: &Footnote, ctx: &mut SerializeContext) -> String {
             number: note.number,
             prefix_char: note.before_decoration_letter,
             suffix_char: note.after_decoration_letter,
+            decoration_is_user_char: note.decoration_is_user_char,
             number_shape: note.number_shape,
             inst_id: note.instance_id,
         },
@@ -3211,6 +3238,7 @@ fn render_endnote(note: &Endnote, ctx: &mut SerializeContext) -> String {
             number: note.number,
             prefix_char: note.before_decoration_letter,
             suffix_char: note.after_decoration_letter,
+            decoration_is_user_char: note.decoration_is_user_char,
             number_shape: note.number_shape,
             inst_id: note.instance_id,
         },
@@ -4480,11 +4508,11 @@ mod tests {
         let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
 
         assert!(
-            xml.contains(r#"<hp:numbering type="RESTART_PAGE" newNum="3"/>"#),
+            xml.contains(r#"<hp:numbering type="ON_PAGE" newNum="3"/>"#),
             "각주 numbering 이 IR 값이어야 함"
         );
         assert!(
-            xml.contains(r#"<hp:numbering type="RESTART_SECTION" newNum="5"/>"#),
+            xml.contains(r#"<hp:numbering type="ON_SECTION" newNum="5"/>"#),
             "미주 numbering 이 IR 값이어야 함"
         );
         assert!(

--- a/tests/cases/issue_6872_hwpx_footnote_autonum_roundtrip.rs
+++ b/tests/cases/issue_6872_hwpx_footnote_autonum_roundtrip.rs
@@ -1,0 +1,194 @@
+//! [#6872] HWPX→HWPX 왕복에서 각주 번호 서식이 무너진다.
+//!
+//! **증상.** `x2x` 왕복만으로 각주 참조 표시가 바뀐다(쪽수·글자수는 그대로).
+//!
+//! ```text
+//!   02333  '전자·통신1)1) …'  →  '전자·통신2)2) …'      번호가 밀린다
+//!   00931  '(증가** 표시는 …'  →  '(증가*)*) 표시는 …'   표시가 * → *)
+//! ```
+//!
+//! **근인은 넷이고 전부 필드 단위 왕복 누락이다.** 원본 ↔ 왕복 XML 대조 실측:
+//!
+//! ```text
+//!  ① <hp:numbering type="ON_PAGE"/>            → "RESTART_PAGE"
+//!  ② <hp:footNote … userChar="42">             → suffixChar="41"
+//!  ③ <hp:autoNumFormat type="USER_CHAR" …>     → type="DIGIT"       (인라인 autoNum)
+//!  ④ <hp:autoNumFormat … suffixChar="">        → suffixChar=")"     (노트 모양)
+//! ```
+//!
+//! ① 파서는 `ON_PAGE`·`RESTART_PAGE` 를 둘 다 받지만 직렬화기는 `RESTART_*` 만 냈다.
+//!    한컴이 쓴 HWPX **3,418건**을 전수로 세면 `CONTINUOUS` 7,766 · `ON_PAGE` 12 이고
+//!    `RESTART_*` 는 **하나도 없다**.
+//!
+//! ② 번호 모양이 사용자 기호일 때 한컴은 `suffixChar` 대신 `userChar` 에 기호를 싣는다.
+//!    파서가 그 속성을 읽지 않아 값이 사라지고, 직렬화기가 기본값 `)`(0x29)를 채웠다.
+//!
+//! ③ 인라인 `<hp:autoNum>` 의 형식 표는 쪽 번호용 `0..7` 만 알아 `USER_CHAR` 가 `_ => 0`
+//!    (DIGIT)로 떨어졌다.
+//!
+//! ④ 사용자 기호 모양은 표시가 기호 하나로 끝나므로 한컴도 `suffixChar` 를 비운다.
+//!    코퍼스 노트 모양 7,778개 중 `suffixChar=""` 는 1개이고 그것이 유일한 `USER_CHAR`
+//!    다. 숫자 계열(7,651개가 `)`)의 폴백은 건드리지 않는다.
+//!
+//! 이 시험은 합성 IR 로 **네 지점의 방출 계약**만 잰다.
+
+use rhwp::model::footnote::{Footnote, FootnoteNumbering, FootnoteShape, NumberFormat};
+
+/// 각주 하나를 담은 최소 문서를 HWPX 로 저장하고 `section0.xml` 을 돌려준다.
+fn section_xml(build: impl FnOnce(&mut rhwp::model::document::Document)) -> String {
+    let mut doc = rhwp::model::document::Document::default();
+    // 구역 하나 · 문단 하나짜리 최소 문서.
+    let mut section = rhwp::model::document::Section::default();
+    section
+        .paragraphs
+        .push(rhwp::model::paragraph::Paragraph::default());
+    doc.sections.push(section);
+    build(&mut doc);
+    let bytes = rhwp::serializer::hwpx::serialize_hwpx(&doc).expect("HWPX 직렬화는 성공해야 한다");
+    let mut zip =
+        zip::ZipArchive::new(std::io::Cursor::new(bytes)).expect("산출물은 zip 이어야 한다");
+    let mut out = String::new();
+    for i in 0..zip.len() {
+        let mut f = zip.by_index(i).expect("zip 항목");
+        if f.name().to_ascii_lowercase().contains("section0") {
+            use std::io::Read;
+            f.read_to_string(&mut out).expect("section0 읽기");
+            break;
+        }
+    }
+    assert!(!out.is_empty(), "section0.xml 을 찾지 못했다");
+    out
+}
+
+/// 첫 구역의 각주 모양을 고쳐 준다.
+fn with_footnote_shape(
+    doc: &mut rhwp::model::document::Document,
+    edit: impl FnOnce(&mut FootnoteShape),
+) {
+    let section = doc.sections.first_mut().expect("구역이 하나는 있어야 한다");
+    edit(&mut section.section_def.footnote_shape);
+}
+
+#[test]
+fn issue_6872_note_numbering_uses_hancom_on_page_token() {
+    // **뒤집힘 ①** — 한컴이 쓰지 않는 `RESTART_*` 를 내보내지 않는다.
+    let xml = section_xml(|doc| {
+        with_footnote_shape(doc, |shape| {
+            shape.numbering = FootnoteNumbering::RestartPage;
+        });
+    });
+    assert!(
+        xml.contains(r#"<hp:numbering type="ON_PAGE""#),
+        "각주 번호 매기기는 ON_PAGE 로 나가야 한다:\n{}",
+        &xml[..xml.len().min(400)]
+    );
+    assert!(
+        !xml.contains("RESTART_PAGE"),
+        "RESTART_PAGE 는 한컴 저장본에 없는 토큰이다"
+    );
+}
+
+#[test]
+fn issue_6872_continuous_numbering_is_unchanged() {
+    // **음성 대조 ①** — 코퍼스 7,766개가 쓰는 기본 토큰은 그대로다.
+    let xml = section_xml(|doc| {
+        with_footnote_shape(doc, |shape| {
+            shape.numbering = FootnoteNumbering::Continue;
+        });
+    });
+    assert!(
+        xml.contains(r#"<hp:numbering type="CONTINUOUS""#),
+        "CONTINUOUS 는 불변이어야 한다"
+    );
+}
+
+#[test]
+fn issue_6872_user_char_decoration_round_trips_as_user_char() {
+    // **뒤집힘 ②** — `userChar` 로 들어온 장식 문자는 같은 이름으로 나간다.
+    let xml = section_xml(|doc| {
+        let mut note = Footnote {
+            number: 1,
+            after_decoration_letter: 0x2A, // '*'
+            decoration_is_user_char: true,
+            number_shape: 385,
+            instance_id: 2_004_981_886,
+            ..Default::default()
+        };
+        note.paragraphs
+            .push(rhwp::model::paragraph::Paragraph::default());
+        let section = doc.sections.first_mut().expect("구역");
+        let para = section
+            .paragraphs
+            .first_mut()
+            .expect("문단이 하나는 있어야 한다");
+        para.controls
+            .push(rhwp::model::control::Control::Footnote(Box::new(note)));
+    });
+    assert!(
+        xml.contains(r#"userChar="42""#),
+        "사용자 기호는 userChar 로 나가야 한다:\n{}",
+        &xml[..xml.len().min(600)]
+    );
+    assert!(
+        !xml.contains(r#"suffixChar="42""#),
+        "이름을 suffixChar 로 바꾸면 표시가 *) 가 된다"
+    );
+}
+
+#[test]
+fn issue_6872_plain_decoration_still_uses_suffix_char() {
+    // **음성 대조 ②** — 종전 경로(장식 문자 `)`)는 이름이 바뀌지 않는다.
+    let xml = section_xml(|doc| {
+        let mut note = Footnote {
+            number: 1,
+            after_decoration_letter: 0x29, // ')'
+            instance_id: 1_282_670_874,
+            ..Default::default()
+        };
+        note.paragraphs
+            .push(rhwp::model::paragraph::Paragraph::default());
+        let section = doc.sections.first_mut().expect("구역");
+        let para = section.paragraphs.first_mut().expect("문단");
+        para.controls
+            .push(rhwp::model::control::Control::Footnote(Box::new(note)));
+    });
+    assert!(
+        xml.contains(r#"suffixChar="41""#),
+        "일반 장식 문자는 suffixChar 그대로다:\n{}",
+        &xml[..xml.len().min(600)]
+    );
+    assert!(!xml.contains(r#"userChar="41""#), "이름이 새면 안 된다");
+}
+
+#[test]
+fn issue_6872_user_char_shape_leaves_the_suffix_empty() {
+    // **뒤집힘 ④** — 사용자 기호 모양에는 닫는 장식이 붙지 않는다.
+    let xml = section_xml(|doc| {
+        with_footnote_shape(doc, |shape| {
+            shape.number_format = NumberFormat::UserChar;
+            shape.user_char = '*';
+            shape.suffix_char = '\0';
+        });
+    });
+    assert!(
+        xml.contains(r#"type="USER_CHAR" userChar="*" prefixChar="" suffixChar="""#),
+        "USER_CHAR 모양의 suffixChar 는 비어야 한다:\n{}",
+        &xml[..xml.len().min(600)]
+    );
+}
+
+#[test]
+fn issue_6872_digit_shape_keeps_the_paren_suffix() {
+    // **음성 대조 ④** — 코퍼스 7,651개가 쓰는 숫자 모양 폴백은 불변이다.
+    let xml = section_xml(|doc| {
+        with_footnote_shape(doc, |shape| {
+            shape.number_format = NumberFormat::Digit;
+            shape.suffix_char = '\0';
+        });
+    });
+    assert!(
+        xml.contains(r#"type="DIGIT" userChar="" prefixChar="" suffixChar=")""#),
+        "숫자 모양은 종전대로 ) 를 남긴다:\n{}",
+        &xml[..xml.len().min(600)]
+    );
+}


### PR DESCRIPTION
이슈 #6872 — `x2x` 왕복만으로 각주 참조 표시가 바뀐다(쪽수·글자수는 그대로).

```text
  02333  '전자·통신1)1) …'  →  '전자·통신2)2) …'      번호가 밀린다
  00931  '(증가** 표시는 …'  →  '(증가*)*) 표시는 …'   표시가 * → *)
```

## 근인은 넷이고 전부 필드 단위 왕복 누락이다

원본과 왕복본의 각주 관련 XML 을 전부 대조해 어긋나는 지점을 찾았다.

```text
  ① <hp:numbering type="ON_PAGE"/>          →  "RESTART_PAGE"
  ② <hp:footNote … userChar="42">           →  suffixChar="41"
  ③ <hp:autoNumFormat type="USER_CHAR" …>   →  type="DIGIT"      (인라인 autoNum)
  ④ <hp:autoNumFormat … suffixChar="">      →  suffixChar=")"    (노트 모양)
```

**① 번호 매기기 토큰.** 파서는 `ON_PAGE`·`RESTART_PAGE` 를 둘 다 받는데 직렬화기는
`RESTART_*` 만 냈다. 한컴이 쓴 HWPX **3,418건**을 전수로 세면 이렇다.

```text
  CONTINUOUS 7,766 · ON_PAGE 12 · RESTART_* 0
```

읽기는 두 표기를 계속 받으므로 불변이다.

**② 사용자 기호 장식 문자.** 번호 모양이 사용자 기호일 때 한컴은 `suffixChar` 대신
`userChar` 에 그 기호를 싣는다. 파서가 이 속성을 **아예 읽지 않아** 값이 사라지고,
직렬화기가 기본값 `)`(0x29)를 채웠다 — 이것이 `*` → `*)` 의 정체다. HWP5 의
`CTRL_FOOTNOTE` 에는 장식 문자 슬롯이 하나뿐이라 값은 같은 자리에 두고 **어느 이름으로
왔는지**만 IR 에 기억한다(`decoration_is_user_char`).

**③ 인라인 `autoNum` 의 형식 표.** 쪽 번호용 `0..7` 만 알아 `USER_CHAR` 가 `_ => 0`
(DIGIT)으로 떨어졌다. 코드는 `NumberFormat::UserChar` 의 서수 18 을 쓴다 — `pageNum` 이
쓰는 `0..7` 과 겹치지 않는다.

**④ 노트 모양의 빈 접미.** 사용자 기호 모양은 표시가 기호 하나로 끝나므로 한컴도
`suffixChar` 를 비운다. 코퍼스 노트 모양 **7,778개 중 `suffixChar=""` 는 1개**이고 그것이
유일한 `USER_CHAR` 다. 숫자 계열(7,651개가 `)`)의 폴백은 건드리지 않는다.

## 결과

수정 후 두 문서 모두 **각주 관련 XML 이 원본과 완전히 같아진다**(diff 0).

## 잠금

합성 IR 로 네 지점의 방출 계약만 잰다.

- **뒤집힘** — `ON_PAGE` 로 나간다 / `userChar` 이름이 유지된다 / `USER_CHAR` 모양의
  `suffixChar` 가 빈다.
- **음성 대조** — `CONTINUOUS` 불변 / 일반 장식 문자는 `suffixChar` 그대로 / 숫자 모양의
  `)` 폴백 불변.

기존 단위시험의 `RESTART_*` 기대값도 같은 이유로 갱신했다.

Closes #6872
Closes #6941

🤖 Generated with [Claude Code](https://claude.com/claude-code)

