### PR TITLE
수정(layout): 한 글줄의 글자처럼 취급 중첩 표를 기준선에 앉힌다 (#7049)

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -9,6 +9,14 @@ use super::super::kerning::{
 };
 use super::super::page_layout::LayoutRect;
 use super::super::render_tree::*;
+
+/// 글자처럼 취급 표에서 줄 기준선 **위**가 차지하는 몫.
+///
+/// [#7049] 저장 `baseline_distance / line_height` 가 세 표본 모두 정확히 `0.8500` 이고,
+/// `composer::line_breaking` 도 글꼴 기준 baseline 을 `line_height * 0.85` 로 복원한다.
+/// 그래서 하단은 `기준선 + 0.15 × 높이` 가 되고, 높이가 다른 두 표의 하단 간격은
+/// 높이차의 `0.15` 배다 — 한/글 2020 정본과 1px 안에서 맞는다.
+const TAC_TABLE_BASELINE_ASCENT_RATIO: f64 = 0.85;
 use super::super::style_resolver::ResolvedStyleSet;
 use super::super::{
     format_number, hwpunit_to_px, px_to_hwpunit, AutoNumberCounter, NumberFormat as NumFmt,
@@ -7509,12 +7517,35 @@ impl LayoutEngine {
                                 // p5: 저장 vpos+om_top == 한글 PDF 상단, 종전 baseline
                                 // 하단정렬식은 om_top 을 소실해 3.8px 상향). #2220 의
                                 // stored_lh_covers_om 과 동일 술어의 px 판.
+                                //
+                                // [#7049] 조건을 **같음**으로 좁힌다. 종전 `>=` 는
+                                // 밴드가 줄에 **들어가기만** 하면 발동해, 한 줄에 높이가
+                                // 다른 TAC 표가 둘 있으면 **둘 다** 이 분기로 빠져
+                                // 상단이 붙었다(결재 서식: 문서번호 상자와 결재란 상자).
+                                // 주석이 규정하는 "표 전용 줄" 은 `lh == h + om` 이다.
                                 let stored_lh_covers_om = (om_top > 0.0 || om_bottom > 0.0)
-                                    && raw_lh >= table_h + om_top + om_bottom - 0.2;
+                                    && (raw_lh - (table_h + om_top + om_bottom)).abs() <= 0.2;
                                 let table_y = if stored_lh_covers_om {
                                     y + om_top
                                 } else {
-                                    (y + baseline + om_bottom - table_h).max(y)
+                                    // [#7049] 글자처럼 취급 표는 줄의 **기준선에 앉는다** —
+                                    // 하단이 `기준선 + 0.15 × 높이` 다. 종전에는
+                                    // `기준선 + om_bottom` 이라, 여백이 같은 두 표의
+                                    // 하단 간격이 0 이 됐다(한/글은 높이차의 0.15배).
+                                    //
+                                    // 한/글 2020 정본 실측(36384689 1쪽) — 같은 `C` 로
+                                    // 두 표가 풀린다:
+                                    //
+                                    //   큰 표   270.26 = C + 0.15 × 168.7  → C = 244.96
+                                    //   짧은 표 260.83 = C + 0.15 × 105.9  → C = 244.93
+                                    //
+                                    // 0.15 는 새 상수가 아니다 — 이 레포는 저장
+                                    // `baseline_distance / line_height` 가 정확히 0.85 임을
+                                    // 이미 쓴다(`composer/line_breaking.rs` 의
+                                    // `line_height * 0.85`). 그림·도형 분기도 같은 기준선
+                                    // 정렬을 하는데 표만 예외였다.
+                                    (y + baseline - table_h * TAC_TABLE_BASELINE_ASCENT_RATIO)
+                                        .max(y)
                                 };
                                 // [Task #2212] 셀 안 인라인 TAC 표는 외곽 셀 경로를
                                 // 확장한 2단 cell_context 로 렌더해야 경로 기반 조회

--- a/tests/cases/issue_7049_tac_nested_tables_sit_on_baseline.rs
+++ b/tests/cases/issue_7049_tac_nested_tables_sit_on_baseline.rs
@@ -1,0 +1,83 @@
+//! [Issue #7049] 한 글줄의 **글자처럼 취급 중첩 표**들이 상단을 맞춰 놓인다 —
+//! 한/글은 줄의 기준선에 앉혀 하단을 높이차의 `0.15` 배로 벌린다.
+//!
+//! 결재 서식의 「문서번호/시행일자」 상자와 「결재란」 상자처럼 한 줄에 높이가 다른
+//! 표 둘이 들어가면 두 상자가 통째로 어긋났다.
+//!
+//! ```text
+//!   36384689 1쪽
+//!     rhwp   짧은 표 y 102.00 .. 207.90   큰 표 y 102.00 .. 270.70   ← 상단이 붙는다
+//!     한/글  짧은 표 y 155.03 .. 260.83   큰 표 y 101.81 .. 270.26
+//! ```
+//!
+//! 걸림돌이 둘이었다.
+//!
+//! 1. `stored_lh_covers_om` 이 `raw_lh >= table_h + om` 이라, 밴드가 줄에 **들어가기만**
+//!    하면 발동했다. 주석이 규정하는 "표 전용 줄" 은 `lh == h + om` 이다. 한 줄에 표가
+//!    둘이면 **둘 다** 이 분기로 빠져 전부 `y + om_top` 이 됐다.
+//! 2. else 분기가 상자 하단을 `기준선 + om_bottom` 에 뒀다. 한/글은
+//!    `기준선 + 0.15 × 높이` 라, 여백이 같은 두 표의 하단 간격이 0 이 됐다.
+//!
+//! `0.15` 는 새 상수가 아니다 — 저장 `baseline_distance / line_height` 가 세 표본 모두
+//! 정확히 `0.8500` 이고, `composer::line_breaking` 도 글꼴 기준 baseline 을
+//! `line_height * 0.85` 로 복원한다. 정본에서 같은 `C` 로 두 표가 풀린다.
+//!
+//! ```text
+//!   큰 표   270.26 = C + 0.15 × 168.7  → C = 244.96
+//!   짧은 표 260.83 = C + 0.15 × 105.9  → C = 244.93
+//! ```
+//!
+//! 정답지: `pdf/hwpx/opengov/36384689_…-hwpx-2020.pdf` (한/글 2020).
+//!
+//! ⚠ 잔차 `−1.2px` 는 남는다. 큰 표가 아직 `stored_lh_covers_om` 분기를 타기 때문인데,
+//! 둘 다 기준선 분기로 태우면 `#3386` 이 고친 156678235 p5 를 되돌린다. 이 핀은
+//! **결함 폭이 53.4px → 1.2px 로 닫혔음**을 잠그고 잔차는 잠그지 않는다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+const SAMPLE: &str =
+    "samples/hwpx/opengov/36384689_결재문서본문_화재발생종합보고서(제2026-298호).hwpx";
+
+/// 한/글 2020 정본의 두 상자 하단 간격.
+const HANGUL_BOTTOM_GAP_PX: f64 = 9.43;
+
+#[test]
+fn issue_7049_tac_nested_tables_sit_on_the_line_baseline() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let core = DocumentCore::from_bytes(&std::fs::read(path).expect("read sample")).expect("open");
+    let tree = core.build_page_render_tree(0).expect("page 1 render tree");
+
+    // 선언 높이(HWPUNIT 7943 · 12651)로 두 TAC 중첩 표를 동정한다.
+    let short = table_with_height(&tree.root, 105.9).expect("짧은 표(7943 HU)");
+    let big = table_with_height(&tree.root, 168.7).expect("큰 표(12651 HU)");
+
+    assert!(
+        (short.0 - big.0).abs() > 10.0,
+        "두 표의 상단이 붙으면 안 된다 (결함 시 둘 다 102.00): 짧은={:.2} 큰={:.2}",
+        short.0,
+        big.0
+    );
+
+    let gap = big.1 - short.1;
+    assert!(
+        (gap - HANGUL_BOTTOM_GAP_PX).abs() < 2.0,
+        "하단 간격이 한/글 정본 {HANGUL_BOTTOM_GAP_PX}px 근처여야 한다 \
+         (결함 시 62.80): {gap:.2}"
+    );
+}
+
+/// 주어진 높이(px, 오차 1.5px)를 가진 첫 `Table` 의 `(top, bottom)`.
+fn table_with_height(node: &RenderNode, height_px: f64) -> Option<(f64, f64)> {
+    if matches!(node.node_type, RenderNodeType::Table(_))
+        && (node.bbox.height - height_px).abs() < 1.5
+    {
+        return Some((node.bbox.y, node.bbox.y + node.bbox.height));
+    }
+    node.children
+        .iter()
+        .find_map(|child| table_with_height(child, height_px))
+}


### PR DESCRIPTION
## 변경 요약

한 글줄에 **글자처럼 취급되는 중첩 표**가 둘 이상 놓이면 rhwp 는 그것들의 **상단을
맞춰** 놓았다. 한/글은 줄의 **기준선에 앉혀** 하단을 높이차의 `0.15` 배로 벌린다.
결재 서식의 「문서번호/시행일자」 상자와 「결재란」 상자가 통째로 어긋났다.

```text
  36384689 1쪽
    rhwp   짧은 표 y 102.00 .. 207.90   큰 표 y 102.00 .. 270.70   ← 상단이 붙는다
    한/글  짧은 표 y 155.03 .. 260.83   큰 표 y 101.81 .. 270.26
```

### 걸림돌 ① — 분기 선택이 자기 주석과 달랐다

```rust
// [#3386] 저장 lh 가 표+상하 외곽여백을 수용하는 줄
// (한글이 lh = h + om 으로 저장한 표 전용 줄)은 …
let stored_lh_covers_om = (om_top > 0.0 || om_bottom > 0.0)
    && raw_lh >= table_h + om_top + om_bottom - 0.2;   // ← 한쪽만 본다
```

주석은 "`lh = h + om` 으로 저장한 **표 전용 줄**" 이라고 규정하는데 조건은 `>=`
한쪽뿐이라, 밴드가 줄에 **들어가기만** 하면 발동한다. 한 줄에 높이가 다른 표가 둘
있으면 **둘 다** 이 분기로 빠져 전부 `y + om_top` 이 된다. 조건을 **같음**으로 좁혔다.

### 걸림돌 ② — else 분기가 15% 규약을 놓쳤다

```rust
(y + baseline + om_bottom - table_h).max(y)     // 종전: 하단 = 기준선 + om_bottom
(y + baseline - table_h * 0.85).max(y)          // 정정: 하단 = 기준선 + 0.15 × 높이
```

여백이 같은 두 표의 하단 간격이 0 이 됐다. `0.15` 는 **새 상수가 아니다** — 저장
`baseline_distance / line_height` 가 세 표본 모두 정확히 `0.8500` 이고,
`composer::line_breaking` 도 글꼴 기준 baseline 을 `line_height * 0.85` 로 복원한다.
같은 파일의 그림·도형 분기는 이미 기준선 정렬을 하는데 **표만 예외였다.**

정본에서 같은 `C` 로 두 표가 풀린다.

```text
  큰 표   270.26 = C + 0.15 × 168.7  → C = 244.96
  짧은 표 260.83 = C + 0.15 × 105.9  → C = 244.93
```

## 실측 — 이슈가 든 세 표본 전부

| 표본 | 한/글 | 수정 전 | 수정 후 | 오차 |
| --- | ---: | ---: | ---: | ---: |
| `36384689_결재문서본문_화재발생종합보고서` | 9.43 | 62.80 | **8.20** | 53.4 → **1.2** |
| `issue2083_hide_fill_page` | 18.22 | 121.80 | **16.90** | 103.6 → **1.3** |
| `issue2470/36382471_masked` | 6.23 | 41.60 | **4.90** | 35.4 → **1.3** |

개체 좌표도 함께 맞는다.

```text
  36384689   짧은 표  한/글 155.03..260.83  →  rhwp 156.60..262.50   (+1.6)
             큰 표    한/글 101.81..270.26  →  rhwp 102.00..270.70   (+0.2 / +0.4)
```

## 남은 잔차 — 세 건 모두 −1.3px 로 일정하다

간격 잔차가 `−1.23 / −1.32 / −1.33` 으로 사실상 같다. 문서·높이·간격이 다 다른데
잔차만 같으므로 비례 오차가 아니라 **계통 상수**다. 큰 표가 아직
`stored_lh_covers_om` 분기(= `y + om_top`)를 타고 짧은 표만 기준선 분기를 타기
때문인데, 둘 다 기준선 분기를 태우면 간격이 정확히 `0.15 × 높이차` 가 된다
(9.42 / 18.20 / 6.25 — 한/글과 0.03px). 다만 그러면 `#3386` 이 고친 156678235 p5
(저장 `vpos + om_top` == 한글 상단)를 되돌리므로 이번에는 건드리지 않는다.

## 관련 이슈

closes #7049

## 테스트

- 변경 범위: Rust (renderer/layout)
- 검증한 commit SHA: `8a7c62927372093733dc5088fe3cb35bf4f8fb82`
- 실행 명령·결과:

```text
  cargo fmt --all -- --check                                           OK
  cargo clippy --locked --workspace --all-targets -- -D warnings       OK
  cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown  OK
  node scripts/rust-unit-test-tiers.mjs --check     4205 tests (불변)
  node scripts/rust-test-suite-manifest.mjs --check   48/48 integration targets
  cargo test --release --workspace --no-fail-fast     101 targets 전부 ok, 실패 0
```

전수 코퍼스 래칫 4종과 `oracle_page_count_baseline` 도 증가 0 이다.

### 회귀 핀

`tests/cases/issue_7049_tac_nested_tables_sit_on_baseline.rs` — 1쪽의 두 TAC 중첩 표를
선언 높이로 동정해 ① 상단이 붙지 않는지 ② 하단 간격이 한/글 9.43px 근처인지 고정한다.
**수정 전 FAILED(둘 다 101.99) · 수정 후 ok** 양쪽 실증했다. 잔차는 잠그지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Atxwm3i6Nkqfar45X9TSzz
