### PR TITLE
Task #7002: 변이 표면 분류의 사각을 Rust 내보내기로 닫는다

### DIFF
--- a/rhwp-studio/src/core/mutation-method-registry.ts
+++ b/rhwp-studio/src/core/mutation-method-registry.ts
@@ -99,4 +99,30 @@ export const EXCLUDED_NON_DOCUMENT: readonly string[] = [
   // restoreSectionRaw 는 passthrough 를 되살리지만 SetSectionPropsCommand.undo 단일
   // 경로로 고정돼 있어(restoreDeleteFragment 와 같은 취급) 제외한다. 히스토리 밖 직접 호출 금지.
   'captureSectionRaw', 'restoreSectionRaw', 'discardSectionRaw',
+  // [#7002] 스냅샷 API — 위 두 저널의 선례이면서 정작 분류가 빠져 있었다
+  // (이 파일의 restoreDeleteFragment 주석이 SnapshotCommand.undo 의 restoreSnapshot 을
+  // 근거로 인용한다). save·discard 는 저장소 적재·해제라 IR 비변경이고,
+  // restoreSnapshot 은 CommandHistory.undo 단일 경로로 고정돼 같은 취급이다.
+  'saveSnapshot', 'restoreSnapshot', 'discardSnapshot',
+  // [#7002] 그림 변환 저널 API — capture·discard 는 IR 비변경.
+  // swapPictureTransform 은 IR 을 바꾸지만 두 경로 다 히스토리 항목을 만들지 않는다:
+  // PictureTransformResizeCommand.execute/undo(Command 안) 와
+  // PictureResizeJournal.cancel(드래그 취소·실패의 원상 복귀 — 되돌릴 편집이 없다).
+  // 위 두 저널과 달리 '단일 경로 고정' 이 아니므로 근거를 따로 적는다.
+  'capturePictureTransform', 'swapPictureTransform', 'discardPictureTransform',
+  // [#7002] 지연 쪽나눔 진행 API — 조판은 파생 상태다. 문서 IR 을 바꾸지 않는다.
+  'beginDeferredPagination', 'stepDeferredPagination',
+  'flushDeferredPagination', 'cancelDeferredPagination',
+  // [#7002] 직렬화 산출 — 코어 호출(export_hwp_with_adapter_snapshot)이 `&self` 라
+  // 문서를 바꾸지 않는다. wasm 래퍼의 `&mut self` 는 불필요한 것이다.
+  'exportHwp', 'exportHwpVerify', 'exportHwpWithPassword',
+  // [#7002 · #4180] 저장 직전 캐럿 스탬프. doc_properties.caret_* 와 DocInfo raw_stream 을
+  // surgical update 하므로 **저장 바이트를 바꾼다**. 그럼에도 제외인 이유는 편집이 아니라
+  // 저장 흐름(onBeforeExport)의 일부이기 때문이다 — 되돌릴 사용자 편집이 없다.
+  'setCaretPosition',
+  // [#7002] 내부 클립보드 적재 — 문서는 읽기만 하고 복사본을 코어 버퍼에 담는다.
+  'copySelection', 'copySelectionInCell', 'copySelectionInCellByPath',
+  'copySelectionInHeaderFooter', 'copyControl', 'copyTableCellsTransposed',
+  // [#7002] 조회 — 본문은 읽기뿐인데 `*_mut` 접근자를 거치느라 `&mut self` 가 됐다.
+  'getCellCharPropertiesAtByPath', 'getCharShapeRunsInCellByPath',
 ];

--- a/rhwp-studio/src/core/mutation-method-registry.ts
+++ b/rhwp-studio/src/core/mutation-method-registry.ts
@@ -113,8 +113,9 @@ export const EXCLUDED_NON_DOCUMENT: readonly string[] = [
   // [#7002] 지연 쪽나눔 진행 API — 조판은 파생 상태다. 문서 IR 을 바꾸지 않는다.
   'beginDeferredPagination', 'stepDeferredPagination',
   'flushDeferredPagination', 'cancelDeferredPagination',
-  // [#7002] 직렬화 산출 — 코어 호출(export_hwp_with_adapter_snapshot)이 `&self` 라
-  // 문서를 바꾸지 않는다. wasm 래퍼의 `&mut self` 는 불필요한 것이다.
+  // [#7002] 직렬화 산출 — 저장 어댑터는 `prepare_hwp_export_snapshot`(document.rs:1598)
+  // 이 뜬 **사본**에 적용되고 live 문서는 그대로다. 세 경로의 `&mut self` 는 실제로
+  // 필요 없는 것이며(좁히는 것은 별건), 지금도 문서를 바꾸지 않는다.
   'exportHwp', 'exportHwpVerify', 'exportHwpWithPassword',
   // [#7002 · #4180] 저장 직전 캐럿 스탬프. doc_properties.caret_* 와 DocInfo raw_stream 을
   // surgical update 하므로 **저장 바이트를 바꾼다**. 그럼에도 제외인 이유는 편집이 아니라

--- a/rhwp-studio/tests/mutation-routing-guard.test.ts
+++ b/rhwp-studio/tests/mutation-routing-guard.test.ts
@@ -79,6 +79,55 @@ test('드리프트: 문서-변경형 브리지 공개 메서드는 모두 분류
   );
 });
 
+/**
+ * [#7002] wasm_api.rs 의 `&mut self` 내보내기 — 변이 표면의 권위.
+ *
+ * `js_name` 이 있으면 그것을, 없으면 Rust 이름의 camelCase 를 쓴다(wasm-bindgen 기본).
+ */
+function rustMutatingExports(): string[] {
+  const src = source('../src/wasm_api.rs');
+  // `#[wasm_bindgen…]` 과 그 뒤 첫 `pub fn …(&mut self` 를 한 쌍으로 집는다.
+  // 중간에 다른 `#[wasm_bindgen` 이 끼면 매치하지 않는다(속성-함수 짝 어긋남 방지).
+  const re = new RegExp(
+    String.raw`#\[wasm_bindgen([^\]]*)\]`
+    + String.raw`(?:(?!#\[wasm_bindgen)[\s\S]){0,400}?`
+    + String.raw`pub (?:async )?fn (\w+)\s*\(\s*&mut self`,
+    'g',
+  );
+  const out: string[] = [];
+  for (const m of src.matchAll(re)) {
+    const named = /js_name\s*=\s*(\w+)/.exec(m[1]);
+    const parts = m[2].split('_');
+    out.push(named?.[1]
+      ?? parts[0] + parts.slice(1).map((w) => w[0].toUpperCase() + w.slice(1)).join(''));
+  }
+  return out;
+}
+
+test('[#7002] Rust `&mut self` 내보내기에 대응하는 브리지 메서드는 모두 분류돼야 한다', () => {
+  // MUTATING_VERB 는 손으로 유지하는 동사 목록인데 드리프트 시험의 **감사 대상을
+  // 정하는 필터**라, 동사에 안 걸리는 이름은 분류를 요구받지 않는다. 실제로 저널·
+  // 스냅샷·지연조판·내보내기·캐럿 14개가 그렇게 빠져 있었다(#7002). 여기서는 동사와
+  // 무관하게 Rust 쪽 변이 표면을 권위로 삼아 같은 사각이 다시 생기지 않게 한다.
+  const classified = new Set([...MUTATING, ...EXCLUDED]);
+  const bridge = new Set(bridgePublicMethods());
+  const unclassified = [...new Set(rustMutatingExports())]
+    .filter((n) => bridge.has(n))
+    .filter((n) => !classified.has(n))
+    .sort();
+  assert.deepEqual(
+    unclassified,
+    [],
+    [
+      `wasm_api.rs 의 \`&mut self\` 내보내기인데 분류되지 않은 브리지 메서드: `
+        + unclassified.join(', '),
+      '→ mutation-method-registry.ts 의 MUTATING_METHODS 또는 EXCLUDED_NON_DOCUMENT 에 '
+        + '사유와 함께 추가하라.',
+      '`&mut self` 가 불필요한 래퍼라면 그 사실을 사유에 적는다.',
+    ].join(' '),
+  );
+});
+
 test('MUTATING_METHODS / EXCLUDED_NON_DOCUMENT 는 서로 겹치지 않는다', () => {
   const dup = MUTATING.filter((m) => EXCLUDED.includes(m));
   assert.deepEqual(dup, [], `양쪽에 중복 분류됨: ${dup.join(', ')}`);


### PR DESCRIPTION
관련 이슈: #7002

## 문제

undo 라우팅 가드의 드리프트 시험이 브리지 뮤테이터 22종을 한 번도 검사하지 않았다.
세 목록(`MUTATING_METHODS`·`EXCLUDED_NON_DOCUMENT`·`MUTATING_VERB`) 어디에도 없이 통과한다.

## 원인

드리프트 시험(`mutation-routing-guard.test.ts:68-80`)은 브리지 공개 메서드를
**`MUTATING_VERB` 로 먼저 거른 뒤** 분류 여부를 묻는다.

```ts
const unclassified = bridgePublicMethods()
  .filter((n) => MUTATING_VERB.test(n))      // ← 감사 대상을 정하는 필터
  .filter((n) => !classified.has(n));
```

`MUTATING_VERB`(`:58`)는 손으로 유지하는 동사 접두어 목록이다. 자기정합 시험(`:60-66`)은
"`MUTATING_METHODS` 의 모든 이름이 동사에 걸리는가" 만 본다 — 즉 **목록에 올린 것**의 커버리지는
강제하지만, **올리지 않은 것**은 묻지 않는다. 그래서 동사에 안 걸리는 새 뮤테이터는 어느 목록에도
들어가지 않은 채 조용히 빠진다. 사각을 만드는 것이 필터 자신이라 기존 시험으로는 드러나지 않는다.

`src/wasm_api.rs` 의 `#[wasm_bindgen]` + `&mut self` 내보내기(변이 표면의 권위)를 브리지 공개
메서드와 교차시켜 두 목록과 대조하니 **22종이 미분류였고, 22개 전부 동사 매치에 걸리지 않았다.**
계열과 실제 변이 여부는 #7002 본문의 표에 있다.

스냅샷 3종이 빠진 것이 특히 드러난다. `mutation-method-registry.ts:93-97` 의
`restoreDeleteFragment` 제외 사유가 **`SnapshotCommand.undo 의 restoreSnapshot`** 을 선례로
인용하는데, 인용된 당사자가 분류돼 있지 않았다.

## 변경

**(1) 22종을 `EXCLUDED_NON_DOCUMENT` 에 계열별 사유와 함께 등재.**
`MUTATING_METHODS` 로 가는 항목은 없어 표면 원장(`BASELINE`)은 그대로다.

- **스냅샷** `saveSnapshot`·`restoreSnapshot`·`discardSnapshot` — save·discard 는 저장소
  적재·해제라 IR 비변경, restore 는 `CommandHistory.undo` 단일 경로 고정. 삭제 조각·구역 raw
  저널과 같은 취급이다.
- **그림 변환 저널** `capture`·`swap`·`discardPictureTransform` — `swap` 은 IR 을 바꾸지만
  두 경로 다 히스토리 항목을 만들지 않는다: `PictureTransformResizeCommand.execute/undo`(Command
  안)와 `PictureResizeJournal.cancel`(드래그 취소·실패의 원상 복귀 — 되돌릴 편집이 없다).
  선례와 달리 "단일 경로 고정" 이 아니라 사유를 따로 적었다.
- **지연 쪽나눔** `begin`·`step`·`flush`·`cancelDeferredPagination` — 조판은 파생 상태다.
- **내보내기** `exportHwp`·`exportHwpVerify`·`exportHwpWithPassword` — 코어 호출
  `export_hwp_with_adapter_snapshot` 이 `&self`(`document.rs:1648`)라 문서를 바꾸지 않는다.
  wasm 래퍼의 `&mut self` 가 불필요한 것이며, 그 사실을 사유에 남겼다.
- **캐럿** `setCaretPosition` — **저장 바이트를 바꾼다.** `stamp_caret`
  (`text_editing.rs:1360-1368`)이 `doc_properties.caret_*` 를 쓰고 DocInfo `raw_stream` 을
  surgical update 한다. 그럼에도 제외인 것은 편집이 아니라 저장 흐름의 일부이기 때문이다 —
  유일한 호출부가 `main.ts:649` 의 `wasm.onBeforeExport` 이고(#4180 저장 시점 캐럿),
  되돌릴 사용자 편집이 없다.
- **내부 클립보드** `copySelection`·`copySelectionInCell`·`copySelectionInCellByPath`·
  `copySelectionInHeaderFooter`·`copyControl`·`copyTableCellsTransposed` — 문서는 읽고
  복사본을 코어 버퍼에 담는다.
- **조회** `getCellCharPropertiesAtByPath`·`getCharShapeRunsInCellByPath` — 읽기뿐인데
  `get_cell_paragraph_mut_by_path` 를 거치느라 `&mut self` 가 됐다.

**(2) 동사와 무관한 완전성 시험 추가** (`mutation-routing-guard.test.ts`).
`wasm_api.rs` 의 `#[wasm_bindgen]` + `&mut self` 내보내기를 권위로 삼아, 브리지에 동명 공개
메서드가 있으면서 두 목록 어디에도 없는 이름이 생기면 깨진다. 원인이 된 필터를 우회하므로
같은 계급이 재발하지 않는다. 새 동사를 쓴 뮤테이터도 이 시험에는 걸린다.

## 검증

base devel `b59323de0`, 검증 commit `5cd58c03d`(최신 devel 로 rebase 후 재실행).

**수정 전 실패 증명.** 새 시험만 두고 레지스트리를 devel 상태로 되돌리면 22종을 이름으로
전부 나열하며 실패한다.

```
✖ [#7002] Rust `&mut self` 내보내기에 대응하는 브리지 메서드는 모두 분류돼야 한다
  AssertionError: wasm_api.rs 의 `&mut self` 내보내기인데 분류되지 않은 브리지 메서드:
  beginDeferredPagination, cancelDeferredPagination, capturePictureTransform, copyControl,
  copySelection, copySelectionInCell, copySelectionInCellByPath, copySelectionInHeaderFooter,
  copyTableCellsTransposed, discardPictureTransform, discardSnapshot, exportHwp,
  exportHwpVerify, exportHwpWithPassword, flushDeferredPagination,
  getCellCharPropertiesAtByPath, getCharShapeRunsInCellByPath, restoreSnapshot, saveSnapshot,
  setCaretPosition, stepDeferredPagination, swapPictureTransform
  ℹ pass 8  ℹ fail 1
```

수정 후 같은 파일 **9/9 통과**.

**프런트엔드 package 경로** (커밋 SHA 의 detached review worktree, `npm ci` 로 의존성 새로 설치).

- `npm --prefix rhwp-studio ci` — 통과
- `scripts/wasm-pack-locked.sh --target web --out-dir pkg --dev` — 이 SHA 에서 새로 만들었다.
  다른 checkout 의 `pkg/` 를 복사하지 않았다.
- `npx tsc --noEmit` — 클린
- `npm --prefix rhwp-studio test` — **1647 중 1645 통과, 0 실패, 2 skip**
  (새 시험 1건이 더해져 devel 의 1646 에서 늘었다)
- `npm --prefix rhwp-studio run build` — 통과
- `git diff --check origin/devel...HEAD` 와 `git diff --check` — 공백·충돌 마커 없음, 트리 clean

**범위와 미실행.** Studio 단독 변경이라(Rust 검증 입력 무변경) CONTRIBUTING 의 package 경로를
적용했다. Rust 전체 fmt·Clippy·integration 은 이 범위에 해당하지 않아 실행하지 않았다.
렌더링·시각 검증도 해당 없음 — 렌더 경로를 건드리지 않는다.

## 범위 외

- 22종 중 `setCaretPosition` 은 저장 바이트를 바꾸므로 "제외" 가 영원히 옳다고 주장하지 않는다.
  저장 흐름의 캐럿 스탬프를 히스토리에 넣을지는 #4180 의 의미론 문제이고 여기서 바꾸지 않는다.
- `MUTATING_VERB` 자체는 손대지 않았다. 새 시험이 동사와 무관하게 사각을 닫으므로 동사 목록을
  늘리는 것은 중복이고, 기존 드리프트 시험의 메시지는 그대로 두는 편이 낫다.
- `&mut self` 가 불필요한 래퍼(export 3종, 조회 2종)를 `&self` 로 좁히는 것은 별건이다.
