### PR TITLE
수정(layout): 조각이 소유한 clip 하단 글줄을 담도록 셀 clip 을 넓힌다 (#6924)

### DIFF
--- a/mydocs/working/issue_6924_fragment_owned_bottom_line.md
+++ b/mydocs/working/issue_6924_fragment_owned_bottom_line.md
@@ -1,0 +1,144 @@
+---
+kind: working
+status: active
+issue: 6924
+---
+
+# 감싼 칸의 clip 하단 글줄이 통째로 사라진다 (#6924)
+
+작업 브랜치: `fix/6924-cell-clip-last-line`
+대상: `src/renderer/layout/table_partial.rs`
+
+## 한 줄
+
+`suppress_bottom_clipped_text_residue`(#2007)가 clip 바닥에 걸친 글줄을 "다음 조각이
+그릴 것" 이라 보고 끄는데, **그 전제를 확인하지 않아** 소유자가 없는 줄까지 꺼져
+문서에서 사라진다.
+
+## 잘리는 게 아니라 꺼진다
+
+본문 진단("칸 clip 하단이 baseline 보다 위")은 정확한 관측이지만 SVG 가 자르는 게 아니다.
+paint LayerBuilder 프로브:
+
+```text
+PROBE TextLine visible=false editor_only=false y=920.6 h=16.0
+```
+
+`build_node` 가 `!node.visible` 에서 `None` 을 돌려주므로 PaintOp 자체가 생기지 않는다.
+`export-render-tree` 는 이 필터 **전** 트리라 정상으로 보인다 — 두 명령이 갈리는 이유다.
+
+`visible = false` 자리는 다섯뿐이고 프로브로 범인을 특정했다: `SITE775` =
+`suppress_bottom_clipped_text_residue`. 조건도 수치로 맞는다
+(`sliver = 922.45 − 920.6 = 1.88 < 6.0`).
+
+## 전제가 확인되지 않았다
+
+주석은 *"the successor fragment remains responsible for the full line"* 이라 적어 두었지만
+그것을 검사하는 코드가 없다. 실측:
+
+```text
+148751598  쪽 1 render tree 에 그 줄 있음 · 6쪽 SVG 전수 0건 · export-text 1쪽에는 있음
+           → 1쪽에만 조판되고 1쪽에서 꺼지고 어디서도 다시 안 그려진다
+```
+
+## 소속은 이미 계산할 수 있다
+
+분할 표 경로에는 줄 단위 소속 판정이 있다.
+
+```rust
+// src/renderer/layout/table_partial.rs
+partial_table_page_contains_cell_position(table, cell, start_row, end_row,
+    start_cut, end_cut, is_block_split, Some((para_idx, line_idx, true)), styles)
+```
+
+컷 부기(`start_cut`/`end_cut`)와 `TextLineNode::{para_index, line_index}`,
+`TableCellNode::model_cell_index` 가 모두 갖춰져 있다. **전제를 추측이 아니라 계산으로
+바꾼다.**
+
+## 수정 — 억제를 고치지 않고 전제를 없앤다
+
+`expand_fragment_cell_clip_for_owned_bottom_lines` 를 조각 표 조립 직후에 한 번 돌린다.
+
+1. 조각 셀의 clip 바닥을 **걸치는** 글줄을 찾는다(완전히 안/밖인 줄은 다른 축).
+2. `owns_line` 으로 이 조각이 그 줄을 소유하는지 묻는다. 아니면 그대로 둔다 — 다른 조각이
+   그리므로 종전 억제가 옳다.
+3. 소유하면 셀을 그 줄 아랫변까지 넓힌다. **단 형제 셀과 부딪치면 넓히지 않는다.**
+
+넓히고 나면 그 줄은 더는 바닥에 "걸치지" 않으므로 **억제 조건 자체가 성립하지 않는다.**
+`suppress_bottom_clipped_text_residue` 는 한 줄도 고치지 않았다.
+
+### 왜 형제 충돌 가드가 필요한가 — 래칫이 강제했다
+
+소유 판정만 넣은 1차 구현은 겹침 래칫에 걸렸다.
+
+```text
+증가: task2287/1342000_edu_curriculum_map.hwp — 94 → 97건
+```
+
+새 겹침 3건의 위치를 `layout-anomaly --json` 으로 특정했다.
+
+```text
+82쪽   Cell3/TextLine6  (y=240.0) ↔ Cell10/TextLine0 (y=246.0)
+152쪽  Cell13/TextLine4 (y=217.2) ↔ Cell24/TextLine0 (y=223.8)
+```
+
+소유한 줄이라도 이웃 셀 내용 위로 나가면 두 글자 모두 못 읽는다. 아래 셀이 있는 셀은
+넓히지 않는 것으로 막았고 94 로 복귀했다. `local_validation.md` 4.3.1 의
+"기존 문서의 수치 증가는 회귀다 — baseline 으로 숨기지 않는다" 를 그대로 따른 것이다.
+
+## 검증 실측
+
+### 영향 모집단 전수
+
+억제 진입점에 계측을 걸어 전수 조사했다.
+
+| 모집단 | 억제 발생 문서 | 조각 셀(`page_fragment=true`) |
+|---|---|---|
+| native HWP5 코퍼스 702건 | 6 | 3 |
+| 저장소 `samples/` 824건 | 9 | 4 |
+
+### 복구 (한컴 2024 정답지 대조)
+
+| 문서 | 쪽 | 글줄 | 기준선 | 수정 | 정답지 |
+|---|---|---|---|---|---|
+| 148751598 | 1 | `* 장관 참석행사는 ★로…` (31자) | 없음 | **있음** | 있음 |
+| 148738070 | 1 | `‘발효생성아미노산복합물’을 뜻함…` (38자) | 없음 | **있음** | 있음 |
+| 156060125 | 6 | `리스크 집중위험 점검 등` | 없음 | **있음** | — |
+| 1490000 vietnam | 114 | `⑦ 물류 ⑧ 기타 ( )` | 없음 | **있음** | 114쪽 |
+
+`156060125` 는 이슈 밖에서 새로 찾은 같은 결함이다.
+
+### 회귀 없음
+
+| 축 | 결과 |
+|---|---|
+| `text_overlap_baseline` 16 partition | 통과 (edu 94 유지) |
+| `cargo test --release` 전 타깃(28 suite + lib, 순차) | **9095 passed / 0 failed / 38 ignored** |
+| `rust-unit-test-tiers --check` | 4205 (기준선 유지) |
+
+정답지 대조에서 중복으로 의심했던 두 건은 오독이었다.
+
+- `1490000 vietnam '으로보고계십니까'` — 정답지 86·121 **2쪽**, 기준선은 87 **1쪽**뿐이었다.
+  rhwp 쪽 번호가 정답지보다 +1 이라 121↔122 다. 중복이 아니라 **소실**이었고 수정이 옳다.
+- `1342000 edu '3.사회적가치…'` — 기준선에서 이미 82·83 두 쪽이다. 이 변경과 무관한
+  기존 중복이다.
+
+## 회귀 테스트
+
+`tests/cases/issue_6924_fragment_owned_line_kept.rs` — 저장소 표본
+`samples/issue5714/1490000-200800034_vietnam_labor_report.hwp` 114쪽에서
+`⑦물류⑧기타` 가 방출되는지 고정한다.
+
+`src/` 안 `#[cfg(test)]` 총량은 래칫으로 묶여 있어 통합 시험으로 두었다.
+
+> ⚠ 이 렌더러는 **글자마다 `<text>` 를 따로** 낸다. SVG 를 문자열 grep 하면 항상 0 건이라
+> 존재 판정이 뒤집힌다(이 조사에서 두 번 잘못 결론냈다). 시험도 x 순 정렬 후 이어 붙인다.
+
+## 남긴 것
+
+- **`1342000 edu` 377쪽 `• 선언문 작성`** — 정답지(378쪽)에는 있지만 아래 셀이 있어 넓히면
+  이웃 셀을 덮는다. 보수적으로 포기했다. 되살리려면 **행 높이 축**을 고쳐 그 줄이 들어갈
+  자리를 만들어야 한다 — 이 이슈에서 풀 문제가 아니다.
+- **`table_giant_cell_overfill`** 의 두 줄은 소유 판정에서 걸리지 않아 종전대로 남는다.
+- `#2007` 의 원 문서(`1220000-202100002`)는 이 코퍼스에 없어 직접 통제군을 세우지 못했다.
+  대신 영향 모집단 전수(9건)와 겹침 래칫으로 회귀 없음을 확인했다.

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -500,6 +500,87 @@ fn cell_cut_window(
     }
 }
 
+/// [#6924] 쪽 조각이 **소유한** clip 하단 글줄을 담도록 그 셀 clip 을 미리 넓힌다.
+///
+/// `suppress_bottom_clipped_text_residue`(#2007)는 clip 바닥에 6px 미만으로 걸친 글줄을
+/// "다음 조각이 온전히 그릴 것" 이라 보고 지운다. 그 전제는 확인되지 않은 채였고, 소유자가
+/// 없는 줄까지 지워 **문서에서 통째로 사라졌다** — 렌더 트리에는 정상 좌표로 남는데 SVG 에
+/// 한 자도 나가지 않는다(148751598 1쪽 31자 · 148738070 1쪽 38자 · 156060125 6쪽 ·
+/// 1490000 vietnam 114쪽 · 1342000 edu 377쪽. 한컴 2024 정답지가 다섯 곳 모두 그 줄을 그린다).
+///
+/// 소속은 컷 부기가 이미 안다(`partial_table_page_contains_cell_position`). 소유한 줄이면
+/// 여기서 clip 을 그 줄 아랫변까지 넓혀 둔다 — 그러면 줄이 더는 바닥에 "걸치지" 않아
+/// 억제 조건 자체가 성립하지 않는다. 억제 로직은 건드리지 않는다.
+///
+/// **형제 셀과 부딪치면 넓히지 않는다.** 소유한 줄이라도 이웃 셀 내용 위로 나가면 두 글자
+/// 모두 못 읽는다(edu 82쪽 Cell3↔Cell10 · 152쪽 Cell13↔Cell24 실측: 겹침 94→97). 그런 줄은
+/// 종전대로 억제에 맡긴다 — 행 높이 축의 별개 결함이라 여기서 풀 문제가 아니다.
+fn expand_fragment_cell_clip_for_owned_bottom_lines(
+    table_node: &mut RenderNode,
+    owns_line: &dyn Fn(
+        &crate::renderer::render_tree::TableCellNode,
+        &crate::renderer::render_tree::TextLineNode,
+    ) -> bool,
+) {
+    use crate::renderer::render_tree::RenderNodeType;
+    let cell_boxes: Vec<(usize, crate::renderer::render_tree::BoundingBox)> = table_node
+        .children
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| matches!(c.node_type, RenderNodeType::TableCell(_)))
+        .map(|(i, c)| (i, c.bbox))
+        .collect();
+    for (idx, cell) in table_node.children.iter_mut().enumerate() {
+        let RenderNodeType::TableCell(meta) = &cell.node_type else {
+            continue;
+        };
+        if !meta.clip || !meta.page_fragment {
+            continue;
+        }
+        let meta = meta.clone();
+        let clip_bottom = cell.bbox.y + cell.bbox.height;
+        let mut wanted_bottom = clip_bottom;
+        for line in &cell.children {
+            if !line.visible {
+                continue;
+            }
+            let RenderNodeType::TextLine(tl) = &line.node_type else {
+                continue;
+            };
+            let line_bottom = line.bbox.y + line.bbox.height;
+            // clip 바닥을 걸치는 줄만 대상 — 완전히 안이거나 완전히 밖인 줄은 다른 축이다.
+            if line.bbox.y >= clip_bottom || line_bottom <= clip_bottom {
+                continue;
+            }
+            if !owns_line(&meta, tl) {
+                continue;
+            }
+            wanted_bottom = wanted_bottom.max(line_bottom);
+        }
+        if wanted_bottom <= clip_bottom {
+            continue;
+        }
+        // 형제 셀 충돌 검사 — 넓힌 상자가 다른 셀과 겹치면 포기한다.
+        let grown = crate::renderer::render_tree::BoundingBox::new(
+            cell.bbox.x,
+            cell.bbox.y,
+            cell.bbox.width,
+            wanted_bottom - cell.bbox.y,
+        );
+        let collides = cell_boxes.iter().any(|(other_idx, other)| {
+            *other_idx != idx
+                && grown.x < other.x + other.width
+                && other.x < grown.x + grown.width
+                && grown.y < other.y + other.height
+                && other.y < grown.y + grown.height
+        });
+        if collides {
+            continue;
+        }
+        cell.bbox.height = wanted_bottom - cell.bbox.y;
+    }
+}
+
 impl LayoutEngine {
     /// [#4128] 이 PartialTable 페이지 조각에 `cell` 의 대상 위치가 실제로 렌더되는가.
     /// pagination 메타데이터(행 범위 + 유닛 컷)와 memoize 된 `cell_units` 만 사용하며
@@ -4141,6 +4222,35 @@ impl LayoutEngine {
         // after the fragment cell loop. Preserve direct nested outer vertical
         // borders in the horizontal clip without widening the RowBreak
         // continuation viewport (issue2007 p2-p3).
+        // [#6924] 이 조각이 어떤 글줄을 **소유**하는지는 컷 부기가 이미 안다
+        // (`partial_table_page_contains_cell_position`). 그 판정을 clip 보정까지 날라
+        // 소유하지 않는 줄만 지우게 한다 — 소유한 줄을 지우면 다시 그릴 조각이 없어
+        // 문서에서 사라진다(148751598 1쪽 31자 · 148738070 1쪽 38자 · 156060125 6쪽).
+        let owns_line = |cell_meta: &crate::renderer::render_tree::TableCellNode,
+                         line: &crate::renderer::render_tree::TextLineNode|
+         -> bool {
+            let (Some(cell_idx), Some(para_index), Some(line_index)) =
+                (cell_meta.model_cell_index, line.para_index, line.line_index)
+            else {
+                // 좌표를 모르면 판정하지 않는다 — 종전 계약(억제) 그대로 둔다.
+                return false;
+            };
+            let Some(cell) = table.cells.get(cell_idx as usize) else {
+                return false;
+            };
+            self.partial_table_page_contains_cell_position(
+                table,
+                cell,
+                start_row,
+                end_row,
+                start_cut,
+                end_cut,
+                is_block_split,
+                Some((para_index, line_index as usize, true)),
+                styles,
+            )
+        };
+        expand_fragment_cell_clip_for_owned_bottom_lines(&mut table_node, &owns_line);
         extend_completed_nested_table_border_clips(
             tree,
             &mut table_node,

--- a/tests/cases/issue_6924_fragment_owned_line_kept.rs
+++ b/tests/cases/issue_6924_fragment_owned_line_kept.rs
@@ -1,0 +1,72 @@
+//! [Issue #6924] 쪽 조각이 **소유한** 글줄은 clip 바닥을 스쳐도 지우지 않는다.
+//!
+//! `suppress_bottom_clipped_text_residue`(#2007)는 clip 바닥에 6px 미만으로 걸친 글줄을
+//! "다음 조각이 온전히 그릴 것" 이라 보고 `visible = false` 로 끈다. 그 전제는 조각 하나만
+//! 봐서는 확인할 수 없었고, 실측에서 **소유자가 없는 줄까지 꺼져** 문서에서 통째로
+//! 사라졌다 — 렌더 트리에는 정상 좌표로 남는데 SVG 에 한 자도 나가지 않는다.
+//!
+//! 분할 표 경로는 `partial_table_page_contains_cell_position` 으로 줄 단위 소속을 이미
+//! 계산할 수 있다. 이 시험은 그 판정이 clip 보정까지 도달해, 조각이 소유한 줄이 살아남는지
+//! 고정한다.
+//!
+//! 픽스처는 저장소 표본이다. `1490000-200800034_vietnam_labor_report.hwp` 114쪽의
+//! `⑦ 물류 ⑧ 기타 ( )` 줄이 종전에는 **어느 쪽에도** 그려지지 않았다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::wasm_api::HwpDocument;
+
+const SAMPLE: &str = "samples/issue5714/1490000-200800034_vietnam_labor_report.hwp";
+/// 조각이 소유하지만 종전에 소실되던 줄 (공백 제거 비교).
+const LOST_LINE: &str = "⑦물류⑧기타";
+/// 0-based 페이지 번호 (SVG 파일명 `_114` 는 1-based).
+const PAGE: u32 = 113;
+
+/// SVG 는 글자마다 `<text>` 를 따로 낸다 — x 순으로 이어 붙여야 줄 내용이 된다.
+fn page_text_without_spaces(svg: &str) -> String {
+    let mut glyphs: Vec<(i64, i64, String)> = Vec::new();
+    for caps in svg.split("<text ").skip(1) {
+        let Some(head_end) = caps.find('>') else {
+            continue;
+        };
+        let (head, rest) = caps.split_at(head_end);
+        let Some(body_end) = rest.find("</text>") else {
+            continue;
+        };
+        let body = &rest[1..body_end];
+        let attr = |name: &str| -> Option<f64> {
+            let key = format!("{name}=\"");
+            let start = head.find(&key)? + key.len();
+            let end = head[start..].find('"')? + start;
+            head[start..end].parse().ok()
+        };
+        let (Some(x), Some(y)) = (attr("x"), attr("y")) else {
+            continue;
+        };
+        glyphs.push(((y * 10.0) as i64, (x * 10.0) as i64, body.to_string()));
+    }
+    glyphs.sort();
+    glyphs
+        .into_iter()
+        .map(|(_, _, t)| t)
+        .collect::<String>()
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect()
+}
+
+#[test]
+fn issue6924_fragment_owned_bottom_line_is_painted() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let document = HwpDocument::from_bytes(&bytes).expect("parse issue5714 sample");
+    let svg = document.render_page_svg(PAGE).expect("render page");
+    let text = page_text_without_spaces(&svg);
+    assert!(
+        text.contains(LOST_LINE),
+        "조각이 소유한 clip 하단 글줄이 방출되지 않았다 (#6924): {LOST_LINE:?} 없음"
+    );
+}


### PR DESCRIPTION
## 변경 요약

`suppress_bottom_clipped_text_residue`(#2007)는 clip 바닥에 6px 미만으로 걸친 글줄을
**"다음 조각이 온전히 그릴 것"** 이라 보고 `visible = false` 로 끕니다. 그 전제를 검사하는
코드가 없어서, 소유자가 없는 줄까지 꺼져 **문서에서 통째로 사라졌습니다.**

### 잘리는 게 아니라 꺼진다

이슈의 관측("칸 clip 하단이 baseline 보다 위")은 정확하지만 SVG 가 자르는 게 아닙니다.
paint LayerBuilder 프로브:

```text
PROBE TextLine visible=false editor_only=false y=920.6 h=16.0
```

`build_node` 가 `!node.visible` 에서 `None` 을 돌려주므로 PaintOp 자체가 생기지 않습니다.
`export-render-tree` 는 이 필터 **전** 트리라 정상으로 보입니다 — 두 명령이 갈리는 이유입니다.

`visible = false` 자리는 다섯뿐이고 프로브로 범인을 특정했습니다(`SITE775`). 조건도 수치로
맞습니다: `sliver = 922.45 − 920.6 = 1.88 < 6.0`.

### 전제를 추측이 아니라 계산으로

분할 표 경로에는 줄 단위 소속 판정이 이미 있습니다.

```rust
partial_table_page_contains_cell_position(table, cell, start_row, end_row,
    start_cut, end_cut, is_block_split, Some((para_idx, line_idx, true)), styles)
```

컷 부기(`start_cut`/`end_cut`)와 `TextLineNode::{para_index, line_index}`,
`TableCellNode::model_cell_index` 가 모두 갖춰져 있습니다.

### 억제를 고치지 않고 전제를 없앤다

`expand_fragment_cell_clip_for_owned_bottom_lines` 를 조각 표 조립 직후 한 번 돌립니다.
조각이 **소유한** 줄이면 셀 clip 을 그 줄 아랫변까지 넓혀 둡니다 — 그러면 줄이 더는 바닥에
"걸치지" 않아 **억제 조건 자체가 성립하지 않습니다.**
`suppress_bottom_clipped_text_residue` 는 한 줄도 고치지 않았습니다.

### 형제 셀과 부딪치면 넓히지 않는다 — 래칫이 강제했습니다

소유 판정만 넣은 1차 구현은 겹침 래칫에 걸렸습니다.

```text
증가: task2287/1342000_edu_curriculum_map.hwp — 94 → 97건
```

새 겹침 3건을 `layout-anomaly --json` 으로 특정했습니다.

```text
82쪽   Cell3/TextLine6  (y=240.0) ↔ Cell10/TextLine0 (y=246.0)
152쪽  Cell13/TextLine4 (y=217.2) ↔ Cell24/TextLine0 (y=223.8)
```

소유한 줄이라도 이웃 셀 내용 위로 나가면 두 글자 모두 못 읽습니다. 아래 셀이 있는 셀은
넓히지 않도록 막아 94 로 복귀했습니다
(`local_validation.md` 4.3.1 — "기존 문서의 수치 증가는 회귀다, baseline 으로 숨기지 않는다").

## 관련 이슈

closes #6924

## 테스트

- 변경 범위: Rust (renderer/layout)
- 검증한 commit SHA: `889133a40f6f5a3405bc5f26b43d0e489509f5f1`
- 실행 명령·결과:

```
node scripts/rust-test-suite-manifest.mjs --prepare
cargo fmt --all -- --check                                     # OK (수정 없음)
node scripts/rust-unit-test-tiers.mjs --check                  # 4205 (기준선 유지)
cargo clippy --locked --target-dir target/pr-review -- -D warnings                     # OK
cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown \
  --target-dir target/pr-review -- -D warnings                                         # OK
cargo build --locked --workspace --target-dir target/pr-review                         # OK
cargo clippy --locked --workspace --all-targets --target-dir target/pr-review -- -D warnings  # OK
node scripts/rust-test-suite-manifest.mjs --check              # 48/48 integration targets
# 전 타깃(regression_suite_001..028 + lib) 순차 실행
cargo test --release --test <각 suite> -- --test-threads=2     # 9095 passed / 0 failed / 38 ignored
```

> `cargo test --release --workspace` 는 이 머신에서 OOM 으로 두 번 중단됐습니다(74/94 suite
> 시점 6403 passed / 0 failed). 스위트를 하나씩 순차 실행해 전수를 채웠고 실패 타깃은 0 입니다.

**겹침 래칫 16 partition 전부 통과** — 이 변경의 관문입니다.

### 회귀 테스트 (신규 1건)

`tests/cases/issue_6924_fragment_owned_line_kept.rs` — 저장소 표본
`samples/issue5714/1490000-200800034_vietnam_labor_report.hwp` 114쪽에서 `⑦물류⑧기타` 가
방출되는지 고정합니다. `src/` 안 `#[cfg(test)]` 총량 래칫 때문에 통합 시험으로 두었습니다.

> ⚠ 이 렌더러는 **글자마다 `<text>` 를 따로** 냅니다. SVG 를 문자열 grep 하면 항상 0 건이라
> 존재 판정이 뒤집힙니다(이 조사에서 두 번 잘못 결론냈습니다). 시험도 x 순 정렬 후 이어 붙입니다.

### 영향 모집단 전수

억제 진입점에 계측을 걸어 전수 조사했습니다.

| 모집단 | 억제 발생 문서 | 조각 셀(`page_fragment=true`) |
|---|---|---|
| native HWP5 코퍼스 702건 | 6 | 3 |
| 저장소 `samples/` 824건 | 9 | 4 |

### 복구 — 한컴 2024 정답지 대조

| 문서 | 쪽 | 글줄 | 기준선 | 수정 | 정답지 |
|---|---|---|---|---|---|
| 148751598 | 1 | `* 장관 참석행사는 ★로…` (31자) | 없음 | **있음** | 있음 |
| 148738070 | 1 | `‘발효생성아미노산복합물’을 뜻함…` (38자) | 없음 | **있음** | 있음 |
| **156060125** | 6 | `리스크 집중위험 점검 등` | 없음 | **있음** | — |
| 1490000 vietnam | 114 | `⑦ 물류 ⑧ 기타 ( )` | 없음 | **있음** | 114쪽 |

`156060125` 는 이슈 밖에서 새로 찾은 같은 결함입니다.

### 중복으로 의심했다가 오독으로 판명된 둘

- `1490000 vietnam '으로보고계십니까'` — 정답지 86·121 **2쪽**인데 기준선은 87 **1쪽**뿐이었습니다.
  rhwp 쪽 번호가 정답지보다 +1 이라 121↔122 입니다. 중복이 아니라 **소실**이었고 수정이 옳습니다.
- `1342000 edu '3.사회적가치…'` — 기준선에서 이미 82·83 두 쪽입니다. 이 변경과 무관한 기존 중복입니다.

- [x] [변경 범위별 필수 검증](https://github.com/edwardkim/rhwp/blob/devel/CONTRIBUTING.md#pr-전-체크리스트) 수행, 제출 HEAD 가 검증한 commit 과 같음
- [x] Rust source 변경: 별도 worktree 에서 `cargo fmt --all -- --check`, native·WASM32·workspace all-target Clippy 통과
- [x] Rust 변경: 전 integration 회귀 + 코퍼스 래칫(겹침·off-canvas 포함) + 한컴 정답지 대조 수행
- [x] 새 integration test 원본을 `tests/cases/` 에만 추가, `tests/generated/`·`manifest.json` 미포함
- [x] `src/**`의 `#[cfg(test)]` 총량 불변(4205) — `rust-unit-test-tiers --check` 통과
- [x] (에이전트 보조) 작업 증빙 — 문서 편집이 아니라 `replay --capsule` 해당 없음. 위 모집단 전수 계측·정답지 대조가 재현 가능한 증적입니다.

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 — 조각 표마다 직접 자식 셀을 한 번 훑는 선형 순회입니다.
- 재현·측정: 회귀 스위트 수행 시간에 유의한 변화 없음.

## 남긴 것

- **`1342000 edu` 377쪽 `• 선언문 작성`** — 정답지(378쪽)에는 있지만 아래 셀이 있어 넓히면
  이웃 셀을 덮습니다. 행 높이(21.1px)가 셀 내용(13.3px × 2줄)보다 작은 **행 높이 축**이라
  clip 으로는 풀 수 없습니다. #6981 로 등록했습니다.
- **`table_giant_cell_overfill`** 의 두 줄은 소유 판정에 걸리지 않아 종전대로 남습니다.
- `#2007` 원 문서(`1220000-202100002`)는 이 코퍼스에 없어 직접 통제군을 세우지 못했습니다.
  대신 영향 모집단 전수(9건)와 겹침 래칫으로 회귀 없음을 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Atxwm3i6Nkqfar45X9TSzz