### PR TITLE
fix(ci): 오래된 event base의 PR merge-tree 증거 발행 보정

### DIFF
--- a/.github/workflows/trusted-postmerge-ci-reuse.yml
+++ b/.github/workflows/trusted-postmerge-ci-reuse.yml
@@ -110,12 +110,38 @@ jobs:
               if (
                 commit.sha !== mergeSha
                 || parents.length !== 2
-                || parents[0] !== pullRequest.base.sha
+                || !/^[0-9a-f]{40}$/.test(parents[0] || '')
                 || parents[1] !== pullRequest.head.sha
                 || !/^[0-9a-f]{40}$/.test(treeSha)
               ) {
                 core.warning('PR merge ref does not match the event base/head pair; no evidence will be published.');
                 return;
+              }
+              // Event payload base can lag behind the immutable merge actually
+              // tested by this run. Never substitute the current PR merge ref.
+              // Accept a stale event base only with two upstream ancestry proofs.
+              if (parents[0] !== pullRequest.base.sha) {
+                const ancestor = async (base, head) => {
+                  if (base === head) return;
+                  const { data: comparison } = await github.rest.repos.compareCommits({
+                    ...context.repo, base, head,
+                  });
+                  if (comparison.status !== 'ahead'
+                    || comparison.base_commit?.sha !== base
+                    || comparison.merge_base_commit?.sha !== base) {
+                    throw new Error('PR tested base ancestry is not proven');
+                  }
+                };
+                await ancestor(pullRequest.base.sha, parents[0]);
+                const { data: branch } = await github.rest.repos.getBranch({
+                  ...context.repo, branch: 'devel',
+                });
+                const currentBase = branch.commit?.sha;
+                if (branch.name !== 'devel' || !/^[0-9a-f]{40}$/.test(currentBase || '')) {
+                  throw new Error('Upstream devel identity is unavailable');
+                }
+                await ancestor(parents[0], currentBase);
+                core.info(`Verified stale PR event base: event_base=${pullRequest.base.sha} tested_base=${parents[0]} current_base=${currentBase}`);
               }
               const artifactName = isFork
                 ? `trusted-postmerge-fork-merge-tree-v1-${pullRequest.number}-${repositoryId}-${pullRequest.head.repo.id}-${runAttempt}-${mergeSha}-${treeSha}`
@@ -130,6 +156,7 @@ jobs:
                 workflow_file: process.env.WORKFLOW_FILE,
                 run_id: String(context.runId),
                 merge_sha: mergeSha,
+                event_base_sha: pullRequest.base.sha,
                 parents,
                 tree_sha: treeSha,
               }, null, 2)}\n`);

--- a/mydocs/working/task_m100_6901_merge_evidence_stage1.md
+++ b/mydocs/working/task_m100_6901_merge_evidence_stage1.md
@@ -1,0 +1,25 @@
+# #6901 Stage 1: PR merge-tree 증거 발행의 오래된 event base 보정
+
+## 분석
+
+- 기준 devel: `045a04e4c9009f9e3b7a917e8b64f012fc13fbc5`.
+- #7037 Full CI `34609842928`은 B/C/D duration을 모두 발행했지만 merge-tree 발행 job `103297274820`은 부모 불일치로 거부했다. 최종 trailing CI `34612013620`도 동일했다.
+- Full caller SHA `e96a26f80be90239c2f4350e83b9bd1e552785c9`의 API 부모는 `b5549292d8f6854fbc86ce825580dbe9496a567a`, `05eeaeef8773d206bdb3afc32a909ad6a087b16b`다. trailing caller `aaeb68771a581ff3cc7c573ee2fbad2cc4b28191`도 첫 부모가 `b5549292d`다.
+- 같은 Full run preflight는 event base 계열 값인 `ddc7bdf229db7f61fdeefee106fd1787c8964995`를 checkout했다. API compare에서 `ddc7bdf22 -> b5549292d`는 ahead이고 merge-base가 ddc7bdf22이며 변경은 오늘할일·#7039 리뷰 두 Markdown뿐이다. 캡처의 event base 동일성 요구가 실제 테스트 merge와 어긋나는 재현이다.
+- devel CI `34612441307` 및 CodeQL `34612441059`는 `fork-pr-merge-tree-evidence-unavailable`로 Full 실행했다. 증거 없는 재사용 거부는 유지해야 한다.
+
+## 수정 범위와 신뢰 계약
+
+1. caller의 정확한 merge SHA·tree·두 부모 및 event head 일치를 유지한다. 최신 PR merge ref를 대신 사용하지 않는다.
+2. event base와 실제 첫 부모가 다르면 API compare로 event base가 실제 첫 부모의 조상임을 증명한다. 실제 첫 부모가 원본 저장소 현재 devel의 조상이라는 별도 증명도 요구한다. API 오류·역방향·분기·잘못된 merge-base·다른 branch 신원은 거부한다.
+3. 발행 JSON에는 실제 parents와 event base를 함께 남긴다. post-merge의 run/attempt/PR/fork/정확한 tree 대조, duration ZIP/JSON 검증과 CodeQL worker 성공 요건은 완화하지 않는다.
+4. 기존 inline capture 코드를 직접 실행하는 JS 계약 테스트로 정상·오래된 base·변조/실패를 검증하고 기존 post-merge/duration JS 및 Python 계약을 함께 실행한다.
+
+## 결과
+
+- reusable workflow의 capture에 두 upstream 계보 증명과 event base 진단 필드를 추가했다. 기존 post-merge 소비자의 정확한 merge-tree·run/attempt 대조와 duration/CodeQL 검증은 변경하지 않았다.
+- 실제 inline capture를 실행하는 신규 JS 테스트 28개를 포함해 post-merge·duration 관련 JavaScript 계약 **492개 통과**, 실패·skip 0개.
+- Python CodeQL·post-merge·nextest archive workflow 계약 **50개 통과**. 처음 `*duration*.py` 검색 실행은 일치하는 테스트 파일이 없어 0개였으며 성공 검증으로 계산하지 않았다. 실제 관련 세 모듈을 명시해 다시 실행했다.
+- `git diff --check` 통과. Rust/Studio 코드를 변경하지 않아 제품 빌드나 전체 Rust 회귀는 중복 실행하지 않았다.
+- GitHub API는 계약 테스트에서 모의 응답이다. 실물 #7037의 merge commit 부모 및 base ancestry는 별도 live API로 확인했지만, 새 capture의 원격 배포·후속 fork Full/trailing/merge 재사용 실증은 아직 수행하지 않았다.
+- 배포 자체의 enforcement 변경 Full CI, 후속 fork의 실제 merge-tree/B/C/D 발행과 post-merge heavy skip·duration refresh·CodeQL 재사용이 남아 있다. #6901은 OPEN 유지하며 완료로 주장하지 않는다.

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -54,6 +54,24 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
         self.assertIn("identity[4] === String(workflowRun.run_attempt)", workflow)
         self.assertIn("artifact.expired !== true", workflow)
 
+    def test_stale_event_base_requires_both_upstream_ancestry_proofs(self) -> None:
+        workflow = REUSABLE.read_text(encoding="utf-8")
+        capture = workflow.split("- name: Capture PR merge-tree evidence", 1)[1].split(
+            "- name: Upload PR merge-tree evidence", 1
+        )[0]
+        for guard in (
+            "parents[1] !== pullRequest.head.sha",
+            "await ancestor(pullRequest.base.sha, parents[0])",
+            "await ancestor(parents[0], currentBase)",
+            "comparison.status !== 'ahead'",
+            "comparison.base_commit?.sha !== base",
+            "comparison.merge_base_commit?.sha !== base",
+            "branch.name !== 'devel'",
+            "event_base_sha: pullRequest.base.sha",
+        ):
+            self.assertIn(guard, capture)
+        self.assertNotIn("ref: process.env.CALLER_REF", capture)
+
     def test_fork_collection_requires_trusted_run_and_independent_tree_proof(self) -> None:
         workflow = REUSABLE.read_text(encoding="utf-8")
         collect = workflow.split("async function collectEvidence()", 1)[1]

--- a/scripts/tests/trusted-postmerge-merge-tree-capture.test.mjs
+++ b/scripts/tests/trusted-postmerge-merge-tree-capture.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+// Execute the deployed inline step itself, not a copy of its implementation.
+const workflow = readFileSync(new URL("../../.github/workflows/trusted-postmerge-ci-reuse.yml", import.meta.url), "utf8");
+const capture = workflow.split("- name: Capture PR merge-tree evidence")[1]
+  .split("- name: Upload PR merge-tree evidence")[0].split("script: |\n")[1]
+  .split("\n").map(line => line.replace(/^ {12}/, "")).join("\n");
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const execute = new AsyncFunction("github", "context", "core", "process", "require", capture);
+const oldBase = "a".repeat(40), testedBase = "b".repeat(40), currentBase = "c".repeat(40);
+const head = "d".repeat(40), merge = "e".repeat(40), tree = "f".repeat(40);
+
+function fixture({ stale = false, advanced = false, fork = true } = {}) {
+  return {
+    env: { CALLER_SHA: merge, CALLER_REF: "refs/pull/42/merge", WORKFLOW_FILE: "ci.yml",
+      GITHUB_REPOSITORY: "owner/repo", GITHUB_REPOSITORY_ID: "10", GITHUB_RUN_ATTEMPT: "2" },
+    context: { repo: { owner: "owner", repo: "repo" }, runId: 123, payload: { pull_request: {
+      number: 42, base: { sha: stale ? oldBase : testedBase, ref: "devel", repo: { id: 10, full_name: "owner/repo" } },
+      head: { sha: head, repo: { id: fork ? 20 : 10, full_name: fork ? "fork/repo" : "owner/repo", fork } },
+    } } },
+    commit: { sha: merge, parents: [{ sha: testedBase }, { sha: head }], commit: { tree: { sha: tree } } },
+    branch: { name: "devel", commit: { sha: advanced ? currentBase : testedBase } },
+    comparison: (base) => ({ status: "ahead", base_commit: { sha: base }, merge_base_commit: { sha: base } }),
+  };
+}
+
+async function run(f) {
+  const files = [], warnings = [], info = [], outputs = {}, calls = [];
+  const github = { rest: { repos: {
+    getCommit: async args => { assert.equal(args.ref, f.env.CALLER_SHA); return { data: f.commit }; },
+    compareCommits: async args => {
+      assert.equal(args.owner, "owner"); assert.equal(args.repo, "repo");
+      calls.push([args.base, args.head]);
+      return { data: f.comparison(args.base, args.head) };
+    },
+    getBranch: async args => {
+      assert.deepEqual(args, { owner: "owner", repo: "repo", branch: "devel" });
+      if (f.branchError) throw new Error("API unavailable");
+      return { data: f.branch };
+    },
+  } } };
+  await execute(github, f.context, {
+    warning: x => warnings.push(x), info: x => info.push(x), setOutput: (k, v) => { outputs[k] = v; },
+  }, { env: f.env }, name => {
+    assert.equal(name, "node:fs");
+    return { writeFileSync: (p, s) => { assert.equal(p, "trusted-postmerge-merge-tree.json"); files.push(JSON.parse(s)); } };
+  });
+  return { files, warnings, info, outputs, calls };
+}
+
+for (const fork of [true, false]) {
+  for (const stale of [true, false]) {
+    test(`실제 capture: fork=${fork}, 오래된 event base=${stale}`, async () => {
+      const f = fixture({ fork, stale, advanced: true });
+      const r = await run(f);
+      assert.equal(r.warnings.length, 0);
+      assert.equal(r.files.length, 1);
+      assert.deepEqual(r.files[0].parents, [testedBase, head]);
+      assert.equal(r.files[0].event_base_sha, stale ? oldBase : testedBase);
+      assert.equal(r.files[0].merge_sha, merge);
+      assert.equal(r.files[0].tree_sha, tree);
+      assert.equal(r.files[0].run_id, "123");
+      assert.equal(r.files[0].run_attempt, 2);
+      assert.equal(r.files[0].head_repository_id, fork ? 20 : 10);
+      assert.equal(r.outputs.artifact_name, fork
+        ? `trusted-postmerge-fork-merge-tree-v1-42-10-20-2-${merge}-${tree}`
+        : `trusted-postmerge-merge-tree-v1-${merge}-${tree}`);
+      assert.deepEqual(r.calls, stale ? [[oldBase, testedBase], [testedBase, currentBase]] : []);
+    });
+  }
+}
+
+test("현재 devel과 tested base가 같으면 첫 계보만 대조한다", async () => {
+  const r = await run(fixture({ stale: true }));
+  assert.equal(r.files.length, 1);
+  assert.deepEqual(r.calls, [[oldBase, testedBase]]);
+});
+
+for (const [name, mutate] of Object.entries({
+  "실행 SHA 불일치": f => { f.commit.sha = head; },
+  "부모 1개": f => { f.commit.parents.pop(); },
+  "부모 3개": f => { f.commit.parents.push({ sha: oldBase }); },
+  "잘못된 첫 부모": f => { f.commit.parents[0].sha = "bad"; },
+  "다른 head": f => { f.commit.parents[1].sha = oldBase; },
+  "잘못된 tree": f => { f.commit.commit.tree.sha = "bad"; },
+  "다른 PR ref": f => { f.env.CALLER_REF = "refs/pull/43/merge"; },
+  "fork 자체 실행": f => { f.env.GITHUB_REPOSITORY = "fork/repo"; },
+  "upstream ID 불일치": f => { f.env.GITHUB_REPOSITORY_ID = "30"; },
+  "head repository 누락": f => { delete f.context.payload.pull_request.head.repo.id; },
+  "fork identity 거짓": f => { f.context.payload.pull_request.head.repo.fork = false; },
+  "attempt 누락": f => { delete f.env.GITHUB_RUN_ATTEMPT; },
+  "다른 base branch": f => { f.context.payload.pull_request.base.ref = "main"; },
+  "event base 누락": f => { delete f.context.payload.pull_request.base.sha; },
+  "base 역방향": f => { f.comparison = () => ({ status: "behind" }); },
+  "base 분기": f => { f.comparison = () => ({ status: "diverged" }); },
+  "다른 비교 base": f => { f.comparison = base => ({ status: "ahead", base_commit: { sha: head }, merge_base_commit: { sha: base } }); },
+  "다른 공통 조상": f => { f.comparison = base => ({ status: "ahead", base_commit: { sha: base }, merge_base_commit: { sha: head } }); },
+  "비교 API 오류": f => { f.comparison = () => { throw new Error("API unavailable"); }; },
+  "devel 조회 오류": f => { f.branchError = true; },
+  "다른 branch 응답": f => { f.branch.name = "main"; },
+  "devel SHA 누락": f => { delete f.branch.commit.sha; },
+  "devel 밖 tested base": f => { f.comparison = base => ({ status: base === testedBase ? "diverged" : "ahead", base_commit: { sha: base }, merge_base_commit: { sha: base } }); },
+})) {
+  test(`capture fail-closed: ${name}`, async () => {
+    const f = fixture({ stale: true, advanced: true }); mutate(f);
+    const r = await run(f);
+    assert.equal(r.files.length, 0);
+    assert.equal(r.outputs.artifact_name, undefined);
+    assert.ok(r.warnings.length > 0);
+  });
+}


### PR DESCRIPTION
## 변경 요약

Refs #6901

#7037의 실제 fork Full CI와 문서 trailing 실행에서 merge-tree 증거가 발행되지 않아 devel CI/CodeQL이 재사용을 거부한 잔여 문제를 보정합니다. 이 PR의 배포 성공만으로 #6901을 닫지 않습니다.

- caller의 정확한 테스트 merge SHA·tree·부모 2개·event head 일치는 유지합니다.
- event base가 실제 테스트 merge의 첫 부모보다 오래된 경우, event base → tested base와 tested base → upstream 현재 devel의 두 계보를 API로 증명해야 증거를 발행합니다.
- 최신 PR merge ref를 대체 증거로 사용하지 않습니다. API 실패·역방향·분기·신원 불일치는 fail-closed입니다.
- duration ZIP/JSON 및 run/attempt/fork/PR 검증, CodeQL 언어별 성공 요건, 최신 실패·취소·pending 거부 조건은 유지합니다.

## 근거

- 원 PR #7037 Full CI: https://github.com/edwardkim/rhwp/actions/runs/34609842928
- devel CI 거부: https://github.com/edwardkim/rhwp/actions/runs/34612441307/job/103306017641
- devel CodeQL 거부: https://github.com/edwardkim/rhwp/actions/runs/34612441059/job/103306009920
- 실제 tested base `b5549292d`와 preflight의 이전 base `ddc7bdf22` 차이를 확인했습니다. 이 사이 변경은 오늘할일·리뷰 Markdown뿐입니다.
- 분석·결과: `mydocs/working/task_m100_6901_merge_evidence_stage1.md`.

## 검증

- 코드 후보 `706da30d80de481cb3be3973e5ea0b17ac058751`.
- JavaScript post-merge/duration 계약 492개 통과, 실패·skip 0. 신규 28개는 실제 workflow inline capture를 직접 실행합니다.
- Python CodeQL/post-merge/nextest archive workflow 계약 50개 통과.
- `git diff --check` 통과.
- Rust/Studio 소스 변경 없음. 제품 전체 회귀는 중복 실행하지 않았습니다.
- API 모의 응답 테스트와 실제 배포 검증을 구분합니다. 배포 후 후속 fork Full → docs trailing → 일반 merge에서 B/C/D 및 merge-tree 발행, 재사용 source run, heavy skip와 duration refresh 성공까지 확인해야 #6901을 종료합니다.

작업지시자의 최종 요청에 따라 self-review·오늘할일 문서 trailing 또는 별도 문서 PR을 만들지 않습니다. 검증 및 후속 처리 결과는 코멘트에 기록합니다. enforcement 변경인 이번 배포 PR 자체의 Full CI는 예상 동작입니다.

