### PR TITLE
수정(layout): 글자처럼 취급 개체 줄의 저장 걸음에 바닥을 준다 (#6928)

### DIFF
--- a/mydocs/working/issue_6928_tac_object_line_advance.md
+++ b/mydocs/working/issue_6928_tac_object_line_advance.md
@@ -1,0 +1,87 @@
+---
+kind: working
+status: active
+issue: 6928
+---
+
+# 글자처럼 취급 개체 줄의 저장 걸음이 바닥 없이 통과한다 (#6928)
+
+작업 브랜치: `fix/6928-tac-picture-line-advance`
+대상: `src/renderer/layout/paragraph_layout.rs`
+
+## 한 줄
+
+저장 사다리가 주는 줄 걸음(`stored_line_advance`)의 바닥 가드가 **글자 높이 하나**뿐이라,
+글리프가 없는 **글자처럼 취급 개체 줄**에서는 가드가 풀려 2.7px 걸음이 107.1px 줄을 덮는다.
+
+## 이슈가 요구한 것
+
+- 1쪽 상단 겹침을 없앤다(배너 그림 뒤 내용이 −106px 위로 올라온다).
+- 배너 자신의 위치(−2.5px)는 별개 축이므로 건드리지 않는다.
+
+## 원인
+
+```rust
+// stored_line_advance
+let step = hwpunit_to_px(next.vertical_pos - seg.vertical_pos, self.dpi) - line_spacing_px;
+(step > 0.0 && step < line_height && (max_fs <= 0.0 || step + 0.5 >= max_fs)).then_some(step)
+```
+
+`flow_step = stored_line_advance.unwrap_or(line_height)` 이므로 이 걸음이 줄 높이를 덮는다.
+바닥은 `max_fs`(그 줄 글리프 높이) 하나인데, **개체가 줄 높이를 정하는 줄에는 글리프가
+없어 `max_fs` 가 0** 이다. `max_fs <= 0.0` 가 참이 되어 가드가 통째로 풀린다.
+
+계측(1쪽 문단 0, 배너 그림 호스트):
+
+```text
+PARA in  pi=0 y_start=94.5 lines=2 line_h_px=[107.1, 107.1] spacing_px=[0.0, 0.0]
+  LINE i=0 y=94.5 flow_h=2.7 branch=normal      ← 줄 높이 107.1 인데 흐름 걸음이 2.7
+  LINE i=1 y=97.1 branch=skip_empty
+PARA out pi=0 y=97.1 (전진 2.7)
+```
+
+대조군은 정상이다.
+
+```text
+  pi=2  20.0px 줄 → 36.0 전진      pi=3  26.7px 줄 → 45.3 전진
+```
+
+곧 이슈가 지적한 "줄 높이는 맞는데 다음 문단이 그 높이를 안 넘겨받는다" 의 기계다.
+
+## 수정
+
+그런 줄의 바닥은 **개체가 정한 줄 높이 자체**다. `ComposedParagraph::inline_controls` 로
+그 줄이 `Table`·`Shape` 를 품는지 보고, 품으면 바닥을 `max_fs.max(line_height)` 로 올린다.
+`step < line_height` 와 함께 걸리므로 그 줄은 저장 걸음을 쓰지 않고 `line_height` 로
+전진한다. 글자 줄은 `max_fs` 그대로라 종전 동작이다.
+
+## 검증 실측 — 한컴 2024 정본 대조
+
+| 요소 | 정본 | 수정 전 | 수정 후 | 잔차 |
+|---|---:|---:|---:|---:|
+| 표 `특허심사2국` | 217.5 | 113.3 | **217.7** | +0.2 |
+| 표 `문 의` | 231.1 | 124.6 | **229.0** | −2.1 |
+| 표 `사무관 이귀남` | 247.3 | 140.7 | **245.1** | −2.2 |
+| 엠바고 1행 | 276.7 | 172.4 | **276.8** | +0.1 |
+| `OPEN` 로고 | 283.2 | 176.5 | **280.9** | −2.3 |
+
+−106px 가 **±2.3px 이내**로 들어온다. 배너 자신(94.5, 정본 97.0)은 이 축과 별개다.
+
+## 게이트
+
+| 게이트 | 결과 |
+|---|---|
+| `cargo fmt --all -- --check` | OK |
+| `rust-unit-test-tiers --check` | 4205 (기준선 유지) |
+| clippy 3단 · workspace build | OK |
+| `rust-test-suite-manifest --check` | 48/48 targets |
+| 전 타깃 순차(28 suite + lib) | **9206 passed / 0 failed / 38 ignored** |
+| 코퍼스 래칫(겹침·off-canvas·overflow-cell) | **증가·신규 발생 0건** |
+
+겹침 래칫은 이 축의 관문이다 — `#6924` 에서 잘못된 구현을 정확히 잡아낸 그 게이트다.
+
+## 남긴 것
+
+- 배너 그림 자신의 −2.5px 는 다른 축이다(이슈도 그렇게 적었다).
+- 표·엠바고·로고에 남는 −2.1~−2.3px 잔차는 저장 걸음이 아니라 그 아래 줄간격 회계
+  쪽으로 보인다. 겹침은 해소됐고 이 이슈의 요구(−106px)는 닫혔다.

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -5162,7 +5162,30 @@ impl LayoutEngine {
                 }
                 let step =
                     hwpunit_to_px(next.vertical_pos - seg.vertical_pos, self.dpi) - line_spacing_px;
-                (step > 0.0 && step < line_height && (max_fs <= 0.0 || step + 0.5 >= max_fs))
+                // [#6928] 줄 바닥은 **글자 높이**(`max_fs`)로 지켜 왔는데, 글자처럼 취급
+                // 개체(그림·표)가 줄 높이를 정하는 줄에는 글리프가 없어 `max_fs` 가 0 이다.
+                // 그래서 저장 사다리가 주는 작은 걸음이 무방비로 통과하고, 뒤 내용이 그
+                // 개체 위로 포개진다 — 148769979 1쪽: 배너 그림 높이 107.1px 인 줄의
+                // 저장 걸음이 2.7px 라 표·엠바고·로고가 전부 106px 위로 올라왔다.
+                //
+                // 그런 줄의 바닥은 개체가 정한 줄 높이 자체다. `step < line_height` 와 함께
+                // 걸리므로 이 줄은 저장 걸음을 쓰지 않고 `line_height` 로 전진한다.
+                let line_has_as_char_object = composed.inline_controls.iter().any(|c| {
+                    c.line_index == line_idx
+                        && matches!(
+                            c.control_type,
+                            crate::renderer::composer::InlineControlType::Table
+                                | crate::renderer::composer::InlineControlType::Shape
+                        )
+                });
+                let flow_floor = if line_has_as_char_object {
+                    max_fs.max(line_height)
+                } else {
+                    max_fs
+                };
+                (step > 0.0
+                    && step < line_height
+                    && (flow_floor <= 0.0 || step + 0.5 >= flow_floor))
                     .then_some(step)
             });
             let flow_step = stored_line_advance.unwrap_or(line_height);


### PR DESCRIPTION
## 변경 요약

저장 사다리가 주는 줄 걸음(`stored_line_advance`)이 줄 높이를 덮는데, 그 **바닥 가드가
`max_fs`(그 줄 글리프 높이) 하나뿐**입니다.

```rust
let step = hwpunit_to_px(next.vertical_pos - seg.vertical_pos, self.dpi) - line_spacing_px;
(step > 0.0 && step < line_height && (max_fs <= 0.0 || step + 0.5 >= max_fs)).then_some(step)
// flow_step = stored_line_advance.unwrap_or(line_height)
```

**글자처럼 취급 개체(그림·표)가 줄 높이를 정하는 줄에는 글리프가 없어 `max_fs` 가 0** 입니다.
`max_fs <= 0.0` 가 참이 되어 가드가 통째로 풀립니다.

### 계측

```text
PARA in  pi=0 y_start=94.5 lines=2 line_h_px=[107.1, 107.1] spacing_px=[0.0, 0.0]
  LINE i=0 y=94.5 flow_h=2.7 branch=normal      ← 줄 높이 107.1 인데 흐름 걸음이 2.7
  LINE i=1 y=97.1 branch=skip_empty
PARA out pi=0 y=97.1 (전진 2.7)
```

대조군은 정상입니다 — `pi=2` 는 20.0px 줄에 36.0 전진, `pi=3` 은 26.7px 줄에 45.3 전진.

곧 이슈가 지적한 "줄 높이는 맞는데 다음 문단이 그 높이를 안 넘겨받는다" 의 기계입니다.

## 수정

그런 줄의 바닥은 **개체가 정한 줄 높이 자체**입니다. `ComposedParagraph::inline_controls` 로
그 줄이 `Table`·`Shape` 를 품는지 보고, 품으면 바닥을 `max_fs.max(line_height)` 로 올립니다.
`step < line_height` 와 함께 걸리므로 그 줄은 저장 걸음 대신 `line_height` 로 전진하고,
**글자 줄은 `max_fs` 그대로라 종전 동작**입니다.

## 관련 이슈

closes #6928

## 테스트

- 변경 범위: Rust (renderer/layout)
- 검증한 commit SHA: `a0fa74b55a038ce316695234d89649e00128b5c5`
- 실행 명령·결과:

```
node scripts/rust-test-suite-manifest.mjs --prepare
cargo fmt --all -- --check                                    # OK
node scripts/rust-unit-test-tiers.mjs --check                 # 4205 (기준선 유지)
cargo clippy --locked --target-dir target/pr-review -- -D warnings                     # OK
cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown \
  --target-dir target/pr-review -- -D warnings                                         # OK
cargo build --locked --workspace --target-dir target/pr-review                         # OK
cargo clippy --locked --workspace --all-targets --target-dir target/pr-review -- -D warnings  # OK
node scripts/rust-test-suite-manifest.mjs --check             # 48/48 integration targets
# 전 타깃 순차(regression_suite_001..028 + lib)
cargo test --release --test <각 suite> -- --test-threads=2    # 9206 passed / 0 failed / 38 ignored
```

> `cargo test --release --workspace` 는 이 머신에서 OOM 으로 중단됩니다. 스위트를 하나씩
> 순차 실행해 전수를 채웠고 실패 타깃은 0 입니다.

**코퍼스 래칫(겹침·off-canvas·overflow-cell): 증가·신규 발생 0건.** 겹침 래칫은 이 축의
관문입니다 — `#6924` 에서 잘못된 구현을 정확히 잡아낸 그 게이트입니다.

### 시각 검증 — 한컴 2024 정본 대조

| 요소 | 정본 | 수정 전 | 수정 후 | 잔차 |
|---|---:|---:|---:|---:|
| 표 `특허심사2국` | 217.5 | 113.3 | **217.7** | +0.2 |
| 표 `문 의` | 231.1 | 124.6 | **229.0** | −2.1 |
| 표 `사무관 이귀남` | 247.3 | 140.7 | **245.1** | −2.2 |
| 엠바고 1행 | 276.7 | 172.4 | **276.8** | +0.1 |
| `OPEN` 로고 | 283.2 | 176.5 | **280.9** | −2.3 |

−106px 가 **±2.3px 이내**로 들어옵니다. 배너 자신(94.5, 정본 97.0)은 이 축과 별개입니다.

재현:

```bash
rhwp export-render-tree "148769979_274 반도체포럼 개최(이귀남 최종).hwp" -o rt -p 0
# 수정 전: TextLine y=94.5 h=107.1 / Table y=100.9   ← 겹친다
# 수정 후: TextLine y=94.5 h=107.1 / Table y=205.3
```

- [x] [변경 범위별 필수 검증](https://github.com/edwardkim/rhwp/blob/devel/CONTRIBUTING.md#pr-전-체크리스트) 수행, 제출 HEAD 가 검증한 commit 과 같음
- [x] Rust source 변경: 별도 worktree 에서 `cargo fmt --all -- --check`, native·WASM32·workspace all-target Clippy 통과
- [x] Rust 변경: 전 integration 회귀 + 코퍼스 래칫 + 한컴 2024 정본 대조 수행
- [x] 새 integration test 없음 — 기존 코퍼스 래칫이 이 축의 회귀 게이트입니다(겹침 래칫)
- [x] `src/**`의 `#[cfg(test)]` 변경 없음 — `rust-unit-test-tiers --check` 4205 유지
- [x] (에이전트 보조) 작업 증빙 — 문서 편집이 아니라 `replay --capsule` 해당 없음. 위 계측(문단·줄 단위 흐름 걸음)과 정본 대조가 재현 가능한 증적입니다.

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 — 줄마다 `inline_controls` 를 한 번 훑는 선형 검사입니다.
- 재현·측정: 회귀 스위트 수행 시간에 유의한 변화 없음.

## 남긴 것

- 배너 그림 자신의 −2.5px 는 다른 축입니다(이슈도 그렇게 적었습니다).
- 표·엠바고·로고에 남는 −2.1~−2.3px 잔차는 저장 걸음이 아니라 그 아래 줄간격 회계 쪽으로
  보입니다. 겹침은 해소됐고 이 이슈의 요구(−106px)는 닫혔습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Atxwm3i6Nkqfar45X9TSzz
