### PR TITLE
docs: PR #7039 배포 결과와 fork 재사용 잔여 검증 기록

### DIFF
--- a/mydocs/orders/20260911.md
+++ b/mydocs/orders/20260911.md
@@ -119,3 +119,11 @@
 - 코드 CI 완료 뒤 이 기록·리뷰·PR 절차 문서를 같은 PR의 문서 전용 trailing commit으로 추가한다. 최신 upstream/devel의 오늘할일을 읽고 기존 내용을 보존하며, 문서 갱신만을 위한 source merge·rebase는 하지 않는다.
 - 원격 임시 head branch는 post-merge 안전 조건을 충족하면 별도 승인 질문 없이 정리하도록 지침을 보완했다. 기여자 fork·기본/보호 branch·다른 작업 branch는 보존한다.
 - 문서 head CI, merge 및 devel CI, #5551 comment·close와 branch/전용 target 정리는 후속 단계이며 아직 완료 사실로 기록하지 않는다.
+
+## #6901 / PR #7039: post-merge 신뢰 계약 보완 배포
+
+- [PR #7039](https://github.com/edwardkim/rhwp/pull/7039)를 `ddc7bdf229db7f61fdeefee106fd1787c8964995`로 devel에 병합했다. [검토 기록](../pr/archives/pr_7039_review.md).
+- 로컬 JavaScript 318개·Python 109개 통과. PR CI·CodeQL·Adapter·Proptest와 merge SHA의 devel CI·CodeQL·Adapter·Proptest·Close Issues 성공을 확인했다. devel archive A/B/C/D와 duration refresh가 실제 성공했다.
+- CI enforcement 변경이므로 이 배포의 full lane은 예상 동작이다. #6901을 자동 close하지 않으며 실제 fork 재사용 실증과 구분한다.
+- 검증 대상 원 fork PR #7037에 최신 devel을 반영했다. 정렬 후 CI는 이전 source 성공을 fast-pass로 재사용해 B/C/D duration을 발행하지 않았다. 새 full 실행·문서 trailing·post-merge 재사용까지 확인해야 한다.
+- 이번 후속 기록은 Markdown 두 파일만 포함한다. #7037 기능/테스트/시각 증적을 이 문서 PR에 섞지 않는다.

--- a/mydocs/pr/archives/pr_7039_review.md
+++ b/mydocs/pr/archives/pr_7039_review.md
@@ -1,0 +1,44 @@
+# PR #7039 검토 및 배포 결과
+
+## 판정: 승인
+
+CI 신뢰 계약 보완 코드와 확인한 로컬·PR·devel 검증 범위의 승인이다. #6901 전체 운영 실증 완료나 issue 종료를 의미하지 않는다.
+
+## 변경 및 귀속
+
+- 작성자: jangster77, collaborator self-review. reviewer 자동 지정 없음.
+- PR: https://github.com/edwardkim/rhwp/pull/7039
+- 코드 head: `158c80285e7cc40da17f926db7edca2da42c8863`.
+- devel merge: `ddc7bdf229db7f61fdeefee106fd1787c8964995`.
+- 관련 issue: [#6901](https://github.com/edwardkim/rhwp/issues/6901), closing reference 없음. 실제 fork 후속 검증까지 OPEN 유지.
+- CodeQL 언어별 Analyze 성공 및 GHAS identity/time 검증을 유지하면서 success/neutral 허용을 PR preflight와 일치시켰다. neutral configuration 경고를 해결했다고 주장하지 않는다.
+- upstream Actions의 fork PR duration을 run/attempt·PR·repository/head·tested merge SHA에 결합하고 read-only verifier에서 ZIP/JSON을 검증·정규화한다. write-capable refresh는 현재 run/attempt의 정규화 JSON만 읽는다.
+- 최신 실패·취소·대기·merge 이후 완료된 재실행을 과거 성공으로 우회하지 않는다. 새 helper는 이전 devel 부모에서만 로드한다.
+- [Stage 1 분석과 실행 기록](../../working/task_m100_6901_codeql_neutral_stage1.md).
+
+## 실행 검증
+
+- 로컬 JavaScript 318개, Python workflow 계약 109개 통과. 실제 Git 객체·ZIP·workflow github-script를 실행했으며 API/네트워크는 모의 응답이다.
+- Rust/Studio 제품 코드는 변경하지 않아 Cargo 전체 회귀·Clippy·WASM은 로컬에서 실행하지 않았다. 시각 검증 대상이 아니다.
+- 원 PR [CI](https://github.com/edwardkim/rhwp/actions/runs/34604536100), [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/34604536037), [Adapter](https://github.com/edwardkim/rhwp/actions/runs/34604536001), [Proptest](https://github.com/edwardkim/rhwp/actions/runs/34604536071) 성공.
+- merge SHA의 [devel CI](https://github.com/edwardkim/rhwp/actions/runs/34606207679)는 Lint, Native Skia, frontend package, archive A/B/C/D build/test, Build & Test 및 duration refresh가 실제 성공했다. WASM Build·frontend unit·workflow promotion의 정책상 skip과 구분한다.
+- merge SHA의 [devel CodeQL](https://github.com/edwardkim/rhwp/actions/runs/34606207667)은 Rust·JavaScript/TypeScript·Python Analyze 모두 성공했다.
+- [devel Adapter](https://github.com/edwardkim/rhwp/actions/runs/34606207567), [devel Proptest](https://github.com/edwardkim/rhwp/actions/runs/34606207576), [Close Issues](https://github.com/edwardkim/rhwp/actions/runs/34606207020) 성공.
+- 이 PR은 CI enforcement 변경이므로 자기 배포에서 full lane을 실행한 것은 예상 동작이다. fork 재사용 성공 증거로 계산하지 않는다.
+
+## 실제 후속 검증: 원 PR #7037
+
+- [#7037](https://github.com/edwardkim/rhwp/pull/7037)은 planet6897/rhwp fork의 renderer 수정이며 원 PR을 유지한다.
+- 원 head `a3a6cc87a2d1af5315f25dac985d76a50f4a636d`에 #7039 포함 devel을 merge하고 `1077cc6b58d06f9a045cf516684314a1f8c6905e`를 원 fork branch로 일반 push했다. contributor commit 재작성 없음.
+- [정렬 후 CI](https://github.com/edwardkim/rhwp/actions/runs/34606501825)는 `current-base-update-merge-tree-green` 경로로 이전 source CI를 재사용했다. archive worker가 skip되어 새 B/C/D duration이 없었다. 따라서 devel 정렬만으로 새 full 실행이 보장된다는 초기 예상을 정정한다.
+- 새 full PR 실행의 duration 발행, 문서 trailing head, 일반 merge 뒤 CI heavy skip·duration refresh·CodeQL/Adapter/Proptest 재사용을 확인한 뒤에만 #6901 종료를 판단한다.
+
+## Merge 후 contributor PR comment 계획
+
+문서 기록 PR이 devel에 반영되고 해당 CI가 성공한 뒤 원 #7039에 한 번만 기록한다. 같은 merge SHA의 기존 댓글이 있으면 새 댓글 대신 수정한다.
+
+- #7039와 merge SHA, 위 실제 PR/devel CI 및 로컬 318/109 결과를 링크한다.
+- 시각 asset은 해당 없음. 존재하지 않는 이미지나 미실행 테스트를 기재하지 않는다.
+- #6901은 #7037 실증 전 OPEN 유지임을 명시한다.
+- UTF-8 body file로 게시하고 API body를 재조회한다.
+- 기본 작업공간의 #7037 검증, contributor fork 및 공유 target을 보존한다. #7039 임시 branch와 이 기록 worktree만 안전 조건 충족 후 정리한다.


### PR DESCRIPTION
## 변경 요약

PR #7039의 archive review와 오늘할일을 보존하는 문서 전용 후속 기록입니다. 실제 로컬·PR·devel CI 성공과 아직 남은 #7037 fork 재사용 실증을 구분했습니다.

Refs #7039, #6901

- 변경은 `mydocs/pr/archives/pr_7039_review.md`, `mydocs/orders/20260911.md` 두 파일뿐입니다.
- 최신 devel의 오늘할일 기존 내용을 보존하고 항목만 추가했습니다.
- 코드·테스트·workflow·sample·PDF·LFS·로그 변경 없음.
- staged diff whitespace 검사 통과. 제품 테스트는 원 코드 PR의 실제 결과를 기록하며 재실행하지 않습니다.
- #6901 자동 종료 없음. 이 기록 PR을 위한 재귀적 후속 리뷰 PR은 만들지 않습니다.
