### PR TITLE
Task #7008: 칸 안 중첩 표 높이를 줄 단위로 센다

### DIFF
--- a/src/renderer/float_placement.rs
+++ b/src/renderer/float_placement.rs
@@ -539,26 +539,61 @@ pub(crate) fn signed_hwpunit(value: HwpUnit) -> i32 {
     value as i32
 }
 
-/// [#6787] 이 문단의 중첩 표들이 **가로 오프셋으로 나란히** 놓이는 무리인가.
+/// [#7008] 문단의 중첩 표가 **어느 줄에 속하는가** — `para.controls` 와 같은 길이로,
+/// 표가 아닌 컨트롤 자리는 `None`.
 ///
-/// 문단-기준(`VertRelTo::Para`) 자리차지(`TopAndBottom`) 비-TAC 표들이 각자
-/// `horzOffset` 을 갖고 **가로로 겹치지 않으면** 한/글은 같은 y 에 놓는다
-/// (`#6494` 의 칸 안 짝). 하나라도 조건을 벗어나면 종전대로 세로 적층으로 본다.
+/// 줄 소속을 추측하지 않는다. 저장 `LINE_SEG` 사다리가 있으면 **그 소속을 보존**하고
+/// (`control_text_positions()` 의 문자 위치를 `LineSeg.text_start` 구간에 넣는다),
+/// 사다리가 없는 문단은 `None` 을 돌려 호출자가 재조판 경로로 가게 한다.
+///
+/// 이 매핑이 있으면 문단 높이는 "줄별 점유 높이의 합" 으로 계산된다 — 같은 줄의 표를
+/// 세로로 합산하지 않고, 여러 줄이면 각 줄이 제 몫을 낸다.
+pub(crate) fn para_nested_table_line_indices(para: &Paragraph) -> Option<Vec<Option<usize>>> {
+    if para.line_segs.is_empty() || crate::renderer::para_has_no_stored_line_segs(para) {
+        return None;
+    }
+    let positions = para.control_text_positions();
+    let mut out = vec![None; para.controls.len()];
+    for (ci, ctrl) in para.controls.iter().enumerate() {
+        if !matches!(ctrl, Control::Table(_)) {
+            continue;
+        }
+        let pos = positions.get(ci).copied().unwrap_or(0);
+        // 이 문자를 담는 마지막 줄 — 저장 사다리가 정한 소속이다.
+        let line = para
+            .line_segs
+            .iter()
+            .rposition(|seg| (seg.text_start as usize) <= pos)
+            .unwrap_or(0);
+        out[ci] = Some(line);
+    }
+    Some(out)
+}
+
+/// [#6787] 한 **줄**에 놓인 중첩 표들이 나란히 놓이는 무리인가 — 즉 그 줄이 예약해야 할
+/// 높이가 합이 아니라 **최댓값**인가.
+///
+/// 나란히 놓이는 길은 둘이다.
+///
+/// - **글줄 안 순서**(`#7008`) — 글자처럼 취급되는 표는 글줄 흐름에 참여하므로, 같은
+///   줄에 있다는 것 자체가 나란함이다. 오프셋을 쓰지 않는다.
+/// - **가로 오프셋**(`#6787`) — 문단-기준(`VertRelTo::Para`) 자리차지(`TopAndBottom`)
+///   비-TAC 표들이 각자 `horzOffset` 을 갖고 **가로로 겹치지 않으면** 한/글은 같은 y 에
+///   놓는다(`#6494` 의 칸 안 짝). 하나라도 조건을 벗어나면 세로 적층으로 본다.
 ///
 /// ⭐ **측정(`height_measurer`)과 배치(`table_layout`)가 이 하나의 판정을 함께 쓴다** —
 /// 두 축이 문자 그대로 같은 함수를 부르므로 발동 조건이 갈리는 일이 구조적으로 없다.
 /// (그 비대칭이 `#6787` 의 실제 결함이었다.)
-/// 종전에는 측정만 `horzOffset == 0` 을 무리의 시작으로 인정하고 배치는 `> 0` 만
-/// 레인에 넣어, 첫 표 오프셋이 0 인 무리에서 측정은 최대 높이만 예약하고 배치는
-/// 세로로 쌓아 뒤 표가 칸 밖으로 사라졌다. 또 배치는 표를 순차 처리하며 뒤 표가
-/// 조건에 걸리면 앞 표의 레인을 되돌리지 못했다 — 문단 단위 사전 판정으로 두 축을
-/// 함께 닫는다.
-pub(crate) fn para_float_group_is_side_by_side(para: &Paragraph) -> bool {
+pub(crate) fn line_nested_table_group_is_side_by_side(tables: &[&Table]) -> bool {
+    if tables.len() < 2 {
+        return false;
+    }
+    // 글자처럼 취급되는 표들은 같은 줄에 있다는 사실만으로 나란하다.
+    if tables.iter().all(|table| table.common.treat_as_char) {
+        return true;
+    }
     let mut spans: Vec<(i32, i32)> = Vec::new();
-    for ctrl in &para.controls {
-        let Control::Table(table) = ctrl else {
-            continue;
-        };
+    for table in tables {
         if !para_float_group_member_is_eligible(table) {
             return false;
         }
@@ -566,12 +601,22 @@ pub(crate) fn para_float_group_is_side_by_side(para: &Paragraph) -> bool {
         let width = table.common.width.min(i32::MAX as u32) as i32;
         spans.push((start, start.saturating_add(width)));
     }
-    if spans.len() < 2 {
-        return false;
-    }
     spans.sort_unstable();
     // 가로 구간이 하나라도 겹치면 나란히 놓을 수 없다.
     spans.windows(2).all(|w| w[0].1 <= w[1].0 + 1)
+}
+
+/// 저장 사다리가 없어 줄 소속을 모르는 문단의 폴백 — 문단 전체를 한 무리로 본다.
+pub(crate) fn para_float_group_is_side_by_side(para: &Paragraph) -> bool {
+    let tables: Vec<&Table> = para
+        .controls
+        .iter()
+        .filter_map(|ctrl| match ctrl {
+            Control::Table(table) => Some(table.as_ref()),
+            _ => None,
+        })
+        .collect();
+    line_nested_table_group_is_side_by_side(&tables)
 }
 
 /// 나란히 무리의 자격 — 무리 판정과 레인 배치가 **같은 술어**를 쓴다.

--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -1905,17 +1905,23 @@ impl HeightMeasurer {
             .iter()
             .enumerate()
             .map(|(pidx, p)| {
-                // [#6787] 같은 문단의 문단-기준 자리차지 중첩 표들이 **가로 오프셋으로
-                // 나란히** 놓이면 높이는 합이 아니라 **최댓값**이다(`#6494` 의 칸 안 짝).
-                // 16774617 1쪽 후보자 카드 2장(`horz=Para(1547)` / `Para(23743)`, 각
-                // 253.2px)은 서로 겹치지 않아 한/글이 같은 y 에 놓는다 — 합산하면 그 칸이
-                // 선언 251.97px 대비 854.7px 로 부풀어 표 전체가 용지를 넘고 361자가 잘린다.
-                let nested_side_by_side =
-                    crate::renderer::float_placement::para_float_group_is_side_by_side(p);
-                let nested_heights: Vec<f64> = p
+                // [#7008] 문단 높이는 **줄별 점유 높이의 합**이다. 같은 줄에 놓인 표를
+                // 세로로 합산하지 않고, 여러 줄이면 각 줄이 제 몫을 낸다.
+                //
+                // 줄 소속은 추측하지 않는다 — 저장 `LINE_SEG` 사다리가 그것을 증언하고
+                // (`para_nested_table_line_indices`), 사다리가 없는 문단만 종전처럼
+                // 문단 전체를 한 무리로 본다. 그 한 줄 무리가 나란한지는 측정과 배치가
+                // 함께 쓰는 `line_nested_table_group_is_side_by_side` 가 가른다.
+                //
+                // [#6787] 16774617 1쪽 후보자 카드 2장(`horz=Para(1547)` / `Para(23743)`,
+                // 각 253.2px)은 가로로 겹치지 않아 한/글이 같은 y 에 놓는다 — 합산하면
+                // 그 칸이 선언 251.97px 대비 854.7px 로 부풀어 361자가 잘린다.
+                let line_of = crate::renderer::float_placement::para_nested_table_line_indices(p);
+                let measured: Vec<(usize, &crate::model::table::Table, f64)> = p
                     .controls
                     .iter()
-                    .filter_map(|ctrl| {
+                    .enumerate()
+                    .filter_map(|(ci, ctrl)| {
                         if let Control::Table(nested) = ctrl {
                             let stretch =
                                 self.render_normalization.nested_table_width_scale(nested);
@@ -1926,17 +1932,39 @@ impl HeightMeasurer {
                             // [#2169] om 가산은 additive 경로(cell_controls_height)
                             // 전담 — vpos 기반 max 경로는 저장 vpos 가 배치를 이미
                             // 반영하므로 미가산 (자기-export HWPX 왕복 이중가산 방지).
-                            Some(mt.total_height.max(declared))
+                            let line = line_of
+                                .as_ref()
+                                .and_then(|v| v.get(ci).copied().flatten())
+                                .unwrap_or(0);
+                            Some((line, nested.as_ref(), mt.total_height.max(declared)))
                         } else {
                             None
                         }
                     })
                     .collect();
-                let nested_h: f64 = if nested_side_by_side {
-                    nested_heights.iter().copied().fold(0.0, f64::max)
-                } else {
-                    nested_heights.iter().sum()
-                };
+                let mut nested_h = 0.0f64;
+                let mut line_idx = 0usize;
+                while !measured.is_empty() {
+                    let group: Vec<&(usize, &crate::model::table::Table, f64)> =
+                        measured.iter().filter(|(l, _, _)| *l == line_idx).collect();
+                    if !group.is_empty() {
+                        let tables: Vec<&crate::model::table::Table> =
+                            group.iter().map(|(_, t, _)| *t).collect();
+                        let side_by_side =
+                            crate::renderer::float_placement::line_nested_table_group_is_side_by_side(
+                                &tables,
+                            );
+                        nested_h += if side_by_side {
+                            group.iter().map(|(_, _, h)| *h).fold(0.0, f64::max)
+                        } else {
+                            group.iter().map(|(_, _, h)| *h).sum::<f64>()
+                        };
+                    }
+                    line_idx += 1;
+                    if line_idx > measured.iter().map(|(l, _, _)| *l).max().unwrap_or(0) {
+                        break;
+                    }
+                }
                 if nested_h <= 0.0 {
                     0.0
                 } else {

--- a/tests/cases/issue_7008_cell_tac_nested_side_by_side.rs
+++ b/tests/cases/issue_7008_cell_tac_nested_side_by_side.rs
@@ -1,0 +1,140 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! [Issue #7008] 칸 안 **글자처럼 취급되는** 중첩 표 둘을 측정만 세로로 쌓아 세서,
+//! 칸이 부풀고 바깥 표가 17.0px 내려와 본문 첫 글줄 위에 괘선이 겹쳤다.
+//!
+//! `21_언어_기출_편집가능본.hwp` 1쪽 머리 표(s0 p0 c2)의 칸 `r2c1` 은 저장 사다리가
+//! **줄 하나**(`vpos 0, lh 3015`)뿐인데 그 줄에 TAC 중첩 표 둘이 들어 있다.
+//!
+//! ```text
+//!   A  14174 x 2449  tac=true  horzOffset=0  outMargin 283/283/283/283  (밴드 3015 = 줄 높이)
+//!   B  21384 x 2448  tac=true  horzOffset=0  outMargin 0
+//!   칸 선언 47274 x 3768 (630.3 x 50.2px)
+//! ```
+//!
+//! ⭐ **배치는 이미 나란히 놓는다** — 칸 TAC 분기는 `inline_x` 만 전진시키고 문단
+//! 커서는 `max(para_y_before_compose + table_h)` 로만 올린다. 측정만
+//! `nested_heights.iter().sum()` 으로 2449+2448 = 65.3px 를 요구했다(최댓값이면
+//! 32.7px). `#6787` 이 고친 측정·배치 비대칭의 TAC 판이다.
+//!
+//! 한/글 2022 기준(`pdf/21_언어_기출_편집가능본-2022.pdf` 1쪽): 머리 표 하단 괘선
+//! `314.7`, 표 높이 `183.1px`, 본문 오른쪽 단 첫 글줄 상단 `326.1`.
+
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+const SAMPLE: &str = "samples/21_언어_기출_편집가능본.hwp";
+
+fn page0() -> rhwp::renderer::render_tree::PageRenderTree {
+    let p = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let core = DocumentCore::from_bytes(&std::fs::read(p).expect("표본 읽기")).expect("문서 로드");
+    core.build_page_render_tree(0).expect("1쪽 render tree")
+}
+
+fn tables(node: &RenderNode, out: &mut Vec<(f64, f64, f64, f64)>) {
+    if matches!(node.node_type, RenderNodeType::Table { .. }) {
+        out.push((node.bbox.x, node.bbox.y, node.bbox.width, node.bbox.height));
+    }
+    for child in &node.children {
+        tables(child, out);
+    }
+}
+
+/// 머리 표 = 1쪽에서 가장 넓은 표.
+fn head_table(tree: &rhwp::renderer::render_tree::PageRenderTree) -> (f64, f64, f64, f64) {
+    let mut all = Vec::new();
+    tables(&tree.root, &mut all);
+    all.into_iter()
+        .max_by(|a, b| a.2.partial_cmp(&b.2).unwrap())
+        .expect("머리 표")
+}
+
+/// 머리 표 안의 TAC 중첩 표 둘(「성명」·「수험번호」 상자).
+fn nested_boxes(tree: &rhwp::renderer::render_tree::PageRenderTree) -> Vec<(f64, f64, f64, f64)> {
+    let head = head_table(tree);
+    let mut all = Vec::new();
+    tables(&tree.root, &mut all);
+    let mut inner: Vec<_> = all
+        .into_iter()
+        .filter(|t| t.2 < head.2 && t.1 >= head.1 && t.1 <= head.1 + head.3)
+        .collect();
+    inner.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+    inner
+}
+
+/// 전제 — 두 상자는 세로로 쌓인 적이 없다. 가로로 떨어져 **같은 띠**를 나눠 갖는다.
+///
+/// 이 시험이 무너지면 아래 두 시험의 "합이 아니라 최댓값" 논거가 통째로 사라진다.
+#[test]
+fn the_two_tac_boxes_share_one_band() {
+    let tree = page0();
+    let boxes = nested_boxes(&tree);
+    assert_eq!(boxes.len(), 2, "머리 표 안 중첩 표 2개: {boxes:?}");
+
+    let (ax, ay, aw, ah) = boxes[0];
+    let (bx, by, _bw, bh) = boxes[1];
+    assert!(
+        bx >= ax + aw,
+        "두 상자는 가로로 떨어져 있다: A x {ax:.1}+{aw:.1}, B x {bx:.1}"
+    );
+    let overlap = (ay + ah).min(by + bh) - ay.max(by);
+    assert!(
+        overlap > ah * 0.8,
+        "두 상자는 같은 띠를 나눠 가져야 한다 (겹침 {overlap:.1}px / 높이 {ah:.1}px): {boxes:?}"
+    );
+}
+
+/// 칸 높이는 두 상자의 **합**이 아니라 **최댓값**이라, 머리 표가 선언 높이를 지킨다.
+///
+/// 수정 전 `200.1px` (한/글 `183.1px` 대비 **+17.0**).
+#[test]
+fn head_table_keeps_its_declared_height() {
+    let tree = page0();
+    let (_x, _y, _w, h) = head_table(&tree);
+    assert!(
+        (h - 183.1).abs() <= 2.0,
+        "머리 표 높이가 한/글 183.1px 와 맞아야 한다 — #7008 회귀          \
+         (실측 {h:.1}px; 수정 전 200.1px = 중첩 표 2449+2448 합산)"
+    );
+}
+
+/// 머리 표 하단 괘선이 본문 오른쪽 단 첫 글줄 **위**에 있어야 한다.
+///
+/// 수정 전 표 하단 `331.8` vs 첫 글줄 `329.9` — 1.9px 덮었다(그려진 괘선은 `331.0`).
+/// 한/글은 괘선 `314.7` vs 글자 상자 `326.1` 로 11.4px 띄운다.
+#[test]
+fn head_table_does_not_overlap_the_first_body_line() {
+    let tree = page0();
+    let (_x, y, _w, h) = head_table(&tree);
+    let table_bottom = y + h;
+
+    // 오른쪽 단의 첫 **본문** 글줄 — 표 안 글줄(「홀수형」 등)은 세지 않도록
+    // 표 노드에서 가지를 끊는다.
+    let mut first_line = f64::INFINITY;
+    fn scan(node: &RenderNode, x_min: f64, out: &mut f64) {
+        if matches!(node.node_type, RenderNodeType::Table { .. }) {
+            return;
+        }
+        if matches!(node.node_type, RenderNodeType::TextLine { .. })
+            && node.bbox.x > x_min
+            && node.bbox.height > 0.0
+        {
+            *out = out.min(node.bbox.y);
+        }
+        for child in &node.children {
+            scan(child, x_min, out);
+        }
+    }
+    scan(&tree.root, 560.0, &mut first_line);
+    assert!(
+        first_line.is_finite(),
+        "오른쪽 단 첫 글줄을 찾아야 한다 (표 하단 {table_bottom:.1})"
+    );
+    assert!(
+        table_bottom <= first_line,
+        "머리 표 하단 괘선이 본문 첫 글줄을 덮는다 — #7008 회귀          \
+         (표 하단 {table_bottom:.1} vs 글줄 {first_line:.1}; 수정 전 331.8 vs 329.9)"
+    );
+}


### PR DESCRIPTION
관련 이슈: #7008

검토 의견 감사합니다. 지적하신 세 가지를 모두 반영해 다시 올립니다. 조건을 더 붙여 대상을 좁히는 대신 **추측 자체를 걷어내는** 방향으로 바꿨고, 래칫 완화는 **더 이상 필요하지 않아 통째로 뺐습니다**.

## 문제

표 칸 안에 중첩 표가 여러 개 있을 때, 측정이 그것들을 무조건 세로로 합산한다. 같은 줄에 놓인 표까지 합산되어 칸이 부풀고, 그 부풀음이 바깥 표를 밀어 본문 첫 글줄 위에 괘선이 겹친다.

![21_언어_기출 1쪽 비교](https://raw.githubusercontent.com/lpaiu-cs/rhwp/assets/7008-line-grouping/img-a-21.png)

## 원인

`renderer/height_measurer.rs` 의 칸 중첩 표 높이 계산이 **문단 단위**로만 판정했다. 문단 전체가 "나란한 무리" 이거나 아니거나 둘 중 하나여서, 표가 실제로 어느 줄에 속하는지는 보지 않았다.

종전 PR 의 구현도 그 틀 안에 있었다 — 문단의 표가 둘 이상이고 모두 `treat_as_char` 이면 한 줄로 간주했다. 지적하신 대로 **"글자처럼 취급" 은 표가 글줄 흐름에 참여한다는 속성이지 같은 줄이라는 보장이 아니다.**

## 변경

**줄 소속을 추측하지 않고 결정한다.**

```rust
// 종전 — 문단 단위 추측
para_float_group_is_side_by_side(para) -> bool     // all(tac) 이면 한 줄로 간주

// 지금 — 줄 소속은 저장 LINE_SEG 가 증언한다
para_nested_table_line_indices(para) -> Option<Vec<Option<usize>>>
    // control_text_positions() 의 문자 위치를 LineSeg.text_start 구간에 넣어 보존
    // 사다리가 없는 문단만 None → 호출자가 종전 폴백

// 한 줄 안에서 나란한지는 측정과 배치가 함께 쓰는 하나의 술어가 가른다
line_nested_table_group_is_side_by_side(&[&Table]) -> bool
    // TAC   → 같은 줄에 있다는 사실 자체가 나란함 (오프셋을 쓰지 않는다)
    // 비-TAC → #6787 의 가로 구간 규칙 그대로
```

**문단 높이는 줄별 점유 높이의 합**이 된다. 같은 줄의 표를 세로로 합산하지 않고, 여러 줄이면 각 줄이 제 몫을 낸다. 종전의 "문단 전체가 무리냐 아니냐" 이분법이 없어졌다.

조건이 늘지 않고 **줄었다** — `treat_as_char` 가정이 사라지고, 판정은 줄 단위 술어 하나로 모인다.

**래칫 픽스처 변경은 뺐다.** 종전 PR 이 올린 `body_overflow_baseline` 2건은 지금 devel 에서 불필요하다(아래 실측).

회귀 테스트 `tests/cases/issue_7008_cell_tac_nested_side_by_side.rs`.

## 검증

devel `a192396cb` 기준. 기준값은 저장소의 한/글 PDF 를 `PyMuPDF` 로 읽어 뽑았다(PDF pt × 96/72). 아래 이미지 세 장은 rhwp `export-svg` 와 한/글 PDF 를 **같은 파이프라인**(PyMuPDF 래스터)으로 같은 px 좌표에서 자른 것이다.

### 한/글 실측 — 같은 줄에 여러 표

| 표본 | 항목 | 한/글 | devel | 이 PR |
|---|---|---:|---:|---:|
| `21_언어_기출_편집가능본.hwp` | 머리 표 높이 | 183.1 | 200.1 | **183.2** |
| | 하단 괘선 y | 314.7 | 331.0 | **314.1** |
| | 괘선 ↔ 본문 첫 글줄 | +11.4 | **−1.1 (겹침)** | **+15.8** |
| `issue6787/16774617` (회귀) | 카드 2장 y | 같음 | 같음 | **같음 (307.60)** |

### 표적 칸이 선언 높이로 돌아온다

![36395325_gyeoljae 결재 블록](https://raw.githubusercontent.com/lpaiu-cs/rhwp/assets/7008-line-grouping/img-b-gyeoljae.png)

| 표본 | 칸 선언 | devel | 이 PR |
|---|---:|---:|---:|
| `task2243/36395325_gyeoljae_consulting.hwpx` | 201.1 | 206.8 | **201.1** |
| `task1706/empty_para_before_pagebreak.hwpx` | 201.1 | 231.8 | **201.1** |

![empty_para 하단](https://raw.githubusercontent.com/lpaiu-cs/rhwp/assets/7008-line-grouping/img-c-emptypara.png)

### 래칫 — 완화가 필요 없다

종전 PR 이 `body_overflow_baseline` 에 올린 2건은 지금 devel 에서 **발생하지 않는다.** devel `a192396cb` 바이너리와 이 PR 바이너리로 두 문서의 **전 쪽**을 `layout-anomaly --overflow-tolerance 2.0` 으로 세었다.

```
                                 devel    이 PR
36395325_gyeoljae (5쪽)            0건      0건
empty_para_before_pagebreak (3쪽)  0건      0건
```

종전 측정은 devel `6806950b1` 기준이었고, 그 뒤 devel 이 움직이며 해당 넘침이 독립적으로 사라졌다. 그래서 픽스처 변경을 되돌렸다 — 이 PR 의 `tests/fixtures/` 차이는 **0줄**이다.

### 줄 구성 — 무엇을 재고 무엇을 못 쟀나

요청하신 네 경우 중 둘은 표본이 있고 둘은 없다. 구분해 적는다.

| 경우 | 근거 |
|---|---|
| 같은 줄에 여러 표 | **한/글 실측** — 위 표 |
| 앞뒤 텍스트·여백이 있는 경우 | **한/글 실측** — `21_언어` 칸 `r2c1` 은 표 앞뒤로 텍스트가 있고 두 표의 바깥여백이 `283/283` 과 `0/0` 로 다르다 |
| 명시적 개행으로 나뉜 표 | **표본 없음** |
| 너비 부족으로 다음 줄에 놓인 표 | **표본 없음** |

`samples/` 전수 **1,038건**을 훑어, 칸 안에 중첩 표가 둘 이상인 문단을 찾고 그중 저장 줄이 2개 이상인 것을 골랐다. **적중 2건**이고 둘 다 두 표가 **같은 줄**에 속한다.

```
issue5712/3184241_medical_exam_equipment.hwpx     줄 2개 · 표 2개(tac 1) · 줄소속 [0, 0]
issue6892/156726122-recycling-press-release.hwpx  줄 2개 · 표 2개(tac 2) · 줄소속 [0, 0]
```

즉 **표가 서로 다른 줄에 놓인 정상 문서가 저장소에 없어**, "줄 사이는 합" 경로에 대한 한/글 증거를 만들 수 없었다. 그 경로는 코드 계약으로만 성립하며 한/글 출력에 대한 증거가 아니라는 점을 분명히 해 둔다.

### 게이트

전체 Rust 회귀 **9,504 통과 / 실패 0 / 건너뜀 46**. `cargo fmt --all -- --check` 통과, clippy 세 단계(`--lib --tests` · `-p rhwp --lib --target wasm32-unknown-unknown` · `--workspace --all-targets`) 모두 `-D warnings` 무경고, `rust-test-suite-manifest.mjs --check` 통과, `rust-unit-test-tiers.mjs --check --base-ref origin/devel` 통과.

## 범위 외

- **겉표의 행 재분배.** 표적 칸이 줄면 같은 겉표의 다른 행이 늘어 표 전체는 오히려 커진다(`gyeoljae` 892.8 → 900.8px, `empty_para` 850.2 → 858.2px). 그 경로는 이 PR 이 건드리지 않았고 재지 않았다.
- **표들의 절대 y.** 위 수치 중 칸·표 높이는 선언값 대조이고, 개체의 절대 y 가 한/글과 맞는지는 줄이 칸 어디에 앉는지(칸 `vertical_align`)에 달려 있어 재지 않았다.
- **저장 사다리가 없는 문단.** `para_nested_table_line_indices` 가 `None` 을 돌려 종전 문단 단위 폴백으로 간다. 재조판 결과로 줄 소속을 정하는 경로는 이번 범위에 넣지 않았다.
