### PR TITLE
Task #7005: 칸 안 도형 레이아웃에 cellPath 를 싣는다

### DIFF
--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -3570,6 +3570,32 @@ impl DocumentCore {
         out
     }
 
+    /// [#7005] 칸 안 도형(사각형·직선·타원·path)의 칸 좌표 JSON.
+    ///
+    /// `ole_layout_context_json` 과 같은 계약이다 — **`cellPath` 가 정본**이고 단일 레벨
+    /// 스칼라는 studio 하위호환이다. 도형 노드는 `CellContext` 대신 #1138 의 평평한 3필드를
+    /// 들고 있으므로 그것으로 1단계 경로를 만든다. 셋은 같은 `table_cell_ref` 에서 함께
+    /// 오므로 전부 있거나 전부 없다.
+    ///
+    /// 종전에는 스칼라만 방출해 studio 의 `hasCellPath` 가 거짓이 됐고, `getObjectProperties`
+    /// 가 본문 API 로 떨어져 던지면서 칸 안 도형의 마우스 조작이 전부 막혔다. 선택 토글도
+    /// `cellPath` 로 개체를 구분하므로 같은 문단의 두 도형을 같은 것으로 봤다.
+    fn shape_cell_context_json(
+        cell_index: Option<usize>,
+        cell_para_index: Option<usize>,
+        outer_table_control_index: Option<usize>,
+    ) -> String {
+        let (Some(cei), Some(cpi), Some(otci)) =
+            (cell_index, cell_para_index, outer_table_control_index)
+        else {
+            return String::new();
+        };
+        format!(
+            ",\"cellIdx\":{cei},\"cellParaIdx\":{cpi},\"outerTableControlIdx\":{otci}\
+             ,\"cellPath\":[{{\"controlIndex\":{otci},\"cellIndex\":{cei},\"cellParaIndex\":{cpi}}}]"
+        )
+    }
+
     /// 컨트롤(표, 이미지 등) 레이아웃 정보 (네이티브 에러 타입)
     pub fn get_page_control_layout_native(&self, page_num: u32) -> Result<String, HwpError> {
         use crate::renderer::render_tree::{RenderNode, RenderNodeType};
@@ -3903,20 +3929,15 @@ impl DocumentCore {
                         rect_node.control_index,
                     ) {
                         // [Task #1138] 표 셀 안 사각형: cellIdx/cellParaIdx/outerTableControlIdx
-                        let cell_str = match (rect_node.cell_index, rect_node.cell_para_index) {
-                            (Some(cei), Some(cpi)) => {
-                                format!(",\"cellIdx\":{},\"cellParaIdx\":{}", cei, cpi)
-                            }
-                            _ => String::new(),
-                        };
-                        let outer_table_str = match rect_node.outer_table_control_index {
-                            Some(otci) => format!(",\"outerTableControlIdx\":{}", otci),
-                            None => String::new(),
-                        };
+                        let cell_str = DocumentCore::shape_cell_context_json(
+                            rect_node.cell_index,
+                            rect_node.cell_para_index,
+                            rect_node.outer_table_control_index,
+                        );
                         controls.push(format!(
-                            "{{\"type\":\"shape\",\"x\":{:.1},\"y\":{:.1},\"w\":{:.1},\"h\":{:.1},\"secIdx\":{},\"paraIdx\":{},\"controlIdx\":{}{}{}{}}}",
+                            "{{\"type\":\"shape\",\"x\":{:.1},\"y\":{:.1},\"w\":{:.1},\"h\":{:.1},\"secIdx\":{},\"paraIdx\":{},\"controlIdx\":{}{}{}}}",
                             node.bbox.x, node.bbox.y, node.bbox.width, node.bbox.height,
-                            si, pi, ci, cell_str, outer_table_str, layer_str
+                            si, pi, ci, cell_str, layer_str
                         ));
                         // [Task #1171] return 하지 않고 자식으로 재귀 — 사각형 글상자(text_box)
                         // 안 중첩 picture/도형이 cellPath(cell_index=0 sentinel)로 수집되도록 한다.
@@ -3931,21 +3952,16 @@ impl DocumentCore {
                         line_node.control_index,
                     ) {
                         // [Task #1138] 표 셀 안 직선
-                        let cell_str = match (line_node.cell_index, line_node.cell_para_index) {
-                            (Some(cei), Some(cpi)) => {
-                                format!(",\"cellIdx\":{},\"cellParaIdx\":{}", cei, cpi)
-                            }
-                            _ => String::new(),
-                        };
-                        let outer_table_str = match line_node.outer_table_control_index {
-                            Some(otci) => format!(",\"outerTableControlIdx\":{}", otci),
-                            None => String::new(),
-                        };
+                        let cell_str = DocumentCore::shape_cell_context_json(
+                            line_node.cell_index,
+                            line_node.cell_para_index,
+                            line_node.outer_table_control_index,
+                        );
                         controls.push(format!(
-                            "{{\"type\":\"line\",\"x\":{:.1},\"y\":{:.1},\"w\":{:.1},\"h\":{:.1},\"x1\":{:.1},\"y1\":{:.1},\"x2\":{:.1},\"y2\":{:.1},\"secIdx\":{},\"paraIdx\":{},\"controlIdx\":{}{}{}{}}}",
+                            "{{\"type\":\"line\",\"x\":{:.1},\"y\":{:.1},\"w\":{:.1},\"h\":{:.1},\"x1\":{:.1},\"y1\":{:.1},\"x2\":{:.1},\"y2\":{:.1},\"secIdx\":{},\"paraIdx\":{},\"controlIdx\":{}{}{}}}",
                             node.bbox.x, node.bbox.y, node.bbox.width, node.bbox.height,
                             line_node.x1, line_node.y1, line_node.x2, line_node.y2,
-                            si, pi, ci, cell_str, outer_table_str, layer_str
+                            si, pi, ci, cell_str, layer_str
                         ));
                         return;
                     }
@@ -3957,20 +3973,15 @@ impl DocumentCore {
                         ell_node.control_index,
                     ) {
                         // [Task #1138] 표 셀 안 타원
-                        let cell_str = match (ell_node.cell_index, ell_node.cell_para_index) {
-                            (Some(cei), Some(cpi)) => {
-                                format!(",\"cellIdx\":{},\"cellParaIdx\":{}", cei, cpi)
-                            }
-                            _ => String::new(),
-                        };
-                        let outer_table_str = match ell_node.outer_table_control_index {
-                            Some(otci) => format!(",\"outerTableControlIdx\":{}", otci),
-                            None => String::new(),
-                        };
+                        let cell_str = DocumentCore::shape_cell_context_json(
+                            ell_node.cell_index,
+                            ell_node.cell_para_index,
+                            ell_node.outer_table_control_index,
+                        );
                         controls.push(format!(
-                            "{{\"type\":\"shape\",\"x\":{:.1},\"y\":{:.1},\"w\":{:.1},\"h\":{:.1},\"secIdx\":{},\"paraIdx\":{},\"controlIdx\":{}{}{}{}}}",
+                            "{{\"type\":\"shape\",\"x\":{:.1},\"y\":{:.1},\"w\":{:.1},\"h\":{:.1},\"secIdx\":{},\"paraIdx\":{},\"controlIdx\":{}{}{}}}",
                             node.bbox.x, node.bbox.y, node.bbox.width, node.bbox.height,
-                            si, pi, ci, cell_str, outer_table_str, layer_str
+                            si, pi, ci, cell_str, layer_str
                         ));
                         return;
                     }
@@ -3982,29 +3993,24 @@ impl DocumentCore {
                         path_node.control_index,
                     ) {
                         // [Task #1138] 표 셀 안 path (다각형/곡선/연결선)
-                        let cell_str = match (path_node.cell_index, path_node.cell_para_index) {
-                            (Some(cei), Some(cpi)) => {
-                                format!(",\"cellIdx\":{},\"cellParaIdx\":{}", cei, cpi)
-                            }
-                            _ => String::new(),
-                        };
-                        let outer_table_str = match path_node.outer_table_control_index {
-                            Some(otci) => format!(",\"outerTableControlIdx\":{}", otci),
-                            None => String::new(),
-                        };
+                        let cell_str = DocumentCore::shape_cell_context_json(
+                            path_node.cell_index,
+                            path_node.cell_para_index,
+                            path_node.outer_table_control_index,
+                        );
                         if let Some((x1, y1, x2, y2)) = path_node.connector_endpoints {
                             // 연결선: 선 선택 방식 (시작/끝 좌표 포함)
                             controls.push(format!(
-                                "{{\"type\":\"line\",\"x\":{:.1},\"y\":{:.1},\"w\":{:.1},\"h\":{:.1},\"x1\":{:.1},\"y1\":{:.1},\"x2\":{:.1},\"y2\":{:.1},\"secIdx\":{},\"paraIdx\":{},\"controlIdx\":{}{}{}{}}}",
+                                "{{\"type\":\"line\",\"x\":{:.1},\"y\":{:.1},\"w\":{:.1},\"h\":{:.1},\"x1\":{:.1},\"y1\":{:.1},\"x2\":{:.1},\"y2\":{:.1},\"secIdx\":{},\"paraIdx\":{},\"controlIdx\":{}{}{}}}",
                                 node.bbox.x, node.bbox.y, node.bbox.width, node.bbox.height,
                                 x1, y1, x2, y2,
-                                si, pi, ci, cell_str, outer_table_str, layer_str
+                                si, pi, ci, cell_str, layer_str
                             ));
                         } else {
                             controls.push(format!(
-                                "{{\"type\":\"shape\",\"x\":{:.1},\"y\":{:.1},\"w\":{:.1},\"h\":{:.1},\"secIdx\":{},\"paraIdx\":{},\"controlIdx\":{}{}{}{}}}",
+                                "{{\"type\":\"shape\",\"x\":{:.1},\"y\":{:.1},\"w\":{:.1},\"h\":{:.1},\"secIdx\":{},\"paraIdx\":{},\"controlIdx\":{}{}{}}}",
                                 node.bbox.x, node.bbox.y, node.bbox.width, node.bbox.height,
-                                si, pi, ci, cell_str, outer_table_str, layer_str
+                                si, pi, ci, cell_str, layer_str
                             ));
                         }
                         return;

--- a/tests/cases/issue_7005_cell_shape_cell_path.rs
+++ b/tests/cases/issue_7005_cell_shape_cell_path.rs
@@ -1,0 +1,115 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! [#7005] 표 칸 안 도형도 레이아웃에 `cellPath` 를 실어야 한다.
+//!
+//! studio 는 `cellPath` 유무로 by-path API 와 본문 API 를 가른다. 칸 안 도형에 이 값이 없으면
+//! `getObjectProperties` 가 본문 `getShapeProperties(sec, ppi, ci)` 로 떨어져 "지정된 컨트롤이
+//! Shape이 아닙니다" 로 던지고(그 자리가 마우스 리사이즈 진입부라 조작이 조용히 막힌다),
+//! 선택 토글도 `cellPath` 로 개체를 구분하므로 같은 `(sec, ppi, ci)` 를 쓰는 칸 안 도형 둘을
+//! 같은 개체로 본다.
+//!
+//! 표본 `21_언어_기출_편집가능본.hwp` 1쪽에는 칸 안 도형 둘(「제 1 교시」·「홀수형」)이 있고
+//! 둘 다 `(sec, ppi, ci) = (0, 0, 0)` 이며 칸만 다르다 — `cellPath` 없이는 구분되지 않는다.
+
+use rhwp::document_core::DocumentCore;
+
+const SAMPLE: &str = "samples/21_언어_기출_편집가능본.hwp";
+
+fn page0_controls() -> Vec<serde_json::Value> {
+    let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let core = DocumentCore::from_bytes(&std::fs::read(p).expect("표본 로드")).expect("파싱");
+    let json = core
+        .get_page_control_layout_native(0)
+        .expect("0쪽 레이아웃");
+    let v: serde_json::Value = serde_json::from_str(&json).expect("레이아웃 JSON");
+    v["controls"].as_array().expect("controls 배열").clone()
+}
+
+/// 칸 안(= `cellIdx` 를 가진) 컨트롤만.
+fn in_cell(controls: &[serde_json::Value], ty: &str) -> Vec<serde_json::Value> {
+    controls
+        .iter()
+        .filter(|c| c["type"] == ty && !c["cellIdx"].is_null())
+        .cloned()
+        .collect()
+}
+
+#[test]
+fn cell_shapes_carry_cell_path() {
+    let controls = page0_controls();
+    let shapes = in_cell(&controls, "shape");
+    assert!(
+        shapes.len() >= 2,
+        "표본 전제: 1쪽에 칸 안 도형이 둘 이상 (실측 {})",
+        shapes.len()
+    );
+
+    for s in &shapes {
+        let path = s["cellPath"].as_array().unwrap_or_else(|| {
+            panic!("칸 안 도형에 cellPath 가 없다 — studio 가 본문 API 로 떨어진다: {s}")
+        });
+        assert_eq!(path.len(), 1, "평평한 3필드는 1단계 경로다: {s}");
+        // 경로 항목이 같은 컨트롤의 스칼라와 일치해야 by-path 조회가 성립한다.
+        assert_eq!(path[0]["controlIndex"], s["outerTableControlIdx"], "{s}");
+        assert_eq!(path[0]["cellIndex"], s["cellIdx"], "{s}");
+        assert_eq!(path[0]["cellParaIndex"], s["cellParaIdx"], "{s}");
+    }
+}
+
+#[test]
+fn cell_shapes_are_distinguishable_by_cell_path() {
+    // studio `togglePictureObjectSelection` 은 (sec, ppi, ci, cellPath) 로 동일성을 본다.
+    // 이 표본의 두 도형은 앞 셋이 같으므로 cellPath 가 갈라 주어야 한다.
+    let controls = page0_controls();
+    let shapes = in_cell(&controls, "shape");
+    let ident: Vec<String> = shapes
+        .iter()
+        .map(|s| {
+            format!(
+                "{}/{}/{}/{}",
+                s["secIdx"], s["paraIdx"], s["controlIdx"], s["cellPath"]
+            )
+        })
+        .collect();
+    let mut uniq = ident.clone();
+    uniq.sort();
+    uniq.dedup();
+    assert_eq!(
+        uniq.len(),
+        ident.len(),
+        "칸 안 도형들이 선택 동일성 판정에서 구분되지 않는다: {ident:?}"
+    );
+
+    let bare: Vec<String> = shapes
+        .iter()
+        .map(|s| format!("{}/{}/{}", s["secIdx"], s["paraIdx"], s["controlIdx"]))
+        .collect();
+    let mut bare_uniq = bare.clone();
+    bare_uniq.sort();
+    bare_uniq.dedup();
+    assert!(
+        bare_uniq.len() < bare.len(),
+        "표본 전제: cellPath 없이는 두 도형이 같은 좌표로 겹쳐야 판정이 의미를 갖는다: {bare:?}"
+    );
+}
+
+#[test]
+fn body_shapes_keep_no_cell_fields() {
+    // 대조 — 본문 직속 도형은 종전대로 칸 필드가 없어야 한다(빈 문자열 방출).
+    let controls = page0_controls();
+    let body: Vec<_> = controls
+        .iter()
+        .filter(|c| (c["type"] == "shape" || c["type"] == "line") && c["cellIdx"].is_null())
+        .collect();
+    assert!(
+        !body.is_empty(),
+        "표본 전제: 1쪽에 본문 직속 도형/직선이 있어야 대조가 선다"
+    );
+    for c in body {
+        assert!(
+            c["cellPath"].is_null(),
+            "본문 도형에 cellPath 가 붙었다: {c}"
+        );
+        assert!(c["outerTableControlIdx"].is_null(), "{c}");
+    }
+}


### PR DESCRIPTION
관련 이슈: #7005

## 문제

표 칸 안 **도형**은 studio 에서 클릭 선택은 되는데 마우스 조작이 전부 막힌다. 핸들을 끌어도 크기가 그대로고, `Shift`+클릭으로 두 번째 도형을 더하려 하면 오히려 선택이 풀린다. 같은 문서의 칸 안 **그림**은 둘 다 정상이다.

## 원인

`get_page_control_layout_native` 의 도형 네 분기(사각형·직선·타원·path)가 #1138 의 평평한 3필드(`cellIdx`·`cellParaIdx`·`outerTableControlIdx`)만 방출하고 `cellPath` 를 내지 않는다. `Image` 분기는 #1161 로 `cellPath` 를 낸다 — 같은 문서에서 칸 안 그림은 `cellPath` 를 받고 칸 안 도형은 못 받는다(실측: 그림 1건 `+cellPath` / 도형 3건 `-cellPath`).

studio 는 그 값으로 갈린다.

- `input-handler-picture.ts` `controlToRef` 는 `cellPath: ctrl.cellPath` 를 그대로 옮긴다 — 레이아웃에 없으니 ref 에도 없다. TS 쪽 누락이 아니다.
- `getObjectProperties` 가 `hasCellPath(ref)` 로 갈라 본문 `getShapeProperties(sec, ppi, ci)` 를 부른다. 본문 0문단 0컨트롤은 그 도형이 아니라 **표**라 `지정된 컨트롤이 Shape이 아닙니다` 로 던진다. 그 호출이 리사이즈 드래그 진입부(`const props = this.getObjectProperties(ref); if (props.sizeProtect) return;`)라 드래그가 시작조차 못 한다. 앞 두 관문은 통과한다 — 계측하면 `getHandleAtPoint(256, 214) → 'e'`, `findPictureBbox → bbox` 다.
- `cursor.ts` `togglePictureObjectSelection` 의 동일성 판정이 `sec`·`ppi`·`ci`·`cellPath` 만 본다. 이 표본의 두 도형은 앞 셋이 `(0, 0, 0)` 으로 같고 `cellPath` 가 둘 다 비어 있어 **같은 개체로 판정**된다 → 추가가 아니라 제거.

## 변경

바로 위 `ole_layout_context_json` 이 세운 계약을 도형에도 적용한다 — 그 주석이 이미 "단일 레벨 스칼라는 studio 의 by_path 폴백 조립과의 하위호환, **`cellPath` 가 정본**" 이라고 적어 두었다. 도형 노드는 `CellContext` 대신 평평한 3필드를 들고 있고 **그 셋이 곧 1단계 경로**라, 같은 값으로 경로를 만들어 함께 낸다.

```rust
fn shape_cell_context_json(
    cell_index: Option<usize>,
    cell_para_index: Option<usize>,
    outer_table_control_index: Option<usize>,
) -> String {
    let (Some(cei), Some(cpi), Some(otci)) = (…) else { return String::new() };
    format!(",\"cellIdx\":{cei},\"cellParaIdx\":{cpi},\"outerTableControlIdx\":{otci}\
             ,\"cellPath\":[{{\"controlIndex\":{otci},\"cellIndex\":{cei},\"cellParaIndex\":{cpi}}}]")
}
```

네 분기에 똑같이 복제돼 있던 `cell_str`·`outer_table_str` 두 블록이 이 헬퍼 한 번 호출로 접힌다. 소스는 **56줄 추가 50줄 삭제**로, 결함을 고치면서 중복 넷이 사라진다. 세 값은 같은 `table_cell_ref` 에서 함께 오므로 전부 있거나 전부 없다 — 본문 직속 도형은 종전대로 빈 문자열이다.

노드 구조체·레이아웃·studio 는 건드리지 않았다. 하류는 이미 `cellPath` 를 받을 준비가 되어 있다.

회귀 테스트 `tests/cases/issue_7005_cell_shape_cell_path.rs` 3건 — 칸 안 도형에 1단계 `cellPath` 가 붙고 그 항목이 같은 컨트롤의 스칼라와 일치하는지, 두 도형이 선택 동일성 판정에서 갈리는지(표본 전제로 `cellPath` 없이는 겹친다는 것도 함께 단언), 그리고 대조로 본문 직속 도형에는 칸 필드가 붙지 않는지.

## 검증

devel `313bd4273` 기준. 표본 `samples/21_언어_기출_편집가능본.hwp` 1쪽 — 칸 안 도형 둘(「제 1 교시」 `cellIdx 2`, 「홀수형」 `cellIdx 4`)이 모두 `(sec, ppi, ci) = (0, 0, 0)` 이라 `cellPath` 없이는 구분되지 않는다.

**수정 전 실패 증명** — 수정 전 devel 에서 🔴 **2건 실패 / 1건 통과**. 통과한 하나는 "본문 직속 도형에는 칸 필드가 없다" 대조라 수정 전에도 통과해야 맞다.

```
칸 안 도형에 cellPath 가 없다 — studio 가 본문 API 로 떨어진다:
{"cellIdx":2,"cellParaIdx":0,"controlIdx":0,"outerTableControlIdx":2,
 "paraIdx":0,"secIdx":0,"type":"shape", …}
```

필요한 세 값이 다 있는데 `cellPath` 만 없다.

**브라우저 실동작** — 이 브랜치로 WASM 을 새로 빌드해 studio 를 띄우고, 문서를 앱의 실제 열기 깔때기로 연 뒤 **실제 마우스**로 조작했다.

| | 수정 전 | 수정 후 |
|---|---|---|
| 핸들 드래그 | 크기 불변(9070 그대로), 콘솔 오류도 없음 | 9070 → 6893, undo 스택 기록, 되돌리기로 9070 복원 |
| `Shift`+클릭 | 1개 → **0개**(선택 해제) | 1개 → **2개**(`cellIdx` 2·4) |

**수정 후** — 새 3건 통과. 전체 Rust 회귀 **9,453 통과 / 실패 0 / 건너뜀 49**, exit 0.

**게이트** — `cargo fmt --all -- --check` 통과, `clippy --locked --lib --tests -D warnings` 무경고, `rust-unit-test-tiers.mjs --check --base-ref origin/devel` 통과(cfg support items 28 무증가), `rust-test-suite-manifest.mjs --check` 통과.

## 범위 외

- **중첩 깊이 2 이상.** 도형 노드가 든 #1138 평평한 3필드는 1단계만 표현한다. 깊은 중첩까지 덮으려면 `ImageNode` 처럼 `cell_context` 를 도형 노드에 전파해야 하고, 그건 노드 구조체와 `layout_shape_object` 의 `table_cell_ref` 시그니처를 함께 바꾸는 별도 작업이다. 이 PR 은 1단계 칸을 닫는다.
- **묶음(`Group`).** `GroupNode` 는 칸 정보를 아예 들고 있지 않아 같은 방식으로 고칠 수 없다. 별도 축이다.
- **회전·이동.** 같은 `getObjectProperties` 를 쓰므로 함께 풀릴 것으로 보이나, 이번에는 리사이즈와 다중 선택만 실측했다.
- **머리말·꼬리말 문맥.** 표본의 머리말에 개체가 없어 재지 않았다.
- **한/글 대조.** 이 PR 은 조판 정합이 아니라 편집기 동작을 고치므로 기준 PDF 를 쓰지 않았다. #7005 본문의 "한/글 2024 에서는 된다" 는 사용자 실측이다.
