### PR TITLE
fix(ci): 한글 Rust 테스트 duration 증거 재사용 보정 (#6901)

### DIFF
--- a/mydocs/working/task_m100_6901_unicode_duration_stage1.md
+++ b/mydocs/working/task_m100_6901_unicode_duration_stage1.md
@@ -1,0 +1,25 @@
+# #6901 Unicode duration 증거 계약 보정 - 단계 1
+
+## 분석
+
+- 실증 대상: [PR #7044](https://github.com/edwardkim/rhwp/pull/7044), merge `78bdfd9aa69417b4a88ffdd43aa76d3cad471f44`.
+- [CI verifier](https://github.com/edwardkim/rhwp/actions/runs/34669914465/job/103489207024)는 `candidate-duration-artifact-check-error`로 Full 전환했다.
+- 원 PR CI `34662415596`의 실제 B/C/D artifact를 소비기로 재현했다. 이름 규칙만 위반한 한글 테스트 13개(B 3, C 2, D 8)가 원인이다. 중복이나 잘못된 duration이 아니다.
+- JUnit 발행기는 Unicode 이름을 보존하지만 소비기는 ASCII만 허용한다. merge-tree 증거는 유효했고 CodeQL은 실제 재사용됐다.
+
+## 수정 범위와 검증 계획
+
+- 소비기의 이름 계약을 Unicode XID 식별자의 `::` 경로로 한정한다. 공백, 경로 문자, 빈 segment, 보이지 않는 제어 문자는 허용하지 않는다.
+- 기존 저장소/PR/head/attempt/merge SHA, ZIP, 크기, 중복, 수치, target 소유 검증을 유지한다.
+- JUnit 발행 → ZIP → 소비 → policy 갱신 계약과 악성 이름 거부를 테스트한다.
+- 실제 #7044 B/C/D artifact를 수정된 소비기로 재검증한다. 계약 테스트도 실행한다.
+- 이 단계는 로컬 계약 보정이다. 배포 후 실제 fork PR의 CI reuse/heavy skip/duration refresh가 입증되기 전 #6901은 종료하지 않는다.
+
+## 결과
+
+- `trusted-postmerge-duration-evidence.mjs`만 제품 로직을 수정했다. 발행기는 이미 이름을 보존하므로 변경하지 않았다. workflow 권한이나 재사용 gate는 완화하지 않았다.
+- Unicode XID segment와 `::`만 허용하고 default-ignorable 문자를 거부한다. 빈 segment, 숫자/결합문자 시작, 경로, 공백, NUL, bidi, ZWJ, variation selector 거부를 회귀 계약으로 잠갔다.
+- 집중 JavaScript 계약 89 PASS, post-merge/duration 전체 JavaScript 계약 520 PASS, Python workflow 계약 17 PASS. 중복 집계이므로 89를 520에 더하지 않는다.
+- 실제 PR CI `34662415596` ZIP의 B 1,973 / C 1,555 / D 1,909개, 총 5,437개 test case를 승인했다. 이전에 실패했던 Unicode 13개도 모두 원문 그대로 보존했다.
+- `git diff --check` 통과. Rust/브라우저를 수정하지 않았으므로 이 보정에서 Rust 회귀·WASM 빌드는 반복하지 않았다.
+- 한글 JUnit → ZIP → 소비 → duration policy 갱신을 검증했다. 실제 원격 post-merge 재사용 성공은 아직 미검증이며 #6901은 OPEN이다.

--- a/scripts/tests/trusted-postmerge-duration-evidence.test.mjs
+++ b/scripts/tests/trusted-postmerge-duration-evidence.test.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { selectDurationArtifacts, decodeDurationArtifact, validateDurationReports } from "../trusted-postmerge-duration-evidence.mjs";
 import { refreshDurationPolicy } from "../refresh-nextest-target-duration-policy.mjs";
+import { collectDurationMeasurement } from "../collect-nextest-target-durations.mjs";
 import { durationFixture, reportZip, zipEntries } from "./helpers/postmerge-duration-fixtures.mjs";
 
 for (const options of [{ fork: true }, { fork: false }, { fork: false, legacy: true }]) {
@@ -20,6 +21,51 @@ for (const options of [{ fork: true }, { fork: false }, { fork: false, legacy: t
     assert.ok(normalized.every(r => r.run_id === "123" && r.sha === f.context.testedMergeSha));
   });
 }
+
+test("#6901 한글 Rust 이름은 JUnit부터 ZIP 소비와 policy 갱신까지 보존한다", () => {
+  const f = durationFixture();
+  const names = [
+    "issue_676_t재정통계_2010_11_single_page",
+    "정산_방어_계약",
+    "감사_보고_기계_대사_계약",
+  ];
+  f.reports.forEach((report, index) => {
+    const label = report.archive_label;
+    Object.assign(report, collectDurationMeasurement(
+      `<testcase name="case_${label}::${names[index]}" classname="rhwp::regression_suite_${label}" time="1.25" />`,
+    ));
+  });
+  const reports = f.reports.map(report => decodeDurationArtifact(reportZip(report), report.archive_label));
+  const normalized = validateDurationReports(reports, f.context);
+  assert.deepEqual(normalized.map(r => r.test_cases), f.reports.map(r => r.test_cases));
+  const policy = JSON.parse(readFileSync(new URL("../../tests/suites/nextest-target-duration-policy.json", import.meta.url), "utf8"));
+  const updated = refreshDurationPolicy(policy, normalized);
+  for (const report of normalized) {
+    for (const [name, seconds] of Object.entries(report.test_cases)) {
+      assert.equal(updated.test_cases[name], seconds);
+    }
+  }
+});
+
+for (const name of ["한글/경로", "한글\\경로", "한글 공백", "한글\n", "한글\u0000", "한글\u202e", "한글\u200d", "한글\ufe0f", "한글::", "한글::::검사", "1한글", "\u0301한글"]) {
+  test(`#6901 안전하지 않은 Unicode 이름은 거부한다: ${JSON.stringify(name)}`, () => {
+    const f = durationFixture();
+    f.reports[0].test_cases = { [`regression_suite_b::case_b::${name}`]: 1 };
+    assert.throws(() => validateDurationReports(f.reports, f.context));
+  });
+}
+
+test("#6901 Unicode case 소유 관계와 중복 방어를 유지한다", () => {
+  const f = durationFixture();
+  f.reports[0].cases = { 한글_모듈: 1 };
+  f.reports[0].test_cases = { "regression_suite_b::한글_모듈::검사": 1 };
+  assert.doesNotThrow(() => validateDurationReports(f.reports, f.context));
+  f.reports[1].cases.한글_모듈 = 1;
+  assert.throws(() => validateDurationReports(f.reports, f.context));
+  delete f.reports[1].cases.한글_모듈;
+  f.reports[0].test_cases = { "regression_suite_b::다른_모듈::검사": 1 };
+  assert.throws(() => validateDurationReports(f.reports, f.context));
+});
 
 for (const [name, mutate] of Object.entries({
   "archive 누락": f => f.artifacts.pop(),

--- a/scripts/trusted-postmerge-duration-evidence.mjs
+++ b/scripts/trusted-postmerge-duration-evidence.mjs
@@ -4,7 +4,9 @@ const LIMIT = 8 * 1024 * 1024;
 const LABELS = ["b", "c", "d"];
 const ID = /^[1-9][0-9]*$/;
 const SHA = /^[0-9a-f]{40}$/;
-const NAME = /^[A-Za-z_][A-Za-z0-9_:]*$/;
+// JUnit preserves Rust Unicode identifiers. Keep this a data-only identifier
+// path, not an arbitrary string: reject empty segments and invisible controls.
+const NAME = /^(?!.*\p{Default_Ignorable_Code_Point})[_\p{XID_Start}][_\p{XID_Continue}]*(?:::[_\p{XID_Start}][_\p{XID_Continue}]*)*$/u;
 const fail = (message) => { throw new Error(`duration-evidence: ${message}`); };
 const record = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
 


### PR DESCRIPTION
## 변경 이유

Related to #6901.

PR #7044 post-merge CI가 유효한 한글 Rust 테스트 이름 13개를 ASCII 전용 duration 이름 검증으로 거부해 Full로 전환했습니다. CodeQL의 동일 merge-tree 재사용은 성공했습니다.

- [실제 실패와 재현 기록](https://github.com/edwardkim/rhwp/issues/6901#issuecomment-5643112336)
- [실패한 verifier](https://github.com/edwardkim/rhwp/actions/runs/34669914465/job/103489207024)

## 보정

- duration 소비기에 Unicode XID 식별자 및 `::` segment 경계를 적용합니다.
- 보이지 않는 문자, 경로, 공백, 빈 segment 및 잘못된 시작 문자는 거부합니다.
- 저장소/PR/head/attempt/merge SHA, ZIP, 수치, 중복, target 소유 검증을 유지합니다. workflow 권한과 재사용 gate를 완화하지 않습니다.
- 발행기는 이미 Unicode 이름을 보존하므로 수정하지 않습니다.
- 분석·결과: `mydocs/working/task_m100_6901_unicode_duration_stage1.md`.

## 검증

- JavaScript post-merge/duration 계약 520 PASS (집중 89개 포함).
- Python workflow 계약 17 PASS.
- 실제 PR CI 34662415596 B/C/D ZIP: 총 5,437개 test case 승인, 한글 13개 보존.
- JUnit 발행 → ZIP → 소비 → policy 갱신 및 부정 입력 거부 계약 통과.
- `git diff --check` 통과. Rust 소스 변경이 없어 Rust 회귀·WASM 빌드는 반복하지 않았습니다.

## 남은 범위

#6901은 자동 종료하지 않습니다. 이 PR의 로컬/CI 계약 성공과 배포 후 실제 fork post-merge reuse·heavy skip·duration refresh 실증은 별개입니다.

#7044 review·오늘할일 후속 기록 PR과 분리된 CI 보정 PR입니다.
