### PR TITLE
수정(layout): 칸 안 자리차지 중첩 표의 vertOffset 리드를 세로 정렬 콘텐츠 높이에도 싣는다 (#7012)

### DIFF
--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -7797,15 +7797,19 @@ impl LayoutEngine {
                     if let Some(seg) = last_para.line_segs.last() {
                         let mut last_end = seg.vertical_pos.saturating_add(seg.line_height);
                         // 마지막 문단에 중첩 표가 있고 lh가 표 높이보다 작으면 보정
+                        // [#6697 후속] 마지막 문단의 문단 기준 어울림 표는 리드만큼 더
+                        // 내려가 그려진다 — `nested_bottom` 과 같은 조건으로 싣는다.
+                        let mut lead_px = 0.0;
                         for ctrl in &last_para.controls {
                             if let Control::Table(t) = ctrl {
                                 let table_h = t.common.height as i32;
                                 if table_h > seg.line_height {
                                     last_end += table_h - seg.line_height;
                                 }
+                                lead_px += para_relative_float_table_lead(t, self.dpi);
                             }
                         }
-                        hwpunit_to_px(last_end, self.dpi)
+                        hwpunit_to_px(last_end, self.dpi) + lead_px
                     } else {
                         0.0
                     }
@@ -8324,12 +8328,26 @@ impl LayoutEngine {
             .iter()
             .enumerate()
             .map(|(pidx, p)| {
+                // [#6697 후속] 문단 기준 어울림 중첩 표의 `vertOffset` 리드는 렌더
+                // (`nested_y`)와 흐름 계상(`cell_units_uncached`)이 이미 싣는데, 세로
+                // 정렬용 콘텐츠 높이가 그 몫을 모르면 표는 리드만큼 내려가고 콘텐츠
+                // 블록은 제자리라 `valign=Center` 칸의 아래 여백만 리드만큼 줄어든다
+                // (재현 문서 `valign=Center` 칸: 한/글 위/아래 여백 95/67px, rhwp
+                // 123.6/37.3px — 표 자체 위치는 한/글과 일치). 흐름 계상과 **같은
+                // 조건**(호스트가 칸의 마지막 문단)으로 싣는다 — 뒤 형제 문단이 있을 때
+                // 그 몫을 싣지 않는 계약(59043 `□ 편익`)은 그대로다.
+                let host_is_cell_last_para = pidx + 1 == paragraphs.len();
                 let nested_h: f64 = p
                     .controls
                     .iter()
                     .map(|ctrl| {
                         if let Control::Table(t) = ctrl {
                             self.calc_nested_table_height(t, styles)
+                                + if host_is_cell_last_para {
+                                    para_relative_float_table_lead(t, self.dpi)
+                                } else {
+                                    0.0
+                                }
                         } else {
                             0.0
                         }

--- a/tests/cases/issue_6697_cell_nested_table_vert_offset.rs
+++ b/tests/cases/issue_6697_cell_nested_table_vert_offset.rs
@@ -28,7 +28,7 @@ use rhwp::model::page::PageDef;
 use rhwp::model::paragraph::{LineSeg, Paragraph};
 use rhwp::model::shape::{TextWrap, VertRelTo};
 use rhwp::model::style::ParaShape;
-use rhwp::model::table::{Cell, Table};
+use rhwp::model::table::{Cell, Table, VerticalAlign};
 use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
 
 const LINE_H: i32 = 800;
@@ -77,6 +77,10 @@ fn nested_float_table(offset: u32) -> Table {
 
 /// 바깥 1×1 표 — 그 칸의 문단이 글자와 중첩 표를 함께 갖는다.
 fn document(offset: u32) -> Document {
+    document_with_valign(offset, VerticalAlign::Top)
+}
+
+fn document_with_valign(offset: u32, valign: VerticalAlign) -> Document {
     let mut doc = Document::default();
     doc.doc_info.para_shapes = vec![ParaShape::default()];
 
@@ -110,6 +114,7 @@ fn document(offset: u32) -> Document {
             height: NESTED_H + 8000,
             paragraphs: vec![host],
             apply_inner_margin: true,
+            vertical_align: valign,
             ..Default::default()
         }],
         ..Default::default()
@@ -151,8 +156,12 @@ fn collect_tables(node: &RenderNode, out: &mut Vec<(bool, f64)>) {
 }
 
 fn nested_top(offset: u32) -> f64 {
+    nested_top_with_valign(offset, VerticalAlign::Top)
+}
+
+fn nested_top_with_valign(offset: u32, valign: VerticalAlign) -> f64 {
     let mut core = DocumentCore::new_empty();
-    core.set_document(document(offset));
+    core.set_document(document_with_valign(offset, valign));
     let tree = core
         .build_page_render_tree(0)
         .expect("render tree 생성 실패");
@@ -196,5 +205,26 @@ fn negative_vert_offset_does_not_lift_the_nested_table() {
         (negative - zero).abs() <= 1.0,
         "음수 vertOffset 은 적용하지 않는다 — u32 를 부호 없이 읽으면 표가 위로 튄다 \
          (오프셋 0 {zero:.1} vs 음수 {negative:.1})"
+    );
+}
+
+/// `valign=Center` 칸에서는 리드가 **절반만** 표를 내린다.
+///
+/// 렌더는 표를 리드만큼 내리고, 세로 정렬용 콘텐츠 높이도 리드만큼 커져 중앙이
+/// 리드의 절반만큼 위로 오르기 때문이다. 콘텍츠 높이가 리드를 모르면 표만 전량
+/// 내려가 아래 여백이 리드만큼 줄어든다(재현 문서: 한/글 위/아래 여백 95/67px 인
+/// 칸이 rhwp 123.6/37.3px — 표 위치는 일치, 블록만 리드/2 처짐).
+#[test]
+fn center_aligned_cell_moves_nested_table_by_half_the_lead() {
+    let zero = nested_top_with_valign(0, VerticalAlign::Center);
+    let offset = nested_top_with_valign(OFFSET_HU, VerticalAlign::Center);
+    let lead = f64::from(OFFSET_HU) / 75.0;
+    let moved = offset - zero;
+    assert!(
+        (moved - lead / 2.0).abs() <= 1.0,
+        "valign=Center 칸의 자리차지 중첩 표는 리드의 절반만 내려가야 한다 — 세로 정렬용 \
+         콘텐츠 높이가 리드를 모르면 전량 내려간다 (기대 +{:.1}px, 실제 +{moved:.1}px; \
+         오프셋 0 일 때 {zero:.1}, 오프셋 {OFFSET_HU}HU 일 때 {offset:.1})",
+        lead / 2.0
     );
 }


### PR DESCRIPTION
Closes #7012

## 무엇을 고쳤나

`#6697`(`8b183f656`)이 칸 안 문단 기준 자리차지 중첩 표의 `vertOffset` 리드를 **렌더**(`nested_y`)와 **흐름 계상**(`cell_units_uncached`)에 실었는데, **세로 정렬용 콘텍츠 높이**는 그 몫을 모릅니다. 그래서 `valign=Center` 칸에서 표는 리드만큼 내려가고 콘텐츠 블록은 제자리라 아래 여백만 리드만큼 줄어듭니다. 한/글은 블록을 리드/2 만큼 위로 올려 위·아래를 다시 맞춥니다.

`total_content_height = max(composed, vpos_height, nested_bottom, wrap_object_bottom)` 의 두 항에 `para_relative_float_table_lead` 를 더합니다 — `calc_nested_controls_bottom_height`(호스트가 칸의 마지막 문단일 때 = 흐름 계상과 같은 조건)와 마지막 문단 `vpos_height` 보정.

## 근거 (재현 문서, `valign=Center` 칸 600.7px)

| | 제목 줄 → 표 상단 | 칸 위 여백 | 칸 아래 여백 |
|---|---|---|---|
| 한/글(웹한글기안기 실측) | 64px | 95px | 67px |
| `devel` `6806950b1` | 64px | 124px | 37px |
| **이 PR** | 64px | 94px | 67px |

표 자체 위치(#6697)는 유지되고 블록만 30.1px 올라옵니다(`dump-extents`: 표 829.8 → 799.7, 제목 줄 744.6 → 714.5).

## 시험

기존 `tests/cases/issue_6697_cell_nested_table_vert_offset.rs` 에 병합(integration target 예산 불변):

- `center_aligned_cell_moves_nested_table_by_half_the_lead` — `valign=Center` 칸에서 오프셋 표는 오프셋 0 대비 **리드의 절반**만 내려간다. `devel` 에서 RED(`기대 +20.4px, 실제 +40.8px`), 이 PR 에서 GREEN.
- 기존 2건(`honors_vert_offset`, `negative_vert_offset_does_not_lift`) 유지 — `document`/`nested_top` 은 `valign` 매개변수화 래퍼로 분리했고 기본은 `Top` 그대로.

## 검증

- `regression_suite_006` `issue_6697` 3/3, `regression_suite_012` `issue_1510` 7/7 (lead 함수 직접 호출 계약 무변)
- `cargo test --lib` 전체 통과
- `cargo fmt --check`, clippy 3종(native · wasm32 lib · workspace all-targets) 통과 — `rust-test-suite-manifest.mjs --prepare` 선행
- 사내 코퍼스 7건 레이아웃 지표 래칫: `devel` 기준선과 동일(변화 없음)

## 범위 밖 (관찰만)

`height_measurer::cell_nested_controls_bottom` 도 같은 리드를 모릅니다(측정 장부 vs paint `cell_units_uncached`). 이 문서의 칸은 선언 높이가 콘텐츠보다 커서 그 축이 드러나지 않아 이 PR 에서는 건드리지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
