### PR TITLE
Task #7021: 저장 경로의 불필요한 &mut self 를 좁힌다

### DIFF
--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1610,7 +1610,7 @@ impl DocumentCore {
     ///
     /// HWPX 원본의 단일 BOTH pageBorderFill은 HWP 저장에는 세 record로 materialize하고,
     /// live IR에는 반영하지 않는다.
-    pub fn export_hwp_with_adapter(&mut self) -> Result<Vec<u8>, HwpError> {
+    pub fn export_hwp_with_adapter(&self) -> Result<Vec<u8>, HwpError> {
         self.prepare_hwp_export_snapshot().serialize()
     }
 
@@ -1677,7 +1677,7 @@ impl DocumentCore {
     /// 일반 HWP 저장과 마찬가지로 HWPX 출처는 반드시 adapter를 먼저 통과한다. 암호화만
     /// 별도 serializer로 우회하면 차트·그림 HWPX IR이 HWP5 계약으로 정규화되지 않는다.
     pub fn export_hwp_with_adapter_with_password(
-        &mut self,
+        &self,
         password: &[u8],
     ) -> Result<Vec<u8>, HwpError> {
         self.prepare_hwp_export_snapshot()
@@ -1700,7 +1700,7 @@ impl DocumentCore {
     ///
     /// 1회 paginate + 1회 직렬화 + 1회 from_bytes (paginate 포함). 작은 문서 ~수 ms,
     /// 큰 문서 수백 ms 가능.
-    pub fn serialize_hwp_with_verify(&mut self) -> Result<HwpExportVerification, HwpError> {
+    pub fn serialize_hwp_with_verify(&self) -> Result<HwpExportVerification, HwpError> {
         let page_count_before = self.page_count();
         let bytes = self.export_hwp_with_adapter()?;
         let bytes_len = bytes.len();

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -6736,7 +6736,7 @@ impl HwpDocument {
     /// 자동 적용하여 한컴 호환성과 자기 재로드 페이지 보존을 보장한다 (#178).
     /// HWP 출처는 어댑터가 no-op 이므로 기존 동작과 동일.
     #[wasm_bindgen(js_name = exportHwp)]
-    pub fn export_hwp(&mut self) -> Result<Vec<u8>, JsValue> {
+    pub fn export_hwp(&self) -> Result<Vec<u8>, JsValue> {
         self.export_hwp_with_adapter_snapshot()
             .map_err(|e| e.into())
     }
@@ -6758,7 +6758,7 @@ impl HwpDocument {
     /// browser UI는 암호를 저장하지 않고 저장 시점에만 전달한다. HWPX 출처 문서는 일반
     /// HWP 저장과 동일하게 HWPX-to-HWP adapter를 먼저 적용한다.
     #[wasm_bindgen(js_name = exportHwpWithPassword)]
-    pub fn export_hwp_with_password_wasm(&mut self, password: &str) -> Result<Vec<u8>, JsValue> {
+    pub fn export_hwp_with_password_wasm(&self, password: &str) -> Result<Vec<u8>, JsValue> {
         self.export_hwp_with_adapter_with_password(password.as_bytes())
             .map_err(|e| e.into())
     }
@@ -6828,7 +6828,7 @@ impl HwpDocument {
     /// 본 함수는 검증 메타데이터만 반환하며 bytes 자체는 별도 호출 (`exportHwp`) 로 받아야 한다.
     /// 검증과 실제 사용을 분리하여 호출자가 결과에 따라 다른 동작을 취할 수 있도록 한다.
     #[wasm_bindgen(js_name = exportHwpVerify)]
-    pub fn export_hwp_verify(&mut self) -> Result<String, JsValue> {
+    pub fn export_hwp_verify(&self) -> Result<String, JsValue> {
         let v = self.serialize_hwp_with_verify().map_err(JsValue::from)?;
         Ok(format!(
             "{{\"bytesLen\":{},\"pageCountBefore\":{},\"pageCountAfter\":{},\"recovered\":{}}}",

--- a/tests/cases/issue_7002_export_receiver_is_immutable.rs
+++ b/tests/cases/issue_7002_export_receiver_is_immutable.rs
@@ -1,0 +1,52 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! [#7002 후속] HWP 저장 경로가 문서를 바꾸지 않는다 — 수신자로 강제한다.
+//!
+//! 저장 어댑터는 `prepare_hwp_export_snapshot`(`&self`)이 뜬 **사본**에 적용되고 live
+//! 문서는 그대로다. 그런데 진입점 셋이 `&mut self` 로 선언돼 있어 그 사실이 서명에
+//! 드러나지 않았고, undo 라우팅 레지스트리는 "저장은 문서를 바꾸지 않는다" 를 주석으로만
+//! 붙들고 있었다(#7002 에서 `exportHwp*` 3종을 EXCLUDED 로 등재하며 적은 사유).
+//!
+//! 수신자를 `&self` 로 좁히면 그 주석이 컴파일러 계약이 된다. 이 시험은 세 진입점이
+//! 불변 참조로 호출 가능한지를 컴파일 시점에 고정한다 — 누군가 다시 `&mut self` 로
+//! 넓히면 여기서 깨진다.
+
+use rhwp::document_core::DocumentCore;
+
+fn sample() -> DocumentCore {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/ta-pic-001-r.hwp");
+    DocumentCore::from_bytes(&std::fs::read(path).expect("표본 로드")).expect("파싱")
+}
+
+/// 세 저장 진입점을 **불변 참조로** 부른다. 서명이 넓어지면 컴파일되지 않는다.
+fn export_all(core: &DocumentCore) -> (usize, usize, usize) {
+    let plain = core.export_hwp_with_adapter().expect("HWP 저장");
+    let secret = core
+        .export_hwp_with_adapter_with_password(b"pw")
+        .expect("비밀번호 저장");
+    let verified = core.serialize_hwp_with_verify().expect("검증 저장");
+    (plain.len(), secret.len(), verified.bytes_len)
+}
+
+#[test]
+fn issue_7002_export_entry_points_take_shared_receiver() {
+    let core = sample();
+    let (plain, secret, verified) = export_all(&core);
+    assert!(
+        plain > 0 && secret > 0 && verified > 0,
+        "저장 산출이 비었다"
+    );
+}
+
+/// 같은 문서를 두 번 저장하면 같은 바이트가 나온다 — 저장이 문서를 바꾸지 않는 것의 관측면.
+/// (`&self` 는 내부 가변성까지 막지는 않으므로 서명만으로는 부족하다.)
+#[test]
+fn issue_7002_export_is_repeatable_without_mutating_document() {
+    let core = sample();
+    let first = core.export_hwp_with_adapter().expect("1회차");
+    let second = core.export_hwp_with_adapter().expect("2회차");
+    assert_eq!(
+        first, second,
+        "같은 문서를 두 번 저장했는데 바이트가 다르다 — 저장이 문서를 바꾼다"
+    );
+}

--- a/tests/issue_2724_passthrough_invalidation_guard.rs
+++ b/tests/issue_2724_passthrough_invalidation_guard.rs
@@ -404,26 +404,6 @@ const EXEMPT: &[(&str, &str, Exempt, &str)] = &[
     ),
     // ── 위임 ───────────────────────────────────────────────────────────────
     (
-        "commands/document.rs",
-        "export_hwp_with_adapter",
-        Exempt::DelegatesTo("convert_if_hwpx_source"),
-        "저장 직전 어댑터 변환. IR 변경은 전부 어댑터 안에서 일어나며 그쪽이 \
-         `raw_stream_dirty` 를 세운다.",
-    ),
-    (
-        "commands/document.rs",
-        "export_hwp_with_adapter_with_password",
-        Exempt::DelegatesTo("convert_if_hwpx_source"),
-        "암호 HWP 저장도 평문 저장과 같은 HWPX-to-HWP 어댑터만 IR을 변경한다. \
-         어댑터가 `raw_stream_dirty` 를 세우고, 비밀번호 직렬화는 IR을 변경하지 않는다.",
-    ),
-    (
-        "commands/document.rs",
-        "serialize_hwp_with_verify",
-        Exempt::DelegatesTo("export_hwp_with_adapter"),
-        "export 후 재로드 검증만 수행. 자체 IR 변경 없음.",
-    ),
-    (
         "commands/table_ops.rs",
         "paste_table_cells_transposed_as_new_table_native",
         Exempt::DelegatesTo("create_table_native"),


### PR DESCRIPTION
관련 이슈: #7021

## 문제

HWP 저장 진입점 셋이 `&mut self` 로 선언돼 있어 "저장은 문서를 바꾸지 않는다" 는 사실이
서명에 드러나지 않는다. 그 사실을 주석과 두 레지스트리가 대신 붙들고 있고, 둘의 사유가
서로 반대다.

## 원인

`prepare_hwp_export_snapshot`(`document.rs:1598`)은 `&self` 이고 첫 줄이
`let mut snapshot = self.document.clone();` 이다 — 어댑터 변환은 **사본**에 적용되고
live 문서는 그대로다. 세 진입점은 이 함수만 거쳐 직렬화하는데 수신자가 `&mut self` 로
남아 있었다.

그 결과 같은 세 함수가 정반대 사유로 두 곳에 등재됐다.

- `tests/issue_2724_passthrough_invalidation_guard.rs` — `Exempt::DelegatesTo` 면제,
  사유는 "어댑터가 IR 을 바꾸고 `raw_stream_dirty` 를 세운다"
- `rhwp-studio/src/core/mutation-method-registry.ts`(#7002) — `EXCLUDED_NON_DOCUMENT`,
  사유는 "문서를 바꾸지 않는다"

앞쪽 사유는 사본을 뜨기 전 전제에 머물러 있다.

## 변경

- `document.rs`: `export_hwp_with_adapter`, `export_hwp_with_adapter_with_password`,
  `serialize_hwp_with_verify` 를 `&self` 로. 본문 변경은 없다 — 셋 다
  `prepare_hwp_export_snapshot(&self)` 만 거친다. 같은 파일의 `*_snapshot*` 변종은 이미
  `&self` 였다.
- `wasm_api.rs`: 대응하는 세 wasm 래퍼도 `&self` 로. js 서명은 그대로라 ABI 변화가 없다.
- `tests/issue_2724_passthrough_invalidation_guard.rs`: 낡은 면제 3건 제거. 면제는
  래칫(줄어들기만)이므로 지우는 방향이 맞고, 무효화할 대상이 없으니 면제도 필요 없다.
- `tests/cases/issue_7002_export_receiver_is_immutable.rs` 추가: 세 진입점을 **불변
  참조로** 호출한다. 누가 다시 `&mut self` 로 넓히면 컴파일되지 않는다. `&self` 가 내부
  가변성까지 막지는 않으므로, 같은 문서 2회 저장의 바이트 동일성도 함께 본다.

## 검증

base devel `b59323de0`, 검증 commit `4635c615f`(최신 devel 로 rebase 후 재실행).

**수정 전 실패 증명.** `src/` 를 devel 상태로 두고 새 시험만 넣으면 컴파일되지 않는다.

```
error[E0596]: cannot borrow `*core` as mutable, as it is behind a `&` reference   (3건)
error[E0596]: cannot borrow `core` as mutable, as it is not declared as mutable   (1건)
error: could not compile `rhwp` (test "regression_suite_010") due to 4 previous errors
```

**면제 래칫이 실제로 잡았다.** 수신자를 좁힌 첫 배터리에서
`issue_2724_passthrough_invalidation_guard::stale_exemptions_are_reclaimed` 가
세 이름을 "`pub fn (&mut self)` 로 실재하지 않음" 으로 보고하며 실패했다. 면제를 거두고
통과시켰다 — 가드가 의도대로 동작한 것이며, 이 PR 이 서명을 실제로 바꿨다는 증거이기도 하다.

**Rust lint 묶음 — 전부 통과.**

- `cargo fmt --all -- --check`
- `cargo clippy --locked -- -D warnings`
- `cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown -- -D warnings`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`

**전체 integration.**

- `cargo nextest run --locked --cargo-profile release-test --tests --no-fail-fast`
  — **9463 tests run: 9463 passed, 46 skipped** (705s)

`git diff --check origin/devel...HEAD` 와 `git diff --check` — 공백·충돌 마커 없음, 트리 clean.

**미실행.** 프런트엔드 검증은 범위에 해당하지 않는다 — `rhwp-studio/` 를 건드리지 않았고
js 서명도 그대로다. 렌더링·시각 검증도 해당 없음(렌더 경로 무변경).

## 범위 외

- `&mut self` 가 불필요한 조회 2종(`getCellCharPropertiesAtByPath`,
  `getCharShapeRunsInCellByPath`)은 `*_mut` 접근자를 거치므로 접근자부터 손대야 한다.
- 내부 클립보드 `copy*` 6종은 코어 버퍼를 실제로 쓰므로 `&mut self` 가 맞다.
- #7002 레지스트리의 export 3종 사유 문구는 그 PR 에서 이미 정확히 했다. 이 PR 이 머지되면
  "`&mut self` 는 불필요하다" 는 문장이 과거형이 되지만, 분류(제외) 자체는 그대로 옳다.
