### PR TITLE
Task #7019: e2e vite 서버를 Node API in-process 기동으로 바꾼다

### DIFF
--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -112,7 +112,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `run-with-vite.mjs` | 유틸 | active | Vite dev server 기동 + 임의 명령 실행 공용 러너 (VITE_URL 주입, 종료 코드 전파) | — | npm e2e:undo-depth |  |
 | `save-as-format.test.mjs` | 상시 | active | 저장 출력 포맷 선택 (file:save-as-hwp / file:save-as-hwpx) E2E — #1613 | biz_plan.hwp, hwpx/footnote-01.hwpx | 수동 |  |
 | `scenario-runner.mjs` | 유틸 | active | 시나리오 실행기 + 렌더 트리 측정기 + 규칙 검증기 | — | 수동 |  |
-| `vite-server.mjs` | 유틸 | active | Vite dev server 기동·대기·종료 공용 헬퍼 — node 직접 기동(win32 .cmd EINVAL 우회), taskkill 트리 정리 | — | 수동 | `run-render-diff.mjs`·`run-with-vite.mjs`에서 import |
+| `vite-server.mjs` | 유틸 | active | Vite dev server 기동·종료 공용 헬퍼 — vite Node API(createServer) in-process 기동, 로그는 customLogger 로 target/ 에 유지 | — | 수동 | `run-render-diff.mjs`·`run-with-vite.mjs`에서 import |
 | `shape-inline.test.mjs` | 상시 | active | 도형 인라인 컨트롤 — 커서 이동 및 텍스트 삽입 | — | 수동 |  |
 | `shift-end.test.mjs` | 상시 | active | shift-return.hwp Shift+End 블록 선택 | shift-return.hwp | 수동 |  |
 | `status-page-number.test.mjs` | 상시 | active | #5749 상태 표시줄 쪽 번호가 물리 순번이 아니라 문서 쪽번호를 따르는 계약 | 쪽기준.hwp | npm e2e:status-page-number |  |

--- a/rhwp-studio/e2e/run-render-diff.mjs
+++ b/rhwp-studio/e2e/run-render-diff.mjs
@@ -1,11 +1,7 @@
-import {
-  spawnNpm,
-  startViteDevServer,
-  waitForServer,
-} from './vite-server.mjs';
+import { spawnNpm, startViteDevServer } from './vite-server.mjs';
 
 async function runNpmScript(script, serverUrl) {
-  const child = spawnNpm(['run', script], { VITE_URL: serverUrl });
+  const child = spawnNpm([script], { VITE_URL: serverUrl });
   const exitCode = await new Promise((resolve, reject) => {
     child.once('error', reject);
     child.once('exit', (code, signal) => {
@@ -24,7 +20,6 @@ async function runNpmScript(script, serverUrl) {
 const server = await startViteDevServer();
 
 try {
-  await waitForServer(server.url, server.child, server.logPath);
   if (process.env.RHWP_RENDER_DIFF_SKIP_CANVAS !== '1') {
     await runNpmScript('e2e:render-diff', server.url);
   }

--- a/rhwp-studio/e2e/run-with-vite.mjs
+++ b/rhwp-studio/e2e/run-with-vite.mjs
@@ -4,18 +4,13 @@
  *   node e2e/run-with-vite.mjs -- <command...>
  *   node e2e/run-with-vite.mjs --npm <script> [<script args...>]
  *
- * 서버는 VITE_PORT(기본 7700)부터 비어 있는 포트를 택해 127.0.0.1 에 바인딩하고
- * readiness 를 기다린 뒤, VITE_URL 환경변수를 주입해 명령을 실행한다. 명령의
- * 종료 코드를 그대로 전파하며 성공·실패와 무관하게 서버를 끝낸다. 이미 같은
- * 포트로 떠 있는 dev server 가 있으면 다음 포트를 택하므로 로컬에서 겹치지 않는다.
+ * 서버는 VITE_PORT(기본 7700)부터 비어 있는 포트를 vite 가 직접 골라 127.0.0.1 에
+ * 바인딩한다. listen 이 끝나면 이미 받을 준비가 된 상태라 별도 readiness 폴링이 없다.
+ * VITE_URL 환경변수를 주입해 명령을 실행하고, 명령의 종료 코드를 그대로 전파하며
+ * 성공·실패와 무관하게 서버를 끝낸다.
  */
 
-import {
-  spawnNpm,
-  spawnStudioCommand,
-  startViteDevServer,
-  waitForServer,
-} from './vite-server.mjs';
+import { spawnIn, spawnNpm, startViteDevServer } from './vite-server.mjs';
 
 const argv = process.argv.slice(2);
 let mode = 'raw';
@@ -33,11 +28,10 @@ if (argv.length === 0) {
 let exitCode = 1;
 const server = await startViteDevServer();
 try {
-  await waitForServer(server.url, server.child, server.logPath);
   const extraEnv = { VITE_URL: server.url };
   const child = mode === 'npm'
-    ? spawnNpm(['run', ...argv], extraEnv)
-    : spawnStudioCommand(argv[0], argv.slice(1), extraEnv);
+    ? spawnNpm(argv, extraEnv)
+    : spawnIn(argv[0], argv.slice(1), extraEnv);
   exitCode = await new Promise((resolve, reject) => {
     child.once('error', reject);
     child.once('exit', (code, signal) => {

--- a/rhwp-studio/e2e/vite-server.mjs
+++ b/rhwp-studio/e2e/vite-server.mjs
@@ -1,157 +1,99 @@
 /**
- * Vite dev server 기동·대기·종료의 공용 헬퍼.
+ * Vite dev server 기동·종료의 공용 헬퍼.
  *
- * run-render-diff.mjs 와 run-with-vite.mjs 가 같은 기동 계약(포트 탐색 →
- * 127.0.0.1 바인딩 → readiness 폴링 → SIGTERM 뒤 5초 안에 SIGKILL)을 쓰도록
- * run-render-diff.mjs 에서 추출했다. 로그는 target/rhwp-studio-vite*.log 에
- * 남기고, 서버가 readiness 전에 죽으면 로그 내용을 함께 던진다.
+ * 서버는 **이 프로세스 안에서** 돈다 — vite 의 Node API(`createServer`)가 포트 선택·
+ * readiness·종료를 모두 책임진다. 종전에는 `node vite.js` 를 자식으로 띄우고 포트를
+ * 직접 스캔한 뒤 HTTP 로 readiness 를 폴링하고 SIGTERM/SIGKILL·taskkill 로 트리를
+ * 정리했는데, 그 전부가 라이브러리가 이미 하는 일이었다. 자식 프로세스 설계의 근거였던
+ * win32 `.cmd` EINVAL 도 spawn 을 안 하면 성립하지 않는다.
+ *
+ * 로그는 `target/rhwp-studio-vite*.log` 에 그대로 남긴다 — CI 가 아티팩트로 올린다
+ * (`.github/workflows/render-diff.yml`). in-process 라 stdout 으로도 보이지만, 기존
+ * 아티팩트 계약을 깨지 않도록 `customLogger` 로 파일에도 쓴다.
+ *
+ * 테스트 명령 자체는 여전히 자식 프로세스다 — `spawnIn` 이 그 몫이다.
  */
 
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
-import net from 'node:net';
 import path from 'node:path';
-import { setTimeout as delay } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
+import { createLogger, createServer } from 'vite';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const studioRoot = path.resolve(__dirname, '..');
 const repoRoot = path.resolve(studioRoot, '..');
 const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
-export function spawnNpm(args, extraEnv = {}, stdio = 'inherit') {
-  return spawn(npmCmd, args, {
+/**
+ * studio 루트에서 명령을 자식으로 띄운다.
+ *
+ * win32 의 npm 은 `npm.cmd` 이고 Node 20.12+ 는 `.cmd` 직접 spawn 을 EINVAL 로 거절하므로
+ * 그때만 shell 을 경유한다(인자는 공백·메타문자 없는 고정값뿐이다).
+ */
+export function spawnIn(command, args, extraEnv = {}) {
+  return spawn(command, args, {
     cwd: studioRoot,
-    stdio,
-    // win32 의 npm 은 npm.cmd 다 — Node 20+ 부터 .cmd 직접 spawn 이 EINVAL 로
-    // 거절되므로 shell 경유로 띄운다(인자는 공백·메타문자 없는 고정값뿐이다).
-    shell: process.platform === 'win32',
-    env: {
-      ...process.env,
-      ...extraEnv,
-    },
+    stdio: 'inherit',
+    shell: process.platform === 'win32' && command.endsWith('.cmd'),
+    env: { ...process.env, ...extraEnv },
   });
 }
 
-export function spawnStudioCommand(command, args, extraEnv = {}, stdio = 'inherit') {
-  return spawn(command, args, {
-    cwd: studioRoot,
-    stdio,
-    env: {
-      ...process.env,
-      ...extraEnv,
-    },
-  });
+export function spawnNpm(args, extraEnv = {}) {
+  return spawnIn(npmCmd, ['run', ...args], extraEnv);
 }
 
 export function viteLogPath(suffix = '') {
   return path.join(repoRoot, 'target', `rhwp-studio-vite${suffix}.log`);
 }
 
-function waitForExit(child, signal) {
-  return new Promise((resolve) => {
-    child.once('exit', () => resolve());
-    child.kill(signal);
-  });
-}
-
-export async function stopServer(child) {
-  if (child.exitCode !== null || child.signalCode) {
-    return;
-  }
-  if (process.platform === 'win32' && child.pid) {
-    // shell 경유로 띄운 자식(cmd.exe 래퍼)은 SIGTERM 으로 트리가 정리되지 않는다.
-    await new Promise((resolve) => {
-      spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' })
-        .once('exit', resolve);
-    });
-    return;
-  }
-  await Promise.race([
-    waitForExit(child, 'SIGTERM'),
-    delay(5000).then(async () => {
-      if (child.exitCode === null && !child.signalCode) {
-        await waitForExit(child, 'SIGKILL');
-      }
-    }),
-  ]);
-}
-
-export async function waitForServer(url, child, logPath, timeoutMs = 30000) {
-  const deadline = Date.now() + timeoutMs;
-  let lastError = null;
-
-  while (Date.now() < deadline) {
-    if (child.exitCode !== null || child.signalCode) {
-      const log = fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf8') : '';
-      throw new Error(`Vite dev server exited before ${url} became ready.\n${log}`);
-    }
-    try {
-      const response = await fetch(url);
-      if (response.ok) {
-        return;
-      }
-      lastError = new Error(`server responded with status ${response.status}`);
-    } catch (error) {
-      lastError = error;
-    }
-    await delay(500);
-  }
-
-  const log = fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf8') : '';
-  throw new Error(`${lastError?.message || `timed out waiting for ${url}`}\n${log}`);
-}
-
-export async function findAvailablePort(startPort, attempts = 20) {
-  for (let port = startPort; port < startPort + attempts; port += 1) {
-    const available = await new Promise((resolve) => {
-      const server = net.createServer();
-      server.once('error', () => resolve(false));
-      server.listen(port, '127.0.0.1', () => {
-        server.close(() => resolve(true));
-      });
-    });
-    if (available) {
-      return port;
-    }
-  }
-  throw new Error(`failed to find an available port starting at ${startPort}`);
-}
-
 /**
- * vite dev server 를 기동한다. npm.cmd 경유가 아니라 node 로 vite.js 를 직접
- * 띄운다 — win32 에서 .cmd spawn 은 EINVAL 로 거절되고 shell 우회는 트리
- * 종료(SIGTERM)를 망가뜨리기 때문. readiness 대기와 로그 핸들 닫기는 호출자의
- * 몫으로 남긴다(waitForServer · 반환 객체의 stop()).
+ * vite dev server 를 이 프로세스에서 띄운다.
+ *
+ * 반환 `url` 은 **origin 만** 담는다 — `resolvedUrls.local[0]` 은 base 가 붙어 끝에
+ * 슬래시가 있고, 호출부가 `${url}/path` 로 이어 붙이면 `//path` 가 되어 dev server 의
+ * SPA 폴백이 index.html 을 돌려준다(조용히 엉뚱한 응답).
  */
 export async function startViteDevServer({
   preferredPort = Number(process.env.VITE_PORT || '7700'),
   logPath = viteLogPath(),
 } = {}) {
-  const port = await findAvailablePort(preferredPort);
-  const url = `http://127.0.0.1:${port}`;
   fs.mkdirSync(path.dirname(logPath), { recursive: true });
   const logFile = fs.openSync(logPath, 'w');
-  const viteJs = path.join(studioRoot, 'node_modules', 'vite', 'bin', 'vite.js');
-  const child = spawn(
-    process.execPath,
-    [viteJs, '--host', '127.0.0.1', '--port', String(port), '--strictPort'],
-    {
-      cwd: studioRoot,
-      stdio: ['ignore', logFile, logFile],
-      env: {
-        ...process.env,
-        BROWSER: 'none',
-      },
-    },
-  );
+  const write = (msg) => fs.writeSync(logFile, `${msg}
+`);
+  const base = createLogger('info', { allowClearScreen: false });
+  const logger = {
+    ...base,
+    info: (msg, opts) => { write(msg); base.info(msg, opts); },
+    warn: (msg, opts) => { write(msg); base.warn(msg, opts); },
+    error: (msg, opts) => { write(msg); base.error(msg, opts); },
+  };
+
+  const server = await createServer({
+    root: studioRoot,
+    configFile: path.join(studioRoot, 'vite.config.ts'),
+    customLogger: logger,
+    server: { host: '127.0.0.1', port: preferredPort },
+  });
+  await server.listen();
+  server.printUrls();
+
+  const resolved = server.resolvedUrls?.local?.[0];
+  if (!resolved) {
+    await server.close();
+    fs.closeSync(logFile);
+    throw new Error(`vite dev server 가 주소를 내놓지 않았다 (로그: ${logPath})`);
+  }
+  const url = new URL(resolved).origin;
+
   return {
     url,
-    port,
-    child,
+    port: server.config.server.port,
     logPath,
     async stop() {
-      await stopServer(child);
+      await server.close();
       fs.closeSync(logFile);
     },
   };


### PR DESCRIPTION
관련 이슈: #7019

## 문제

e2e 의 vite dev server 헬퍼가 포트 탐색·readiness 폴링·프로세스 트리 종료를 손으로
구현한다. 전부 vite 의 Node API 가 이미 하는 일이고, 그 과정에서 TOCTOU 경합이 하나 생겼다.

## 원인

자식 프로세스 설계의 근거는 `vite-server.mjs:121-126` 에 있다 — win32 에서 `.cmd` 직접
spawn 이 EINVAL 로 거절되고 shell 우회는 트리 종료를 망가뜨린다는 것. 이는 **어떻게
spawn 할 것인가**에 대한 근거이고, spawn 자체를 하지 않는 선택지를 배제하지 않는다.
추출 이전 러너(`f7f8984be:run-render-diff.mjs:109-113`)의 `npm run dev` 자식 기동 형태를
물려받으면서 기동 방식만 `node vite.js` 로 바뀌고 배관은 남았다.

같은 저장소가 이미 Node API 를 쓴다 — `rhwp-studio/e2e/renderer-contract.test.mjs:5,727-742`
가 `createServer`/`vite.close()` 를 쓰고 `.github/workflows/render-diff.yml:812` 에서 돈다.

## 변경

`createServer` + `listen()` + `close()` 로 대체. `vite-server.mjs` 158 → 100 줄.

- `findAvailablePort`(L105-119)와 `--strictPort`(L138) 제거. 후자는 vite 의 자동 포트
  탐색을 **끄는** 플래그였고, 전자는 그 탐색을 다시 짠 것이었다. bind→close→vite bind
  사이의 TOCTOU 도 함께 사라진다.
- `waitForServer`(L80-103) 제거. `listen()` 이 끝나면 이미 받을 준비가 된 상태다.
- `stopServer`·`waitForExit`(L51-78)와 win32 taskkill 분기 제거. `server.close()` 하나다.
- `spawnNpm`·`spawnStudioCommand` 쌍둥이를 `spawnIn` 하나로. shell 은 win32 의 `.cmd`
  에서만 필요하므로 명령 이름으로 판정한다. 아무 호출부도 넘기지 않던 `stdio` 인자 제거.
- `MANIFEST.md:115` 의 설계 설명을 새 구조로 갱신.

### url 은 origin 만 반환한다 — 조용한 오답을 막는다

`server.resolvedUrls.local[0]` 은 base 가 붙어 **끝에 슬래시가 있다**(`http://127.0.0.1:7731/`).
호출부는 `${VITE_URL}/@vite/client`(`bridge-lifecycle.test.mjs:28`) 처럼 이어 붙이므로
그대로 쓰면 `//@vite/client` 가 되고, dev server 의 SPA 폴백이 **200 으로 index.html 을
돌려준다**. 실측:

```
url = "http://127.0.0.1:7731"          ← new URL(...).origin 적용
/@vite/client   -> 200 text/javascript   (정상)
//@vite/client  -> 200 text/html         (SPA 폴백 — 조용히 index.html)
```

시험이 vite 클라이언트 대신 index.html 을 받고도 통과할 수 있어, `new URL(...).origin`
으로 막고 그 이유를 코드 주석에 남겼다.

### 로그 아티팩트 계약은 그대로다

`.github/workflows/render-diff.yml:866` 이 `target/rhwp-studio-vite.log` 를 아티팩트로
올린다. in-process 라 stdout 으로도 보이지만, 기존 계약을 깨지 않도록 `customLogger` 로
파일에도 쓴다. 실측으로 파일이 생성되고 내용이 들어가는 것을 확인했다.

파일명은 그대로다 — `scripts/tests/test_undo_depth_e2e_workflow.py:20-21,40-41` 이
`run-with-vite.mjs`·`vite-server.mjs` 의 존재를 핀한다.

## 검증

base devel `b59323de0`, 검증 commit `be12909a0`(최신 devel 로 rebase 후 재실행).

**실제 브라우저 e2e 2건** (`CHROME_PATH` 로 로컬 Chrome 지정, in-process 서버 사용).

- `npm run e2e:undo-depth` — 통과. 스택 276 · 스냅샷 슬롯 0 · 연속 undo 276/276,
  무축출 계약 통과.
- `npm run e2e:responsive` — **1082 passed, 0 failed**.

두 시험 모두 서버 기동·`VITE_URL` 주입·종료를 새 경로로 거친다. 종료 후 프로세스가
스스로 빠져나오는 것(핸들 누수 없음)도 확인했다.

**프런트엔드 package 경로.**

- `scripts/wasm-pack-locked.sh --target web --out-dir pkg --dev` — 이 SHA 에서 새로 빌드
- `npx tsc --noEmit` — 클린
- `npm --prefix rhwp-studio test` — 1646 중 1644 통과, 0 실패, 2 skip

> **관측: 무관한 플래키 1건.** `npm test` 에서
> `EditorTransport는 exact origin의 v1 port로 binary를 caller detach 없이 전송한다`
> 가 간헐적으로 실패한다. 같은 트리·같은 조건에서 연속 실행하면 한 번은 1643/1, 다음은
> 1644/0 이다. 해당 계약 시험만 격리해 돌리면 32/32 로 3회 연속 통과하므로 전체 suite
> 안에서의 간섭으로 보인다. CI 에서 같은 것을 보면 이 관측을 참고하시라.
>
> 이 PR 은 `rhwp-studio/e2e/*` 만 바꾸는데 `npm test` 는 `tests/*.test.ts` 와
> `../npm/editor/tests/*.test.mjs` 를 돌린다 — 글롭이 `e2e/` 에 닿지 않으므로 구조적으로
> 이 변경이 원인일 수 없다.
- `npm --prefix rhwp-studio run build` — 통과
- `python scripts/check_e2e_manifest.py` — 129/129, 이상 없음 (MANIFEST 설명 갱신분 포함)
- `python -m unittest … test_undo_depth_e2e_workflow.py` — 5/5 (파일 존재·npm script 배선 핀)

**미실행.** Rust 전체 fmt·Clippy·integration 은 범위에 해당하지 않는다(Rust 검증 입력
무변경). `render-diff` 워크플로 자체는 self-hosted 러너가 필요해 로컬에서 돌리지 않았다 —
로그 파일 생성은 위처럼 직접 확인했다.

## 범위 외

- 테스트 명령은 계속 자식 프로세스다. 서버만 in-process 로 옮긴다.
- `renderer-contract.test.mjs` 는 이미 Node API 를 쓰므로 손대지 않았다.
- 로그를 stdout 에만 두고 `render-diff.yml:866` 을 빼는 선택지도 있으나, 아티팩트 계약을
  바꾸는 판단이라 하지 않았다. 그쪽을 원하시면 `customLogger` 세 줄과 그 한 줄을 함께 뺀다.
