### PR TITLE
ci: post-merge CodeQL 및 fork duration 재사용 신뢰 계약 보완 (#6901)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1623,30 +1623,24 @@ jobs:
 
       - name: Download trusted PR Archive B duration measurement
         if: ${{ needs.preflight.outputs.postmerge_reuse == 'true' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SOURCE_RUN_ID: ${{ needs.preflight.outputs.postmerge_source_run_id }}
-        run: >-
-          gh run download "${SOURCE_RUN_ID}" --repo "${GITHUB_REPOSITORY}"
-          --name "nextest-target-durations-${SOURCE_RUN_ID}-b" --dir duration-b
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: trusted-postmerge-durations-${{ github.run_id }}-${{ github.run_attempt }}-b
+          path: duration-b
 
       - name: Download trusted PR Archive C duration measurement
         if: ${{ needs.preflight.outputs.postmerge_reuse == 'true' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SOURCE_RUN_ID: ${{ needs.preflight.outputs.postmerge_source_run_id }}
-        run: >-
-          gh run download "${SOURCE_RUN_ID}" --repo "${GITHUB_REPOSITORY}"
-          --name "nextest-target-durations-${SOURCE_RUN_ID}-c" --dir duration-c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: trusted-postmerge-durations-${{ github.run_id }}-${{ github.run_attempt }}-c
+          path: duration-c
 
       - name: Download trusted PR Archive D duration measurement
         if: ${{ needs.preflight.outputs.postmerge_reuse == 'true' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SOURCE_RUN_ID: ${{ needs.preflight.outputs.postmerge_source_run_id }}
-        run: >-
-          gh run download "${SOURCE_RUN_ID}" --repo "${GITHUB_REPOSITORY}"
-          --name "nextest-target-durations-${SOURCE_RUN_ID}-d" --dir duration-d
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: trusted-postmerge-durations-${{ github.run_id }}-${{ github.run_attempt }}-d
+          path: duration-d
 
       - name: Refresh duration policy data branch
         shell: bash

--- a/.github/workflows/run-nextest-archives.yml
+++ b/.github/workflows/run-nextest-archives.yml
@@ -66,6 +66,10 @@ jobs:
           FILTERSET: ${{ inputs.filterset }}
           PARTITION: ${{ inputs.partition }}
           RHWP_SECURITY_SWEEP_SAMPLES_JSON: ${{ inputs.security_sweep_samples_json }}
+          DURATION_PULL_NUMBER: ${{ github.event.pull_request.number }}
+          DURATION_HEAD_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id }}
+          DURATION_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          DURATION_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
           partition_args=()
@@ -114,14 +118,14 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-      # Same-repository PR artifact is only a short-lived candidate. It cannot
-      # update the policy until a trusted post-merge verifier accepts its exact
-      # workflow run, merge lineage, and artifact provenance.
-      - name: Upload same-repository PR B/C/D target durations
-        if: ${{ success() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (inputs.archive_label == 'b' || inputs.archive_label == 'c' || inputs.archive_label == 'd') }}
+      # Upstream-run same-repository and fork PRs may publish untrusted metrics.
+      # This read-only job cannot update the policy. The trusted post-merge
+      # verifier binds the exact PR/run/attempt/tree and validates JSON before use.
+      - name: Upload upstream PR B/C/D target durations
+        if: ${{ success() && github.event_name == 'pull_request' && github.repository == 'edwardkim/rhwp' && github.event.pull_request.base.repo.id == github.repository_id && github.event.pull_request.base.ref == 'devel' && (inputs.archive_label == 'b' || inputs.archive_label == 'c' || inputs.archive_label == 'd') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: nextest-target-durations-${{ github.run_id }}-${{ inputs.archive_label }}
+          name: nextest-target-durations-${{ github.run_id }}-attempt-${{ github.run_attempt }}-${{ inputs.archive_label }}
           path: target-durations-${{ inputs.archive_label }}.json
           retention-days: 3
           if-no-files-found: error

--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -50,10 +50,10 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      reuse: ${{ steps.evaluate.outputs.reuse || steps.defaults.outputs.reuse }}
-      reason: ${{ steps.evaluate.outputs.reason || steps.defaults.outputs.reason }}
-      source_run_id: ${{ steps.evaluate.outputs.source_run_id || '' }}
-      refresh_duration_data: ${{ steps.evaluate.outputs.refresh_duration_data || 'false' }}
+      reuse: ${{ steps.finalize.outputs.reuse || 'false' }}
+      reason: ${{ steps.finalize.outputs.reason || 'reuse-finalization-unavailable' }}
+      source_run_id: ${{ steps.finalize.outputs.source_run_id || '' }}
+      refresh_duration_data: ${{ steps.finalize.outputs.refresh_duration_data || 'false' }}
     steps:
       - name: Default to full verification
         id: defaults
@@ -217,6 +217,7 @@ jobs:
           ref: ${{ steps.source-base.outputs.sha }}
           sparse-checkout: |
             scripts/verify-trusted-postmerge-ci-reuse.mjs
+            scripts/trusted-postmerge-duration-evidence.mjs
             scripts/ci-impact-classifier.cjs
           sparse-checkout-cone-mode: false
 
@@ -248,6 +249,9 @@ jobs:
             let verifyReviewOnlyBaseAdvance;
             let trustedPullRequestSource;
             let trustedPullRequestWorkflowRun;
+            let selectDurationArtifacts;
+            let decodeDurationArtifact;
+            let validateDurationReports;
             const repositoryId = Number(process.env.GITHUB_REPOSITORY_ID);
             try {
               ({ classifyReviewOnlyCommit, evaluateTrustedPostMergeReuse, frontendOnlyCiRunIsReusable, fullLaneWorkflowJobsAreGreen,
@@ -263,6 +267,11 @@ jobs:
                 throw new Error('trusted base has no review-bridge verifier');
               }
               if (process.env.WORKFLOW_FILE === 'ci.yml') {
+                ({ selectDurationArtifacts, decodeDurationArtifact, validateDurationReports } = await import(pathToFileURL(path.join(
+                  process.env.GITHUB_WORKSPACE, 'scripts/trusted-postmerge-duration-evidence.mjs',
+                )).href));
+                if ([selectDurationArtifacts, decodeDurationArtifact, validateDurationReports]
+                  .some((fn) => typeof fn !== 'function')) throw new Error('trusted duration validator unavailable');
                 ({ classifyChanges } = require(path.join(
                   process.env.GITHUB_WORKSPACE, 'scripts/ci-impact-classifier.cjs',
                 )));
@@ -517,6 +526,7 @@ jobs:
                 },
               }[process.env.WORKFLOW_FILE];
               const fullLaneRunIds = [];
+              const durationArtifactsByRunId = {};
               if (requireFullLaneEvidence) {
                 for (const workflowRun of workflowRuns) {
                   if (!matchesRun(workflowRun) || workflowRun.status !== "completed" || workflowRun.conclusion !== "success") {
@@ -534,19 +544,23 @@ jobs:
                       github.rest.actions.listWorkflowRunArtifacts,
                       { owner, repo, run_id: workflowRun.id, per_page: 100 },
                     );
-                    const expected = new Set(["b", "c", "d"].map((label) => (
-                      `nextest-target-durations-${workflowRun.id}-${label}`
-                    )));
-                    const available = new Set(artifacts
-                      .filter((artifact) => artifact.expired !== true)
-                      .map((artifact) => artifact.name));
-                    if ([...expected].every((name) => available.has(name))) {
+                    await recordMergeTreeEvidence(workflowRun, artifacts);
+                    try {
+                      durationArtifactsByRunId[String(workflowRun.id)] = selectDurationArtifacts(
+                        artifacts, workflowRun, pr, repositoryId,
+                      );
                       fullLaneRunIds.push(String(workflowRun.id));
-                      await recordMergeTreeEvidence(workflowRun, artifacts);
+                    } catch (error) {
+                      core.warning(`CI candidate ${workflowRun.id}: duration evidence rejected: ${error.message}`);
                     }
                     continue;
                   }
                   if (process.env.WORKFLOW_FILE === "codeql.yml") {
+                    // Match codeql.yml PR preflight: every language Analyze job
+                    // must already have succeeded above. A completed GHAS neutral
+                    // aggregate is not a language verdict or full alert coverage;
+                    // retain its identity/attempt checks and never accept skipped.
+                    const allowedSecurityConclusions = new Set(['success', 'neutral']);
                     const checks = await github.paginate(github.rest.checks.listForRef, {
                       owner, repo, ref: workflowRun.head_sha, filter: "latest", per_page: 100,
                     });
@@ -559,8 +573,13 @@ jobs:
                     if (!Number.isFinite(startedAt) || !securityCheck
                       || !Number.isFinite(Date.parse(securityCheck.started_at || ""))
                       || Date.parse(securityCheck.started_at) < startedAt
-                      || securityCheck.status !== "completed" || securityCheck.conclusion !== "success") {
+                      || securityCheck.status !== "completed"
+                      || !allowedSecurityConclusions.has(securityCheck.conclusion)) {
+                      core.warning(`CodeQL candidate ${workflowRun.id}: GHAS evidence rejected (${securityCheck?.status || 'missing'}/${securityCheck?.conclusion || 'missing'})`);
                       continue;
+                    }
+                    if (securityCheck.conclusion === "neutral") {
+                      core.info(`CodeQL candidate ${workflowRun.id}: accepting neutral GHAS check ${securityCheck.id} after all language analyses succeeded`);
                     }
                   }
                   {
@@ -682,6 +701,7 @@ jobs:
                 forkMergeTreeEvidenceByRunId,
                 reviewOnlyBaseAdvanceByRunId,
                 frontendOnlyRunIds,
+                durationArtifactsByRunId,
               };
               if (requireFullLaneEvidence) {
                 evidence.fullLaneRunIds = fullLaneRunIds;
@@ -693,8 +713,9 @@ jobs:
             }
 
             let result;
+            let evidence;
             try {
-              const evidence = await collectEvidence();
+              evidence = await collectEvidence();
               result = evaluateTrustedPostMergeReuse({
                 eventName: process.env.CALLER_EVENT_NAME,
                 ref: process.env.CALLER_REF,
@@ -716,28 +737,29 @@ jobs:
             if (result.reuse && process.env.REQUIRE_DURATION_ARTIFACTS === 'true') {
               if (result.refreshDurationData !== false) {
                 try {
-                  const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
-                    owner,
-                    repo,
-                    run_id: Number(result.sourceRunId),
-                    per_page: 100,
-                  });
-                  const expected = new Set([
-                    `nextest-target-durations-${result.sourceRunId}-b`,
-                    `nextest-target-durations-${result.sourceRunId}-c`,
-                    `nextest-target-durations-${result.sourceRunId}-d`,
-                  ]);
-                  const available = new Set(artifacts
-                        .filter((artifact) => artifact.expired !== true)
-                        .map((artifact) => artifact.name));
-                  if (![...expected].every((name) => available.has(name))) {
-                    result = {
-                      reuse: false,
-                      reason: 'candidate-duration-artifacts-unavailable',
-                      sourceRunId: '',
-                      pullNumber: '',
-                    };
+                  const selected = evidence.durationArtifactsByRunId?.[String(result.sourceRunId)];
+                  const run = evidence.workflowRuns.find((item) => String(item.id) === String(result.sourceRunId));
+                  const pr = evidence.pullRequests.find((item) => String(item.number) === String(result.pullNumber));
+                  const tested = evidence.mergeTreeEvidenceByRunId[String(result.sourceRunId)];
+                  if (!selected || !run || !pr || !tested) throw new Error('candidate-duration-artifacts-unavailable');
+                  const reports = [];
+                  for (const { label, artifact } of selected) {
+                    const response = await github.rest.actions.downloadArtifact({
+                      owner, repo, artifact_id: artifact.id, archive_format: 'zip', request: { timeout: 15000 },
+                    });
+                    reports.push(decodeDurationArtifact(response.data, label));
                   }
+                  const normalized = validateDurationReports(reports, {
+                    run, pr, repositoryId, testedMergeSha: tested.sha, legacy: selected[0].legacy,
+                  });
+                  const fs = require('node:fs');
+                  const directory = fs.mkdtempSync(path.join(process.env.RUNNER_TEMP, 'trusted-postmerge-durations-'));
+                  for (const report of normalized) fs.writeFileSync(
+                    path.join(directory, `target-durations-${report.archive_label}.json`),
+                    `${JSON.stringify(report)}\n`, { flag: 'wx' },
+                  );
+                  core.setOutput('duration_path', directory);
+                  core.info(`Validated duration JSON for PR ${pr.number}, run ${run.id}, attempt ${run.run_attempt}`);
                 } catch (error) {
                   core.warning(`Could not inspect candidate duration artifacts; running full. ${error.message}`);
                   result = {
@@ -756,3 +778,57 @@ jobs:
               result.reuse && process.env.REQUIRE_DURATION_ARTIFACTS === 'true'
                 && result.refreshDurationData !== false ? 'true' : 'false');
             core.info(`reuse=${result.reuse} reason=${result.reason} source_run_id=${result.sourceRunId || 'none'} refresh_duration_data=${result.reuse && process.env.REQUIRE_DURATION_ARTIFACTS === 'true' && result.refreshDurationData !== false}`);
+
+      # Only normalized JSON is handed to the write-capable metrics job.
+      - name: Publish validated Archive B duration measurement
+        id: publish-duration-b
+        if: ${{ steps.evaluate.outputs.reuse == 'true' && steps.evaluate.outputs.refresh_duration_data == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trusted-postmerge-durations-${{ github.run_id }}-${{ github.run_attempt }}-b
+          path: ${{ steps.evaluate.outputs.duration_path }}/target-durations-b.json
+          retention-days: 3
+          if-no-files-found: error
+
+      - name: Publish validated Archive C duration measurement
+        id: publish-duration-c
+        if: ${{ steps.evaluate.outputs.reuse == 'true' && steps.evaluate.outputs.refresh_duration_data == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trusted-postmerge-durations-${{ github.run_id }}-${{ github.run_attempt }}-c
+          path: ${{ steps.evaluate.outputs.duration_path }}/target-durations-c.json
+          retention-days: 3
+          if-no-files-found: error
+
+      - name: Publish validated Archive D duration measurement
+        id: publish-duration-d
+        if: ${{ steps.evaluate.outputs.reuse == 'true' && steps.evaluate.outputs.refresh_duration_data == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trusted-postmerge-durations-${{ github.run_id }}-${{ github.run_attempt }}-d
+          path: ${{ steps.evaluate.outputs.duration_path }}/target-durations-d.json
+          retention-days: 3
+          if-no-files-found: error
+
+      - name: Finalize reuse after validated evidence publication
+        id: finalize
+        if: ${{ always() }}
+        env:
+          REUSE: ${{ steps.evaluate.outputs.reuse || 'false' }}
+          REASON: ${{ steps.evaluate.outputs.reason || steps.defaults.outputs.reason || 'reuse-evaluation-unavailable' }}
+          SOURCE_RUN_ID: ${{ steps.evaluate.outputs.source_run_id || '' }}
+          REFRESH: ${{ steps.evaluate.outputs.refresh_duration_data || 'false' }}
+          PUBLISH_B: ${{ steps.publish-duration-b.outcome }}
+          PUBLISH_C: ${{ steps.publish-duration-c.outcome }}
+          PUBLISH_D: ${{ steps.publish-duration-d.outcome }}
+        run: |
+          if [[ "$REUSE" == 'true' && "$REFRESH" == 'true' && ( "$PUBLISH_B" != 'success' || "$PUBLISH_C" != 'success' || "$PUBLISH_D" != 'success' ) ]]; then
+            REUSE=false
+            REASON=validated-duration-publication-failed
+          fi
+          if [[ "$REUSE" != 'true' ]]; then
+            SOURCE_RUN_ID=''
+            REFRESH=false
+          fi
+          printf 'reuse=%s\nreason=%s\nsource_run_id=%s\nrefresh_duration_data=%s\n' \
+            "$REUSE" "$REASON" "$SOURCE_RUN_ID" "$REFRESH" >> "$GITHUB_OUTPUT"

--- a/mydocs/working/task_m100_6901_codeql_neutral_stage1.md
+++ b/mydocs/working/task_m100_6901_codeql_neutral_stage1.md
@@ -1,0 +1,65 @@
+# #6901 보완 Stage 1: post-merge CodeQL 재사용 판정 일치
+
+## 분석
+
+- 재현 PR: #7038, merge `8661e75af8ec5ef06efcb236ccfaa3aa06c8aa70`.
+- [devel CI](https://github.com/edwardkim/rhwp/actions/runs/34601192203)는 `current-base-review-bridge-green-pr-workflow-reused`로 코드 CI `34598844280`을 재사용하고 heavy worker를 skip했다.
+- [devel CodeQL](https://github.com/edwardkim/rhwp/actions/runs/34601192197)은 `latest-pr-workflow-candidate-not-successful`로 거부하고 분석 worker를 실행했다.
+- 코드 head `d2668706f7f7ac9a1c4f070e311d1ded57998100`의 [CodeQL run](https://github.com/edwardkim/rhwp/actions/runs/34598844306)과 최종 문서 head의 [CodeQL run](https://github.com/edwardkim/rhwp/actions/runs/34600878896)은 모두 success였다.
+- 코드 head의 [GHAS CodeQL check](https://github.com/edwardkim/rhwp/runs/103262048486)는 completed/neutral이었다. 출력은 Python 분석 configuration 하나가 없어 PR에서 새로 유입된 alert를 판단할 수 없다는 경고다. 이를 모든 언어의 alert 비교가 정상 완료됐다는 증거로 해석하지 않는다.
+- PR `codeql.yml` preflight는 각 언어 Analyze 성공을 별도로 요구하면서 GHAS `success`와 `neutral`을 허용한다. post-merge 후보 수집은 GHAS `success`만 허용해 같은 성공 후보를 제외했다. 이후 과거 취소 head `ae38528acf9711869457a26d67e29cbbaf896247`의 run `34598002635`에 도달해 취소 후보 사유가 최종 진단으로 출력됐다.
+
+## 이슈 관련성과 범위
+
+- [#6901](https://github.com/edwardkim/rhwp/issues/6901)의 post-merge 재사용 신뢰 계약과 같은 기능 영역이다. 기존 fork duration artifact 미발행 문제와는 원인이 다르며, 이번 사례는 same-repository PR이다.
+- [추가 재현 댓글](https://github.com/edwardkim/rhwp/issues/6901#issuecomment-5634815793)을 게시하고 API body 재조회를 완료했다. 사용자의 전체 개선 지시에 따라 아래 fork duration 발행·소비 보완도 같은 작업에 포함한다. 실제 후속 fork PR 실증 전에는 #6901 전체 완료를 주장하거나 close하지 않는다.
+- 초기 CodeQL 보정 대상은 `.github/workflows/trusted-postmerge-ci-reuse.yml`의 full 후보 수집이다. 전체 개선 범위에는 아래에서 확정한 duration 발행·소비와 최신 rerun 거부를 추가하며, 제품 소스와 기존 SHA/tree/PR 신뢰 조건은 완화하지 않는다.
+
+## 수정 계약
+
+- workflow 자체 completed/success 및 CodeQL preflight와 JavaScript/TypeScript·Python·Rust Analyze 전부 success라는 기존 선행조건을 유지한다.
+- GHAS 발행자, CodeQL check 이름, exact candidate SHA, 최신 check 선택, 해당 run 시작 이후의 check 시각과 completed 조건을 유지한다.
+- 위 조건을 충족한 GHAS conclusion만 PR preflight와 동일하게 success/neutral을 허용한다. skipped, failure, cancelled, pending, 누락·과거 attempt의 check는 계속 거부한다.
+- neutral을 수용할 때 실제 check ID를 로그에 남겨 운영자가 원 경고를 추적할 수 있게 한다. check 상태를 success로 바꾸거나 경고를 숨기지 않는다.
+- 이미 시작한 devel run에는 소급 적용되지 않는다. 개선 PR 자체는 CI enforcement 변경이므로 full 검증이 예상된다. devel 반영 뒤 후속 PR에서 reuse=true와 CodeQL Analyze worker skip을 실증해야 한다.
+
+## 결과 및 검증 상태
+
+- CodeQL 판정 보정을 반영했다. 아래 전체 잔여 분석에 따른 duration·rerun 보정도 같은 작업 단계에 반영했다. 테스트 통과나 배포 완료를 의미하지 않는다.
+- 이번 요청은 코드 수정이며, 아직 계약 테스트·실제 수정본 run을 실행하지 않았다. 기존 #7038 성공 결과를 수정본 검증으로 재사용하지 않는다.
+- 후속 검증은 성공/neutral의 정상 조건, 언어 worker 실패·skip, GHAS 실패·skip·pending·누락, SHA/발행자/시각 불일치, 최신 취소 run 거부를 포함해야 한다.
+
+## 전체 잔여 범위 추가 분석
+
+- `run-nextest-archives.yml` 117행 이후는 여전히 same-repository PR만 duration을 업로드한다. upstream에서 실행된 정상 fork PR도 read-only 권한으로 측정 artifact를 발행하도록 변경한다. fork 자체 저장소의 실행과 metrics branch 쓰기는 허용하지 않는다.
+- 기존 duration JSON은 run/ref/sha가 세 파일 사이에서 같은지만 검사한다. API가 선택한 run·attempt·PR·저장소·head·실제 테스트 merge SHA와의 결합, ZIP/JSON 크기·중복·경로·수치 경계 검증을 추가해야 한다.
+- artifact 이름에 attempt를 추가하고, fork에는 새 provenance 필드를 필수로 요구한다. 기존 same-repository의 attempt 1 자료는 기존 형식의 엄격한 run/ref/merge SHA 검증을 거쳐 제한적으로 호환한다. 오래된 fork 또는 이전 attempt 자료는 거부한다.
+- 비신뢰 원본 ZIP은 actions:read/contents:read verifier에서만 제한된 크기로 읽는다. 경로·추출을 허용하지 않고 JSON 한 파일만 검사한다. 검증된 세 JSON은 현재 run/attempt의 정규화 artifact로 다시 발행한다. contents:write refresh job은 이 정규화 자료만 받는다.
+- 새 신뢰 helper도 enforcement surface에 포함한다. 개선 PR이 자신의 새 verifier를 신뢰하는 일을 방지하도록 이전 devel 부모의 helper만 로드하고, 미배포 상태에서는 full lane으로 fallback한다.
+- 실패·취소된 최신 후보를 더 오래된 성공으로 우회하지 않는다. duration 누락·변조와 CodeQL 증거 거부의 상세 원인을 후보 run 단위로 로그에 남긴다.
+- 구현 완료와 검증 완료를 구분한다. 변경 계약 테스트와 실제 fork full/trailing/merge의 B/C/D 발행·CI skip·refresh·CodeQL/Adapter/Proptest 실증은 별도 완료 gate다.
+
+## 전체 범위 코드 보정 결과
+
+- upstream의 devel 대상 PR은 fork도 B/C/D duration을 발행할 수 있게 했다. 이름과 JSON에 run attempt를 결합하고 PR·head repository·head SHA/ref를 기록한다. worker는 contents:read를 유지한다.
+- 신뢰 helper `scripts/trusted-postmerge-duration-evidence.mjs`를 추가했다. API artifact ID·run·저장소·head·생성 시각·만료·크기, 세 archive의 완전성, ZIP 단일 JSON·경로/링크/암호화/크기·중복 JSON key, report schema·provenance·수치/식별자·중복 target/case를 검사한다.
+- 선택한 원본은 read-only verifier에서만 다운로드·검사하고 정규화된 JSON을 현재 run/attempt의 새 artifact로 발행한다. 발행이 실패하면 reuse=false로 마감한다. write-capable refresh job은 정규화된 현재 run artifact만 읽고 원본 fork ZIP을 직접 추출하지 않는다.
+- 기존 same-repository attempt 1의 legacy report는 검증된 run/ref/tested merge SHA와 세 archive 내용 검사를 거쳐 지원한다. fork의 legacy/이전 attempt 자료는 허용하지 않는다. policy의 measurement_sources에도 새 provenance를 보존한다.
+- 후보 run 선택에서 merge 이후 updated_at이라는 이유로 최신 rerun을 목록에서 먼저 버리지 않도록 했다. 최신 실패·취소·pending 및 merge 이후 완료된 성공은 거부하고 과거 성공으로 우회하지 않는다.
+- 다음 미완료 항목: 기존/신규 계약 테스트 갱신 및 실행, PR CI, 개선이 배포된 devel에서 실제 fork full/trailing/post-merge 재사용 실증. 이 항목들이 남아 있으므로 #6901은 OPEN 유지다.
+
+## 계약 테스트 검증 결과
+
+앞 절의 테스트 미실행·대기 상태를 아래 결과로 갱신한다.
+
+- JavaScript 계약 테스트: 318개 통과, 실패 0개, 건너뜀 0개.
+- Python workflow 계약 테스트: 109개 통과, 실패 0개.
+- 실제 reusable workflow의 github-script를 실행하고 Git 객체와 ZIP을 사용해 fork full 실행 → 문서 trailing commit → 일반 merge 경로를 검증했다. GitHub API와 네트워크 호출은 모의 응답이므로 실제 Actions 배포 검증과 구분한다.
+- CI, CodeQL, Adapter inter-diff, Proptest의 fork 재사용 허용 경로를 확인했다. 저장소·head·attempt 불일치, 만료·누락·변조 artifact, 안전하지 않은 ZIP, 최신 실패·취소·대기 실행은 거부한다.
+- CodeQL의 모든 언어 Analyze 성공을 요구한 상태에서 동일 SHA의 GHAS neutral을 허용한다. neutral의 configuration warning 자체를 해결했다고 주장하지 않는다.
+- 테스트 작성 중 fork Git fetch 인자를 same-repository bridge 인자로만 제한한 모의 환경 오류를 수정했다. 운영 검증 조건을 완화하지 않았다.
+- Rust 제품 코드 변경이 아니므로 Cargo 전체 회귀 및 WASM 빌드는 수행하지 않았다.
+
+### 남은 실제 검증
+
+변경 배포 후 실제 fork PR의 full → 문서 trailing → merge에서 heavy worker skip, 검증·정규화한 B/C/D duration 전달 및 refresh, CodeQL/Adapter/Proptest 결과를 확인해야 한다. 이 검증 전에는 #6901 전체 해결이나 종료를 선언하지 않는다. 현재 변경은 아직 commit/push하지 않았다.

--- a/scripts/collect-nextest-target-durations.mjs
+++ b/scripts/collect-nextest-target-durations.mjs
@@ -137,6 +137,13 @@ function main() {
     run_id: process.env.GITHUB_RUN_ID ?? null,
     ref: process.env.GITHUB_REF ?? null,
     sha: process.env.GITHUB_SHA ?? null,
+    run_attempt: process.env.GITHUB_RUN_ATTEMPT ?? null,
+    repository_id: process.env.GITHUB_REPOSITORY_ID ?? null,
+    repository: process.env.GITHUB_REPOSITORY ?? null,
+    pull_number: process.env.DURATION_PULL_NUMBER ?? null,
+    head_repository_id: process.env.DURATION_HEAD_REPOSITORY_ID ?? null,
+    head_sha: process.env.DURATION_HEAD_SHA ?? null,
+    head_ref: process.env.DURATION_HEAD_REF ?? null,
     ...measurement,
   };
   fs.mkdirSync(path.dirname(options.output), { recursive: true });

--- a/scripts/refresh-nextest-target-duration-policy.mjs
+++ b/scripts/refresh-nextest-target-duration-policy.mjs
@@ -34,6 +34,14 @@ function parseArgs(args) {
   return options;
 }
 
+function measurementSource(measurement) {
+  return Object.fromEntries([
+    "run_id", "ref", "sha", "run_attempt", "repository", "repository_id",
+    "pull_number", "head_repository_id", "head_sha", "head_ref",
+  ].filter((field) => typeof measurement[field] === "string" && measurement[field].length > 0)
+    .map((field) => [field, measurement[field]]));
+}
+
 export function refreshDurationPolicy(policy, measurements) {
   if (policy.schema_version === 2) {
     if (
@@ -92,11 +100,7 @@ export function refreshDurationPolicy(policy, measurements) {
       fallback_seconds_per_test: policy.fallback_seconds_per_test,
       parallelism_factor: parsedPolicy.parallelismFactor,
       measurement_sources: Object.fromEntries(measurements
-        .map((measurement) => [measurement.archive_label, {
-          run_id: measurement.run_id,
-          ref: measurement.ref,
-          sha: measurement.sha,
-        }])
+        .map((measurement) => [measurement.archive_label, measurementSource(measurement)])
         .sort(([left], [right]) => left.localeCompare(right))),
       targets: Object.fromEntries(Object.entries(targets).sort(([left], [right]) => left.localeCompare(right))),
       cases: Object.fromEntries(Object.entries(cases).sort(([left], [right]) => left.localeCompare(right))),
@@ -137,11 +141,7 @@ export function refreshDurationPolicy(policy, measurements) {
     schema_version: 1,
     fallback_seconds: policy.fallback_seconds,
     measurement_sources: Object.fromEntries(measurements
-      .map((measurement) => [measurement.archive_label, {
-        run_id: measurement.run_id ?? null,
-        ref: measurement.ref ?? null,
-        sha: measurement.sha ?? null,
-      }])
+      .map((measurement) => [measurement.archive_label, measurementSource(measurement)])
       .sort(([left], [right]) => left.localeCompare(right))),
     targets: Object.fromEntries(Object.entries(durations).sort(([left], [right]) => left.localeCompare(right))),
   };

--- a/scripts/tests/helpers/postmerge-duration-fixtures.mjs
+++ b/scripts/tests/helpers/postmerge-duration-fixtures.mjs
@@ -1,0 +1,44 @@
+import { execFileSync } from "node:child_process";
+
+export function zipEntries(entries) {
+  return execFileSync("python3", ["-c", `
+import io,json,sys,zipfile
+output=io.BytesIO()
+with zipfile.ZipFile(output,'w',compression=zipfile.ZIP_DEFLATED) as archive:
+    for entry in json.load(sys.stdin):
+        info=zipfile.ZipInfo(entry['name'])
+        info.compress_type=zipfile.ZIP_DEFLATED
+        info.external_attr=entry.get('mode',0o100644)<<16
+        archive.writestr(info,entry['content'])
+sys.stdout.buffer.write(output.getvalue())
+`], { input: JSON.stringify(entries), maxBuffer: 20 * 1024 * 1024 });
+}
+
+export function reportZip(report, label = report.archive_label) {
+  return zipEntries([{ name: `target-durations-${label}.json`, content: JSON.stringify(report) }]);
+}
+
+export function durationFixture({ fork = true, legacy = false, attempt = legacy ? 1 : 2 } = {}) {
+  const repositoryId = 10;
+  const run = { id: 123, run_attempt: attempt, head_sha: "2".repeat(40),
+    repository: { id: 10, full_name: "edwardkim/rhwp" },
+    event: "pull_request", status: "completed", conclusion: "success",
+    created_at: "2026-09-06T11:04:00Z", run_started_at: "2026-09-06T11:04:00Z",
+    updated_at: "2026-09-06T11:27:30Z" };
+  const pr = { number: 42, merged_at: "2026-09-06T11:29:16Z",
+    base: { repo: run.repository, ref: "devel" },
+    head: { ref: "feature", repo: { id: fork ? 20 : 10, full_name: fork ? "contributor/rhwp" : "edwardkim/rhwp" } } };
+  const testedMergeSha = "3".repeat(40);
+  const reports = ["b", "c", "d"].map(label => ({ schema_version: 2, archive_label: label,
+    run_id: String(run.id), run_attempt: String(attempt), repository: run.repository.full_name,
+    repository_id: "10", head_repository_id: String(pr.head.repo.id), pull_number: "42",
+    head_sha: run.head_sha, head_ref: pr.head.ref, ref: "refs/pull/42/merge", sha: testedMergeSha,
+    targets: { [`regression_suite_${label}`]: 1 }, cases: { [`case_${label}`]: 1 },
+    test_cases: { [`regression_suite_${label}::case_${label}::works`]: 1 } }));
+  const artifacts = reports.map((report, index) => ({ id: index + 100, expired: false,
+    name: `nextest-target-durations-123${legacy ? "" : `-attempt-${attempt}`}-${report.archive_label}`,
+    created_at: "2026-09-06T11:20:00Z", size_in_bytes: 1024,
+    workflow_run: { id: run.id, repository_id: 10, head_repository_id: pr.head.repo.id, head_sha: run.head_sha } }));
+  return { reports, artifacts, run, pr, repositoryId,
+    context: { run, pr, repositoryId, testedMergeSha, legacy } };
+}

--- a/scripts/tests/test_nextest_archive_workflow.py
+++ b/scripts/tests/test_nextest_archive_workflow.py
@@ -191,9 +191,13 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         self.assertIn("github.ref == 'refs/heads/devel'", runner)
         self.assertIn("github.event_name == 'pull_request'", runner)
         self.assertIn(
-            "github.event.pull_request.head.repo.full_name == github.repository",
+            "github.event.pull_request.base.repo.id == github.repository_id",
             runner,
         )
+        self.assertIn("github.repository == 'edwardkim/rhwp'", runner)
+        self.assertIn("github.event.pull_request.base.ref == 'devel'", runner)
+        self.assertIn("-attempt-${{ github.run_attempt }}-", runner)
+        self.assertNotIn("github.event.pull_request.head.repo.full_name == github.repository", runner)
         self.assertIn("inputs.archive_label == 'b'", runner)
         self.assertIn("inputs.archive_label == 'c'", runner)
         self.assertIn("inputs.archive_label == 'd'", runner)

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -118,7 +118,8 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
         self.assertIn("listJobsForWorkflowRun", workflow)
         self.assertIn("fullLaneRunIds", workflow)
         self.assertIn('"ci.yml", "codeql.yml"', workflow)
-        self.assertIn('`nextest-target-durations-${workflowRun.id}-${label}`', workflow)
+        self.assertIn('selectDurationArtifacts(', workflow)
+        self.assertIn('validateDurationReports(reports,', workflow)
         self.assertIn("never checks out or executes", workflow)
         self.assertIn("the merged PR head", workflow)
         self.assertIn("Capture PR merge-tree evidence", workflow)
@@ -156,6 +157,41 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
         self.assertIn("postmerge_source_run_id", ci)
         self.assertIn("Download trusted PR Archive B duration measurement", ci)
         self.assertIn("Download trusted PR Archive C duration measurement", ci)
+
+    def test_fork_upload_remains_read_only_and_attempt_bound(self) -> None:
+        runner = (REPO_ROOT / ".github/workflows/run-nextest-archives.yml").read_text(encoding="utf-8")
+        upload = runner.split("- name: Upload upstream PR B/C/D target durations", 1)[1].split("# Only successful devel", 1)[0]
+        self.assertIn("github.repository == 'edwardkim/rhwp'", upload)
+        self.assertIn("github.event.pull_request.base.repo.id == github.repository_id", upload)
+        self.assertIn("github.event.pull_request.base.ref == 'devel'", upload)
+        self.assertNotIn("head.repo.full_name == github.repository", upload)
+        self.assertIn("-attempt-${{ github.run_attempt }}-", upload)
+        self.assertIn("contents: read", runner)
+        self.assertNotIn("contents: write", runner)
+
+    def test_privileged_refresh_consumes_only_normalized_current_run_data(self) -> None:
+        workflow = REUSABLE.read_text(encoding="utf-8")
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        for label in ("b", "c", "d"):
+            name = f"trusted-postmerge-durations-${{{{ github.run_id }}}}-${{{{ github.run_attempt }}}}-{label}"
+            self.assertIn(name, workflow)
+            self.assertIn(name, ci)
+        self.assertIn("decodeDurationArtifact(response.data, label)", workflow)
+        self.assertIn("scripts/trusted-postmerge-duration-evidence.mjs", workflow)
+        self.assertIn("validated-duration-publication-failed", workflow)
+        self.assertIn("steps.finalize.outputs.reuse", workflow)
+        block = ci.split("- name: Download trusted PR Archive B duration measurement", 1)[1].split("- name: Refresh duration policy data branch", 1)[0]
+        self.assertNotIn("gh run download", block)
+
+    def test_codeql_neutral_is_not_a_substitute_for_language_success(self) -> None:
+        workflow = REUSABLE.read_text(encoding="utf-8")
+        codeql = WORKFLOWS["codeql"].read_text(encoding="utf-8")
+        self.assertIn("new Set(['success', 'neutral'])", workflow)
+        self.assertIn("new Set(['success', 'neutral'])", codeql)
+        self.assertLess(workflow.index("if (!fullLaneWorkflowJobsAreGreen("), workflow.index("const allowedSecurityConclusions"))
+        self.assertIn("securityCheck.status !== \"completed\"", workflow)
+        self.assertIn("check.app?.slug === \"github-advanced-security\"", workflow)
+        self.assertIn("check.head_sha === workflowRun.head_sha", workflow)
 
     def test_direct_review_only_reuse_requires_the_exact_skipped_worker(self) -> None:
         workflow = REUSABLE.read_text(encoding="utf-8")

--- a/scripts/tests/trusted-postmerge-duration-evidence.test.mjs
+++ b/scripts/tests/trusted-postmerge-duration-evidence.test.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { selectDurationArtifacts, decodeDurationArtifact, validateDurationReports } from "../trusted-postmerge-duration-evidence.mjs";
+import { refreshDurationPolicy } from "../refresh-nextest-target-duration-policy.mjs";
+import { durationFixture, reportZip, zipEntries } from "./helpers/postmerge-duration-fixtures.mjs";
+
+for (const options of [{ fork: true }, { fork: false }, { fork: false, legacy: true }]) {
+  test(`duration provenance 정상 발행·소비: ${JSON.stringify(options)}`, () => {
+    const f = durationFixture(options);
+    const selected = selectDurationArtifacts(f.artifacts, f.run, f.pr, f.repositoryId);
+    assert.equal(selected.length, 3);
+    assert.ok(selected.every(s => s.legacy === Boolean(options.legacy)));
+    const reports = selected.map(s => decodeDurationArtifact(reportZip(f.reports.find(r => r.archive_label === s.label)), s.label));
+    const normalized = validateDurationReports(reports, f.context);
+    assert.deepEqual(normalized.map(r => r.archive_label), ["b", "c", "d"]);
+    assert.ok(normalized.every(r => r.run_id === "123" && r.sha === f.context.testedMergeSha));
+  });
+}
+
+for (const [name, mutate] of Object.entries({
+  "archive 누락": f => f.artifacts.pop(),
+  "archive 중복": f => f.artifacts.push({ ...f.artifacts[0] }),
+  "ID 중복": f => { f.artifacts[1].id = f.artifacts[0].id; },
+  "만료": f => { f.artifacts[0].expired = true; },
+  "만료 여부 누락": f => { delete f.artifacts[0].expired; },
+  "크기 초과": f => { f.artifacts[0].size_in_bytes = 8 * 1024 * 1024 + 1; },
+  "음수 크기": f => { f.artifacts[0].size_in_bytes = -1; },
+  "다른 run": f => { f.artifacts[0].workflow_run.id++; },
+  "다른 head": f => { f.artifacts[0].workflow_run.head_sha = "f".repeat(40); },
+  "다른 fork": f => { f.artifacts[0].workflow_run.head_repository_id++; },
+  "다른 upstream": f => { f.artifacts[0].workflow_run.repository_id++; },
+  "fork 자체 Actions": f => { f.run.repository.id = 20; },
+  "실패 run": f => { f.run.conclusion = "failure"; },
+  "취소 run": f => { f.run.conclusion = "cancelled"; },
+  "pending run": f => { f.run.status = "in_progress"; },
+  "이전 attempt 이름": f => { f.run.run_attempt++; },
+  "이전 attempt 생성 시각": f => { f.artifacts[0].created_at = "2020-01-01T00:00:00Z"; },
+  "merge 이후 artifact": f => { f.artifacts[0].created_at = "2027-01-01T00:00:00Z"; },
+})) {
+  test(`duration artifact 거부: ${name}`, () => {
+    const f = durationFixture(); mutate(f);
+    assert.throws(() => selectDurationArtifacts(f.artifacts, f.run, f.pr, f.repositoryId));
+  });
+}
+
+test("fork legacy와 same-repository 이전 attempt는 허용하지 않는다", () => {
+  for (const options of [{ fork: true, legacy: true }, { fork: false, legacy: true, attempt: 2 }]) {
+    const f = durationFixture(options);
+    assert.throws(() => selectDurationArtifacts(f.artifacts, f.run, f.pr, f.repositoryId));
+  }
+});
+
+for (const [name, mutate] of Object.entries({
+  "run": f => { f.reports[0].run_id = "124"; },
+  "attempt": f => { f.reports[0].run_attempt = "1"; },
+  "PR": f => { f.reports[0].pull_number = "43"; },
+  "upstream ID": f => { f.reports[0].repository_id = "11"; },
+  "upstream 이름": f => { f.reports[0].repository = "attacker/rhwp"; },
+  "fork ID": f => { f.reports[0].head_repository_id = "21"; },
+  "head SHA": f => { f.reports[0].head_sha = "a".repeat(40); },
+  "head branch": f => { f.reports[0].head_ref = "other"; },
+  "테스트 merge SHA": f => { f.reports[0].sha = f.run.head_sha; },
+  "merge ref": f => { f.reports[0].ref = "refs/heads/devel"; },
+  "누락 archive": f => f.reports.pop(),
+  "중복 archive": f => { f.reports[1].archive_label = "b"; },
+  "없는 schema": f => { f.reports[0].schema_version = 99; },
+  "빈 targets": f => { f.reports[0].targets = {}; },
+  "음수 duration": f => { f.reports[0].targets.regression_suite_b = -1; },
+  "무한 duration": f => { f.reports[0].targets.regression_suite_b = Infinity; },
+  "NaN duration": f => { f.reports[0].targets.regression_suite_b = NaN; },
+  "초과 duration": f => { f.reports[0].targets.regression_suite_b = 86401; },
+  "문자 duration": f => { f.reports[0].targets.regression_suite_b = "1"; },
+  "경로 식별자": f => { f.reports[0].cases = { "../../evil": 1 }; },
+  "prototype 식별자": f => { f.reports[0].cases = { constructor: 1 }; },
+  "알 수 없는 target": f => { f.reports[0].test_cases = { "other::test": 1 }; },
+  "알 수 없는 case": f => { f.reports[0].test_cases = { "regression_suite_b::other::test": 1 }; },
+  "서로 중복 target": f => { f.reports[1].targets.regression_suite_b = 1; },
+  "서로 중복 case": f => { f.reports[1].cases.case_b = 1; },
+})) {
+  test(`duration JSON 거부: ${name}`, () => {
+    const f = durationFixture(); mutate(f);
+    assert.throws(() => validateDurationReports(f.reports, f.context));
+  });
+}
+
+test("정규화 report는 알 수 없는 필드를 버리고 policy에 provenance를 보존한다", () => {
+  const f = durationFixture(); f.reports[0].command = "do not execute";
+  const normalized = validateDurationReports(f.reports, f.context);
+  assert.equal(normalized[0].command, undefined);
+  const policy = JSON.parse(readFileSync(new URL("../../tests/suites/nextest-target-duration-policy.json", import.meta.url), "utf8"));
+  const updated = refreshDurationPolicy(policy, normalized);
+  assert.equal(updated.measurement_sources.b.run_attempt, "2");
+  assert.equal(updated.measurement_sources.b.head_repository_id, "20");
+  assert.equal(updated.measurement_sources.b.pull_number, "42");
+});
+
+for (const [name, entries] of [
+  ["추가 파일", [{ name: "target-durations-b.json", content: "{}" }, { name: "extra", content: "x" }]],
+  ["경로 탈출", [{ name: "../target-durations-b.json", content: "{}" }]],
+  ["절대 경로", [{ name: "/tmp/target-durations-b.json", content: "{}" }]],
+  ["심볼릭 링크", [{ name: "target-durations-b.json", content: "elsewhere", mode: 0o120777 }]],
+  ["디렉터리", [{ name: "target-durations-b.json/", content: "" }]],
+  ["중복 JSON key", [{ name: "target-durations-b.json", content: '{"run_id":"123","run_id":"456"}' }]],
+  ["JSON NaN", [{ name: "target-durations-b.json", content: '{"number":NaN}' }]],
+  ["잘못된 JSON", [{ name: "target-durations-b.json", content: "not JSON" }]],
+]) {
+  test(`원본 ZIP 거부: ${name}`, () => assert.throws(() => decodeDurationArtifact(zipEntries(entries), "b")));
+}
+test("ZIP 암호화 flag, 크기 제한, 큰 압축 해제 결과를 거부한다", () => {
+  const encrypted = reportZip(durationFixture().reports[0]);
+  const central = encrypted.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02]));
+  encrypted.writeUInt16LE(encrypted.readUInt16LE(central + 8) | 1, central + 8);
+  assert.throws(() => decodeDurationArtifact(encrypted, "b"));
+  assert.throws(() => decodeDurationArtifact(Buffer.alloc(8 * 1024 * 1024 + 1), "b"));
+  assert.throws(() => decodeDurationArtifact(zipEntries([{ name: "target-durations-b.json", content: "x".repeat(8 * 1024 * 1024 + 1) }]), "b"));
+});
+
+const workflow = readFileSync(new URL("../../.github/workflows/trusted-postmerge-ci-reuse.yml", import.meta.url), "utf8");
+const finalize = workflow.split("- name: Finalize reuse after validated evidence publication")[1]
+  .split("run: |\n")[1].split("\n").map(line => line.replace(/^ {10}/, "")).join("\n");
+for (const failed of [null, "B", "C", "D"]) {
+  test(`정규화 artifact 발행 ${failed || "모두 성공"} 최종 reuse 계약`, t => {
+    const directory = mkdtempSync(path.join(tmpdir(), "duration-finalize-"));
+    t.after(() => rmSync(directory, { recursive: true, force: true }));
+    const output = path.join(directory, "output");
+    execFileSync("bash", ["-e", "-c", finalize], { env: { ...process.env, GITHUB_OUTPUT: output,
+      REUSE: "true", REASON: "verified", SOURCE_RUN_ID: "123", REFRESH: "true",
+      PUBLISH_B: failed === "B" ? "failure" : "success", PUBLISH_C: failed === "C" ? "skipped" : "success",
+      PUBLISH_D: failed === "D" ? "cancelled" : "success" } });
+    const result = Object.fromEntries(readFileSync(output, "utf8").trim().split("\n").map(line => line.split("=")));
+    assert.equal(result.reuse, failed ? "false" : "true");
+    assert.equal(result.refresh_duration_data, failed ? "false" : "true");
+    assert.equal(result.source_run_id, failed ? "" : "123");
+  });
+}

--- a/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs
@@ -1,4 +1,5 @@
 import "./verify-trusted-postmerge-green-merge.test.mjs";
+import "./trusted-postmerge-duration-evidence.test.mjs";
 import assert from "node:assert/strict";
 import "./verify-trusted-postmerge-base-advance.test.mjs";
 import test from "node:test";
@@ -589,6 +590,22 @@ test("fork 최신 rerun 실패를 이전 green run으로 대체하지 않는다"
   data.workflowRuns.push({ ...data.workflowRuns[0], id: 124, run_attempt: 2,
     conclusion: "failure", updated_at: "2026-08-27T10:02:30Z" });
   assert.equal(evaluateTrustedPostMergeReuse(data).reuse, false);
+});
+
+for (const conclusion of ["success", "failure", "cancelled", null]) {
+  test(`merge 이후 최신 rerun을 이전 성공으로 우회하지 않는다: ${conclusion}`, () => {
+    for (const data of [input(), forkInput()]) {
+      data.workflowRuns.push({ ...data.workflowRuns[0], id: 124, run_attempt: 2,
+        status: conclusion ? "completed" : "in_progress", conclusion,
+        updated_at: "2026-08-27T10:04:00Z" });
+      assert.equal(evaluateTrustedPostMergeReuse(data).reuse, false);
+    }
+  });
+}
+
+test("duration 신뢰 helper 변경은 enforcement fast-pass 대상이 아니다", () => {
+  const data = input(); data.pullFiles.push({ filename: "scripts/trusted-postmerge-duration-evidence.mjs" });
+  assert.equal(evaluateTrustedPostMergeReuse(data).reason, "pr-changes-ci-enforcement-surface");
 });
 
 for (const mutate of [

--- a/scripts/tests/verify-trusted-postmerge-review-bridge.test.mjs
+++ b/scripts/tests/verify-trusted-postmerge-review-bridge.test.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
+import { reportZip, durationFixture } from "./helpers/postmerge-duration-fixtures.mjs";
 import {
   evaluateTrustedPostMergeReuse, selectTrustedPostMergeCandidate,
   currentBaseReviewBridgeSource, verifyPostMergeReviewBridgeTree,
@@ -212,15 +213,21 @@ test("Git object proof works with the runner's depth=1 fetched commits", t => {
 // Execute the actual github-script body over real Git objects, with only API/network calls mocked.
 const workflow = readFileSync(new URL("../../.github/workflows/trusted-postmerge-ci-reuse.yml", import.meta.url), "utf8");
 const script = workflow.split("- name: Evaluate exact PR workflow evidence")[1]
-  .split("script: |\n")[1].split("\n").map(line => line.replace(/^ {12}/, "")).join("\n");
+  .split("script: |\n")[1].split("\n      # Only normalized JSON")[0]
+  .split("\n").map(line => line.replace(/^ {12}/, "")).join("\n");
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
 const require = createRequire(import.meta.url);
 
 async function runWorkflow(t, workflowFile = "ci.yml", options = {}) {
   const f = gitFixture(t, options.changedPath);
-  const { baseSha, candidateSha, bridgeSha, mergeSha, testedMergeSha } = f.identity;
+  const { baseSha, candidateSha, bridgeSha, mergeSha: originalMergeSha, testedMergeSha } = f.identity;
+  const finalTree = f.git("show", "-s", "--format=%T", originalMergeSha);
+  const mergeSha = options.fork
+    ? f.git("commit-tree", finalTree, "-p", baseSha, "-p", f.headSha, "-m", "merged fork")
+    : originalMergeSha;
+  const finalTestedSha = f.git("commit-tree", finalTree, "-p", baseSha, "-p", f.headSha, "-m", "tested final head");
   const commits = new Map();
-  for (const sha of [baseSha, candidateSha, f.sourceSha, bridgeSha, f.headSha, mergeSha, testedMergeSha]) {
+  for (const sha of [baseSha, candidateSha, f.sourceSha, bridgeSha, f.headSha, mergeSha, testedMergeSha, finalTestedSha]) {
     const [parents, tree] = f.git("show", "-s", "--format=%P%n%T", sha).split("\n");
     commits.set(sha, { sha, parents: parents.split(" ").map(sha => ({ sha })),
       commit: { tree: { sha: tree } }, files: [file(
@@ -229,18 +236,26 @@ async function runWorkflow(t, workflowFile = "ci.yml", options = {}) {
   }
   const data = fixture();
   const pr = { ...data.pullRequests[0], changed_files: 2, merge_commit_sha: mergeSha,
-    head: { ...data.pullRequests[0].head, sha: f.headSha } };
+    base: { ref: "devel", repo: { id: 10, full_name: "edwardkim/rhwp" } },
+    head: { ...data.pullRequests[0].head, sha: f.headSha,
+      repo: options.fork ? { id: 20, full_name: "contributor/rhwp", fork: true } : { id: 10, full_name: "edwardkim/rhwp" } } };
   const summary = { ...pr };
   delete summary.changed_files;
   const runs = data.workflowRuns.map((run, index) => ({ ...run,
     head_sha: index === 0 ? candidateSha : f.headSha,
+    run_attempt: 1, repository: { id: 10, full_name: "edwardkim/rhwp" },
+    head_repository: { ...pr.head.repo },
+    path: `.github/workflows/${workflowFile}`, pull_requests: [],
   }));
   const headers = [candidateSha, f.sourceSha, bridgeSha, f.headSha].map(sha => ({ sha }));
-  const artifacts = ["b", "c", "d"].map(label => ({
-    name: `nextest-target-durations-${fullRunId}-${label}`, expired: false,
+  const artifacts = ["b", "c", "d"].map((label, index) => ({
+    name: `nextest-target-durations-${fullRunId}${options.fork ? "-attempt-1" : ""}-${label}`, expired: false,
+    id: index + 100, size_in_bytes: 1024, created_at: "2026-09-06T11:20:00Z",
   }));
-  artifacts.push({ name: `trusted-postmerge-merge-tree-v1-${testedMergeSha}-${commits.get(testedMergeSha).commit.tree.sha}`,
+  const mergeArtifactPrefix = options.fork ? `trusted-postmerge-fork-merge-tree-v1-${pr.number}-10-20-1` : "trusted-postmerge-merge-tree-v1";
+  artifacts.push({ name: `${mergeArtifactPrefix}-${testedMergeSha}-${commits.get(testedMergeSha).commit.tree.sha}`,
     expired: false });
+  const finalArtifacts = [{ name: `${mergeArtifactPrefix}-${finalTestedSha}-${finalTree}`, expired: false }];
   const requiredNames = {
     "ci.yml": ["CI preflight", "Build & Test", "Lint (fmt, clippy, WASM check)"],
     "codeql.yml": ["CodeQL preflight", "Analyze (rust)", "Analyze (javascript-typescript)", "Analyze (python)"],
@@ -250,7 +265,11 @@ async function runWorkflow(t, workflowFile = "ci.yml", options = {}) {
   const jobs = requiredNames.map(name => ({ name, status: "completed", conclusion: "success" }));
   const securityChecks = [{ name: "CodeQL", app: { slug: "github-advanced-security" },
     head_sha: candidateSha, status: "completed", conclusion: "success", started_at: runs[0].created_at }];
-  const state = { pr, runs, headers, artifacts, commits, jobs, securityChecks };
+  const reports = durationFixture({ fork: false, legacy: true }).reports.map(report => ({ ...report,
+    run_id: String(fullRunId), ref: `refs/pull/${pr.number}/merge`, sha: testedMergeSha,
+    pull_number: String(pr.number), head_repository_id: String(pr.head.repo.id),
+    head_sha: candidateSha, head_ref: pr.head.ref }));
+  const state = { pr, runs, headers, artifacts, commits, jobs, securityChecks, reports, finalArtifacts };
   options.mutate?.(state);
   const apiCalls = [], gitCalls = [], outputs = {}, warnings = [];
   const endpoint = name => name;
@@ -267,7 +286,12 @@ async function runWorkflow(t, workflowFile = "ci.yml", options = {}) {
     },
     pulls: { get: async () => ({ data: pr }), listFiles: endpoint("files"), listCommits: endpoint("commits") },
     actions: { listWorkflowRuns: endpoint("runs"), listWorkflowRunArtifacts: endpoint("artifacts"),
-      listJobsForWorkflowRun: endpoint("jobs") },
+      listJobsForWorkflowRun: endpoint("jobs"),
+      downloadArtifact: async ({ artifact_id }) => {
+        apiCalls.push(["downloadArtifact", artifact_id]);
+        if (options.downloadFailure) throw new Error("artifact download failed");
+        return { data: reportZip(state.reports[artifact_id - 100]) };
+      } },
   }, paginate: async (method, args) => {
     apiCalls.push([method, args]);
     switch (method) {
@@ -275,7 +299,7 @@ async function runWorkflow(t, workflowFile = "ci.yml", options = {}) {
       case "files": return [file("src/lib.rs"), file("mydocs/pr/review.md")];
       case "commits": return headers;
       case "runs": return runs;
-      case "artifacts": return args.run_id === fullRunId ? artifacts : [];
+      case "artifacts": return args.run_id === fullRunId ? artifacts : finalArtifacts;
       case "checks": return state.securityChecks;
       case "jobs": return state.jobs.map(job => ({ ...job,
         conclusion: args.run_id === fullRunId ? job.conclusion : "skipped",
@@ -284,7 +308,7 @@ async function runWorkflow(t, workflowFile = "ci.yml", options = {}) {
     }
   } };
   mkdirSync(path.join(f.directory, "scripts"));
-  for (const name of ["verify-trusted-postmerge-ci-reuse.mjs", "ci-impact-classifier.cjs"]) {
+  for (const name of ["verify-trusted-postmerge-ci-reuse.mjs", "ci-impact-classifier.cjs", "trusted-postmerge-duration-evidence.mjs"]) {
     copyFileSync(new URL(`../${name}`, import.meta.url), path.join(f.directory, "scripts", name));
   }
   const testRequire = name => name === "node:child_process" ? {
@@ -296,7 +320,7 @@ async function runWorkflow(t, workflowFile = "ci.yml", options = {}) {
       if (args[0] === "fetch") {
         assert.deepEqual(args.slice(0, 7), ["fetch", "--no-tags", "--filter=blob:none", "--depth=1",
           "--no-write-fetch-head", "origin", mergeSha]);
-        assert.deepEqual(args.slice(7), [bridgeSha, testedMergeSha]);
+        assert.deepEqual(args.slice(7), options.fork ? [testedMergeSha] : [bridgeSha, testedMergeSha]);
         if (options.fetch === "failure") throw new Error("fetch failed");
         return Buffer.alloc(0);
       }
@@ -307,6 +331,7 @@ async function runWorkflow(t, workflowFile = "ci.yml", options = {}) {
     testRequire, github, { repo: { owner: "edwardkim", repo: "rhwp" } },
     { setOutput: (key, value) => { outputs[key] = value; }, warning: message => warnings.push(message), info: () => {} },
     { env: { GITHUB_WORKSPACE: f.directory, GITHUB_REPOSITORY: "edwardkim/rhwp", WORKFLOW_FILE: workflowFile,
+      GITHUB_REPOSITORY_ID: "10", RUNNER_TEMP: f.directory,
       CALLER_EVENT_NAME: "push", CALLER_REF: "refs/heads/devel", CALLER_SHA: mergeSha,
       REQUIRE_DURATION_ARTIFACTS: workflowFile === "ci.yml" ? "true" : "false" } },
   );
@@ -316,9 +341,14 @@ async function runWorkflow(t, workflowFile = "ci.yml", options = {}) {
 for (const workflowFile of ["ci.yml", "codeql.yml", "adapter-diff.yml", "proptest-roundtrip.yml"]) {
   test(`actual ${workflowFile} collector traverses bridge and reuses the tested full run`, async t => {
     const result = await runWorkflow(t, workflowFile);
-    assert.deepEqual(result.outputs, { reuse: "true",
+    const { duration_path: durationPath, ...outputs } = result.outputs;
+    assert.deepEqual(outputs, { reuse: "true",
       reason: "current-base-review-bridge-green-pr-workflow-reused", source_run_id: String(fullRunId),
       refresh_duration_data: workflowFile === "ci.yml" ? "true" : "false" });
+    if (workflowFile === "ci.yml") {
+      assert.equal(result.apiCalls.filter(([method]) => method === "downloadArtifact").length, 3);
+      assert.equal(JSON.parse(readFileSync(path.join(durationPath, "target-durations-b.json"))).run_id, String(fullRunId));
+    } else assert.equal(durationPath, undefined);
     assert.ok(result.apiCalls.some(([method, ref]) => method === "getCommit" && ref === result.candidateSha));
     assert.deepEqual(result.warnings, []);
   });
@@ -335,6 +365,9 @@ for (const [name, options] of [
   ["code conflict resolution", { changedPath: "src/lib.rs" }],
   ["expired immutable artifact", { mutate: d => { d.artifacts.at(-1).expired = true; } }],
   ["missing duration artifact", { mutate: d => { d.artifacts.shift(); } }],
+  ["duration JSON run mismatch", { mutate: d => { d.reports[0].run_id = "999"; } }],
+  ["duration JSON merge mismatch", { mutate: d => { d.reports[0].sha = "f".repeat(40); } }],
+  ["duration download failure", { downloadFailure: true }],
   ["failed final head", { mutate: d => { d.runs[1].conclusion = "failure"; } }],
   ["truncated file listing", { mutate: d => { d.pr.changed_files += 1; } }],
   ["PR commit API cap", { mutate: d => { d.headers.push(...Array(246).fill(d.headers[0])); } }],
@@ -362,11 +395,52 @@ for (const [name, mutate] of [
   ["missing language", d => { d.jobs.pop(); }],
   ["pending worker", d => { d.jobs[1].status = "in_progress"; }],
   ["failed security check", d => { d.securityChecks[0].conclusion = "failure"; }],
+  ["skipped security check", d => { d.securityChecks[0].conclusion = "skipped"; }],
+  ["pending security check", d => { d.securityChecks[0].status = "in_progress"; }],
+  ["wrong SHA security check", d => { d.securityChecks[0].head_sha = "f".repeat(40); }],
+  ["wrong app security check", d => { d.securityChecks[0].app.slug = "untrusted"; }],
   ["missing security check", d => { d.securityChecks.length = 0; }],
   ["stale security check", d => { d.securityChecks[0].started_at = "2020-01-01T00:00:00Z"; }],
 ]) {
   test(`actual CodeQL collector refuses ${name}`, async t => {
     const result = await runWorkflow(t, "codeql.yml", { mutate });
+    assert.equal(result.outputs.reuse, "false");
+  });
+}
+test("#6901: all language analyses green plus same-run neutral GHAS permits reuse", async t => {
+  const result = await runWorkflow(t, "codeql.yml", { mutate: d => { d.securityChecks[0].conclusion = "neutral"; } });
+  assert.equal(result.outputs.reuse, "true");
+  assert.equal(result.outputs.source_run_id, String(fullRunId));
+});
+
+test("#6901: neutral GHAS does not hide a skipped language analysis", async t => {
+  const result = await runWorkflow(t, "codeql.yml", { mutate: d => {
+    d.securityChecks[0].conclusion = "neutral"; d.jobs[1].conclusion = "skipped";
+  } });
+  assert.equal(result.outputs.reuse, "false");
+});
+
+for (const workflowFile of ["ci.yml", "codeql.yml", "adapter-diff.yml", "proptest-roundtrip.yml"]) {
+  test(`#6901: 실제 ${workflowFile} 수집기가 fork의 full→문서 tail→일반 merge 증거를 재사용한다`, async t => {
+    const result = await runWorkflow(t, workflowFile, { fork: true });
+    assert.equal(result.outputs.reuse, "true", JSON.stringify({ outputs: result.outputs, warnings: result.warnings }));
+    assert.equal(result.outputs.source_run_id, String(fullRunId));
+    if (workflowFile === "ci.yml") {
+      const report = JSON.parse(readFileSync(path.join(result.outputs.duration_path, "target-durations-b.json")));
+      assert.equal(report.head_repository_id, "20");
+      assert.equal(report.run_attempt, "1");
+    }
+  });
+}
+for (const [name, mutate] of [
+  ["fork Actions run", d => { d.runs[0].repository.id = 20; }],
+  ["fork duration attempt 변조", d => { d.reports[0].run_attempt = "2"; }],
+  ["fork duration head 변조", d => { d.reports[0].head_repository_id = "99"; }],
+  ["fork duration 만료", d => { d.artifacts[0].expired = true; }],
+  ["fork merge artifact 누락", d => { d.finalArtifacts.length = 0; }],
+]) {
+  test(`#6901: 실제 fork 수집기 거부: ${name}`, async t => {
+    const result = await runWorkflow(t, "ci.yml", { fork: true, mutate });
     assert.equal(result.outputs.reuse, "false");
   });
 }

--- a/scripts/trusted-postmerge-duration-evidence.mjs
+++ b/scripts/trusted-postmerge-duration-evidence.mjs
@@ -1,0 +1,136 @@
+import { execFileSync } from "node:child_process";
+
+const LIMIT = 8 * 1024 * 1024;
+const LABELS = ["b", "c", "d"];
+const ID = /^[1-9][0-9]*$/;
+const SHA = /^[0-9a-f]{40}$/;
+const NAME = /^[A-Za-z_][A-Za-z0-9_:]*$/;
+const fail = (message) => { throw new Error(`duration-evidence: ${message}`); };
+const record = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
+
+// The caller supplies GitHub API data, never values from the downloaded report.
+export function selectDurationArtifacts(artifacts, run, pr, repositoryId) {
+  if (!Array.isArray(artifacts) || !Number.isSafeInteger(run?.id) || run.id <= 0
+    || !Number.isSafeInteger(run.run_attempt) || run.run_attempt <= 0
+    || !Number.isSafeInteger(repositoryId) || repositoryId <= 0
+    || pr?.base?.repo?.id !== repositoryId || run.repository?.id !== repositoryId
+    || run.event !== "pull_request" || run.status !== "completed" || run.conclusion !== "success") {
+    fail("invalid successful upstream run identity");
+  }
+  const started = Date.parse(run.run_started_at || run.created_at);
+  const merged = Date.parse(pr.merged_at);
+  if (!Number.isFinite(started) || !Number.isFinite(merged) || started > merged) fail("invalid run time");
+  const prefix = `nextest-target-durations-${run.id}-attempt-${run.run_attempt}`;
+  const useNew = artifacts.some((artifact) => artifact?.name?.startsWith(`${prefix}-`));
+  const legacy = !useNew && pr.head?.repo?.id === repositoryId && run.run_attempt === 1;
+  if (!useNew && !legacy) fail("attempt-bound B/C/D artifacts unavailable");
+  const selected = LABELS.map((label) => {
+    const name = `${legacy ? `nextest-target-durations-${run.id}` : prefix}-${label}`;
+    const matches = artifacts.filter((artifact) => artifact?.name === name);
+    if (matches.length !== 1) fail(`missing or duplicate artifact: ${label}`);
+    const artifact = matches[0];
+    const created = Date.parse(artifact.created_at);
+    if (!Number.isSafeInteger(artifact.id) || artifact.id <= 0 || artifact.expired !== false
+      || !Number.isSafeInteger(artifact.size_in_bytes) || artifact.size_in_bytes <= 0 || artifact.size_in_bytes > LIMIT
+      || !Number.isFinite(created) || created < started || created > merged
+      || (artifact.workflow_run && (artifact.workflow_run.id !== run.id
+        || artifact.workflow_run.repository_id !== repositoryId
+        || artifact.workflow_run.head_repository_id !== pr.head.repo.id
+        || artifact.workflow_run.head_sha !== run.head_sha))) {
+      fail(`expired, oversized, stale, or mismatched artifact: ${label}`);
+    }
+    return { label, artifact, legacy };
+  });
+  if (new Set(selected.map(({ artifact }) => artifact.id)).size !== 3) fail("duplicate artifact IDs");
+  return selected;
+}
+
+// No extraction: reject additional entries, paths, links, encryption and zip bombs.
+// object_pairs_hook also rejects duplicate JSON keys before JS can discard them.
+export function decodeDurationArtifact(bytes, label) {
+  if (!LABELS.includes(label)) fail("invalid archive label");
+  const buffer = Buffer.from(bytes);
+  if (buffer.length === 0 || buffer.length > LIMIT) fail("invalid ZIP size");
+  const script = `
+import io,json,stat,sys,zipfile
+limit=${LIMIT}
+def pairs(items):
+    result={}
+    for key,value in items:
+        if key in result: raise ValueError('duplicate JSON key')
+        result[key]=value
+    return result
+def constant(value): raise ValueError('non-finite JSON number')
+with zipfile.ZipFile(io.BytesIO(sys.stdin.buffer.read(limit+1))) as archive:
+    entries=archive.infolist()
+    if len(entries)!=1: raise ValueError('expected one JSON entry')
+    entry=entries[0]
+    mode=(entry.external_attr >> 16) & 0xffff
+    if (entry.filename!=sys.argv[1] or entry.is_dir() or entry.flag_bits & 1
+        or stat.S_ISLNK(mode) or stat.S_IFMT(mode) not in (0,stat.S_IFREG)
+        or entry.file_size<=0 or entry.file_size>limit
+        or entry.compress_size<=0 or entry.compress_size>limit):
+        raise ValueError('invalid ZIP entry')
+    with archive.open(entry) as stream: data=stream.read(limit+1)
+    if len(data)>limit or len(data)!=entry.file_size: raise ValueError('invalid expanded size')
+    value=json.loads(data.decode('utf-8'),object_pairs_hook=pairs,parse_constant=constant)
+    sys.stdout.write(json.dumps(value,allow_nan=False,separators=(',',':')))
+`;
+  return JSON.parse(execFileSync("python3", ["-c", script, `target-durations-${label}.json`], {
+    input: buffer, timeout: 15000, maxBuffer: LIMIT * 4,
+  }).toString("utf8"));
+}
+
+export function validateDurationReports(reports, { run, pr, repositoryId, testedMergeSha, legacy = false }) {
+  if (!Array.isArray(reports) || reports.length !== 3 || !SHA.test(testedMergeSha || "")
+    || !SHA.test(run?.head_sha || "") || !ID.test(String(run?.id || ""))
+    || !Number.isSafeInteger(pr?.number) || pr.number <= 0
+    || !Number.isSafeInteger(run.run_attempt) || run.run_attempt <= 0
+    || (legacy && (pr.head?.repo?.id !== repositoryId || run.run_attempt !== 1))) fail("invalid report context");
+  const labels = new Set();
+  const keys = { targets: new Set(), cases: new Set(), test_cases: new Set() };
+  const schemas = new Set();
+  const output = reports.map((report) => {
+    if (!record(report) || !LABELS.includes(report.archive_label) || labels.has(report.archive_label)
+      || ![1, 2].includes(report.schema_version) || (!legacy && report.schema_version !== 2)) fail("invalid report schema or label");
+    labels.add(report.archive_label);
+    schemas.add(report.schema_version);
+    if (report.run_id !== String(run.id) || report.ref !== `refs/pull/${pr.number}/merge`
+      || report.sha !== testedMergeSha) fail("report run/ref/tested merge SHA mismatch");
+    if (!legacy && (report.run_attempt !== String(run.run_attempt)
+      || report.repository_id !== String(repositoryId) || report.repository !== run.repository.full_name
+      || report.pull_number !== String(pr.number) || report.head_repository_id !== String(pr.head.repo.id)
+      || report.head_sha !== run.head_sha || report.head_ref !== pr.head.ref)) fail("report PR/repository/attempt/head mismatch");
+    const normalized = { schema_version: report.schema_version, archive_label: report.archive_label,
+      run_id: report.run_id, ref: report.ref, sha: report.sha };
+    if (!legacy) Object.assign(normalized, { run_attempt: report.run_attempt, repository_id: report.repository_id,
+      repository: report.repository, pull_number: report.pull_number, head_repository_id: report.head_repository_id,
+      head_sha: report.head_sha, head_ref: report.head_ref });
+    for (const field of report.schema_version === 2 ? ["targets", "cases", "test_cases"] : ["targets"]) {
+      if (!record(report[field])) fail(`invalid ${field} dictionary`);
+      const entries = Object.entries(report[field]);
+      if (!entries.length || entries.length > 50000) fail(`invalid ${field} count`);
+      for (const [name, seconds] of entries) {
+        if (name.length > 512 || !NAME.test(name) || ["__proto__", "constructor", "prototype"].includes(name)
+          || !Number.isFinite(seconds) || seconds <= 0 || seconds > 86400 || keys[field].has(name)) {
+          fail(`invalid or duplicate ${field} entry`);
+        }
+        keys[field].add(name);
+      }
+      normalized[field] = Object.fromEntries(entries);
+    }
+    if (report.schema_version === 2) {
+      for (const name of Object.keys(normalized.test_cases)) {
+        const separator = name.indexOf("::");
+        if (separator < 1 || !Object.hasOwn(normalized.targets, name.slice(0, separator))) fail("unknown testcase target");
+        const target = name.slice(0, separator);
+        const test = name.slice(separator + 2);
+        const sourceCase = target.startsWith("regression_suite_") ? test.split("::")[0] : target;
+        if (!Object.hasOwn(normalized.cases, sourceCase)) fail("unknown testcase source case");
+      }
+    }
+    return normalized;
+  });
+  if (labels.size !== 3 || schemas.size !== 1) fail("incomplete or mixed B/C/D schemas");
+  return output.sort((a, b) => a.archive_label.localeCompare(b.archive_label));
+}

--- a/scripts/verify-trusted-postmerge-ci-reuse.mjs
+++ b/scripts/verify-trusted-postmerge-ci-reuse.mjs
@@ -72,6 +72,7 @@ function enforcementPathChanged(files) {
     || path === "scripts/select-nextest-archive-targets.mjs"
     || path === "scripts/collect-nextest-target-durations.mjs"
     || path === "scripts/refresh-nextest-target-duration-policy.mjs"
+    || path === "scripts/trusted-postmerge-duration-evidence.mjs"
     || path === "scripts/verify-trusted-postmerge-ci-reuse.mjs"
     || path === "tests/suites/nextest-target-duration-policy.json"
   ));
@@ -355,7 +356,8 @@ function latestCandidateRun(runs, pullRequest, repository, candidateSha, reposit
     trustedPullRequestWorkflowRun(run, pullRequest, repository, repositoryId, workflowFile)
     && run?.head_sha === candidateSha
     && timestamp(run.created_at) >= createdAt
-    && timestamp(run.updated_at) <= mergedAt
+    // Do not hide a newer rerun just because it completed after the merge.
+    // Select it first, then reject non-pre-merge evidence at the caller.
   ));
   if (matches.length === 0) {
     return null;
@@ -575,6 +577,10 @@ export function evaluateTrustedPostMergeReuse(input) {
     || finalHeadCandidate.conclusion !== "success") {
     return denied("final-head-pr-workflow-not-successful");
   }
+  if (!Number.isFinite(timestamp(finalHeadCandidate.updated_at))
+    || timestamp(finalHeadCandidate.updated_at) > timestamp(pullRequest.merged_at)) {
+    return denied("final-head-pr-workflow-not-completed-before-merge");
+  }
   const exactMergeTreeEvidence = hasExactMergeTreeEvidence(
     input,
     finalHeadCandidate,
@@ -694,6 +700,10 @@ export function evaluateTrustedPostMergeReuse(input) {
     // A newer failed or incomplete candidate must not be hidden by older green runs.
     if (candidate.status !== "completed" || candidate.conclusion !== "success") {
       return denied("latest-pr-workflow-candidate-not-successful");
+    }
+    if (!Number.isFinite(timestamp(candidate.updated_at))
+      || timestamp(candidate.updated_at) > timestamp(pullRequest.merged_at)) {
+      return denied("latest-pr-workflow-candidate-not-completed-before-merge");
     }
     if (!hasFullLaneEvidence(input, candidate)) {
       continue;


### PR DESCRIPTION
## 변경 요약

- CodeQL 언어별 Analyze 성공과 exact SHA·GHAS 발행자·시각 검증을 유지하면서 post-merge GHAS `success/neutral` 판정을 PR preflight와 일치시킵니다.
- upstream에서 실행되는 devel 대상 fork PR도 read-only worker에서 B/C/D duration을 발행합니다. run/attempt·PR·저장소·head·tested merge SHA를 증거에 결합합니다.
- read-only verifier에서 artifact ID·만료·크기와 ZIP/JSON 구조·provenance·수치·중복을 검증합니다. write-capable refresh job에는 현재 run/attempt의 정규화 JSON만 전달합니다. 발행 실패 시 재사용을 거부합니다.
- 최신 실패·취소·대기 또는 merge 후 완료된 재실행을 과거 성공으로 우회하지 않습니다.
- 새 helper는 enforcement surface에 포함하고 이전 devel 부모에서 로드합니다. 자신의 새 검증기로 자신을 승인하지 않습니다.

## 관련 이슈

Refs #6901

실제 배포 후 fork full → 문서 trailing commit → merge 재사용 실증이 남아 있어 자동 종료하지 않습니다.

## 검증

- 변경 범위: GitHub Actions, JavaScript/Python 계약, 분석 문서. Rust/Studio 제품 소스 변경 없음.
- 검증 후 커밋: `158c80285`.
- JavaScript **318개 통과**, 실패 0, 건너뜀 0.
- Python **109개 통과**.

```sh
node --test --test-reporter=tap \
  scripts/tests/verify-trusted-postmerge-ci-reuse.test.mjs \
  scripts/tests/verify-trusted-postmerge-ci-reuse-squash.test.mjs \
  scripts/tests/verify-trusted-postmerge-review-bridge.test.mjs \
  scripts/tests/nextest-target-duration-policy.test.mjs
python3 -m unittest \
  scripts.tests.test_trusted_postmerge_ci_reuse_workflow \
  scripts.tests.test_nextest_archive_workflow \
  scripts.tests.test_codeql_workflow \
  scripts.tests.test_review_only_fast_pass_workflows \
  scripts.tests.test_ci_impact_workflow
```

실제 workflow github-script와 실제 Git 객체·ZIP을 사용했습니다. GitHub API/네트워크는 모의 응답이므로 실제 Actions 결과와 구분합니다. 잘못된 저장소/head/attempt, 누락·만료·변조 artifact, 안전하지 않은 ZIP 및 최신 실패 실행의 재사용 거부도 포함합니다. 테스트 로그·임시 산출물은 커밋하지 않았습니다.

Rust 변경이 없어 Cargo 전체 회귀·Clippy·WASM 빌드는 수행하지 않았습니다. 이미 통과한 계약 테스트는 PR 생성 단계에서 중복 실행하지 않았습니다.

## 잔여 검증과 주의사항

- CI enforcement 변경 PR이므로 이 PR 자체의 full lane은 예상 동작입니다.
- 배포 후 실제 fork PR에서 full → 문서 trailing → merge, heavy worker skip, duration refresh 및 CodeQL/Adapter/Proptest 결과를 확인해야 합니다.
- GHAS neutral의 configuration warning 자체를 해결하거나 alert 비교 완료로 간주하지 않습니다.
- 성능 단축 수치는 실환경 미측정입니다.
- PR review와 오늘할일은 CI 결과를 확인한 뒤 같은 PR의 문서 trailing commit으로 기록합니다.

분석·코드 보정·로컬 검증 기록: [Stage 1](https://github.com/edwardkim/rhwp/blob/158c80285/mydocs/working/task_m100_6901_codeql_neutral_stage1.md)
