### PR TITLE
ci: 문서 후속 커밋의 검증된 병합 후보 및 재사용 증거 보완

### DIFF
--- a/.github/workflows/adapter-diff.yml
+++ b/.github/workflows/adapter-diff.yml
@@ -153,6 +153,8 @@ jobs:
               per_page: 100,
             });
             const reviewOnlyCandidates = [];
+            const candidatesContainingBase = new Set();
+            let baseMergeCandidateIndex = -1;
             let codeCandidateSha = '';
             let newerTailCommit = null;
             let baseMergeBridge = null;
@@ -178,6 +180,12 @@ jobs:
                   sourceParentSha: sourceParent.sha,
                 };
                 newerTailCommit = { parents: [{ sha: sourceParent.sha }] };
+                // The merge can itself have a green run; do not only search its source parent.
+                baseMergeCandidateIndex = reviewOnlyCandidates.length;
+                for (const candidateSha of reviewOnlyCandidates) {
+                  candidatesContainingBase.add(candidateSha);
+                }
+                candidatesContainingBase.add(commit.sha);
                 core.info(`including current-base update merge bridge ${commit.sha}`);
                 continue;
               }
@@ -218,6 +226,9 @@ jobs:
               }
               reviewOnlyCandidates.push(codeCandidateSha);
             }
+            if (baseMergeBridge) {
+              reviewOnlyCandidates.splice(baseMergeCandidateIndex, 0, baseMergeBridge.mergeSha);
+            }
 
             const candidateRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
               owner: context.repo.owner,
@@ -248,7 +259,7 @@ jobs:
                 setResult(true, 'review-tail-candidate-run-unavailable');
                 return;
               }
-              if (baseMergeBridge) {
+              if (baseMergeBridge && !candidatesContainingBase.has(candidateSha)) {
                 setPendingBaseMergeResult(
                   `adapter-run-green:${latestCandidateRun.conclusion}`,
                   candidateSha,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,9 @@ jobs:
                 };
               }
 
+              if (workflowRun.conclusion !== 'success') {
+                return { state: 'failed', reason: `workflow-not-success:${workflowRun.conclusion}` };
+              }
               const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
                 owner,
                 repo,
@@ -461,8 +464,11 @@ jobs:
               }
 
               const reviewOnlyCandidates = [];
+              const candidatesContainingBase = new Set();
+              let baseMergeCandidateIndex = -1;
               let codeCandidateSha = '';
               let baseMergeBridge = null;
+              let expectedSha = pr.head.sha;
 
               for (let index = commits.length - 1; index >= 0; index -= 1) {
                 const sha = commits[index].sha;
@@ -472,6 +478,10 @@ jobs:
                   ref: sha,
                 });
                 const parents = commit.parents || [];
+                if (sha !== expectedSha || commit.sha !== sha) {
+                  setResult(false, 'review-tail-parent-mismatch');
+                  return;
+                }
                 if (isCurrentBaseUpdateMerge(commit, pr.base.sha)) {
                   if (baseMergeBridge) {
                     setResult(false, `multiple-current-base-update-merges:${sha}`);
@@ -479,6 +489,13 @@ jobs:
                   }
                   const sourceParent = parents.find((parent) => parent.sha !== pr.base.sha);
                   baseMergeBridge = { mergeSha: sha, sourceParentSha: sourceParent.sha };
+                  expectedSha = sourceParent.sha;
+                  // The merge can itself have a green run; do not only search its source parent.
+                  baseMergeCandidateIndex = reviewOnlyCandidates.length;
+                  for (const candidateSha of reviewOnlyCandidates) {
+                    candidatesContainingBase.add(candidateSha);
+                  }
+                  candidatesContainingBase.add(sha);
                   core.info(`including current-base update merge bridge ${sha}`);
                   continue;
                 }
@@ -492,8 +509,9 @@ jobs:
 
                 const reviewOnly = files.every((file) => isAllowedReviewPath(file));
                 if (reviewOnly) {
-                  if (parents.length === 1) {
+                  if (parents.length === 1 && /^[0-9a-f]{40}$/.test(parents[0]?.sha || '')) {
                     reviewOnlyCandidates.push(sha);
+                    expectedSha = parents[0].sha;
                     continue;
                   }
                   setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
@@ -511,11 +529,14 @@ jobs:
               if (codeCandidateSha) {
                 reviewOnlyCandidates.push(codeCandidateSha);
               }
+              if (baseMergeBridge) {
+                reviewOnlyCandidates.splice(baseMergeCandidateIndex, 0, baseMergeBridge.mergeSha);
+              }
 
               for (const candidateSha of reviewOnlyCandidates) {
                 const result = await buildResult(candidateSha, pr);
                 if (result.state === 'green') {
-                  if (baseMergeBridge) {
+                  if (baseMergeBridge && !candidatesContainingBase.has(candidateSha)) {
                     setPendingBaseMergeResult(
                       `build-and-test-green:${result.conclusion}`,
                       candidateSha,

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -283,6 +283,9 @@ jobs:
                   reason: `codeql-workflow-not-completed:${workflowRun.status}`,
                 };
               }
+              if (workflowRun.conclusion !== 'success') {
+                return { state: 'failed', reason: `workflow-not-success:${workflowRun.conclusion}` };
+              }
               const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
                 owner,
                 repo,
@@ -430,8 +433,11 @@ jobs:
               }
 
               const reviewOnlyCandidates = [];
+              const candidatesContainingBase = new Set();
+              let baseMergeCandidateIndex = -1;
               let codeCandidateSha = '';
               let baseMergeBridge = null;
+              let expectedSha = pr.head.sha;
 
               for (let index = commits.length - 1; index >= 0; index -= 1) {
                 const sha = commits[index].sha;
@@ -441,6 +447,10 @@ jobs:
                   ref: sha,
                 });
                 const parents = commit.parents || [];
+                if (sha !== expectedSha || commit.sha !== sha) {
+                  setResult(false, 'review-tail-parent-mismatch');
+                  return;
+                }
                 if (isCurrentBaseUpdateMerge(commit, pr.base.sha)) {
                   if (baseMergeBridge) {
                     setResult(false, `multiple-current-base-update-merges:${sha}`);
@@ -448,6 +458,13 @@ jobs:
                   }
                   const sourceParent = parents.find((parent) => parent.sha !== pr.base.sha);
                   baseMergeBridge = { mergeSha: sha, sourceParentSha: sourceParent.sha };
+                  expectedSha = sourceParent.sha;
+                  // The merge can itself have a green run; do not only search its source parent.
+                  baseMergeCandidateIndex = reviewOnlyCandidates.length;
+                  for (const candidateSha of reviewOnlyCandidates) {
+                    candidatesContainingBase.add(candidateSha);
+                  }
+                  candidatesContainingBase.add(sha);
                   core.info(`including current-base update merge bridge ${sha}`);
                   continue;
                 }
@@ -461,8 +478,9 @@ jobs:
 
                 const reviewOnly = files.every((file) => isAllowedReviewPath(file));
                 if (reviewOnly) {
-                  if (parents.length === 1) {
+                  if (parents.length === 1 && /^[0-9a-f]{40}$/.test(parents[0]?.sha || '')) {
                     reviewOnlyCandidates.push(sha);
+                    expectedSha = parents[0].sha;
                     continue;
                   }
                   setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
@@ -480,11 +498,14 @@ jobs:
               if (codeCandidateSha) {
                 reviewOnlyCandidates.push(codeCandidateSha);
               }
+              if (baseMergeBridge) {
+                reviewOnlyCandidates.splice(baseMergeCandidateIndex, 0, baseMergeBridge.mergeSha);
+              }
 
               for (const candidateSha of reviewOnlyCandidates) {
                 const result = await codeqlResult(candidateSha, pr);
                 if (result.state === 'green') {
-                  if (baseMergeBridge) {
+                  if (baseMergeBridge && !candidatesContainingBase.has(candidateSha)) {
                     setPendingBaseMergeResult(
                       'codeql-checks-green',
                       candidateSha,

--- a/.github/workflows/proptest-roundtrip.yml
+++ b/.github/workflows/proptest-roundtrip.yml
@@ -160,6 +160,8 @@ jobs:
               per_page: 100,
             });
             const reviewOnlyCandidates = [];
+            const candidatesContainingBase = new Set();
+            let baseMergeCandidateIndex = -1;
             let codeCandidateSha = '';
             let newerTailCommit = null;
             let baseMergeBridge = null;
@@ -185,6 +187,12 @@ jobs:
                   sourceParentSha: sourceParent.sha,
                 };
                 newerTailCommit = { parents: [{ sha: sourceParent.sha }] };
+                // The merge can itself have a green run; do not only search its source parent.
+                baseMergeCandidateIndex = reviewOnlyCandidates.length;
+                for (const candidateSha of reviewOnlyCandidates) {
+                  candidatesContainingBase.add(candidateSha);
+                }
+                candidatesContainingBase.add(commit.sha);
                 core.info(`including current-base update merge bridge ${commit.sha}`);
                 continue;
               }
@@ -225,6 +233,9 @@ jobs:
               }
               reviewOnlyCandidates.push(codeCandidateSha);
             }
+            if (baseMergeBridge) {
+              reviewOnlyCandidates.splice(baseMergeCandidateIndex, 0, baseMergeBridge.mergeSha);
+            }
 
             const candidateRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
               owner: context.repo.owner,
@@ -255,7 +266,7 @@ jobs:
                 setResult(false, 'review-tail-candidate-run-unavailable');
                 return;
               }
-              if (baseMergeBridge) {
+              if (baseMergeBridge && !candidatesContainingBase.has(candidateSha)) {
                 setPendingBaseMergeResult(
                   `proptest-run-green:${latestCandidateRun.conclusion}`,
                   candidateSha,

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -410,8 +410,11 @@ jobs:
               }
 
             const reviewOnlyCandidates = [];
+            const candidatesContainingBase = new Set();
+            let baseMergeCandidateIndex = -1;
             let codeCandidateSha = '';
             let baseMergeBridge = null;
+            let expectedSha = pr.head.sha;
 
             for (let index = commits.length - 1; index >= 0; index -= 1) {
               const sha = commits[index].sha;
@@ -421,6 +424,10 @@ jobs:
                 ref: sha,
               });
               const parents = commit.parents || [];
+              if (sha !== expectedSha || commit.sha !== sha) {
+                setResult(false, 'review-tail-parent-mismatch');
+                return;
+              }
               if (isCurrentBaseUpdateMerge(commit, pr.base.sha)) {
                 if (baseMergeBridge) {
                   setResult(false, `multiple-current-base-update-merges:${sha}`);
@@ -428,6 +435,13 @@ jobs:
                 }
                 const sourceParent = parents.find((parent) => parent.sha !== pr.base.sha);
                 baseMergeBridge = { mergeSha: sha, sourceParentSha: sourceParent.sha };
+                expectedSha = sourceParent.sha;
+                // The merge can itself have a green run; do not only search its source parent.
+                baseMergeCandidateIndex = reviewOnlyCandidates.length;
+                for (const candidateSha of reviewOnlyCandidates) {
+                  candidatesContainingBase.add(candidateSha);
+                }
+                candidatesContainingBase.add(sha);
                 core.info(`including current-base update merge bridge ${sha}`);
                 continue;
               }
@@ -441,8 +455,9 @@ jobs:
 
               const reviewOnly = files.every((file) => isAllowedReviewPath(file));
               if (reviewOnly) {
-                if (parents.length === 1) {
+                if (parents.length === 1 && /^[0-9a-f]{40}$/.test(parents[0]?.sha || '')) {
                   reviewOnlyCandidates.push(sha);
+                  expectedSha = parents[0].sha;
                   continue;
                 }
                 setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
@@ -460,11 +475,14 @@ jobs:
             if (codeCandidateSha) {
               reviewOnlyCandidates.push(codeCandidateSha);
             }
+            if (baseMergeBridge) {
+              reviewOnlyCandidates.splice(baseMergeCandidateIndex, 0, baseMergeBridge.mergeSha);
+            }
 
             for (const candidateSha of reviewOnlyCandidates) {
-              const result = await renderDiffResult(candidateSha, pr, Boolean(baseMergeBridge));
+              const result = await renderDiffResult(candidateSha, pr, Boolean(baseMergeBridge) && !candidatesContainingBase.has(candidateSha));
               if (result.state === 'green') {
-                if (baseMergeBridge) {
+                if (baseMergeBridge && !candidatesContainingBase.has(candidateSha)) {
                   setPendingBaseMergeResult(
                     'canvas-visual-diff-success',
                     candidateSha,

--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -239,6 +239,7 @@ jobs:
             let classifyReviewOnlyCommit;
             let evaluateTrustedPostMergeReuse;
             let frontendOnlyCiRunIsReusable;
+            let fullLaneWorkflowJobsAreGreen;
             let classifyChanges;
             let currentBaseReviewBridgeSource;
             let selectTrustedPostMergeCandidate;
@@ -249,14 +250,14 @@ jobs:
             let trustedPullRequestWorkflowRun;
             const repositoryId = Number(process.env.GITHUB_REPOSITORY_ID);
             try {
-              ({ classifyReviewOnlyCommit, evaluateTrustedPostMergeReuse, frontendOnlyCiRunIsReusable,
+              ({ classifyReviewOnlyCommit, evaluateTrustedPostMergeReuse, frontendOnlyCiRunIsReusable, fullLaneWorkflowJobsAreGreen,
                 currentBaseReviewBridgeSource, selectTrustedPostMergeCandidate,
                 verifyPostMergeReviewBridgeTree, verifyForkPostMergeTree, verifyReviewOnlyBaseAdvance,
                 trustedPullRequestSource, trustedPullRequestWorkflowRun } = await import(pathToFileURL(path.join(
                 process.env.GITHUB_WORKSPACE,
                 'scripts/verify-trusted-postmerge-ci-reuse.mjs',
               )).href));
-              if ([currentBaseReviewBridgeSource, selectTrustedPostMergeCandidate,
+              if ([currentBaseReviewBridgeSource, selectTrustedPostMergeCandidate, fullLaneWorkflowJobsAreGreen,
                 verifyPostMergeReviewBridgeTree, verifyForkPostMergeTree,
                 trustedPullRequestSource, trustedPullRequestWorkflowRun].some((fn) => typeof fn !== 'function')) {
                 throw new Error('trusted base has no review-bridge verifier');
@@ -503,7 +504,7 @@ jobs:
                   }
                 }
               }
-              const requireFullLaneEvidence = ["ci.yml", "codeql.yml"]
+              const requireFullLaneEvidence = ["ci.yml", "codeql.yml", "adapter-diff.yml", "proptest-roundtrip.yml"]
                 .includes(process.env.WORKFLOW_FILE) || isFork;
               const reviewOnlyWorker = {
                 "proptest-roundtrip.yml": {
@@ -519,6 +520,13 @@ jobs:
               if (requireFullLaneEvidence) {
                 for (const workflowRun of workflowRuns) {
                   if (!matchesRun(workflowRun) || workflowRun.status !== "completed" || workflowRun.conclusion !== "success") {
+                    continue;
+                  }
+                  const jobs = await github.paginate(
+                    github.rest.actions.listJobsForWorkflowRun,
+                    { owner, repo, run_id: workflowRun.id, filter: "latest", per_page: 100 },
+                  );
+                  if (!fullLaneWorkflowJobsAreGreen(process.env.WORKFLOW_FILE, jobs)) {
                     continue;
                   }
                   if (process.env.WORKFLOW_FILE === "ci.yml") {
@@ -538,20 +546,24 @@ jobs:
                     }
                     continue;
                   }
-                  const jobs = await github.paginate(
-                    github.rest.actions.listJobsForWorkflowRun,
-                    { owner, repo, run_id: workflowRun.id, per_page: 100 },
-                  );
-                  const executed = reviewOnlyWorker
-                    ? [reviewOnlyWorker.preflight, reviewOnlyWorker.worker].every((name) => jobs.some((job) => (
-                      job.name === name && job.status === 'completed' && job.conclusion === 'success'
-                    )))
-                    : jobs.some((job) => (
-                    /^Analyze \(.+\)$/.test(job.name || "")
-                    && job.status === "completed"
-                    && job.conclusion === "success"
-                  ));
-                  if (executed) {
+                  if (process.env.WORKFLOW_FILE === "codeql.yml") {
+                    const checks = await github.paginate(github.rest.checks.listForRef, {
+                      owner, repo, ref: workflowRun.head_sha, filter: "latest", per_page: 100,
+                    });
+                    const startedAt = Date.parse(workflowRun.run_started_at || workflowRun.created_at);
+                    const securityCheck = checks.filter((check) => (
+                      check.app?.slug === "github-advanced-security" && check.name === "CodeQL"
+                      && check.head_sha === workflowRun.head_sha
+                    )).sort((a, b) => Date.parse(b.started_at || "") - Date.parse(a.started_at || "")
+                      || Number(b.id) - Number(a.id))[0];
+                    if (!Number.isFinite(startedAt) || !securityCheck
+                      || !Number.isFinite(Date.parse(securityCheck.started_at || ""))
+                      || Date.parse(securityCheck.started_at) < startedAt
+                      || securityCheck.status !== "completed" || securityCheck.conclusion !== "success") {
+                      continue;
+                    }
+                  }
+                  {
                     fullLaneRunIds.push(String(workflowRun.id));
                     const artifacts = await github.paginate(
                       github.rest.actions.listWorkflowRunArtifacts,

--- a/mydocs/orders/20260910.md
+++ b/mydocs/orders/20260910.md
@@ -104,3 +104,18 @@
 - [ ] 문서 trailing head CI가 success 또는 정책상 expected skip이고 merge 조건을 만족하면 승인된 merge 및 `post_merge.md` 후속처리, 이번 local/upstream 브랜치 정리를 수행한다.
 
 실제 code CI: [CI](https://github.com/edwardkim/rhwp/actions/runs/34468254010), [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/34468253850), [Render Diff](https://github.com/edwardkim/rhwp/actions/runs/34468253715), [Adapter inter-diff](https://github.com/edwardkim/rhwp/actions/runs/34468253961), [Proptest roundtrip](https://github.com/edwardkim/rhwp/actions/runs/34468253906).
+
+## PR #6990 병합 및 후속처리 완료
+
+- [x] 최종 head `bc5ab3bd80c8db2b98e1ba2129d99827d80854d6`의 CI gate 확인 후 일반 merge commit `2a780e0d296846df577866eba6ac8f388527551b`으로 병합했다.
+- [x] 기본 작업공간 devel을 동기화하고 devel CI·CodeQL·Adapter·Proptest·Close Issues 성공을 확인했다. CI heavy worker는 정책상 skip, nextest timing 갱신은 성공했다.
+- [x] 원 PR 8개와 해결 이슈 7개에 실제 증적 코멘트를 남기고 종료했다. #6976은 단계적 진행 코멘트만 남기고 OPEN을 유지했다.
+- [x] 이번 local branch 2개, upstream 통합 head 및 control worktree를 정리했다. 전용 target 2개는 휴지통으로 이동했다. contributor fork 및 다른 작업은 보존했다.
+
+## #6815 CI 재사용 보완 / PR #6991
+
+- [x] current-base merge 자체의 green CI 후보 누락과 post-merge 필수 worker·Git 객체 증거 검증을 보완했다.
+- [x] 최신 devel `2a780e0d2` 위 코드 `0462bdf826fea5065ee77c5cb5645e1b67c56f98`에서 Node 220개와 Python workflow 233개가 통과했다. 기존 SC2016 1건을 제외한 actionlint 및 whitespace 검사도 통과했다.
+- [x] [PR #6991](https://github.com/edwardkim/rhwp/pull/6991)을 생성했다. [self-review](../pr/archives/pr_6991_review.md)와 이 기록만 문서 trailing commit으로 추가한다. 기존 오늘할일 내용은 보존했다.
+- [ ] 최신 PR head의 Full CI와 merge gate 확인. 현재 로컬 검토 승인이며 GitHub CI 완료 전 머지 보류다.
+- [ ] 병합 후 별도 코드 PR의 문서 trailing/current-base merge 사례에서 실제 heavy skip·timing 재사용을 관찰한 뒤 #6815 완료 여부를 결정한다. #6990의 기존 post-merge 성공을 이번 코드의 효과로 주장하지 않는다.

--- a/mydocs/pr/archives/pr_6991_review.md
+++ b/mydocs/pr/archives/pr_6991_review.md
@@ -1,0 +1,53 @@
+# PR #6991 검토: 검증된 current-base merge와 문서 후속 커밋의 CI 재사용
+
+## 판정: 로컬 검토 승인, GitHub CI 완료 전 머지 보류
+
+- 대상: [PR #6991](https://github.com/edwardkim/rhwp/pull/6991), [Issue #6815](https://github.com/edwardkim/rhwp/issues/6815).
+- 기준 devel: `2a780e0d296846df577866eba6ac8f388527551b`.
+- 검증 코드: `0462bdf826fea5065ee77c5cb5645e1b67c56f98`.
+- 경로: collaborator self-review. 저장소 owner를 reviewer로 자동 지정하지 않았다.
+- 로컬 계약 검증에서 미해결 실패는 없다. 최신 GitHub required check와 실제 운영 재사용 성공은 아직 확인하지 않았으므로 머지 또는 이슈 전체 종료를 승인한 기록이 아니다.
+
+## 원인과 보정 범위
+
+#6813의 문서 충돌 해소 merge 뒤 post-merge 후보 탐색과 #6990의 PR preflight 사례를 함께 다뤘다. #6990에서는 current-base merge `cc11b55e69656450a57629f2b7a2122732b08dc9`의 Full CI가 성공했지만, 문서 trailing head가 해당 merge 자체를 후보에서 건너뛰어 Full CI를 재실행했다.
+
+CI·CodeQL·Render Diff·Adapter·Proptest의 후보 탐색에 merge 자체를 포함하고, merge 이후 후보와 이전 후보를 구분했다. 이전 후보를 재사용할 때의 독립 merge-tree 증명은 유지했다. head에서 후보까지의 부모 계보, 저장소·브랜치·SHA, 실행 완료와 성공을 확인한다.
+
+post-merge collector와 verifier는 신뢰 base 코드로 Git 객체와 필수 worker 증거를 검사한다. 증거가 없거나 worker가 누락·실패·진행 중인 경우 재사용하지 않는다. 문서 밖에서 들어오는 rename, symlink·실행 파일 및 실행 계약 변경은 문서-only로 인정하지 않는다. CodeQL 분석과 보안 check, CI B/C/D artifact 및 timing 갱신 계약도 보존했다. PR head 코드는 실행하지 않는다.
+
+## 실제 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| Node verifier·실제 preflight/collector 계약 | 220개 통과, 실패 0, skip 0 |
+| Python workflow 계약 | 233개 통과, 실패 0 |
+| 최신 devel 정렬 후 위 두 검증 재실행 | 모두 통과 |
+| actionlint 6개 workflow | 기준선에도 있는 SC2016 경고 1건을 제외하고 통과 |
+| git diff whitespace 검사 | 통과 |
+
+실행 명령:
+
+```sh
+node --test scripts/tests/verify-trusted-postmerge-ci-reuse*.test.mjs scripts/tests/verify-trusted-postmerge-review-bridge.test.mjs
+python3 -m unittest discover -s scripts/tests -p 'test_*workflow*.py'
+actionlint -ignore 'SC2016' .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/render-diff.yml .github/workflows/adapter-diff.yml .github/workflows/proptest-roundtrip.yml .github/workflows/trusted-postmerge-ci-reuse.yml
+git diff --check
+```
+
+SC2016은 수정 전 ci.yml에서도 재현한 기존 경고다. 무경고 통과라고 주장하지 않는다. 초기 CodeQL 계약 실패 6개는 테스트 모형의 실제 SHA 형식 및 head/getCommit.sha 누락을 보완한 뒤 해소했다. 성공 판정을 위해 제품 검증 조건을 완화하지 않았다.
+
+CI 정책 변경 범위이므로 Rust 전체 회귀·WASM 빌드·문서 시각 sweep은 실행하지 않았다. 원시 로그·임시 JSON 등은 제출하지 않는다. 제품 화면 변경이 없어 PNG/PDF 증적은 불필요하다.
+
+## 적용 경계와 남은 검증
+
+이 PR은 CI 실행 정책을 변경하므로 자체 Full CI를 통과해야 한다. 로컬 mock·Git 객체 계약 성공은 GitHub 운영 성공과 구분한다. 병합 후 별도 코드 PR의 문서 trailing/current-base merge 사례에서 heavy skip과 timing 재사용을 실제 run으로 확인해야 #6815를 최종 완료할 수 있다.
+
+#6990의 [PR CI](https://github.com/edwardkim/rhwp/actions/runs/34469847029)는 중복 Full 실행 사례다. 이후 [devel CI](https://github.com/edwardkim/rhwp/actions/runs/34472004648)와 [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/34472004649)의 재사용 성공은 기존 코드의 결과이며, 아직 병합하지 않은 #6991의 개선 효과가 아니다.
+
+## 후속 코멘트와 정리 계획
+
+- PR 및 #6815에는 실제 merge SHA, 최종 PR/devel CI run URL, 확인된 재사용/Full fallback과 timing 갱신 결과를 기록한다. 미완료 운영 검증을 완료로 적지 않는다.
+- 기존 #6815 코멘트를 갱신하여 동일 내용의 중복 코멘트를 만들지 않는다. 종료 조건을 충족하기 전에는 이슈를 열린 상태로 유지한다.
+- UTF-8 body-file 방식으로 게시하고 API로 본문을 다시 확인한다. 시각 변경이 없으므로 무관한 PNG/PDF를 첨부하지 않는다.
+- post_merge.md의 gate 충족 뒤에만 이 작업의 local/upstream `fix/6815-green-merge-review-tail-20260910` 및 전용 worktree를 정리한다. 기본 작업공간·다른 작업은 보존한다.

--- a/scripts/tests/test_codeql_workflow.py
+++ b/scripts/tests/test_codeql_workflow.py
@@ -86,7 +86,7 @@ class CodeQLWorkflowTests(unittest.TestCase):
     def test_green_analyze_jobs_cannot_reuse_a_failed_security_check(self) -> None:
         outputs = self._run_preflight("failure")
         self.assertEqual(outputs["fast_pass"], "false")
-        self.assertEqual(outputs["candidate_sha"], "code-candidate")
+        self.assertEqual(outputs["candidate_sha"], "cccccccccccccccccccccccccccccccccccccccc")
         self.assertEqual(
             outputs["reason"],
             "security-check-not-green:CodeQL:failure",
@@ -95,19 +95,19 @@ class CodeQLWorkflowTests(unittest.TestCase):
     def test_green_analyze_jobs_and_early_security_check_remain_reusable(self) -> None:
         outputs = self._run_preflight("success")
         self.assertEqual(outputs["fast_pass"], "true")
-        self.assertEqual(outputs["candidate_sha"], "code-candidate")
+        self.assertEqual(outputs["candidate_sha"], "cccccccccccccccccccccccccccccccccccccccc")
         self.assertEqual(outputs["reason"], "codeql-checks-green")
 
     def test_green_analyze_jobs_and_neutral_security_summary_remain_reusable(self) -> None:
         outputs = self._run_preflight("neutral")
         self.assertEqual(outputs["fast_pass"], "true")
-        self.assertEqual(outputs["candidate_sha"], "code-candidate")
+        self.assertEqual(outputs["candidate_sha"], "cccccccccccccccccccccccccccccccccccccccc")
         self.assertEqual(outputs["reason"], "codeql-checks-green")
 
     def test_green_analyze_jobs_cannot_reuse_a_skipped_security_summary(self) -> None:
         outputs = self._run_preflight("skipped")
         self.assertEqual(outputs["fast_pass"], "false")
-        self.assertEqual(outputs["candidate_sha"], "code-candidate")
+        self.assertEqual(outputs["candidate_sha"], "cccccccccccccccccccccccccccccccccccccccc")
         self.assertEqual(
             outputs["reason"],
             "security-check-not-green:CodeQL:skipped",
@@ -349,12 +349,12 @@ const endpoints = {
   listForRef: Symbol('listForRef'),
 };
 const commits = {
-  'review-record': {
-    parents: [{ sha: 'code-candidate' }],
+  'dddddddddddddddddddddddddddddddddddddddd': {
+    parents: [{ sha: 'cccccccccccccccccccccccccccccccccccccccc' }],
     files: [{ filename: 'mydocs/working/review.md', status: 'modified' }],
   },
-  'code-candidate': {
-    parents: [{ sha: 'base-sha' }],
+  'cccccccccccccccccccccccccccccccccccccccc': {
+    parents: [{ sha: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' }],
     files: [{ filename: 'src/lib.rs', status: 'modified' }],
   },
 };
@@ -370,7 +370,7 @@ const github = {
     },
     checks: { listForRef: endpoints.listForRef },
     repos: {
-      getCommit: async ({ ref }) => ({ data: commits[ref] }),
+      getCommit: async ({ ref }) => ({ data: { sha: ref, ...commits[ref] } }),
     },
   },
   paginate: async (endpoint, params) => {
@@ -381,14 +381,14 @@ const github = {
       ];
     }
     if (endpoint === endpoints.listCommits) {
-      return [{ sha: 'code-candidate' }, { sha: 'review-record' }];
+      return [{ sha: 'cccccccccccccccccccccccccccccccccccccccc' }, { sha: 'dddddddddddddddddddddddddddddddddddddddd' }];
     }
     if (endpoint === endpoints.listWorkflowRuns) {
       return [{
         id: 3790,
         path: '.github/workflows/codeql.yml',
         event: 'pull_request',
-        head_sha: 'code-candidate',
+        head_sha: 'cccccccccccccccccccccccccccccccccccccccc',
         head_branch: 'feature-3790',
         head_repository: { id: 7 },
         status: 'completed',
@@ -433,8 +433,8 @@ const context = {
     pull_request: {
       number: 4310,
       created_at: '2026-08-09T00:00:00Z',
-      base: { sha: 'base-sha' },
-      head: { ref: 'feature-3790', repo: { id: 7 } },
+      base: { sha: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' },
+      head: { sha: 'dddddddddddddddddddddddddddddddddddddddd', ref: 'feature-3790', repo: { id: 7 } },
     },
   },
 };

--- a/scripts/tests/test_review_only_fast_pass_workflows.py
+++ b/scripts/tests/test_review_only_fast_pass_workflows.py
@@ -202,7 +202,7 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
         self.assertIn("allowPriorPrBase\n                  ? step.name.startsWith(identityPrefix)", workflow)
         self.assertIn("await renderDiffResult(sourceParent.sha, pr, true)", workflow)
         self.assertIn(
-            "await renderDiffResult(candidateSha, pr, Boolean(baseMergeBridge))",
+            "await renderDiffResult(candidateSha, pr, Boolean(baseMergeBridge) && !candidatesContainingBase.has(candidateSha))",
             workflow,
         )
 
@@ -210,8 +210,8 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
         base_sha = "b" * 40
         prior_base_sha = "a" * 40
         code_candidate = "c" * 40
-        merge_sha = "m" * 40
-        review_tail = "r" * 40
+        merge_sha = "1" * 40
+        review_tail = "2" * 40
         files = [
             {"filename": "src/renderer/layout.rs", "status": "modified"},
             {"filename": "mydocs/orders/20260827.md", "status": "modified"},
@@ -257,7 +257,7 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
     ) -> None:
         base_sha = "b" * 40
         code_candidate = "c" * 40
-        review_tail = "r" * 40
+        review_tail = "2" * 40
         commits = [
             {
                 "sha": code_candidate,
@@ -295,8 +295,8 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
     ) -> None:
         base_sha = "b" * 40
         code_candidate = "c" * 40
-        merge_sha = "m" * 40
-        review_tail = "r" * 40
+        merge_sha = "1" * 40
+        review_tail = "2" * 40
         files = [
             {"filename": "src/renderer/layout.rs", "status": "modified"},
             {"filename": "mydocs/orders/20260827.md", "status": "modified"},
@@ -410,7 +410,7 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
                 self.assertEqual(output["fast_pass"], "false")
                 self.assertEqual(output["reason"], reason)
 
-        second_merge = "n" * 40
+        second_merge = "3" * 40
         multiple_merge_output = self._run_render_diff_preflight(
             files=files,
             commits=[
@@ -514,7 +514,7 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
     ) -> None:
         code_candidate = "c" * 40
         evidence_commit = "e" * 40
-        review_commit = "r" * 40
+        review_commit = "2" * 40
         files = [
             {"filename": "src/renderer/layout.rs", "status": "modified"},
             {"filename": "pdf/pr_5772_reference.pdf", "status": "added"},
@@ -558,7 +558,7 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
     def test_worker_preflights_require_a_verified_base_merge_bridge(self) -> None:
         base_sha = "b" * 40
         code_candidate = "c" * 40
-        merge_sha = "m" * 40
+        merge_sha = "1" * 40
         files = [
             {"filename": "src/renderer/layout.rs", "status": "modified"},
             {"filename": "mydocs/orders/20260827.md", "status": "modified"},
@@ -613,7 +613,7 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
     ) -> None:
         code_candidate = "c" * 40
         green_review_head = "g" * 40
-        trailing_review = "r" * 40
+        trailing_review = "2" * 40
         files = [
             {"filename": "src/renderer/layout.rs", "status": "modified"},
             {"filename": "mydocs/pr/archives/pr_5832_review.md", "status": "added"},
@@ -672,7 +672,7 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
     ) -> None:
         code_candidate = "c" * 40
         failed_review_head = "f" * 40
-        trailing_review = "r" * 40
+        trailing_review = "2" * 40
         files = [
             {"filename": "src/renderer/layout.rs", "status": "modified"},
             {"filename": "mydocs/pr/archives/pr_5834_review.md", "status": "added"},
@@ -724,7 +724,7 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
 
     def test_worker_preflights_reuse_modified_pdf_tail_and_reject_wrong_fork_candidate(self) -> None:
         code_candidate = "c" * 40
-        modified_pdf = "m" * 40
+        modified_pdf = "1" * 40
         modified_pdf_commits = [
             {
                 "sha": code_candidate,
@@ -746,7 +746,7 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
             "conclusion": "success",
             "created_at": "2026-08-20T12:00:00Z",
         }
-        trailing_review = "r" * 40
+        trailing_review = "2" * 40
         trusted_tail = [
             modified_pdf_commits[0],
             {

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -61,7 +61,7 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
         self.assertIn("trustedPullRequestWorkflowRun(", collect)
         self.assertIn("pr.head.repo.id !== summary.head.repo.id", collect)
         self.assertIn('.includes(process.env.WORKFLOW_FILE) || isFork', collect)
-        self.assertIn("[reviewOnlyWorker.preflight, reviewOnlyWorker.worker].every", collect)
+        self.assertIn("fullLaneWorkflowJobsAreGreen(process.env.WORKFLOW_FILE, jobs)", collect)
         self.assertIn("verifyForkPostMergeTree(process.env.GITHUB_WORKSPACE", collect)
         self.assertIn("tested.parents[0] !== baseParent", collect)
         self.assertIn("forkMergeTreeEvidenceByRunId", collect)

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs
@@ -55,6 +55,7 @@ function input(overrides = {}) {
       files: [{ filename: "src/lib.rs", status: "modified" }],
     }],
     workflowRuns: [candidate()],
+    fullLaneRunIds: ["123"],
     ...overrides,
   };
 }

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
@@ -1,3 +1,4 @@
+import "./verify-trusted-postmerge-green-merge.test.mjs";
 import assert from "node:assert/strict";
 import "./verify-trusted-postmerge-base-advance.test.mjs";
 import test from "node:test";
@@ -61,6 +62,7 @@ function input(overrides = {}) {
       files: [{ filename: "src/renderer/layout.rs", status: "modified" }],
     }],
     workflowRuns: [candidate()],
+    fullLaneRunIds: ["123"],
     ...overrides,
   };
 }
@@ -156,7 +158,7 @@ test("reuses the preceding full CI through a linear review-only tail", () => {
         ],
       },
     ],
-    workflowRuns: [candidate({ id: 456, head_sha: code })],
+    workflowRuns: [candidate(), candidate({ id: 456, head_sha: code })],
     fullLaneRunIds: ["456"],
   }));
   assert.deepEqual(result, {
@@ -261,7 +263,7 @@ test("fails closed when an intermediate full review candidate lacks merge-tree e
         files: [{ filename: "mydocs/pr/archives/pr_6279_review.md", status: "added" }],
       },
     ],
-    workflowRuns: [candidate({ id: 456, head_sha: reviewed })],
+    workflowRuns: [candidate(), candidate({ id: 456, head_sha: reviewed })],
     fullLaneRunIds: ["456"],
   }));
   assert.equal(
@@ -645,4 +647,10 @@ test("실제 Git tree 대조는 fork의 문서 trailing만 허용하고 source �
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("worker evidence is mandatory even when workflow status is green", () => {
+  const data = input();
+  delete data.fullLaneRunIds;
+  assert.equal(evaluateTrustedPostMergeReuse(data).reason, "candidate-full-lane-evidence-unavailable");
 });

--- a/scripts/tests/verify-trusted-postmerge-green-merge.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-green-merge.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { classifyReviewOnlyCommit, fullLaneWorkflowJobsAreGreen } from "../verify-trusted-postmerge-ci-reuse.mjs";
+
+const base = "b".repeat(40);
+const code = "c".repeat(40);
+const bridge = "d".repeat(40);
+const head = "e".repeat(40);
+const workflows = ["ci.yml", "codeql.yml", "render-diff.yml", "adapter-diff.yml", "proptest-roundtrip.yml"];
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const scripts = new Map(workflows.map(name => {
+  const text = readFileSync(new URL(`../../.github/workflows/${name}`, import.meta.url), "utf8");
+  const blocks = [...text.matchAll(/^          script: \|\n((?:            .*\n|\n)+)/gm)];
+  const source = blocks.map(match => match[1].replace(/^ {12}/gm, ""))
+    .find(block => block.includes("const reviewOnlyCandidates = []"));
+  assert.ok(source, `preflight script missing: ${name}`);
+  return [name, source];
+}));
+
+async function preflight(name, options = {}) {
+  const pr = { number: 6990, created_at: "2026-09-10T09:00:00Z",
+    base: { ref: "devel", sha: base },
+    head: { sha: head, ref: "review/6990", repo: { id: 123 } } };
+  const docs = { filename: "mydocs/orders/20260910.md", status: "modified" };
+  const source = { filename: "src/lib.rs", status: "modified" };
+  const commits = [
+    { sha: code, parents: [{ sha: "a".repeat(40) }], files: [source] },
+    { sha: bridge, parents: [{ sha: code }, { sha: base }], files: [docs] },
+    { sha: head, parents: [{ sha: bridge }], files: [docs] },
+  ];
+  const candidate = options.olderCandidate ? code : bridge;
+  const runs = [{ id: 10, path: `.github/workflows/${name}`, event: "pull_request",
+    head_sha: candidate, head_branch: pr.head.ref, head_repository: pr.head.repo,
+    created_at: "2026-09-10T10:00:00Z", run_started_at: "2026-09-10T10:00:00Z",
+    status: "completed", conclusion: "success" }];
+  const names = name === "ci.yml" ? ["Build & Test"]
+    : name === "codeql.yml" ? ["Analyze (javascript-typescript)", "Analyze (python)", "Analyze (rust)"]
+    : name === "render-diff.yml" ? ["Canvas visual diff"] : [];
+  const jobs = names.map((name, index) => ({ id: index + 100, name, status: "completed", conclusion: "success",
+    started_at: "2026-09-10T10:01:00Z",
+    steps: [{ name: `Render Diff identity PR #6990 base ${base}`, status: "completed", conclusion: "success" }] }));
+  const checks = [{ id: 200, name: "CodeQL", app: { slug: "github-advanced-security" }, head_sha: candidate,
+    started_at: "2026-09-10T10:01:00Z", status: "completed", conclusion: "success" }];
+  const files = [source, docs];
+  options.mutate?.({ commits, runs, jobs, checks, files, pr });
+  const outputs = {};
+  const requested = [];
+  const github = { rest: {
+    pulls: { listFiles: "files", listCommits: "commits" },
+    actions: { listWorkflowRuns: "runs", listJobsForWorkflowRun: "jobs" },
+    checks: { listForRef: "checks" },
+    repos: { getCommit: async ({ ref }) => ({ data: commits.find(commit => commit.sha === ref) }) },
+  }, paginate: async (method, args) => {
+    if (method === "files") return files;
+    if (method === "commits") return commits;
+    if (method === "runs") { requested.push(args.head_sha || "all"); return runs.filter(run => !args.head_sha || args.head_sha === run.head_sha); }
+    if (method === "jobs") return jobs;
+    if (method === "checks") return checks.filter(check => check.head_sha === args.ref);
+    throw new Error(`Unexpected API ${method}`);
+  } };
+  const warnings = [];
+  await new AsyncFunction("github", "context", "core", scripts.get(name))(github,
+    { eventName: "pull_request", repo: { owner: "edwardkim", repo: "rhwp" }, payload: { pull_request: pr } },
+    { setOutput: (key, value) => { outputs[key] = value; }, info: () => {}, warning: message => warnings.push(message) });
+  return { outputs, requested, warnings };
+}
+const reused = (name, outputs) => name === "adapter-diff.yml" ? outputs.adapter_required === "false" : outputs.fast_pass === "true";
+for (const name of workflows) {
+  test(`#6990 ${name}: green base-update merge remains a candidate behind docs`, async () => {
+    const { outputs, warnings } = await preflight(name);
+    assert.equal(reused(name, outputs), true, JSON.stringify({ outputs, warnings }));
+    assert.equal(outputs.base_merge_sha, undefined);
+    assert.deepEqual(warnings, []);
+  });
+  test(`${name}: earlier green source still requires independent merge-tree proof`, async () => {
+    const { outputs } = await preflight(name, { olderCandidate: true });
+    assert.equal(name === "adapter-diff.yml" ? outputs.adapter_required : outputs.fast_pass, "pending-base-merge-tree", JSON.stringify(outputs));
+    assert.equal(outputs.candidate_sha, code);
+    assert.equal(outputs.base_merge_sha, bridge);
+  });
+  for (const [label, mutate] of [
+    ["failed merge run", data => { data.runs[0].conclusion = "failure"; }],
+    ["cancelled merge run", data => { data.runs[0].conclusion = "cancelled"; }],
+    ["pending merge run", data => { data.runs[0].status = "in_progress"; data.runs[0].conclusion = null; }],
+    ["missing merge run", data => { data.runs.length = 0; }],
+    ["wrong repository", data => { data.runs[0].head_repository = { id: 999 }; }],
+    ["wrong branch", data => { data.runs[0].head_branch = "unrelated"; }],
+    ["code tail", data => { data.commits[2].files = [{ filename: "src/new.rs", status: "added" }]; }],
+    ["disconnected tail", data => { data.commits[2].parents[0].sha = "f".repeat(40); }],
+    ["wrong base", data => { data.pr.base.sha = "f".repeat(40); }],
+    ["second bridge", data => { data.commits[0].parents.push({ sha: base }); }],
+    ["execution policy change", data => { data.files.push({ filename: `.github/workflows/${name}`, status: "modified" }); }],
+  ]) {
+    test(`${name}: fail closed on ${label}`, async () => {
+      const { outputs } = await preflight(name, { mutate });
+      assert.equal(reused(name, outputs), false, JSON.stringify(outputs));
+    });
+  }
+}
+
+test("Render Diff merge candidate must match current base, not a prior base", async () => {
+  const { outputs } = await preflight("render-diff.yml", { mutate: data => {
+    data.jobs[0].steps[0].name = `Render Diff identity PR #6990 base ${"a".repeat(40)}`;
+  } });
+  assert.equal(outputs.fast_pass, "false");
+  assert.equal(outputs.reason, "canvas-visual-diff-identity-mismatch");
+});
+
+for (const [name, required] of Object.entries({
+  "ci.yml": ["CI preflight", "Build & Test", "Lint (fmt, clippy, WASM check)"],
+  "codeql.yml": ["CodeQL preflight", "Analyze (javascript-typescript)", "Analyze (python)", "Analyze (rust)"],
+  "adapter-diff.yml": ["adapter inter-diff preflight", "adapter inter-diff"],
+  "proptest-roundtrip.yml": ["Proptest preflight", "prop roundtrip"],
+})) {
+  test(`${name}: required worker evidence rejects missing, skipped, duplicate and non-green jobs`, () => {
+    const jobs = required.map(name => ({ name, status: "completed", conclusion: "success" }));
+    assert.equal(fullLaneWorkflowJobsAreGreen(name, jobs), true);
+    assert.equal(fullLaneWorkflowJobsAreGreen(name, jobs.slice(1)), false);
+    assert.equal(fullLaneWorkflowJobsAreGreen(name, [...jobs, jobs[0]]), false);
+    for (const conclusion of ["skipped", "neutral", "failure", "cancelled"]) {
+      assert.equal(fullLaneWorkflowJobsAreGreen(name, [{ ...jobs[0], conclusion }, ...jobs.slice(1)]), false);
+    }
+    assert.equal(fullLaneWorkflowJobsAreGreen(name, [{ ...jobs[0], status: "in_progress" }, ...jobs.slice(1)]), false);
+  });
+}
+test("a source rename into mydocs is not review-only evidence", () => {
+  assert.equal(classifyReviewOnlyCommit({ sha: head, parents: [{ sha: bridge }],
+    files: [{ filename: "mydocs/a.md", previous_filename: "src/lib.rs", status: "renamed" }] }).kind, "code");
+});

--- a/scripts/tests/verify-trusted-postmerge-review-bridge.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-review-bridge.test.mjs
@@ -241,11 +241,21 @@ async function runWorkflow(t, workflowFile = "ci.yml", options = {}) {
   }));
   artifacts.push({ name: `trusted-postmerge-merge-tree-v1-${testedMergeSha}-${commits.get(testedMergeSha).commit.tree.sha}`,
     expired: false });
-  const state = { pr, runs, headers, artifacts, commits };
+  const requiredNames = {
+    "ci.yml": ["CI preflight", "Build & Test", "Lint (fmt, clippy, WASM check)"],
+    "codeql.yml": ["CodeQL preflight", "Analyze (rust)", "Analyze (javascript-typescript)", "Analyze (python)"],
+    "adapter-diff.yml": ["adapter inter-diff preflight", "adapter inter-diff"],
+    "proptest-roundtrip.yml": ["Proptest preflight", "prop roundtrip"],
+  }[workflowFile];
+  const jobs = requiredNames.map(name => ({ name, status: "completed", conclusion: "success" }));
+  const securityChecks = [{ name: "CodeQL", app: { slug: "github-advanced-security" },
+    head_sha: candidateSha, status: "completed", conclusion: "success", started_at: runs[0].created_at }];
+  const state = { pr, runs, headers, artifacts, commits, jobs, securityChecks };
   options.mutate?.(state);
   const apiCalls = [], gitCalls = [], outputs = {}, warnings = [];
   const endpoint = name => name;
   const github = { rest: {
+    checks: { listForRef: endpoint("checks") },
     repos: {
       getCommit: async ({ ref }) => {
         apiCalls.push(["getCommit", ref]);
@@ -266,9 +276,9 @@ async function runWorkflow(t, workflowFile = "ci.yml", options = {}) {
       case "commits": return headers;
       case "runs": return runs;
       case "artifacts": return args.run_id === fullRunId ? artifacts : [];
-      case "jobs": return ["rust", "javascript-typescript", "python"].map(language => ({
-        name: `Analyze (${language})`, status: "completed",
-        conclusion: args.run_id === fullRunId ? "success" : "skipped",
+      case "checks": return state.securityChecks;
+      case "jobs": return state.jobs.map(job => ({ ...job,
+        conclusion: args.run_id === fullRunId ? job.conclusion : "skipped",
       }));
       default: throw new Error(`unexpected API: ${method}`);
     }
@@ -303,7 +313,7 @@ async function runWorkflow(t, workflowFile = "ci.yml", options = {}) {
   return { outputs, apiCalls, gitCalls, warnings, candidateSha };
 }
 
-for (const workflowFile of ["ci.yml", "codeql.yml"]) {
+for (const workflowFile of ["ci.yml", "codeql.yml", "adapter-diff.yml", "proptest-roundtrip.yml"]) {
   test(`actual ${workflowFile} collector traverses bridge and reuses the tested full run`, async t => {
     const result = await runWorkflow(t, workflowFile);
     assert.deepEqual(result.outputs, { reuse: "true",
@@ -335,5 +345,47 @@ for (const [name, options] of [
     assert.equal(outputs.reuse, "false");
     assert.equal(outputs.source_run_id, "");
     assert.equal(outputs.refresh_duration_data, "false");
+  });
+}
+
+for (const mode of ["100755", "120000"]) {
+  test(`Git bridge proof rejects non-regular review file mode: ${mode}`, t => {
+    const { directory, identity, git } = gitFixture(t);
+    const blob = git("rev-parse", `${identity.mergeSha}:mydocs/pr/review.md`);
+    git("update-index", "--add", "--cacheinfo", `${mode},${blob},mydocs/pr/review.md`);
+    const unsafeMerge = git("commit-tree", git("write-tree"), "-p", identity.baseSha, "-m", "unsafe mode");
+    assert.throws(() => verifyPostMergeReviewBridgeTree(directory, { ...identity, mergeSha: unsafeMerge }), /non-review-tree-change/);
+  });
+}
+for (const [name, mutate] of [
+  ["one language skipped", d => { d.jobs[1].conclusion = "skipped"; }],
+  ["missing language", d => { d.jobs.pop(); }],
+  ["pending worker", d => { d.jobs[1].status = "in_progress"; }],
+  ["failed security check", d => { d.securityChecks[0].conclusion = "failure"; }],
+  ["missing security check", d => { d.securityChecks.length = 0; }],
+  ["stale security check", d => { d.securityChecks[0].started_at = "2020-01-01T00:00:00Z"; }],
+]) {
+  test(`actual CodeQL collector refuses ${name}`, async t => {
+    const result = await runWorkflow(t, "codeql.yml", { mutate });
+    assert.equal(result.outputs.reuse, "false");
+  });
+}
+test("#6990: post-merge accepts the green bridge itself with independent tree proof", () => {
+  const data = provenFixture();
+  data.workflowRuns[0].head_sha = bridge;
+  data.mergeTreeEvidenceByRunId[fullRunId].parents[1] = bridge;
+  data.reviewBridgeTreeEvidenceByRunId[fullRunId].candidateSha = bridge;
+  assert.equal(evaluateTrustedPostMergeReuse(data).sourceRunId, String(fullRunId));
+  delete data.reviewBridgeTreeEvidenceByRunId[fullRunId];
+  assert.equal(evaluateTrustedPostMergeReuse(data).reuse, false);
+});
+
+for (const status of ["failure", "cancelled", "in_progress"]) {
+  test(`newer ${status} candidate is not hidden by the earlier green full run`, () => {
+    const data = provenFixture();
+    data.workflowRuns.push({ ...data.workflowRuns[0], id: fullRunId + 1, head_sha: docs,
+      status: status === "in_progress" ? status : "completed",
+      conclusion: status === "in_progress" ? null : status });
+    assert.equal(evaluateTrustedPostMergeReuse(data).reason, "latest-pr-workflow-candidate-not-successful");
   });
 }

--- a/scripts/verify-trusted-postmerge-ci-reuse.mjs
+++ b/scripts/verify-trusted-postmerge-ci-reuse.mjs
@@ -81,6 +81,9 @@ function allowedReviewOnlyFile(file) {
   if (!file || typeof file.filename !== "string") {
     return false;
   }
+  if (file.previous_filename && !file.previous_filename.startsWith("mydocs/")) {
+    return false;
+  }
   if (file.filename.startsWith("mydocs/")) {
     return true;
   }
@@ -208,13 +211,19 @@ function verifyPostMergeTree(repository, identity, requireBridge) {
     || final.parents[0].sha !== baseSha) {
     throw new Error("review-bridge-base-mismatch");
   }
-  const paths = git("diff", "--name-only", "-z", "--no-renames", "--no-ext-diff",
-    "--no-textconv", "--ignore-submodules=none", tested.treeSha, final.treeSha, "--")
-    .split("\0").filter(Boolean);
-  if (!paths.every(path => path.startsWith("mydocs/")
-    && path !== "mydocs/tech/text-ir-v2.md"
-    && path !== "mydocs/tech/canvaskit-parity-implementation.md")) {
-    throw new Error("review-bridge-non-review-tree-change");
+  const fields = git("diff", "--raw", "--no-abbrev", "-z", "--no-renames", "--no-ext-diff",
+    "--no-textconv", "--ignore-submodules=none", tested.treeSha, final.treeSha, "--").split("\0");
+  if (fields.pop() !== "" || fields.length % 2 !== 0) {
+    throw new Error("review-bridge-incomplete-tree-diff");
+  }
+  for (let index = 0; index < fields.length; index += 2) {
+    const path = fields[index + 1];
+    if (!/^:(000000|100644) (000000|100644) [0-9a-f]{40} [0-9a-f]{40} [AMD]$/.test(fields[index])
+      || !path.startsWith("mydocs/")
+      || path === "mydocs/tech/text-ir-v2.md"
+      || path === "mydocs/tech/canvaskit-parity-implementation.md") {
+      throw new Error("review-bridge-non-review-tree-change");
+    }
   }
   return { baseSha, ...(requireBridge ? { bridgeSha } : {}), mergeSha, candidateSha, testedMergeSha,
     testedTreeSha: tested.treeSha, finalTreeSha: final.treeSha };
@@ -405,6 +414,25 @@ export function frontendOnlyCiRunIsReusable(impact, jobs) {
   return expected.size === 0;
 }
 
+// Workflow success alone is not proof that the required workers actually ran.
+export function fullLaneWorkflowJobsAreGreen(workflowFile, jobs) {
+  const required = {
+    "ci.yml": ["CI preflight", "Build & Test", "Lint (fmt, clippy, WASM check)"],
+    "codeql.yml": ["CodeQL preflight", "Analyze (javascript-typescript)", "Analyze (python)", "Analyze (rust)"],
+    "adapter-diff.yml": ["adapter inter-diff preflight", "adapter inter-diff"],
+    "proptest-roundtrip.yml": ["Proptest preflight", "prop roundtrip"],
+  }[workflowFile];
+  if (!required || !Array.isArray(jobs) || jobs.length === 0
+    || jobs.some((job) => job?.status !== "completed"
+      || !["success", "skipped"].includes(job.conclusion))) {
+    return false;
+  }
+  return required.every((name) => {
+    const matches = jobs.filter((job) => job.name === name);
+    return matches.length === 1 && matches[0].conclusion === "success";
+  });
+}
+
 function hasFrontendOnlyEvidence(input, run) {
   const runId = String(run?.id || "");
   return Array.isArray(input?.frontendOnlyRunIds)
@@ -414,7 +442,7 @@ function hasFrontendOnlyEvidence(input, run) {
 
 function hasFullLaneEvidence(input, run) {
   if (!Array.isArray(input?.fullLaneRunIds)) {
-    return true;
+    return false;
   }
   const runId = String(run?.id || "");
   return runId !== "" && input.fullLaneRunIds.some((id) => String(id) === runId);
@@ -543,6 +571,10 @@ export function evaluateTrustedPostMergeReuse(input) {
     input.repositoryId,
     input.workflowFile,
   );
+  if (!finalHeadCandidate || finalHeadCandidate.status !== "completed"
+    || finalHeadCandidate.conclusion !== "success") {
+    return denied("final-head-pr-workflow-not-successful");
+  }
   const exactMergeTreeEvidence = hasExactMergeTreeEvidence(
     input,
     finalHeadCandidate,
@@ -659,14 +691,14 @@ export function evaluateTrustedPostMergeReuse(input) {
       continue;
     }
     foundCandidateRun = true;
+    // A newer failed or incomplete candidate must not be hidden by older green runs.
+    if (candidate.status !== "completed" || candidate.conclusion !== "success") {
+      return denied("latest-pr-workflow-candidate-not-successful");
+    }
     if (!hasFullLaneEvidence(input, candidate)) {
       continue;
     }
     foundFullLaneCandidate = true;
-    if (candidate.status !== "completed" || candidate.conclusion !== "success") {
-      unsuccessfulCandidate = true;
-      continue;
-    }
     if (isFork && !hasForkCandidateTreeEvidence(input, candidate, pullRequest, baseParent, mergeTreeSha)) {
       missingIntermediateCandidateEvidence = true;
       continue;


### PR DESCRIPTION
## 목적

Refs #6815

문서-only trailing commit과 current-base merge가 이어질 때, 실제로 검증된 Full CI 후보를 누락하지 않도록 PR preflight와 post-merge 증거 검증을 보완합니다. #6990에는 이 CI 변경을 추가하지 않았습니다.

## 변경

- CI·CodeQL·Render Diff·Adapter·Proptest가 성공한 current-base merge 자체를 후보로 조회합니다. bridge 이전 후보에 필요한 독립 merge-tree 검사는 유지합니다.
- PR head부터 후보까지의 실제 부모 계보와 run의 저장소·브랜치·SHA·완료 상태를 확인합니다. 실패하거나 진행 중인 최신 후보를 이전 성공 결과로 덮지 않습니다.
- post-merge collector는 실제 필수 worker 완료, CodeQL 분석과 보안 check, 기존 CI artifact 증거를 요구합니다. 누락된 full-lane 증거를 승인하지 않습니다.
- 신뢰 base의 코드로 Git 객체를 검사하며, 문서 밖 rename·실행 파일·symlink·실행 계약 변경은 문서-only로 인정하지 않습니다. PR head 코드는 실행하지 않습니다.
- 기존 required check 이름, 최소 권한, B/C/D duration artifact 및 nextest timing 갱신은 유지합니다.

## 검증

최신 devel `2a780e0d296846df577866eba6ac8f388527551b` 위 code candidate `0462bdf826fea5065ee77c5cb5645e1b67c56f98`에서:

- Node verifier·실제 preflight/collector 계약 220개 통과.
- Python workflow 계약 233개 통과.
- actionlint: 기존 기준선에서도 발생하는 SC2016 경고 1건을 제외하고 통과. 해당 경고를 새 결함이나 무경고 성공으로 기록하지 않습니다.
- `git diff --check` 통과.
- CI 정책·스크립트 변경에 집중했으며 무관한 Rust 전체 회귀·WASM 빌드·시각 검증은 실행하지 않았습니다. 로그·임시 산출물은 커밋하지 않습니다.

## 적용 및 완료 경계

이 PR 자체는 CI 정책 변경이므로 Full CI 대상입니다. 로컬 계약 성공을 GitHub 운영 재사용 성공으로 간주하지 않습니다. 병합 후 별도 코드 PR의 문서 trailing/current-base merge 사례에서 실제 heavy skip과 timing 재사용을 확인해야 #6815를 최종 종료할 수 있습니다.

#6990의 PR 문서 trailing에서는 Full CI가 중복 실행됐으나, 병합 후 devel 재사용은 이미 성공했습니다. 두 이벤트를 구분하며 #6990 post-merge 성공을 이번 미병합 코드의 효과로 주장하지 않습니다.

[self-review](https://github.com/edwardkim/rhwp/blob/66f25e744edd3a5f8cfd6a09836c1372729791e0/mydocs/pr/archives/pr_6991_review.md)와 오늘할일을 같은 PR의 문서 trailing commit `ffbaf8301`에 포함했습니다. 로컬 검토 승인, GitHub CI 완료 전 머지 보류입니다.


병합 후 최종 검증과 별도 문서 PR 처리는 [후속 코멘트](https://github.com/edwardkim/rhwp/pull/6991#issuecomment-5618670867)에 기록했습니다. #6815는 후속 운영 검증 전까지 OPEN을 유지합니다.
