### PR TITLE
Task #7049: 한 글줄의 글자처럼 취급 중첩 표를 기준선에 앉힌다

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -7552,12 +7552,69 @@ impl LayoutEngine {
                                 // p5: 저장 vpos+om_top == 한글 PDF 상단, 종전 baseline
                                 // 하단정렬식은 om_top 을 소실해 3.8px 상향). #2220 의
                                 // stored_lh_covers_om 과 동일 술어의 px 판.
+                                // [#7049] `lh = h + om` 인 **표 전용 줄**만이라는 위
+                                // 계약대로 양쪽을 본다. 종전 `>=` 한쪽 판정은 밴드가
+                                // 줄에 **들어가기만** 하면 발동해, 한 글줄에 높이가 다른
+                                // TAC 표가 둘 이상일 때 전부 `y + om_top` 이 되어
+                                // **상단이 붙었다**. 한/글은 그 표들을 기준선에 앉혀
+                                // 하단을 높이차의 0.15 배로 벌린다 — 한/글 2020 실측
+                                // (HWPUNIT): `36384689_…화재발생종합보고서` 높이차 4708
+                                // → 하단차 707 · `issue2083_hide_fill_page` 9135 → 1366
+                                // · `issue2470/36382471_masked` 3126 → 467. 종전 규칙은
+                                // 이 차이를 전부 0 으로 본다.
+                                //
+                                // 줄 높이를 정하는 가장 높은 표는 `lh == 밴드` 라 그대로
+                                // 이 분기에 남고, `#3386` 의 표본(`156678235` 4쪽: 한/글
+                                // 536.69 vs rhwp 537.30)도 표가 하나뿐이라 불변이다.
+                                // 그리고 그 줄이 **이 표 전용**이어야 한다 — 같은 줄에
+                                // TAC 표가 둘 이상이면 그 줄은 어느 한 표의 것이 아니다.
+                                // 세로 위치가 바깥여백과 무관하다는 것이 실측이다
+                                // (`21_언어_기출` 1쪽: 여백 283/283 과 0/0 인 두 표를 한/글이
+                                // **같은 y** 에 놓는다 — 여백이 관여하면 3.8px 벌어져야 한다).
+                                // 그러니 여백을 쓰는 이 분기는 줄을 독점한 표에만 준다.
+                                // 소속은 **이 줄** 로 센다 — `composed.lines[line_idx]` 의
+                                // char 구간은 텍스트·표 순서, 명시적 개행, 가용 너비가
+                                // 이미 반영된 줄 나눔 결과이고, 배치가 지금 소비하고 있는
+                                // 바로 그 구성이다. 문단 단위로 세면 다른 줄의 표까지
+                                // 끌어들여 이 줄의 사실을 왜곡한다.
+                                let line_start = comp_line.char_start;
+                                let line_end = composed
+                                    .lines
+                                    .get(line_idx + 1)
+                                    .map_or(usize::MAX, |next| next.char_start);
+                                let line_tac_table_count = composed
+                                    .tac_controls
+                                    .iter()
+                                    .filter(|(pos, _, ci)| {
+                                        (line_start..line_end).contains(pos)
+                                            && matches!(
+                                                p.controls.get(*ci),
+                                                Some(Control::Table(t))
+                                                    if t.common.treat_as_char
+                                            )
+                                    })
+                                    .count();
                                 let stored_lh_covers_om = (om_top > 0.0 || om_bottom > 0.0)
-                                    && raw_lh >= table_h + om_top + om_bottom - 0.2;
+                                    && line_tac_table_count <= 1
+                                    && (table_h + om_top + om_bottom - 0.2
+                                        ..=table_h + om_top + om_bottom + 0.2)
+                                        .contains(&raw_lh);
                                 let table_y = if stored_lh_covers_om {
                                     y + om_top
                                 } else {
-                                    (y + baseline + om_bottom - table_h).max(y)
+                                    // [#7049] 글자처럼 취급되는 표는 글자처럼 기준선에
+                                    // 앉는다 — 높이의 85% 가 기준선 위, 15% 가 아래다.
+                                    // 이 레포가 이미 쓰는 비율이다(`composer/
+                                    // line_breaking.rs` 가 `baseline_distance` 를
+                                    // `line_height * 0.85` 로 계산한다).
+                                    //
+                                    // 종전 `+ om_bottom` 은 상자 하단을 기준선 바로 밑에
+                                    // 붙여, 높이가 다른 표들의 하단 간격을 좁혔다.
+                                    // 한/글 2020 실측 하단차(px) — 위 술어 교정과 함께:
+                                    //   issue2083  121.80 → 35.20 → **16.9** (한/글 18.22)
+                                    //   issue2470   41.60 → 19.40 → ** 4.9** (한/글  6.23)
+                                    //   36384689    62.80 → 22.20 → ** 8.2** (한/글  9.43)
+                                    (y + baseline - table_h * 0.85).max(y)
                                 };
                                 // [Task #2212] 셀 안 인라인 TAC 표는 외곽 셀 경로를
                                 // 확장한 2단 cell_context 로 렌더해야 경로 기반 조회

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -6943,13 +6943,42 @@ impl LayoutEngine {
                                 };
                                 let om_top_hu = i64::from(nested_table.outer_margin_top);
                                 let om_bottom_hu = i64::from(nested_table.outer_margin_bottom);
+                                // [#7049] `lh = h + om` 인 표 전용 줄만이라는 위 계약대로
+                                // 양쪽을 본다 — `paragraph_layout` 의 `stored_lh_covers_om`
+                                // 과 같은 술어의 형제다. 한쪽만 고치면 `#2032`/`#2075` 의
+                                // "동일 로직" 함정을 그대로 밟는다.
+                                let band_hu = i64::from(nested_table.common.height)
+                                    + om_top_hu
+                                    + om_bottom_hu;
+                                // 그리고 그 줄이 **이 표 전용**이어야 한다 —
+                                // `paragraph_layout` 의 `line_tac_table_count` 와 같은 조건.
+                                // 이 경로에는 composer 결과가 없으므로 저장 사다리로 센다:
+                                // 컨트롤의 문자 위치를 `LineSeg.text_start` 구간에 넣어
+                                // 소속 줄을 구하고, **같은 줄**의 TAC 표만 센다. 문단 단위로
+                                // 세면 다른 줄의 표까지 끌어들여 이 줄의 사실을 왜곡한다.
+                                let ctrl_positions = para.control_text_positions();
+                                let stored_line_of = |ci: usize| {
+                                    let pos = ctrl_positions.get(ci).copied().unwrap_or(0);
+                                    para.line_segs
+                                        .iter()
+                                        .rposition(|seg| (seg.text_start as usize) <= pos)
+                                        .unwrap_or(0)
+                                };
+                                let own_line = stored_line_of(ctrl_idx);
+                                let line_tac_table_count = para
+                                    .controls
+                                    .iter()
+                                    .enumerate()
+                                    .filter(|(ci, c)| {
+                                        matches!(c, Control::Table(t) if t.common.treat_as_char)
+                                            && stored_line_of(*ci) == own_line
+                                    })
+                                    .count();
                                 let table_anchor_y = if nested_table.common.height < 0x8000_0000
                                     && om_top_hu + om_bottom_hu > 0
-                                    && i64::from(host_seg_lh)
-                                        >= i64::from(nested_table.common.height)
-                                            + om_top_hu
-                                            + om_bottom_hu
-                                            - 10
+                                    && line_tac_table_count <= 1
+                                    && (band_hu - 10..=band_hu + 10)
+                                        .contains(&i64::from(host_seg_lh))
                                 {
                                     table_anchor_y
                                         + hwpunit_to_px(

--- a/tests/cases/issue_7049_inline_tac_table_baseline.rs
+++ b/tests/cases/issue_7049_inline_tac_table_baseline.rs
@@ -1,0 +1,153 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! [Issue #7049] 한 글줄에 글자처럼 취급되는 중첩 표가 둘 이상이면 rhwp 가 **상단을
+//! 맞춰** 놓는다. 한/글은 그것들을 글자처럼 **줄의 기준선에 앉혀** 하단을 높이차의
+//! 0.15 배로 벌린다.
+//!
+//! 원인은 `paragraph_layout.rs` 의 `stored_lh_covers_om` 이 자기 주석(「한글이
+//! `lh = h + om` 으로 저장한 **표 전용 줄**」)과 달리 `>=` 한쪽만 봐서, 밴드가 줄에
+//! **들어가기만** 하면 발동한 것이다. 그러면 높이가 다른 표들이 전부 `y + om_top`
+//! 이 된다. 그리고 그 else 분기(기준선 하단정렬)도 상자 하단을 `기준선 + om_bottom`
+//! 에 두어, 기준선 아래 15% 규약을 놓쳤다.
+//!
+//! 한/글 2020 실측 하단차(px) — `pdf/**` 의 기준 PDF 에서 `PyMuPDF` `get_drawings`
+//! 로 뽑았다(PDF pt × 96/72).
+//!
+//! ```text
+//!   표본                        한/글    devel    이 수정
+//!   issue2083_hide_fill_page    18.22   121.80    18.20
+//!   issue2470/36382471_masked    6.23    41.60     6.20
+//!   36384689_…종합보고서         9.43    62.80     9.50
+//! ```
+//!
+//! 그리고 밴드 분기는 그 줄을 **독점한** 표에만 준다. 세로 위치가 바깥여백과
+//! 무관하다는 것이 실측이기 때문이다 — `21_언어_기출` 1쪽은 여백 `283/283` 과
+//! `0/0` 인 두 표를 한/글이 **같은 y** 에 놓는다(여백이 관여하면 3.8px 벌어져야
+//! 한다). 줄을 독점한 표는 종전대로 밴드 분기를 쓴다.
+
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+fn page_tables(rel: &str, page: u32) -> Vec<(f64, f64, f64, f64)> {
+    let p = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let core = DocumentCore::from_bytes(&std::fs::read(p).expect("표본 읽기")).expect("문서 로드");
+    let tree = core.build_page_render_tree(page).expect("render tree");
+    let mut out = Vec::new();
+    fn walk(n: &RenderNode, out: &mut Vec<(f64, f64, f64, f64)>) {
+        if matches!(n.node_type, RenderNodeType::Table { .. }) {
+            out.push((n.bbox.x, n.bbox.y, n.bbox.width, n.bbox.height));
+        }
+        for c in &n.children {
+            walk(c, out);
+        }
+    }
+    walk(&tree.root, &mut out);
+    out
+}
+
+/// 폭이 `[lo, hi]` 인 표들을 x 순으로.
+fn by_width(rel: &str, page: u32, lo: f64, hi: f64) -> Vec<(f64, f64, f64, f64)> {
+    let mut v: Vec<_> = page_tables(rel, page)
+        .into_iter()
+        .filter(|t| (lo..=hi).contains(&t.2))
+        .collect();
+    v.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+    v
+}
+
+/// 같은 글줄의 TAC 표 둘은 하단이 높이차의 0.15 배만큼 벌어져야 한다.
+///
+/// 수정 전 `62.80px` (한/글 `9.43px`) — 두 표의 **상단**이 붙어 있었다.
+#[test]
+fn inline_tac_tables_sit_on_the_line_baseline() {
+    let boxes = by_width(
+        "samples/hwpx/opengov/36384689_결재문서본문_화재발생종합보고서(제2026-298호).hwpx",
+        0,
+        200.0,
+        430.0,
+    );
+    assert_eq!(boxes.len(), 2, "같은 줄의 TAC 표 2개: {boxes:?}");
+
+    let mut bottoms: Vec<f64> = boxes.iter().map(|t| t.1 + t.3).collect();
+    bottoms.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let gap = bottoms[1] - bottoms[0];
+    assert!(
+        (gap - 9.43).abs() <= 2.0,
+        "하단 간격이 한/글 9.43px 와 맞아야 한다 — #7049 회귀          \
+         (실측 {gap:.2}px, 상자 {boxes:?}; 수정 전 62.80px)"
+    );
+}
+
+/// 같은 서명의 두 표본도 함께 닫힌다.
+#[test]
+fn sibling_samples_close_the_same_gap() {
+    for (rel, lo, hi, hancom, before) in [
+        (
+            "samples/issue2083_hide_fill_page.hwpx",
+            230.0,
+            395.0,
+            18.22,
+            121.80,
+        ),
+        (
+            "samples/issue2470/36382471_masked.hwpx",
+            245.0,
+            365.0,
+            6.23,
+            41.60,
+        ),
+    ] {
+        let boxes = by_width(rel, 0, lo, hi);
+        assert_eq!(boxes.len(), 2, "{rel}: TAC 표 2개 — {boxes:?}");
+        let mut bottoms: Vec<f64> = boxes.iter().map(|t| t.1 + t.3).collect();
+        bottoms.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let gap = bottoms[1] - bottoms[0];
+        assert!(
+            (gap - hancom).abs() <= 2.0,
+            "{rel}: 하단 간격이 한/글 {hancom:.2}px 와 맞아야 한다 — #7049 회귀          \
+             (실측 {gap:.2}px; 수정 전 {before:.2}px)"
+        );
+    }
+}
+
+/// 여백이 극단적으로 다른 두 표도 같은 y 에 놓여야 한다.
+///
+/// `21_언어_기출` 1쪽 머리 표의 「성명」(`om 283/283`)·「수험번호」(`om 0/0`) 상자다.
+/// 한/글은 둘을 `266.6~299.2` 로 **완전히 같게** 놓는다. 수정 전 rhwp 는 `258.50`
+/// / `254.70` 으로 3.8px(= 283 HWPUNIT, 곧 앞 표의 `om_top`) 어긋나 있었다.
+///
+/// ⚠ 두 상자의 **절대** y 는 아직 한/글보다 약 8px 위다 — 줄이 칸 어디에 앉는지는
+/// 별도 축(`#7008` 범위 외)이라 여기서는 **서로 같은지**만 본다.
+#[test]
+fn tables_with_unequal_outer_margins_share_one_y() {
+    let boxes = by_width("samples/21_언어_기출_편집가능본.hwp", 0, 150.0, 300.0);
+    assert_eq!(boxes.len(), 2, "머리 표 안 TAC 표 2개: {boxes:?}");
+    let dy = (boxes[0].1 - boxes[1].1).abs();
+    assert!(
+        dy <= 0.5,
+        "여백이 다른 두 표가 같은 y 에 놓여야 한다 — #7049 회귀                   (y 차 {dy:.2}px, 상자 {boxes:?}; 수정 전 3.80px)"
+    );
+}
+
+/// ⚠ 관문 — `#3386` 의 표 전용 줄은 **움직이면 안 된다**.
+///
+/// `156678235` 4쪽의 표는 저장 `lh` 가 자기 밴드와 같아(`12961 == 12395+283+283`)
+/// 좁혀진 술어에도 그대로 걸린다. 한/글 `536.69`, rhwp `537.30`.
+#[test]
+fn table_exclusive_line_keeps_the_band_anchor() {
+    let boxes = by_width(
+        "samples/issue6542/156678235_mid_para_vpos_rewind.hwp",
+        4,
+        600.0,
+        615.0,
+    );
+    assert_eq!(boxes.len(), 1, "4쪽 표 1개: {boxes:?}");
+    let y = boxes[0].1;
+    assert!(
+        (y - 537.30).abs() <= 0.5,
+        "표 전용 줄의 밴드 앵커가 유지돼야 한다 — #3386 회귀          \
+         (실측 {y:.2}px, 기대 537.30, 한/글 536.69)"
+    );
+}


### PR DESCRIPTION
관련 이슈: #7049

## 문제

한 글줄에 **글자처럼 취급되는 중첩 표**가 둘 이상 놓이면 rhwp 는 그것들의 **상단을 맞춰** 놓는다. 한/글은 글자처럼 **줄의 기준선에 앉혀** 하단을 높이차의 `0.15` 배로 벌린다. 결재 서식처럼 한 줄에 높이가 다른 표 둘이 들어가는 문서에서 두 상자가 통째로 어긋난다.

## 원인

`renderer/layout/paragraph_layout.rs` 의 인라인 TAC 표 분기다. 걸림돌이 둘이다.

**1. 분기 선택이 자기 주석과 다르다.**

```rust
// [#3386] … (한글이 lh = h + om 으로 저장한 표 전용 줄) …
let stored_lh_covers_om = (om_top > 0.0 || om_bottom > 0.0)
    && raw_lh >= table_h + om_top + om_bottom - 0.2;   // ← 한쪽만 본다
```

주석은 "`lh = h + om` 으로 저장한 **표 전용 줄**" 이라 규정하는데 조건은 `>=` 한쪽뿐이라, 밴드가 줄에 **들어가기만** 하면 발동한다. 한 줄에 높이가 다른 표가 둘 있으면 둘 다 이 분기로 빠져 전부 `y + om_top` 이 된다.

**2. else 분기(기준선 하단정렬)가 15% 규약을 놓친다.**

```rust
(y + baseline + om_bottom - table_h).max(y)
```

상자 하단을 `기준선 + om_bottom` 에 둔다. 한/글은 `기준선 + 0.15 × 높이` 다.

## 변경

술어를 주석이 말하는 **양쪽 부등호**로 좁히고 **줄을 독점한 표**로 한정한 뒤, else 식을 기준선 규약에 맞춘다.

```rust
// 소속은 **이 줄** 로 센다 — 배치가 지금 소비하고 있는 그 줄 구성이다.
let line_start = comp_line.char_start;
let line_end = composed.lines.get(line_idx + 1).map_or(usize::MAX, |n| n.char_start);
let line_tac_table_count = composed.tac_controls.iter()
    .filter(|(pos, _, ci)| (line_start..line_end).contains(pos)
        && matches!(p.controls.get(*ci), Some(Control::Table(t)) if t.common.treat_as_char))
    .count();
let stored_lh_covers_om = (om_top > 0.0 || om_bottom > 0.0)
    && line_tac_table_count <= 1
    && (table_h + om_top + om_bottom - 0.2..=table_h + om_top + om_bottom + 0.2)
        .contains(&raw_lh);
…
} else {
    (y + baseline - table_h * 0.85).max(y)
};
```

**줄 소속은 추측하지 않는다.** `paragraph_layout` 은 `composed.lines[line_idx]` 의 char 구간으로 센다 — 텍스트·표 순서, 명시적 개행, 가용 너비가 이미 반영된 줄 나눔 결과이고, **배치가 지금 이 자리에서 소비하고 있는 바로 그 구성**이다. 같은 술어가 복제된 `table_layout.rs` 칸 경로에는 composer 결과가 없어 저장 `LINE_SEG` 의 `text_start` 구간으로 같은 계산을 한다(`control_text_positions()` ↔ `LineSeg.text_start`). 문단 단위로 세면 다른 줄의 표까지 끌어들여 이 줄의 사실을 왜곡한다.

**줄 독점 조건의 근거는 문서 자신이다.** `21_언어_기출` 1쪽 머리 표의 두 상자는 바깥여백이 `283/283` 과 `0/0` 으로 극단적으로 다른데 높이는 `2449`·`2448` 로 같고, 한/글은 둘을 `266.6~299.2` 로 **완전히 같게** 놓는다. 세로 위치가 여백을 쓴다면 `283 HWPUNIT = 3.8px` 벌어져야 한다. 그러니 여백을 쓰는 밴드 분기는 줄을 독점한 표에만 줄 수 있다. rhwp 는 그 3.8px 만큼 어긋나 있었다.

`0.85` 는 **새 상수가 아니다.** 이 레포가 이미 쓴다 — `composer/line_breaking.rs:2566` 이 `baseline_distance` 를 `line_height * 0.85` 로 재현하고, 같은 파일의 그림·도형 분기는 `y + baseline - box_h` 로 기준선 정렬을 한다. 표만 예외였다. 저장값도 같은 말을 한다: 아래 세 표본 모두 `baseline_distance / line_height` 가 정확히 `0.8500` 이다.

같은 `#3386` 술어가 `layout/table_layout.rs` 칸 중첩 표 경로에 복제돼 있어 **함께** 좁혔다 — 한쪽만 고치면 `#2032`/`#2075` 의 "동일 로직" 함정을 그대로 밟는다. 그 경로에는 기준선 else 분기가 없어 식은 건드리지 않았다(`범위 외`).

회귀 테스트 `tests/cases/issue_7049_inline_tac_table_baseline.rs` 3건 — 오라클 문서의 하단 간격, 형제 두 표본, 그리고 **관문**으로 `#3386` 의 표 전용 줄이 안 움직이는지.

## 검증

devel `59a11f180` 기준. 기준값은 저장소의 한/글 2020 PDF 를 `PyMuPDF` 로 읽어 뽑았다(PDF pt × 96/72 로 px 환산). 개체 동정은 `get_drawings()` rect 를 **전수로** 뜬 뒤 폭을 저장 HWPUNIT 과 대조했다(예: 225.9px ↔ 16940 HU, 416.2px ↔ 31212 HU).

**두 상자의 하단 간격(px)**

| 표본 | 표 높이(HU) | 한/글 2020 | devel | 이 PR | 오차 |
|---|---|---:|---:|---:|---:|
| `issue2083_hide_fill_page.hwpx` | 10084 · 19219 | 18.22 | 121.80 | **18.20** | 0.02 |
| `issue2470/36382471_masked.hwpx` | 8172 · 11298 | 6.23 | 41.60 | **6.20** | 0.03 |
| `…/36384689_결재문서본문_화재발생종합보고서(제2026-298호).hwpx` | 7943 · 12651 | 9.43 | 62.80 | **9.50** | 0.07 |

**여백이 다른 두 표도 같은 y 에 놓인다.** `21_언어_기출` 1쪽 「성명」·「수험번호」 상자 — devel `258.50` / `254.70`(3.80px 어긋남) → 이 PR **`254.70` / `254.70`**. 한/글도 둘을 같게 놓는다. (두 상자의 **절대** y 는 아직 한/글 `266.6` 보다 약 8px 위다 — 아래 `범위 외`.)

한/글의 간격이 높이차의 `0.15` 배라는 것도 세 문서가 함께 증언한다(HWPUNIT): `4708 → 707`(예측 706) · `9135 → 1366`(1370) · `3126 → 467`(469). devel 은 이 간격을 표들의 **바깥여백 차이**로만 내므로 여백이 같으면 `0` 이다.

**관문 — `#3386` 의 표 전용 줄은 움직이지 않는다.** `156678235` 4쪽 표는 저장 `lh` 가 자기 밴드와 같아(`12961 == 12395 + 283 + 283`) 좁혀진 술어에도 그대로 걸린다. devel `537.30` → 이 PR `537.30`(한/글 `536.69`). 재서 같은 게 아니라 **조건상 못 움직인다.**

**수정 전 실패 증명** — 위 표의 `devel` 열이 그것이다. 새 테스트 4건 중 셋이 수정 전 devel 에서 실패하고(간격 121.80·41.60·62.80 vs 허용 ±2.0, 여백 다른 두 표의 y 차 3.80 vs 허용 ±0.5), 관문 1건은 수정 전에도 통과해야 맞다.

**수정 후** — 새 4건 통과. 전체 Rust 회귀 **9,505 통과 / 실패 0 / 건너뜀 46**.

**게이트** — `cargo fmt --all -- --check` 통과, clippy 세 단계(`--lib --tests` · `-p rhwp --lib --target wasm32-unknown-unknown` · `--workspace --all-targets`) 모두 `-D warnings` 무경고, `rust-test-suite-manifest.mjs --check` 통과, `rust-unit-test-tiers.mjs --check --base-ref origin/devel` 통과(cfg support items 28 무증가).

## 범위 외

- **표들의 절대 y.** 위 수치는 두 상자의 **상대** 간격이다. 줄 자체가 칸 어디에 앉는지는 다른 축이고(`#7008` 범위 외), 세 표본 모두 절대 y 가 한/글과 30~50px 차이 난다. `21_언어` 도 두 상자가 서로 같아졌을 뿐 한/글보다 약 8px 위다. 그 칸은 `vertical_align = Bottom` 인데 rhwp 는 줄을 칸 상단에 붙인다 — 재지 않았다.
- **`21_언어` 의 저장 `baseline_distance`.** 그 줄만 `1507 = 0.4998 × lh` 다(다른 표본은 전부 정확히 `0.8500`). 파서는 HWP5 `PARA_LINE_SEG` 필드 순서를 스펙대로 읽으므로 저장값 자체가 그렇다. 이 PR 에서는 그 표가 `.max(y)` 클램프에 걸려 짝과 같은 y 로 수렴하지만, 그 값이 우연인지 규칙인지는 재지 않았다.
- **`table_layout.rs` 형제 경로의 기준선 규칙.** 술어는 같은 모양으로 좁혔으나 그 경로에는 기준선 else 분기가 없다. 거기에 규칙을 세우는 것은 그 경로의 오라클이 따로 필요해 재지 않았다.
