### PR TITLE
Task #7003: 죽은 코드·불필요한 우회 표현 5건을 정리한다

### DIFF
--- a/rhwp-studio/e2e/run-with-vite.mjs
+++ b/rhwp-studio/e2e/run-with-vite.mjs
@@ -2,7 +2,6 @@
  * Vite dev server 를 띄운 뒤 그 위에서 인자로 받은 명령을 실행하는 공용 러너.
  *
  *   node e2e/run-with-vite.mjs -- <command...>
- *   node e2e/run-with-vite.mjs --npm <script> [<script args...>]
  *
  * 서버는 VITE_PORT(기본 7700)부터 비어 있는 포트를 택해 127.0.0.1 에 바인딩하고
  * readiness 를 기다린 뒤, VITE_URL 환경변수를 주입해 명령을 실행한다. 명령의
@@ -11,22 +10,17 @@
  */
 
 import {
-  spawnNpm,
   spawnStudioCommand,
   startViteDevServer,
   waitForServer,
 } from './vite-server.mjs';
 
 const argv = process.argv.slice(2);
-let mode = 'raw';
-if (argv[0] === '--npm') {
-  mode = 'npm';
-  argv.shift();
-} else if (argv[0] === '--') {
+if (argv[0] === '--') {
   argv.shift();
 }
 if (argv.length === 0) {
-  console.error('usage: node e2e/run-with-vite.mjs [--npm <script> | -- <command...>]');
+  console.error('usage: node e2e/run-with-vite.mjs -- <command...>');
   process.exit(2);
 }
 
@@ -34,10 +28,7 @@ let exitCode = 1;
 const server = await startViteDevServer();
 try {
   await waitForServer(server.url, server.child, server.logPath);
-  const extraEnv = { VITE_URL: server.url };
-  const child = mode === 'npm'
-    ? spawnNpm(['run', ...argv], extraEnv)
-    : spawnStudioCommand(argv[0], argv.slice(1), extraEnv);
+  const child = spawnStudioCommand(argv[0], argv.slice(1), { VITE_URL: server.url });
   exitCode = await new Promise((resolve, reject) => {
     child.once('error', reject);
     child.once('exit', (code, signal) => {

--- a/rhwp-studio/e2e/vite-server.mjs
+++ b/rhwp-studio/e2e/vite-server.mjs
@@ -19,10 +19,10 @@ export const studioRoot = path.resolve(__dirname, '..');
 const repoRoot = path.resolve(studioRoot, '..');
 const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
-export function spawnNpm(args, extraEnv = {}, stdio = 'inherit') {
+export function spawnNpm(args, extraEnv = {}) {
   return spawn(npmCmd, args, {
     cwd: studioRoot,
-    stdio,
+    stdio: 'inherit',
     // win32 의 npm 은 npm.cmd 다 — Node 20+ 부터 .cmd 직접 spawn 이 EINVAL 로
     // 거절되므로 shell 경유로 띄운다(인자는 공백·메타문자 없는 고정값뿐이다).
     shell: process.platform === 'win32',
@@ -33,10 +33,10 @@ export function spawnNpm(args, extraEnv = {}, stdio = 'inherit') {
   });
 }
 
-export function spawnStudioCommand(command, args, extraEnv = {}, stdio = 'inherit') {
+export function spawnStudioCommand(command, args, extraEnv = {}) {
   return spawn(command, args, {
     cwd: studioRoot,
-    stdio,
+    stdio: 'inherit',
     env: {
       ...process.env,
       ...extraEnv,

--- a/src/document_core/commands/delete_fragment.rs
+++ b/src/document_core/commands/delete_fragment.rs
@@ -171,12 +171,15 @@ impl DocumentCore {
             )));
         }
 
-        // [start] 자리의 삭제 후 잔여(병합) 문단을 원본으로 교체 + 나머지 원본 재삽입
-        let mut restored: Vec<Paragraph> = Vec::with_capacity(frag.pre_para_count);
-        restored.extend_from_slice(&section.paragraphs[..frag.start_para]);
-        restored.extend(frag.captured_paras.iter().cloned());
-        restored.extend_from_slice(&section.paragraphs[frag.start_para + 1..]);
-        section.paragraphs = restored;
+        // [start] 자리의 삭제 후 잔여(병합) 문단을 캡처한 원본 범위로 통째 교체.
+        // 주변 문단을 깊은 복사하지 않고 캡처분만 clone 한다. 주소 안정성은 기대하지
+        // 않는다 — 여러 문단으로 교체하면 뒤 원소가 밀리고 용량이 모자라면 재할당된다.
+        // 포인터 키 캐시(composer.rs SingleLineOverflowCache)는 아래
+        // rebuild_derived_state -> invalidate_page_tree_cache -> clear_layout_caches 가 비운다.
+        section.paragraphs.splice(
+            frag.start_para..=frag.start_para,
+            frag.captured_paras.iter().cloned(),
+        );
 
         // 꼬리 줄 좌표 저널 복원 — recalculate_section_vpos 의 덮어쓰기를 되돌린다
         for (offset, segs) in frag.tail_line_segs.iter().enumerate() {

--- a/tests/cases/issue_5890_raw_cache_inventory.rs
+++ b/tests/cases/issue_5890_raw_cache_inventory.rs
@@ -62,7 +62,7 @@ fn fields_in_source() -> BTreeMap<String, usize> {
     collect_model_files(&dir, &dir, &mut files);
     for (file, path) in files {
         let text = std::fs::read_to_string(&path).expect("모델 파일 읽기");
-        for (i, line) in text.lines().enumerate() {
+        for line in text.lines() {
             let t = line.trim_start();
             if !t.starts_with("pub raw_") {
                 continue;
@@ -76,7 +76,6 @@ fn fields_in_source() -> BTreeMap<String, usize> {
             if name.is_empty() || name.contains(' ') {
                 continue;
             }
-            let _ = i;
             *out.entry(format!("{name}@{file}")).or_insert(0) += 1;
         }
     }

--- a/tools/hangul_rotation_oracle/oracle.py
+++ b/tools/hangul_rotation_oracle/oracle.py
@@ -54,6 +54,7 @@ import re
 import subprocess
 import sys
 import tempfile
+from typing import NamedTuple
 
 sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
@@ -65,17 +66,18 @@ TRANSFORM = re.compile(
 )
 
 
-class Transform:
-    """그림 하나의 변환 상태 — 판정 단위."""
+class Transform(NamedTuple):
+    """그림 하나의 변환 상태 — 판정 단위.
 
-    __slots__ = ("horz_flip", "vert_flip", "angle", "flip", "rotate_image")
+    필드 순서가 곧 판정 키다. 튜플이므로 동등 비교는 다섯 필드 전수 비교이고,
+    별도 key() 를 두지 않는다.
+    """
 
-    def __init__(self, horz_flip, vert_flip, angle, flip, rotate_image):
-        self.horz_flip = horz_flip
-        self.vert_flip = vert_flip
-        self.angle = angle
-        self.flip = flip
-        self.rotate_image = rotate_image
+    horz_flip: bool
+    vert_flip: bool
+    angle: int
+    flip: int
+    rotate_image: bool
 
     @property
     def bit19(self) -> bool:
@@ -84,18 +86,6 @@ class Transform:
     @property
     def rotated(self) -> bool:
         return self.angle % 360 != 0
-
-    def __eq__(self, other) -> bool:
-        return isinstance(other, Transform) and self.key() == other.key()
-
-    def key(self):
-        return (
-            self.horz_flip,
-            self.vert_flip,
-            self.angle,
-            self.flip,
-            self.rotate_image,
-        )
 
     def __str__(self) -> str:
         return (


### PR DESCRIPTION
관련 이슈: #7003

## 문제

독립 검토로 확인된 죽은 코드·불필요한 우회 표현 5건. 동작에는 영향이 없으나 각각 없는 계약이
있는 것처럼 보이게 한다.

## 원인

- `tools/hangul_rotation_oracle/oracle.py:68-104` — `Transform` 이 `__slots__`·`__init__`·
  `__eq__`·`key()` 를 손으로 구현한다. 생성은 `:120` 한 곳뿐이고 전부 위치 인자이며 생성자 밖에서
  필드를 대입하는 곳이 없다. `key()` 는 `__eq__` 안에서만 쓰인다.
- `src/document_core/commands/delete_fragment.rs:175-179` — 조각 복원이 문단 목록을 새로 만들며
  `extend_from_slice` 로 앞뒤 문단을 전부 clone 한다. 실제로 되돌리는 자리는 `start_para` 하나다.
- `tests/cases/issue_5890_raw_cache_inventory.rs:65,79` — `enumerate()` 인덱스를 `let _ = i;` 로
  버린다. 같은 파일 L20-21 이 "라인 번호는 대조에 쓰지 않는다" 고 이미 못 박았다.
- `rhwp-studio/e2e/run-with-vite.mjs:5,22-24,38-39` — `--npm` 모드에 호출부가 없다.
  `rhwp-studio/package.json` 의 e2e 스크립트 11개가 모두 `-- <command>` 형태이고, CI 워크플로·
  문서에도 `--npm` 호출이 없다.
- `rhwp-studio/e2e/vite-server.mjs:22,36` — `stdio` 인자를 어느 호출부도 넘기지 않는다
  (`run-render-diff.mjs:8`, `run-with-vite.mjs:39,40` 모두 두 인자).

## 변경

- `Transform` 을 `NamedTuple` 로 바꿔 `__slots__`·`__init__`·`__eq__`·`key()` 를 없앴다.
  `bit19`·`rotated` property 와 `__str__` 은 그대로다.
- 문단 목록 재구축을 `Vec::splice(start..=start, …)` 한 줄로 바꿨다. 앞뒤 문단은 제자리에서
  이동하고 조각만 clone 한다.
- 죽은 `enumerate()` 와 `let _ = i;` 를 뺐다.
- `--npm` 모드와 그에 딸린 `spawnNpm` import·분기·usage 문자열을 뺐다.
- `stdio` 매개변수를 빼고 본문에 `'inherit'` 을 직접 적었다.

새 테스트는 없다. 다섯 항목 모두 기존 계약을 유지하는 표현 변경이고, 각 항목의 계약은 이미
기존 시험이 덮는다 — `tools/hangul_rotation_oracle/test_oracle.py`(파싱·판정),
`issue_5769_delete_fragment_byte_identity`(조각 복원 바이트 동일성),
`issue_5890_raw_cache_inventory`(인벤토리 대조).

### 포인터 주소 캐시에 대한 확인

주소를 키로 쓰는 캐시가 있어 확인했다 — `src/renderer/composer.rs:123-137`
`SingleLineOverflowCache` 가 `para as *const Paragraph as usize` 를 키로 쓴다.

**`splice` 는 주소를 보존하지 않는다.** 잔여 1문단을 캡처한 N문단으로 교체하면 뒤 원소가
N-1 만큼 밀리고, 용량이 모자라면 벡터가 재할당돼 앞부분 주소까지 바뀐다. 실측하면
교체분 2개 이상에서 재할당이 일어난다(`cap 6 -> 12`, 앞·뒤 주소 모두 변경). 주소가
그대로인 것은 N=1 일 때뿐이다.

안전 근거는 주소 보존이 아니라 **캐시 무효화**다. 복원 경로가 이 캐시를 무조건 비운다.

`delete_fragment.rs` `rebuild_derived_state()`
→ `src/document_core/queries/rendering.rs:7135-7141` `invalidate_page_tree_cache()`
→ `src/renderer/layout.rs:3074-3079` `clear_layout_caches()`
→ `single_line_overflow_cache.clear()`

종전 재구축도 매번 새 벡터를 만들어 주소가 바뀌었으므로 이 축의 동작 차이는 없다.
근거를 코드 주석으로 함께 남겼다.

## 검증

base devel `b59323de0`, 검증 commit `7586000fc`(최신 devel 로 rebase 후 전 항목 재실행).
아래 수치는 그 재실행 결과다. 원본 commit 후 같은 SHA 의 detached review
worktree 에서 `node scripts/rust-test-suite-manifest.mjs --prepare` 를 먼저 돌린 뒤 실행했다.

Rust lint 묶음 — 전부 통과.

- `cargo fmt --all -- --check`
- `cargo clippy --locked -- -D warnings`
- `cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown -- -D warnings`
- `cargo build --locked --workspace`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`

회귀.

- `node --test scripts/tests/rust-test-suite-manifest.test.mjs` — 23/23 (integration test source 변경분)
- `node scripts/run-rust-test.mjs issue_5769_delete_fragment_byte_identity -- --cargo-profile release-test`
  — **7/7**. 구역 머리·꼬리 경계, 다중 문단 범위, 표 포함 선택, 삭제 없는 복원 거부, discard 를
  모두 포함한다. `splice` 전환이 지켜야 할 계약이 이것이다.
- `node scripts/run-rust-test.mjs issue_5890_raw_cache_inventory -- --cargo-profile release-test` — 1/1
- `cargo nextest run --locked --cargo-profile release-test --tests --no-fail-fast`
  — **9461 tests run: 9461 passed, 46 skipped** (471s)

프런트엔드(혼합 변경이므로 같은 SHA 의 같은 worktree 에서 수행).

- `npm --prefix rhwp-studio ci`
- `scripts/wasm-pack-locked.sh --target web --out-dir pkg --dev` — 이 SHA 에서 새로 만들었다.
  다른 checkout 의 `pkg/` 를 복사하지 않았다.
- `npx tsc --noEmit` — 클린
- `npm --prefix rhwp-studio test` — 1646 중 1644 통과, 0 실패, 2 skip
- `npm --prefix rhwp-studio run build` — 통과

그 밖.

- `python tools/hangul_rotation_oracle/test_oracle.py` — 8/8 (`Transform` 변경 대상)
- `python scripts/check_e2e_manifest.py` — 129/129, 이상 없음
- `python -m unittest scripts/tests/test_undo_depth_e2e_workflow.py` — 5/5
  (`run-with-vite.mjs`·`vite-server.mjs` 존재와 npm script 배선을 핀하는 가드)
- `git diff --check origin/devel...HEAD` 와 `git diff --check` — 공백·충돌 마커 없음, 트리 clean

**실행하지 않은 것.** 렌더링 출력·release WASM·시각 검증은 이 변경의 범위가 아니다 — 렌더러·
레이아웃·paint 경로를 건드리지 않았고 `--dev` WASM 성공을 release 검증으로 적지 않는다.
수정 전 실패 증명도 없다. 결함 수정이 아니라 동작 동일성을 전제로 한 표현 정리이며, 그 동일성은
위 회귀(특히 조각 복원 바이트 동일성 7건과 전체 9442건)로 대신한다.

## 범위 외

같은 검토에서 나온 두 건은 성격이 달라 뺐다.

- 스냅샷 예산 상수 이중화(`src/document_core/commands/document.rs:2318` `MAX_SNAPSHOTS` ↔
  `rhwp-studio/src/engine/history.ts:20` `WASM_MAX_SNAPSHOTS`) 단일 출처화 — 새 WASM API 와
  `FakeWasm` 스텁이 필요해 삭제가 아니라 계약 변경이다.
- e2e vite 서버의 자식 프로세스 기동을 vite Node API 로 바꾸는 것 —
  `.github/workflows/render-diff.yml:866` 의 로그 아티팩트와
  `rhwp-studio/e2e/MANIFEST.md:115` 의 설계 설명을 함께 정해야 한다.
