### PR TITLE
fix(ci): 병합 후 duration만 갱신하고 API 증거 불일치를 대기 처리

### DIFF
--- a/.github/workflows/adapter-diff.yml
+++ b/.github/workflows/adapter-diff.yml
@@ -8,8 +8,6 @@ name: Adapter inter-diff
 on:
   pull_request:
     branches: [main, devel]
-  push:
-    branches: [main, devel]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci-impact-policy.yml
+++ b/.github/workflows/ci-impact-policy.yml
@@ -152,6 +152,7 @@ jobs:
           sparse-checkout: |
             scripts/ci-impact-classifier.cjs
             scripts/ci-impact-policy.cjs
+            scripts/ci-workflow-evidence.cjs
             scripts/ci-impact-report.cjs
             scripts/verify_review_only_merge_resolution.py
           sparse-checkout-cone-mode: false
@@ -180,6 +181,10 @@ jobs:
             const { selectLatestWorkflowRun, selectReviewOnlyCandidate } = require(path.join(
               process.env.GITHUB_WORKSPACE,
               'trusted-base/scripts/ci-impact-policy.cjs',
+            ));
+            const { collectWorkflowEvidence } = require(path.join(
+              process.env.GITHUB_WORKSPACE,
+              'trusted-base/scripts/ci-workflow-evidence.cjs',
             ));
             let files = [];
             let forceFullReason = '';
@@ -300,7 +305,7 @@ jobs:
                 core.warning(`Workflow run collection failed; audit will remain pending. ${error.message}`);
               }
               async function collectRun(name, expectedPath, headSha, allowPriorBase) {
-                const run = selectLatestWorkflowRun(runs, {
+                let run = selectLatestWorkflowRun(runs, {
                   name,
                   path: expectedPath,
                   pullNumber: Number(process.env.PULL_NUMBER),
@@ -312,23 +317,19 @@ jobs:
                   allowPriorBase,
                 });
                 if (!run) return null;
-                let jobs = [];
-                let jobsCollected = false;
-                try {
-                  jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
-                    owner,
-                    repo,
-                    run_id: run.id,
-                    filter: 'latest',
-                    per_page: 100,
-                  });
-                  jobsCollected = true;
-                } catch (error) {
-                  core.warning(
-                    `Could not collect ${name} jobs after configured retries; `
-                    + `audit will remain pending. ${error.message}`,
-                  );
-                }
+                const snapshot = await collectWorkflowEvidence({
+                  run,
+                  getRun: async (id) => (await github.rest.actions.getWorkflowRun({
+                    owner, repo, run_id: id, request: { timeout: 10000 },
+                  })).data,
+                  listJobs: async (id) => github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                    owner, repo, run_id: id, filter: 'latest', per_page: 100,
+                    request: { timeout: 10000 },
+                  }),
+                  warn: (message) => core.warning(message),
+                });
+                run = snapshot.run;
+                const { jobs, jobsCollected, collectionFailure, collectionPendingReason } = snapshot;
                 const collected = {
                   run: {
                     id: run.id,
@@ -347,6 +348,8 @@ jobs:
                     createdAt: run.created_at || '',
                   },
                   jobsCollected,
+                  collectionFailure,
+                  collectionPendingReason,
                   jobs: jobs.map((job) => ({
                     id: job.id,
                     runId: job.run_id,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,25 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, devel]
     tags: ['v*']
-    paths-ignore:
-      - 'mydocs/**'
-      - 'samples/**'
-      - 'pdf/**'
-      - 'assets/chrome/**'
-      - 'assets/edge/**'
-      - 'assets/logo/**'
-      - 'assets/screenshots/**'
-      - '*.md'
-      - 'LICENSE'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/FUNDING.yml'
-      - '.github/CODE_OF_CONDUCT.md'
-      - '.github/SECURITY.md'
-      - '.github/pull_request_template.md'
-      - '.github/dependabot.yml'
-      - 'rhwp-logo.*'
   pull_request:
     branches: [main, devel]
     types: [opened, reopened, synchronize]
@@ -52,7 +34,7 @@ env:
   CARGO_TERM_COLOR: always
 
 # [Task #1192 F] 같은 PR 에 새 push 가 오면 진행 중 run 을 취소해 중복 실행 제거.
-# cancel-in-progress 는 PR 이벤트에서만 활성화 — devel/main push 머지 검증 run 은 보존.
+# Branch push에서는 검증 CI를 시작하지 않는다. tag/manual 실행은 명시 실행이다.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -996,6 +978,9 @@ jobs:
         run: |
           node --test scripts/tests/ci-impact-classifier.test.cjs
           node --test scripts/tests/ci-impact-policy.test.cjs
+          node --test scripts/tests/ci-workflow-evidence.test.cjs
+          node --test scripts/tests/collect-postmerge-duration-data.test.mjs
+          python3 -m unittest scripts/tests/test_postmerge_duration_workflow.py
           node --test scripts/tests/ci-impact-report.test.cjs
           python3 -m unittest scripts/tests/test_ci_impact_workflow.py
 
@@ -1552,137 +1537,6 @@ jobs:
       partition: "hash:1/1"
       security_sweep_samples_json: ${{ needs.preflight.outputs.security_sweep_samples_json || '[]' }}
 
-
-  # B/C/D duration data is refreshed from this devel run, or from the exact green
-  # same-repository PR run accepted by trusted_postmerge_reuse.
-  refresh-nextest-target-duration-data:
-    name: Refresh nextest target duration data
-    runs-on: ubuntu-latest
-    needs:
-      - preflight
-      - test-archive-b-shard-1
-      - test-archive-c-shard-1
-      - test-archive-d-shard-1
-    if: >-
-      ${{
-        always()
-        && github.event_name == 'push'
-        && github.ref == 'refs/heads/devel'
-        && needs.preflight.result == 'success'
-        && (
-          needs.preflight.outputs.postmerge_reuse != 'true'
-          || needs.preflight.outputs.postmerge_refresh_duration_data == 'true'
-        )
-        && needs.preflight.outputs.rust_required == 'true'
-        && (
-          (
-            needs.preflight.outputs.postmerge_reuse != 'true'
-            && needs.preflight.outputs.fast_pass != 'true'
-            && needs.test-archive-b-shard-1.result == 'success'
-            && needs.test-archive-c-shard-1.result == 'success'
-            && needs.test-archive-d-shard-1.result == 'success'
-          )
-          || (
-            needs.preflight.outputs.postmerge_reuse == 'true'
-            && needs.preflight.outputs.postmerge_source_run_id != ''
-          )
-        )
-      }}
-    permissions:
-      actions: read
-      contents: write
-    concurrency:
-      group: nextest-target-duration-data
-      cancel-in-progress: false
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.sha }}
-          fetch-depth: 1
-
-      - name: Download Archive B duration measurement
-        if: ${{ needs.preflight.outputs.postmerge_reuse != 'true' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: nextest-target-durations-${{ github.run_id }}-b
-          path: duration-b
-
-      - name: Download Archive C duration measurement
-        if: ${{ needs.preflight.outputs.postmerge_reuse != 'true' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: nextest-target-durations-${{ github.run_id }}-c
-          path: duration-c
-
-      - name: Download Archive D duration measurement
-        if: ${{ needs.preflight.outputs.postmerge_reuse != 'true' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: nextest-target-durations-${{ github.run_id }}-d
-          path: duration-d
-
-      - name: Download trusted PR Archive B duration measurement
-        if: ${{ needs.preflight.outputs.postmerge_reuse == 'true' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: trusted-postmerge-durations-${{ github.run_id }}-${{ github.run_attempt }}-b
-          path: duration-b
-
-      - name: Download trusted PR Archive C duration measurement
-        if: ${{ needs.preflight.outputs.postmerge_reuse == 'true' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: trusted-postmerge-durations-${{ github.run_id }}-${{ github.run_attempt }}-c
-          path: duration-c
-
-      - name: Download trusted PR Archive D duration measurement
-        if: ${{ needs.preflight.outputs.postmerge_reuse == 'true' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: trusted-postmerge-durations-${{ github.run_id }}-${{ github.run_attempt }}-d
-          path: duration-d
-
-      - name: Refresh duration policy data branch
-        shell: bash
-        env:
-          METRICS_BRANCH: ci-metrics/nextest-target-durations
-          OUTPUT_POLICY: ${{ runner.temp }}/nextest-target-duration-policy.json
-        run: |
-          set -euo pipefail
-
-          current_devel_sha="$(git ls-remote origin refs/heads/devel | awk 'NR == 1 { print $1 }')"
-          if [[ "${current_devel_sha}" != "${GITHUB_SHA}" ]]; then
-            echo "::notice::A newer devel commit exists; this older measurement is not published."
-            exit 0
-          fi
-
-          node scripts/refresh-nextest-target-duration-policy.mjs \
-            --policy tests/suites/nextest-target-duration-policy.json \
-            --measurement duration-b/target-durations-b.json \
-            --measurement duration-c/target-durations-c.json \
-            --measurement duration-d/target-durations-d.json \
-            --output "${OUTPUT_POLICY}"
-
-          if git ls-remote --exit-code origin "refs/heads/${METRICS_BRANCH}" >/dev/null 2>&1; then
-            git fetch --depth=1 origin \
-              "refs/heads/${METRICS_BRANCH}:refs/remotes/origin/${METRICS_BRANCH}"
-            git switch --detach "refs/remotes/origin/${METRICS_BRANCH}"
-          else
-            git switch --orphan "${METRICS_BRANCH}"
-            git rm -rf . >/dev/null 2>&1 || true
-          fi
-
-          cp "${OUTPUT_POLICY}" nextest-target-duration-policy.json
-          git add nextest-target-duration-policy.json
-          if git diff --cached --quiet; then
-            echo 'Duration policy data is unchanged.'
-            exit 0
-          fi
-
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit -m "ci: nextest target duration data ${GITHUB_SHA}"
-          git push origin "HEAD:refs/heads/${METRICS_BRANCH}"
 
   workflow-promotion-preflight:
     name: Workflow promotion preflight

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,22 +1,6 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [main, devel]
-    paths-ignore:
-      - 'mydocs/**'
-      - 'samples/**'
-      - 'pdf/**'
-      - 'assets/**'
-      - '*.md'
-      - 'LICENSE'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/FUNDING.yml'
-      - '.github/CODE_OF_CONDUCT.md'
-      - '.github/SECURITY.md'
-      - '.github/pull_request_template.md'
-      - '.github/dependabot.yml'
-      - 'rhwp-logo.*'
   pull_request:
     branches: [main, devel]
     paths-ignore:
@@ -37,7 +21,7 @@ on:
   workflow_dispatch:
 
 # [Task #1192 F] 같은 PR 에 새 push 가 오면 진행 중 run 을 취소해 중복 실행 제거.
-# cancel-in-progress 는 PR 이벤트에서만 활성화 — push/schedule(주간 cron) run 은 보존.
+# Branch push에서는 분석하지 않는다. schedule/manual 분석은 별도 명시 정책이다.
 concurrency:
   group: codeql-${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/oracle-public-advisory.yml
+++ b/.github/workflows/oracle-public-advisory.yml
@@ -18,11 +18,9 @@
 name: Oracle Public Advisory
 
 on:
-  # workflow_dispatch identity가 아직 기본 브랜치에 등록되지 않은 후보도
-  # workflow 파일 자체를 바꾼 신뢰 push에서 한 번 실실행한다.
+  # 후보 브랜치의 명시적 workflow 변경만 검증한다. devel 병합 뒤에는 실행하지 않는다 (#7070).
   push:
     branches:
-      - devel
       - 'task_m100_*'
     paths:
       - '.github/workflows/oracle-public-advisory.yml'

--- a/.github/workflows/proptest-roundtrip.yml
+++ b/.github/workflows/proptest-roundtrip.yml
@@ -11,8 +11,6 @@ name: Proptest roundtrip
 on:
   pull_request:
     branches: [main, devel]
-  push:
-    branches: [main, devel]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/refresh-nextest-duration.yml
+++ b/.github/workflows/refresh-nextest-duration.yml
@@ -1,0 +1,92 @@
+name: Refresh nextest target duration data
+
+# #7070: branch merges run metadata refresh only. Never build/test or request a CI fallback.
+on:
+  push:
+    branches: [devel]
+  workflow_dispatch:
+
+permissions: {}
+concurrency:
+  group: nextest-target-duration-data
+  cancel-in-progress: false
+
+jobs:
+  refresh-nextest-target-duration-data:
+    name: Refresh nextest target duration data
+    if: github.ref == 'refs/heads/devel'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+      - name: Collect verified PR duration measurements
+        id: collect
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DURATION_DIR: ${{ runner.temp }}/postmerge-duration-data
+        with:
+          script: |
+            const path = require('node:path');
+            const { pathToFileURL } = require('node:url');
+            const { collectPostmergeDurations } = await import(pathToFileURL(path.join(
+              process.env.GITHUB_WORKSPACE, 'scripts/collect-postmerge-duration-data.mjs',
+            )).href);
+            const result = await collectPostmergeDurations({
+              github, ...context.repo, mergeSha: context.sha, outputDir: process.env.DURATION_DIR,
+              notice: (message) => core.notice(message),
+            });
+            core.setOutput('ready', String(result.ready));
+            core.info(JSON.stringify(result));
+            await core.summary.addHeading('PR duration metadata refresh')
+              .addCodeBlock(JSON.stringify(result, null, 2), 'json').write();
+      - name: Refresh duration policy data branch
+        if: steps.collect.outputs.ready == 'true'
+        shell: bash
+        env:
+          METRICS_BRANCH: ci-metrics/nextest-target-durations
+          DURATION_DIR: ${{ runner.temp }}/postmerge-duration-data
+          OUTPUT_POLICY: ${{ runner.temp }}/nextest-target-duration-policy.json
+        run: |
+          set -euo pipefail
+
+          current_devel_sha="$(git ls-remote origin refs/heads/devel | awk 'NR == 1 { print $1 }')"
+          if [[ "${current_devel_sha}" != "${GITHUB_SHA}" ]]; then
+            echo "::notice::A newer devel commit exists; this older measurement is not published."
+            exit 0
+          fi
+
+          node scripts/refresh-nextest-target-duration-policy.mjs \
+            --policy tests/suites/nextest-target-duration-policy.json \
+            --measurement "${DURATION_DIR}/duration-b/target-durations-b.json" \
+            --measurement "${DURATION_DIR}/duration-c/target-durations-c.json" \
+            --measurement "${DURATION_DIR}/duration-d/target-durations-d.json" \
+            --output "${OUTPUT_POLICY}"
+
+          if git ls-remote --exit-code origin "refs/heads/${METRICS_BRANCH}" >/dev/null 2>&1; then
+            git fetch --depth=1 origin \
+              "refs/heads/${METRICS_BRANCH}:refs/remotes/origin/${METRICS_BRANCH}"
+            git switch --detach "refs/remotes/origin/${METRICS_BRANCH}"
+          else
+            git switch --orphan "${METRICS_BRANCH}"
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          cp "${OUTPUT_POLICY}" nextest-target-duration-policy.json
+          git add nextest-target-duration-policy.json
+          if git diff --cached --quiet; then
+            echo 'Duration policy data is unchanged.'
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -m "ci: nextest target duration data ${GITHUB_SHA}"
+          git push origin "HEAD:refs/heads/${METRICS_BRANCH}"
+

--- a/mydocs/manual/github_operations.md
+++ b/mydocs/manual/github_operations.md
@@ -2,7 +2,7 @@
 kind: canonical
 status: active
 canonical: mydocs/manual/github_operations.md
-last_verified: 2026-09-05
+last_verified: 2026-09-13
 ---
 
 # GitHub 저장소 운영 매뉴얼
@@ -12,6 +12,33 @@ last_verified: 2026-09-05
 > 검토·통합은 [PR 리뷰·통합 워크플로우](pr_review_workflow.md), 실제 패키지 배포는
 > [배포 가이드](publish_guide.md)를 함께 따른다. 이 문서는 그 절차를 복제하지 않고 운영 변경의
 > 분류, 비례 검증, 적용 후 관찰과 복구를 담당한다.
+
+## 병합 후 자동 실행 정책 (#7070)
+
+검증 CI는 PR에서 완료한다. main/devel branch push는 CI·CodeQL·Adapter inter-diff·Proptest
+roundtrip을 시작하지 않으며, Oracle advisory도 devel push를 구독하지 않는다. 재사용 증거가
+없다는 이유로 병합 후 Full CI를 실행하거나 수동으로 재실행하지 않는다.
+
+`devel` push에서는 `Refresh nextest target duration data`가 실행 시간 메타데이터만 갱신한다.
+성공 PR CI의 정확한 head 또는 완전한 linear review-only 후행 변경을 확인한 후보에서 B/C/D
+실측을 읽는다. artifact의 run/repository/head/PR/tested merge와 worker별 실제 attempt를
+검증하므로 lint만 재실행한 attempt 2에서도 성공 worker attempt 1의 실측을 사용할 수 있다.
+증거 누락·만료·불일치는 갱신 보류이며 검증 CI fallback이 아니다. 기록은
+`ci-metrics/nextest-target-durations`에만 쓰고, 쓰기 전 최신 devel SHA를 확인한다.
+
+GitHub `latest` Jobs API는 부분 재실행에서 실행하지 않은 worker도 새 ID/attempt로 복사할 수 있다.
+#7068 실측에서는 B/C/D 실행 시각이 동일한 채 attempt 2로 표시되고 artifact는 attempt 1에 남았다.
+수집기는 attempt별 Jobs API의 원본과 name/run/head/status/시작·완료 시각을 모두 대조한 경우에만
+원본 attempt로 복원한다. 다른 실행 시각의 과거 성공 job으로 대체하지 않는다.
+
+
+issue close 자동화는 업무 메타데이터 처리로 유지한다. release tag 빌드, main Pages 배포,
+독립적인 정기 보안 분석, 명시적인 workflow_dispatch는 병합 후 검증 CI와 별도 목적이다.
+이 예외를 devel 병합의 중복 검증 경로로 사용하지 않는다.
+
+push trigger 제거와 새 duration workflow는 해당 변경의 devel 병합부터 적용된다. 반면
+CI Impact Policy Controller의 `pull_request_target`/`workflow_run` 배선 변경은 기본 branch
+main에 정상 release된 뒤 활성화된다. policy 모듈은 live base에서 로드하므로 이를 구분해 보고한다.
 
 ## 1. 목적과 범위
 
@@ -247,7 +274,7 @@ fast-pass로 숨기지 않고 CI 영향 분류가 fail-closed 해야 한다. 기
 현재 반복적으로 대형 참조 자료가 들어오는 경로는 `samples/**`, `pdf/**`다.
 운영 정책은 다음처럼 분리한다.
 
-- protected branch의 reference-only push는 제품 소스 CI와 CodeQL을 다시 실행하지 않는 것을 기본으로 한다.
+- protected branch push는 변경 경로와 무관하게 검증 CI와 CodeQL을 다시 실행하지 않는다.
 - PR에서는 새 참조 자산만 있는 변경을 review-only fast-pass로 판정할 수 있다.
 - 기존 sample·PDF의 수정·삭제·rename은 데이터 회귀 의미가 있을 수 있으므로 PR에서 자동 fast-pass로
   확장하지 않는다.

--- a/mydocs/manual/pr_review/post_merge.md
+++ b/mydocs/manual/pr_review/post_merge.md
@@ -2,7 +2,7 @@
 kind: guide
 status: active
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-08-30
+last_verified: 2026-09-13
 ---
 
 # Merge 후속 처리
@@ -13,7 +13,10 @@ last_verified: 2026-08-30
 
 ## 7. 필수 실행 순서
 
-1. 원 코드 PR merge 완료와 merge SHA를 확인한다.
+1. 원 코드 PR merge 완료와 merge SHA를 확인한다. 검증 CI는 병합 전 PR에서 완료한다.
+   병합 뒤에는 `Refresh nextest target duration data`의 성공 또는 증거 부족에 따른 갱신 보류를
+   확인한다. CI·CodeQL·Adapter·Proptest·Oracle 검증을 시작하거나 재실행하지 않는다.
+   예상 밖 실행은 트리거 회귀로 조사한다. [실행 경계](../github_operations.md#병합-후-자동-실행-정책-7070)를 따른다.
 2. review 문서·asset·오늘할일의 후속 반영 필요 여부를 결정한다.
 3. archive 이동과 오늘할일을 준비하고, maintainer 직접 반영 또는 후속 기록 PR을 완료한다.
 4. 최종 devel을 upstream/devel로 fast-forward한다.
@@ -246,7 +249,7 @@ git fetch upstream --prune
 승인은 이번 작업에서 만든 PR 전용 임시 upstream head branch의 삭제까지 포함한다. 아래 조건을 모두
 충족하면 별도 승인 질문 없이 자동 삭제한다.
 
-- PR이 실제 MERGED이고 필수 post-merge CI와 comment·issue 처리가 완료되어야 한다.
+- PR이 실제 MERGED이고 duration 갱신 결과 확인과 comment·issue 처리가 완료되어야 한다. 자료 부족으로 duration 갱신이 보류되면 그 이유를 기록하며 검증 CI를 다시 실행하지 않는다.
 - PR head repository가 `edwardkim/rhwp`이며 이번 작업에서 만든 exact `headRefName`이어야 한다.
 - merge SHA가 최신 `upstream/devel`에 포함되고 기본 작업공간이 clean이며 관련 활성 작업이 없어야 한다.
 - `main`, `devel`, 저장소 기본 branch, 보호 branch, 다른 OPEN PR 또는 다른 작업이 사용하는 branch는 제외한다.

--- a/mydocs/manual/pr_review/review_only_fast_pass.md
+++ b/mydocs/manual/pr_review/review_only_fast_pass.md
@@ -140,43 +140,19 @@ all-review-only-no-code-impact fast-pass를 즉시 선택한다. candidate의 �
 
 따라서 순수 문서·review 기준 자료 PR에 A 경로의 candidate-check 조회 조건을 잘못 적용하지 않는다.
 
-### B.1 `devel` 병합 후 worker 재사용
+### B.1 병합 후에는 검증 workflow를 시작하지 않는다
 
-Adapter inter-diff와 Proptest roundtrip은 `devel` push에도 required check 이름을 유지한다. PR event가
-아닌 push에는 PR payload가 없으므로, 일반 preflight는 단독으로 review-only 판정을 하지 않고 Full로
-닫힌다. 다만 trusted post-merge controller가 아래를 모두 확인한 같은 저장소 PR이면 worker를 다시
-실행하지 않는다.
+#7070부터 CI·CodeQL·Adapter inter-diff·Proptest roundtrip은 main/devel branch push를 구독하지
+않는다. Oracle advisory도 devel push에서 실행하지 않는다. review-only 여부나 재사용 증거에
+따라 병합 후 Full CI로 돌아가는 경로는 없다. 검증은 병합 전 PR에서 완료한다.
 
-1. merge commit이 유일한 `devel` 대상 PR에 대응하고, merge tree와 PR head tree가 일치한다.
-2. PR 전체 파일과 linear PR commit이 모두 B 경로 허용 범위다.
-3. 해당 PR head의 성공한 `pull_request` workflow run에서 해당 preflight는 success이고 worker는
-   실제로 `skipped`였다.
+`Refresh nextest target duration data`만 devel push에서 duration 메타데이터를 갱신한다.
+PR의 성공 B/C/D worker와 그 worker의 실제 attempt에 묶인 artifact를 검증하며, 자료가 없거나
+불일치하면 갱신을 보류한다. 이전 Full candidate는 최종 head까지 linear review-only 변경으로
+이어질 때만 시간 추정 자료로 사용한다. 이는 PR 승인이나 병합 tree 검증을 대신하지 않는다.
+자세한 실행 경계는 [GitHub 운영 정책](../github_operations.md#병합-후-자동-실행-정책-7070)을 따른다.
 
-direct push, fork PR, PR 식별 불명확, merge tree 불일치, workflow·CI policy 변경, 비허용 파일, merge
-commit 또는 worker-skip 증거 누락은 재사용하지 않고 Full 실행한다.
-
-### B.2 Full candidate 뒤 문서 merge의 post-merge 재사용
-
-코드 PR의 문서-only trailing 사이에 current-base 충돌 해소 merge가 있으면, CI/CodeQL의 공통
-post-merge verifier가 다음 조건에서만 이전 Full 검증을 재사용한다.
-
-- source 부모 + 최종 devel base 부모 순서의 bridge 한 개이며, 그 앞뒤 commit 계보가 연속이다.
-- 최종 head workflow가 성공했고, 선택한 이전 Full 실행의 PR/branch/repository/SHA/time이 일치한다.
-- CI는 만료되지 않은 B/C/D duration artifact, CodeQL은 실제 분석 성공 증거를 요구한다.
-- Full 실행에 속한 immutable merge-tree artifact의 base/head/tree를 Git 객체와 대조한다.
-- 그 실제 검사 tree와 최종 merge tree 차이는 `mydocs/**` 문서뿐이다.
-  `mydocs/tech/text-ir-v2.md`, `mydocs/tech/canvaskit-parity-implementation.md`는 실행 계약이므로 제외한다.
-
-단순히 부모가 둘이거나 PR fast-pass aggregate가 green이라는 이유로 승인하지 않는다. base의 신뢰
-검증 코드가 객체를 fetch/diff하며 PR head를 checkout/실행하지 않는다. 코드·테스트·기준 PDF 변경,
-stale base, 복수 bridge, 목록 잘림, fetch 실패, 증거 불일치는 Full로 닫는다.
-정상 재사용 시 초기 Full run의 duration artifact로 timing을 갱신하며 required check 이름은 유지한다.
-
-재사용 정책 자체를 바꾸는 PR은 Full 대상이다. trusted verifier는 병합 전 base에서 로드하므로 최초
-적용 PR의 post-merge도 Full일 수 있다. 지원 완료는 이후 코드 PR의 문서 merge 사례에서 실제
-`reuse=true`, CI/CodeQL heavy skip, duration 재사용을 확인한 뒤 판단한다.
-
-## Full CI fallback
+## PR 검증의 Full CI fallback
 
 다음 중 하나면 fast-pass로 단정하지 않고 workflow의 full CI 결과를 기다린다.
 

--- a/mydocs/orders/20260913.md
+++ b/mydocs/orders/20260913.md
@@ -9,3 +9,12 @@
 - [Self-review](../pr/archives/pr_7068_review.md) 판정은 승인이다. 최신 head CI·병합 승인이 남아 있다.
 - #5819의 표 생성 옵션 요청은 충족했으므로 PR에 `Closes #5819`를 지정했다. devel 병합 후 이슈 종료를 확인한다.
 - 중첩 필드·235쪽 템플릿 overflow·PDF 시각 일치는 미검증 범위이며 #5819의 종료를 막는 추가 조건으로 두지 않는다.
+
+## #7069·#7070 CI 개선
+
+- [PR #7071](https://github.com/edwardkim/rhwp/pull/7071)을 devel 대상 Open PR로 생성했다.
+- 성공 workflow의 미완료 job/step을 pending으로 구분하고 API 증거를 제한적으로 재조회했다.
+- 검증 workflow의 branch push를 제거하고 devel에는 duration 메타데이터 전용 갱신을 분리했다.
+- #7068 실제 부분 재실행의 복사 job/원본 artifact를 대조해 로컬 42 target 갱신을 검증했다.
+- Node 450 PASS, Python workflow 179 PASS. [Self-review](../pr/archives/pr_7071_review.md)는 승인이다.
+- 최신 PR CI와 병합 판단이 남아 있다. controller 배선은 정상 main release 뒤 활성화된다.

--- a/mydocs/orders/20260913.md
+++ b/mydocs/orders/20260913.md
@@ -16,5 +16,5 @@
 - 성공 workflow의 미완료 job/step을 pending으로 구분하고 API 증거를 제한적으로 재조회했다.
 - 검증 workflow의 branch push를 제거하고 devel에는 duration 메타데이터 전용 갱신을 분리했다.
 - #7068 실제 부분 재실행의 복사 job/원본 artifact를 대조해 로컬 42 target 갱신을 검증했다.
-- Node 450 PASS, Python workflow 179 PASS. [Self-review](../pr/archives/pr_7071_review.md)는 승인이다.
+- Node 450 PASS, Python workflow 240 PASS. [Self-review](../pr/archives/pr_7071_review.md)는 승인이다.
 - 최신 PR CI와 병합 판단이 남아 있다. controller 배선은 정상 main release 뒤 활성화된다.

--- a/mydocs/plans/task_m100_7069.md
+++ b/mydocs/plans/task_m100_7069.md
@@ -1,0 +1,28 @@
+# #7069 CI audit 증거 불일치 개선 계획
+
+- Issue: [#7069](https://github.com/edwardkim/rhwp/issues/7069)
+- 기준: `3f34869b9c4d15a27b181dd22c63cd0a3730d46a`
+- 경로: collaborator self PR, GitHub 운영 O3, intake/local validation/review-only 보조 절차.
+
+## 원인과 범위
+
+#7068에서 CI run success와 lint job in_progress가 동시에 반환됐다. 세부 단계 26개는 성공했으나
+정책이 미완료 job을 즉시 failure로 분류했다. workflow 미완료는 pending인 반면 job 미완료에는
+그 처리가 없고, 자료 수집의 HTTP 재시도는 성공 응답의 불일치를 해결하지 않는다.
+GitHub 내부 갱신 문제의 원인은 미확정이며, 동일 자료에 대한 정책 함수 재생으로 오실패를 확인했다.
+
+## 구현
+
+1. 알려진 nonterminal job/step 증거는 pending으로 구분한다. 실제 실패·취소, 누락·중복,
+   잘못된 skip, 출처 불일치가 성공으로 바뀌지 않게 기존 엄격한 검사를 유지한다.
+2. 정확한 run/head를 고정해 run과 latest job 증거를 제한적으로 재조회한다. 재실행 attempt 변경이나
+   수집 실패 시 이전 성공 snapshot을 사용하지 않는다. PR 코드·artifact는 실행하지 않는다.
+3. 재조회 한도를 소진하면 pending으로 유지하고 해당 audit 재실행 절차를 운영 문서에 명시한다.
+   새로운 권한·자동 재실행 루프를 추가하지 않는다. workflow 변경의 main 활성화 경계를 명시한다.
+4. 실제 응답을 축소한 fixture와 합성 경계·반례, collector mock으로 수렴·비수렴·실패·출처 변경을 검증한다.
+
+## 검증
+
+Node CI classifier/policy/collector 계약, 관련 post-merge reuse 회귀, Python workflow 계약,
+변경 Markdown 링크·metadata, Git diff와 최신 base 병합 simulation을 실행한다.
+Rust·renderer·fixture·baseline 변경이 없으므로 Cargo/visual sweep은 적용하지 않는다.

--- a/mydocs/plans/task_m100_7070.md
+++ b/mydocs/plans/task_m100_7070.md
@@ -1,0 +1,28 @@
+# #7070 검증 CI의 PR 한정과 duration 전용 후속 처리
+
+- Issue: [#7070](https://github.com/edwardkim/rhwp/issues/7070)
+- 작업지시: post-merge에는 검증 CI를 시작하지 않고 duration 자료 갱신만 실행한다.
+
+## 원인
+
+기존 4개 workflow는 branch push에서 먼저 시작한 뒤 재사용 증거를 확인했다. 증거가 없으면
+Full 실행으로 돌아가므로 재사용 verifier 개선만으로 중복 실행을 제거할 수 없다. #7068에서는
+merge-tree 증거 부재 판정과, lint만 재실행한 최신 attempt 2에 B/C/D artifact가 없는 문제가 확인됐다.
+
+## 구현과 검증
+
+- CI의 branch push, CodeQL/Adapter/Proptest의 push 트리거를 제거한다. PR 검증·명시 수동 실행과
+  release tag/정기 보안 분석은 별개의 실행 목적이므로 유지한다.
+- duration 갱신을 devel push의 독립 workflow/job으로 분리한다. 재사용 verifier나 Cargo/CodeQL을
+  호출하지 않고, 실패 시 Full CI를 요청하지 않는다.
+- 병합 PR의 정확한 head 또는 문서-only 선행 후보를 확인한다. 성공 CI의 latest B/C/D job별
+  실제 attempt와 artifact 출처를 검증한다. 부분 재실행을 workflow 전체 attempt로 오인하지 않는다.
+- duration JSON/ZIP은 기존 엄격한 크기·경로·키·숫자 검증을 유지한다. 이 자료는 실행 시간 추정용이며
+  병합된 코드의 CI 성공을 대신하는 권한이 아니다. 증거가 없으면 갱신만 보류한다.
+- fixture/mock 동작 테스트, trigger topology와 관련 workflow/정책 계약, 실제 #7068 PR artifact의
+  read-only 수집·검증을 실행한다. metrics branch 쓰기 전 최신 devel SHA를 다시 확인한다.
+
+GitHub `latest` Jobs API는 부분 재실행에서 실행하지 않은 worker도 새 ID/attempt로 복사할 수 있다.
+#7068 실측에서는 B/C/D 실행 시각이 동일한 채 attempt 2로 표시되고 artifact는 attempt 1에 남았다.
+수집기는 attempt별 Jobs API의 원본과 name/run/head/status/시작·완료 시각을 모두 대조한 경우에만
+원본 attempt로 복원한다. 다른 실행 시각의 과거 성공 job으로 대체하지 않는다.

--- a/mydocs/pr/archives/pr_7071_review.md
+++ b/mydocs/pr/archives/pr_7071_review.md
@@ -16,7 +16,7 @@ last_verified: 2026-09-13
 | 관련 issue | Closes [#7069](https://github.com/edwardkim/rhwp/issues/7069), Closes [#7070](https://github.com/edwardkim/rhwp/issues/7070) |
 | 작성자 / 검토자 | jangster77 / jangster77 self-review, reviewer 미지정 |
 | base / branch | devel / fix/7069-ci-evidence-convergence |
-| 검증 후보 | `4855fffdba4d7985200fbe6ea0d90f3bb4758316` |
+| 최초 검증 후보 | `4855fffdba4d7985200fbe6ea0d90f3bb4758316` |
 | 기준 / 병합 simulation | `3f34869b9c4d15a27b181dd22c63cd0a3730d46a` / tree `044e1f598878029f00d4e0bc2afa569cb4c8bb61`, 충돌 없음 |
 | 최초 규모 | 28 files, +1309 / -295; 본 문서와 오늘할일은 문서-only 후행 변경 |
 | 생성 직후 상태 | Open, non-draft, MERGEABLE / BLOCKED, PR CI 진행 중인 시점의 참고값 |
@@ -50,7 +50,7 @@ PR 승인·병합 tree 검증의 대체물이 아니다.
 | 검증 | 결과 |
 | --- | --- |
 | Node classifier/policy/evidence/duration/reuse | 450 PASS, exit 0 |
-| Python workflow 계약 | 179 PASS, exit 0 |
+| Python workflow 계약 | 240 PASS, exit 0 |
 | actionlint 구조·expression | 변경 workflow 7개 통과 |
 | ShellCheck 포함 비교 | 기존 CI·Oracle SC2016 2건 동일; 신규 duration workflow 없음 |
 | 실제 #7068 artifact read-only 수집 | run `34702678657`, latest attempt 2, 측정 B/C/D attempt 1, provenance 통과 |
@@ -78,3 +78,11 @@ Rust 및 renderer 변경이 없으므로 Cargo, HWP/HWPX/PDF fixture, visual swe
 main/devel push 제거와 duration workflow는 devel 병합부터 적용되지만, #7069 controller 수집
 배선은 기본 branch main의 정상 release 이후 활성화된다. main 직접 push는 범위에 없다.
 코멘트·devel 동기화 후 이 PR 소유 branch/worktree만 정리하며 공유 target과 다른 작업은 보존한다.
+
+## 최초 CI 실패 보정
+
+`5a5095d58`의 lint에서 새 Node evidence 테스트의 discovery 기대 목록 누락을 발견했다.
+`test_workflow_contract_wiring.py`를 갱신하고 실제 CI의 `Validate workflow contracts` 명령을
+그대로 재실행해 exit 0을 확인했다. Python 검색 범위는 `test_*workflow*.py`로 넓혀 240 PASS를
+확인했다. 이후 변경은 workflow 계약 테스트 2개와 본 검증 기록이며 제품 코드 변경은 없다.
+새 최종 head의 CI 결과로 병합 판단해야 한다.

--- a/mydocs/pr/archives/pr_7071_review.md
+++ b/mydocs/pr/archives/pr_7071_review.md
@@ -1,0 +1,80 @@
+---
+kind: snapshot
+status: historical
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-09-13
+---
+
+# PR #7071 — CI 증거 수렴과 병합 후 duration 전용 처리 self-review
+
+**최종 판정: 승인.** 구현과 로컬 검증의 판정이며 GitHub 병합을 뜻하지 않는다.
+최종 head의 PR CI와 별도 병합 판단이 남아 있다.
+
+| 항목 | 확인 내용 |
+| --- | --- |
+| PR | [#7071](https://github.com/edwardkim/rhwp/pull/7071) |
+| 관련 issue | Closes [#7069](https://github.com/edwardkim/rhwp/issues/7069), Closes [#7070](https://github.com/edwardkim/rhwp/issues/7070) |
+| 작성자 / 검토자 | jangster77 / jangster77 self-review, reviewer 미지정 |
+| base / branch | devel / fix/7069-ci-evidence-convergence |
+| 검증 후보 | `4855fffdba4d7985200fbe6ea0d90f3bb4758316` |
+| 기준 / 병합 simulation | `3f34869b9c4d15a27b181dd22c63cd0a3730d46a` / tree `044e1f598878029f00d4e0bc2afa569cb4c8bb61`, 충돌 없음 |
+| 최초 규모 | 28 files, +1309 / -295; 본 문서와 오늘할일은 문서-only 후행 변경 |
+| 생성 직후 상태 | Open, non-draft, MERGEABLE / BLOCKED, PR CI 진행 중인 시점의 참고값 |
+| base route | collaborator_self_merge |
+| modifiers | intake_and_review, local_validation, review_only_fast_pass, rework_and_exceptions |
+
+## 범위·원인·코드 검토
+
+1,000줄 초과 변경이므로 [#7069 계획](../../plans/task_m100_7069.md)과
+[#7070 계획](../../plans/task_m100_7070.md)을 나눠 구현·검증·커밋했다.
+[source-side 보고서](../../report/task_m100_7069_report.md)와
+[duration 보고서](../../report/task_m100_7070_report.md)에 실제 API, 원인과 적용 경계를 남겼다.
+
+#7069는 성공 run 아래 미완료 job/step을 failure와 구분하고, 같은 run의 API 전후 snapshot을
+대조하여 제한적으로 재조회한다. job 성공을 step 성공으로 합성하지 않는다. identity 변경,
+완료 실패·취소·잘못된 skip·누락·중복에 대한 방어는 유지한다. 수렴하지 않으면 pending으로
+남기고 해당 policy audit 재실행을 안내한다. 자동 재실행 루프와 추가 쓰기 권한은 없다.
+
+#7070은 검증 CI의 branch push 시작 경로 자체를 제거한다. devel의 duration 전용 workflow는
+병합된 코드만 실행하고, PR artifact는 엄격히 검증한 JSON 자료로만 소비한다. 증거 부족은
+메타데이터 갱신 보류이며 전체 검증 fallback이 없다. 모든 workflow의 devel push 구독을
+allowlist 검사해 새 경로가 생기면 테스트가 실패한다.
+
+#7068의 latest Jobs API가 원래 실행된 B/C/D 작업을 새 ID/attempt로 복사한 점을 실제 자료로
+확인했다. 원본 attempt API와 실행 시각까지 동일할 때만 artifact의 실제 측정 attempt를 쓴다.
+새로 실행한 worker를 옛 성공 worker로 대체하지 않는다. duration 자료는 실행 시간 추정용이며
+PR 승인·병합 tree 검증의 대체물이 아니다.
+
+## 완료한 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| Node classifier/policy/evidence/duration/reuse | 450 PASS, exit 0 |
+| Python workflow 계약 | 179 PASS, exit 0 |
+| actionlint 구조·expression | 변경 workflow 7개 통과 |
+| ShellCheck 포함 비교 | 기존 CI·Oracle SC2016 2건 동일; 신규 duration workflow 없음 |
+| 실제 #7068 artifact read-only 수집 | run `34702678657`, latest attempt 2, 측정 B/C/D attempt 1, provenance 통과 |
+| 기존 refresh script의 로컬 갱신 | 42 target, 원격 metrics 쓰기 미실행 |
+| 변경 문서 링크·canonical/guide metadata | 통과 |
+| 공백 검사 / 병합 simulation | 통과 / 충돌 없음 |
+
+새 회귀는 실제 API 최소 응답, 수렴·미수렴, 부분 재실행·혼합 attempt·복사 job, 실행 시각 변경,
+identity 불일치, 자료 누락·중복·만료·과대 크기, run 중간 변경과 code/review-only 후보를 포함한다.
+원본 ZIP 검증은 경로·키·Unicode 이름·수치·target 소유 관계 보호를 유지한다.
+Rust 및 renderer 변경이 없으므로 Cargo, HWP/HWPX/PDF fixture, visual sweep은 비해당이다.
+
+## 공통 검토 원칙
+
+- 구현 근거·일반성: 실제 GitHub API와 workflow trigger를 근거로 하며 PR 번호별 분기는 없다.
+- 측정·배치·줄 소속·점유 높이·좌표계: 렌더러 조판 변경이 없어 비해당.
+- 사례와 증거 독립성: 실제 API/ZIP read-only 검증과 synthetic 반례를 구분했다.
+- 기준값·허용치: golden/baseline 수정과 검증 완화 없음. 미완료 자료는 승인하지 않는다.
+- 주장 범위: 로컬 검사와 운영 활성화를 구분한다. 미실행 원격 갱신이나 새 정책의 병합 후 관찰을 완료로 표시하지 않는다.
+
+## 병합 후 확인할 항목
+
+최신 head CI 통과와 병합 판단 뒤 merge SHA에 검증 workflow가 새로 시작하지 않는지,
+`Refresh nextest target duration data` 결과와 #7069/#7070 close 상태를 확인한다.
+main/devel push 제거와 duration workflow는 devel 병합부터 적용되지만, #7069 controller 수집
+배선은 기본 branch main의 정상 release 이후 활성화된다. main 직접 push는 범위에 없다.
+코멘트·devel 동기화 후 이 PR 소유 branch/worktree만 정리하며 공유 target과 다른 작업은 보존한다.

--- a/mydocs/report/task_m100_7069_report.md
+++ b/mydocs/report/task_m100_7069_report.md
@@ -1,0 +1,26 @@
+# #7069 CI audit의 비동기 증거 불일치 개선
+
+- Issue: [#7069](https://github.com/edwardkim/rhwp/issues/7069)
+- 기준: `3f34869b9c4d15a27b181dd22c63cd0a3730d46a`
+- 실제 응답: [최소 보존 fixture](../../scripts/tests/fixtures/ci-impact-policy/issue7069-lint-snapshot.json)
+
+성공 workflow 아래 known nonterminal job/step을 failure와 구분해 pending으로 처리했다.
+세부 단계의 성공으로 job 성공을 합성하지 않는다. 완료 실패·취소·잘못된 skip·누락·중복에 대한
+기존 검사를 유지했다. 실제 API 응답을 재생한 테스트와 수렴/비수렴 반례를 실행했다.
+
+새 수집기는 동일 run/head/저장소/branch/workflow를 확인하고 Jobs API 전후 run snapshot을
+대조한다. attempt 또는 상태가 바뀌면 자료를 버리고 재수집한다. job은 같은 run/head에 속해야
+하며 현재 attempt보다 미래이면 거부한다. 부분 재실행의 이전 attempt 성공 job은 latest 응답에
+남을 수 있으므로 허용하되 현재 attempt의 job이 적어도 하나 있어야 한다.
+
+최대 4회, 재조회 간격 5초, 경과 예산 45초로 추가 재시도를 제한했다. 각 HTTP 요청 timeout은
+10초이며 pagination/HTTP 요청 자체 시간과 controller의 10분 상한은 별개다. 예산 소진 시
+pending을 유지하고 완료 이벤트가 더 없으면 해당 policy audit run을 재실행하도록 경고한다.
+자동 재실행 루프나 추가 권한은 도입하지 않았다.
+
+2026-09-13 로컬 Node classifier/policy/collector/post-merge 회귀 **333 PASS**, Python workflow
+계약 **176 PASS**. Rust·renderer·HWP/PDF 입력 변경이 없으므로 Cargo/시각 검증은 비해당이다.
+
+policy 모듈의 판정 변경은 live devel base에서 로드된다. collector workflow 배선은 기본 branch
+main에 정상 release로 반영된 뒤 활성화된다. 이 PR의 devel 병합만으로 controller 배선까지
+운영 중이라고 주장하지 않는다. 별도 post-merge 실행 제거는 #7070으로 추적한다.

--- a/mydocs/report/task_m100_7070_report.md
+++ b/mydocs/report/task_m100_7070_report.md
@@ -1,0 +1,59 @@
+# #7070 병합 후 검증 CI 제거와 duration 전용 갱신
+
+- Issue: [#7070](https://github.com/edwardkim/rhwp/issues/7070)
+- 연계: [#7069 API 증거 수렴 개선](task_m100_7069_report.md)
+- 기준: `3f34869b9c4d15a27b181dd22c63cd0a3730d46a`
+
+## 원인과 변경
+
+기존 구조는 devel push로 CI·CodeQL·Adapter·Proptest를 시작한 뒤 재사용을 판정했다.
+#7068 뒤 4개 run은 `reuse=false reason=pr-merge-tree-evidence-unavailable`로 전체 실행에
+진입했다. CI에는 `attempt-bound B/C/D artifacts unavailable`도 기록됐다. duration 문제만으로
+네 workflow의 모든 tree 판정 원인이 설명된다고 주장하지 않는다. GitHub 내부 지연 원인도 미확정이다.
+
+재사용 verifier를 반복 수정해도 push trigger와 Full fallback이 남으면 중복 실행은 반복된다.
+이에 네 workflow의 main/devel branch push를 제거했다. Oracle advisory의 devel bootstrap도
+제거했다. 전체 workflow의 push 구독을 검사하는 계약 테스트로 새 우회 경로를 방지한다.
+PR 검증, 명시 수동 실행, release tag, main Pages 배포, 독립 보안 schedule과 issue-close 자동화는 유지한다.
+
+devel push는 독립 `Refresh nextest target duration data`에서 메타데이터만 갱신한다.
+신뢰된 병합 commit의 수집 코드로 GitHub API와 ZIP 내부 JSON을 읽으며, PR artifact에서 코드를
+실행하지 않는다. 성공 PR CI와 B/C/D 원본 worker의 run/head/repository/PR/attempt/시각,
+실제 tested merge의 PR head 부모, 자료 크기·키·수치·소유 관계를 검증한다. 후보가 최종 head가
+아니면 완전한 linear review-only diff를 요구한다. 이는 실행 시간 추정 자료이며 CI 승인 증거가 아니다.
+증거가 없으면 갱신만 보류하며 Cargo/CodeQL/CI 재실행 fallback을 호출하지 않는다.
+
+## 실제 부분 재실행 증거
+
+[보존 API fixture](../../scripts/tests/fixtures/ci-impact-policy/issue7070-copied-worker-attempts.json)는
+#7068 PR CI `34702678657`의 실제 응답이다. lint만 재실행한 최신 attempt 2의 Jobs API는
+B/C/D까지 새 job ID와 attempt 2로 복사했지만 시작·완료 시각은 attempt 1과 동일했다.
+artifact 이름과 JSON의 attempt는 1이었다. latest job의 attempt만 신뢰하는 초기 구현도
+실제 자료에서 실패했으므로 attempt별 원본 Jobs API로 보정했다.
+
+수집기는 원본과 latest의 name/run/head/status/conclusion/시작·완료 시각이 모두 같은 경우만
+원본 측정 attempt를 사용한다. 실제로 재실행돼 시간이 달라진 worker, 실패·미완료 worker,
+중복·만료 artifact 또는 다른 head의 과거 성공 자료는 대체 후보로 승인하지 않는다.
+
+2026-09-13 read-only 실제 수집 결과:
+
+- source run `34702678657`, latest attempt **2**, B/C/D measurement attempt **1/1/1**.
+- source head `85f08bda8e1b394e398c404004c27fd4bcd37fca`.
+- tested merge `b6c6d3e2e3f40c58286514c8dcdc45ecc9bf23e7`.
+- artifact IDs B `10301251247`, C `10301655406`, D `10301346099`.
+- 기존 refresh script로 로컬 정책 **42 target 갱신**. 원격 metrics branch 쓰기는 실행하지 않았다.
+
+## 검증과 적용 경계
+
+- Node classifier/policy/evidence/duration/reuse 회귀 **450 PASS**, exit 0.
+- Python workflow 계약 **179 PASS**, exit 0.
+- 변경 workflow actionlint 구조·expression 검사 통과. ShellCheck 포함 실행의 SC2016 두 건은
+  기존 CI와 Oracle의 의도적인 single-quote 문자열에서 발생한 baseline이며 신규 workflow에는 없다.
+- 원본/복사 attempt 동일 실행, 혼합 attempt, 실행 시각 변경, identity/자료 누락·실패·만료,
+  run 중간 변경, review-only/code 변경 후보와 실제 #7068 응답을 검사했다.
+- Rust·렌더러·fixture HWP/PDF 변경 없음. Cargo 및 시각 검증 비해당.
+
+push trigger 제거와 duration workflow는 devel 병합부터 적용된다. #7069 policy 모듈은 live base에서
+로드되지만 controller 수집 배선은 main의 정상 release 반영 후 활성화된다. 이 변경을 main에 직접
+push하거나 release를 강제하지 않는다. 운영 적용 뒤 merge SHA에 검증 workflow가 생기지 않는지와
+duration 결과를 확인해야 하며, 로컬 검사만으로 해당 운영 확인이 끝났다고 기록하지 않는다.

--- a/mydocs/report/task_m100_7070_report.md
+++ b/mydocs/report/task_m100_7070_report.md
@@ -46,7 +46,7 @@ artifact 이름과 JSON의 attempt는 1이었다. latest job의 attempt만 신�
 ## 검증과 적용 경계
 
 - Node classifier/policy/evidence/duration/reuse 회귀 **450 PASS**, exit 0.
-- Python workflow 계약 **179 PASS**, exit 0.
+- Python workflow 계약 **240 PASS**, exit 0.
 - 변경 workflow actionlint 구조·expression 검사 통과. ShellCheck 포함 실행의 SC2016 두 건은
   기존 CI와 Oracle의 의도적인 single-quote 문자열에서 발생한 baseline이며 신규 workflow에는 없다.
 - 원본/복사 attempt 동일 실행, 혼합 attempt, 실행 시각 변경, identity/자료 누락·실패·만료,
@@ -57,3 +57,12 @@ push trigger 제거와 duration workflow는 devel 병합부터 적용된다. #70
 로드되지만 controller 수집 배선은 main의 정상 release 반영 후 활성화된다. 이 변경을 main에 직접
 push하거나 release를 강제하지 않는다. 운영 적용 뒤 merge SHA에 검증 workflow가 생기지 않는지와
 duration 결과를 확인해야 하며, 로컬 검사만으로 해당 운영 확인이 끝났다고 기록하지 않는다.
+
+## PR #7071 최초 CI 보정
+
+최초 trailing head `5a5095d58`의 lint는 `Validate workflow contracts`에서 실패했다.
+새 `ci-workflow-evidence.test.cjs`의 CI 실행 줄은 추가했지만, 기존 discovery 검사의 기대 목록을
+갱신하지 않은 원인이었다. 초기 로컬 패턴 `test_*workflow.py`는 `test_workflow_contract_wiring.py`와
+복수형 `workflows.py`를 놓쳤다. 기대 목록을 갱신하고 실제 CI step의 명령 전체를 그대로 실행해
+exit 0을 확인했다. 넓힌 `test_*workflow*.py` 검사도 240 PASS / exit 0이다. 이는 #7069의 API 지연과
+다른, 이번 변경의 테스트 목록 누락이며 해당 범위에서 보정했다. push guard는 `.yaml` 확장자도 검사한다.

--- a/scripts/ci-impact-policy.cjs
+++ b/scripts/ci-impact-policy.cjs
@@ -16,24 +16,7 @@ const BOOLEAN_VALUES = new Set(['true', 'false']);
 const CLASSIFICATION_STATUSES = new Set(['classified', 'full']);
 const CODEQL_LANGUAGE_ORDER = ['javascript-typescript', 'python', 'rust'];
 
-const CI_PUSH_PATHS_IGNORE = [
-  'mydocs/**',
-  'samples/**',
-  'pdf/**',
-  'assets/chrome/**',
-  'assets/edge/**',
-  'assets/logo/**',
-  'assets/screenshots/**',
-  '*.md',
-  'LICENSE',
-  '.github/ISSUE_TEMPLATE/**',
-  '.github/FUNDING.yml',
-  '.github/CODE_OF_CONDUCT.md',
-  '.github/SECURITY.md',
-  '.github/pull_request_template.md',
-  '.github/dependabot.yml',
-  'rhwp-logo.*',
-];
+const CI_PUSH_PATHS_IGNORE = []; // CI push is release-tag-only; no branch push checks.
 
 const CI_PULL_REQUEST_PATHS_IGNORE = [
   'assets/chrome/**',
@@ -51,21 +34,7 @@ const CI_PULL_REQUEST_PATHS_IGNORE = [
   'rhwp-logo.*',
 ];
 
-const CODEQL_PUSH_PATHS_IGNORE = [
-  'mydocs/**',
-  'samples/**',
-  'pdf/**',
-  'assets/**',
-  '*.md',
-  'LICENSE',
-  '.github/ISSUE_TEMPLATE/**',
-  '.github/FUNDING.yml',
-  '.github/CODE_OF_CONDUCT.md',
-  '.github/SECURITY.md',
-  '.github/pull_request_template.md',
-  '.github/dependabot.yml',
-  'rhwp-logo.*',
-];
+const CODEQL_PUSH_PATHS_IGNORE = []; // CodeQL has no push trigger.
 
 const CODEQL_PULL_REQUEST_PATHS_IGNORE = [
   'assets/**',
@@ -190,7 +159,6 @@ const CI_AUDITED_JOB_IDS = {
   'build-test-archive-c': 'build-test-archive-c',
   'build-test-archive-d': 'build-test-archive-d',
   'resolve-nextest-duration-policy': 'resolve-nextest-duration-policy',
-  'refresh-nextest-target-duration-data': 'refresh-nextest-target-duration-data',
   'test-archive-a-shard-1': 'test-archive-a-shard-1',
   'test-archive-b-shard-1': 'test-archive-b-shard-1',
   'test-archive-c-shard-1': 'test-archive-c-shard-1',
@@ -294,6 +262,7 @@ function changesEnforcementSurface(files) {
     || filename === 'scripts/ci-impact-classifier.cjs'
     || filename === 'scripts/ci-impact-policy.cjs'
     || filename === 'scripts/ci-workflow-evidence.cjs'
+    || filename === 'scripts/collect-postmerge-duration-data.mjs'
     || filename === 'scripts/verify_review_only_merge_resolution.py'
   ));
 }
@@ -1153,6 +1122,7 @@ module.exports = {
   determinePolicy,
   expectedWorkflowMap,
   fullClassification,
+  isAllowedReviewFile,
   parseStatusDescription,
   runCli,
   selectReviewOnlyCandidate,

--- a/scripts/ci-impact-policy.cjs
+++ b/scripts/ci-impact-policy.cjs
@@ -293,6 +293,7 @@ function changesEnforcementSurface(files) {
     || filename.startsWith('.github/actions/')
     || filename === 'scripts/ci-impact-classifier.cjs'
     || filename === 'scripts/ci-impact-policy.cjs'
+    || filename === 'scripts/ci-workflow-evidence.cjs'
     || filename === 'scripts/verify_review_only_merge_resolution.py'
   ));
 }
@@ -620,6 +621,16 @@ function determinePolicy(input = {}) {
   return policy;
 }
 
+// A successful workflow can become visible before its Jobs API snapshot converges.
+// Nonterminal evidence blocks approval without claiming a completed test failed.
+const NONTERMINAL_EVIDENCE = new Set(['queued', 'in_progress', 'waiting', 'pending', 'requested']);
+function pendingEvidence(value) {
+  return NONTERMINAL_EVIDENCE.has(value.status) && !value.conclusion;
+}
+function pendingAuditReason(reason) {
+  return reason.startsWith('pending-') || reason.includes(':pending-');
+}
+
 function normalizedJobs(jobs) {
   const byName = new Map();
   for (const job of Array.isArray(jobs) ? jobs : []) {
@@ -652,6 +663,7 @@ function requireJobConclusion(byName, name, conclusion) {
   const resolved = exactJob(byName, name);
   if (resolved.error) return resolved.error;
   const job = resolved.job;
+  if (pendingEvidence(job)) return `pending-job:${name}:${job.status}`;
   if (job.status !== 'completed' || job.conclusion !== conclusion) {
     return `job-not-${conclusion}:${name}:${job.status || 'unknown'}:${job.conclusion || 'unknown'}`;
   }
@@ -667,6 +679,7 @@ function requireSafeJobConclusion(byName, name, expected) {
   if (resolved.error) return resolved.error;
   const job = resolved.job;
   const allowed = safeConclusions(expected);
+  if (pendingEvidence(job)) return `pending-job:${name}:${job.status}`;
   if (job.status !== 'completed' || !allowed.has(job.conclusion)) {
     return `job-not-${[...allowed].join('-or-')}:${name}:`
       + `${job.status || 'unknown'}:${job.conclusion || 'unknown'}`;
@@ -686,6 +699,7 @@ function requireSafeAliasedJobConclusion(byName, logicalName, expected) {
   }
   const { name, job } = matches[0];
   const allowed = safeConclusions(expected);
+  if (pendingEvidence(job)) return `pending-job:${name}:${job.status}`;
   if (job.status !== 'completed' || !allowed.has(job.conclusion)) {
     return `job-not-${[...allowed].join('-or-')}:${name}:`
       + `${job.status || 'unknown'}:${job.conclusion || 'unknown'}`;
@@ -707,6 +721,7 @@ function requireStepConclusion(job, name, conclusion) {
     return entries.length === 0 ? `missing-step:${name}` : `duplicate-step:${name}`;
   }
   const step = entries[0];
+  if (pendingEvidence(step)) return `pending-step:${name}:${step.status}`;
   if (step.status !== 'completed' || step.conclusion !== conclusion) {
     return `step-not-${conclusion}:${name}:${step.status || 'unknown'}:${step.conclusion || 'unknown'}`;
   }
@@ -723,6 +738,9 @@ function preflightFastPass(byName, jobName, checkoutStepName) {
     return { error: checkout.length === 0
       ? `missing-step:${checkoutStepName}`
       : `duplicate-step:${checkoutStepName}` };
+  }
+  if (pendingEvidence(checkout[0])) {
+    return { error: `pending-step:${checkoutStepName}:${checkout[0].status}` };
   }
   if (checkout[0].status !== 'completed') {
     return { error: `step-not-completed:${checkoutStepName}:${checkout[0].status || 'unknown'}` };
@@ -835,6 +853,9 @@ function auditCodeql(policy, jobs) {
       if (analyzeResolved.error) return `${name}:${analyzeResolved.error}`;
       const skipStep = skipResolved.step;
       const analyzeStep = analyzeResolved.step;
+      if (pendingEvidence(skipStep) || pendingEvidence(analyzeStep)) {
+        return `${name}:pending-unselected-steps:${skipStep.status}:${analyzeStep.status}`;
+      }
       if (skipStep.status !== 'completed' || analyzeStep.status !== 'completed') {
         return `${name}:unselected-steps-not-completed:`
           + `${skipStep.status || 'unknown'}:${analyzeStep.status || 'unknown'}`;
@@ -993,6 +1014,9 @@ function auditPolicyRuns(input = {}) {
     ) {
       return { publish: 'true', conclusion: 'failure', reason: `workflow-identity-mismatch:${workflow}` };
     }
+    if (evidence.collectionFailure) {
+      return { publish: 'true', conclusion: 'failure', reason: `${workflow}:${evidence.collectionFailure}` };
+    }
     if (String(run.status || '') !== 'completed') {
       pending.push(`workflow-not-completed:${workflow}:${run.status || 'unknown'}`);
       continue;
@@ -1014,7 +1038,14 @@ function auditPolicyRuns(input = {}) {
         ? auditCodeql(policy, evidence.jobs)
         : auditRenderDiff(policy, evidence.jobs);
     if (failure) {
+      if (pendingAuditReason(failure)) {
+        pending.push(`${workflow}:${failure}`);
+        continue;
+      }
       return { publish: 'true', conclusion: 'failure', reason: `${workflow}:${failure}` };
+    }
+    if (evidence.collectionPendingReason) {
+      pending.push(`${workflow}:${evidence.collectionPendingReason}`);
     }
   }
   if (pending.length > 0) {

--- a/scripts/ci-workflow-evidence.cjs
+++ b/scripts/ci-workflow-evidence.cjs
@@ -1,0 +1,80 @@
+'use strict';
+
+// GitHub run and job endpoints are separate snapshots. Never synthesize success
+// from successful steps, and never carry a prior snapshot across a rerun.
+const NONTERMINAL = new Set(['queued', 'in_progress', 'waiting', 'pending', 'requested']);
+function pending(value) {
+  return NONTERMINAL.has(value?.status) && !value?.conclusion;
+}
+function sameIdentity(left, right) {
+  return ['id', 'head_sha', 'head_branch', 'event', 'path', 'workflow_id']
+    .every((key) => left[key] === right[key])
+    && left.head_repository?.full_name === right.head_repository?.full_name;
+}
+function sameSnapshot(left, right) {
+  return left.run_attempt === right.run_attempt
+    && left.status === right.status && left.conclusion === right.conclusion;
+}
+
+async function collectWorkflowEvidence({
+  run: selected, getRun, listJobs, warn = () => {},
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  now = Date.now, maxAttempts = 4, delayMs = 5000, maxElapsedMs = 45000,
+}) {
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1 || maxAttempts > 4
+      || !Number.isFinite(delayMs) || delayMs < 0 || delayMs > 5000
+      || !Number.isFinite(maxElapsedMs) || maxElapsedMs < 0 || maxElapsedMs > 45000) {
+    throw new Error('invalid evidence retry budget');
+  }
+  const started = now();
+  let last = { run: selected, jobs: [], jobsCollected: false };
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    let reason = '';
+    try {
+      const before = await getRun(selected.id);
+      if (!sameIdentity(selected, before)) {
+        return { ...last, jobs: [], jobsCollected: false, collectionFailure: 'workflow-evidence-identity-mismatch' };
+      }
+      const jobs = await listJobs(selected.id);
+      const after = await getRun(selected.id);
+      if (!sameIdentity(selected, after)) {
+        return { ...last, jobs: [], jobsCollected: false, collectionFailure: 'workflow-evidence-identity-mismatch' };
+      }
+      last = { run: after, jobs: [], jobsCollected: false, collectionAttempts: attempt };
+      if (!sameSnapshot(before, after)) {
+        reason = 'workflow-snapshot-changed';
+      } else if (!Number.isSafeInteger(after.run_attempt) || after.run_attempt < 1) {
+        return { ...last, collectionFailure: 'invalid-workflow-attempt' };
+      } else if (!Array.isArray(jobs) || jobs.some((job) => (
+        job.run_id !== after.id || job.head_sha !== after.head_sha
+        || !Number.isSafeInteger(job.run_attempt) || job.run_attempt < 1
+        || job.run_attempt > after.run_attempt
+      ))) {
+        return { ...last, collectionFailure: 'job-evidence-identity-mismatch' };
+      } else if (jobs.length > 0 && !jobs.some((job) => job.run_attempt === after.run_attempt)) {
+        // filter=latest includes unchanged jobs from earlier attempts. At least one
+        // job must belong to the current attempt; otherwise rerun evidence is stale.
+        reason = 'current-attempt-jobs-unavailable';
+      } else {
+        last = { ...last, jobs, jobsCollected: true };
+        const incomplete = jobs.some((job) => pending(job) || (job.steps || []).some(pending));
+        if (after.status !== 'completed' || after.conclusion !== 'success' || !incomplete) {
+          return last; // The policy still checks missing/duplicate jobs and real failures.
+        }
+        reason = 'completed-workflow-nonterminal-evidence';
+      }
+    } catch (error) {
+      last = { ...last, jobs: [], jobsCollected: false, collectionAttempts: attempt };
+      reason = 'workflow-evidence-unavailable';
+      warn(`Workflow evidence request failed: ${error.message}`);
+    }
+    last.collectionPendingReason = reason;
+    if (attempt === maxAttempts || now() - started + delayMs > maxElapsedMs) break;
+    warn(`Recollect workflow ${selected.id}: ${reason} (${attempt}/${maxAttempts}).`);
+    await sleep(delayMs);
+  }
+  warn(`Workflow evidence remains pending: ${last.collectionPendingReason}; rerun this policy audit after API convergence.`);
+  return last;
+}
+
+module.exports = { collectWorkflowEvidence };

--- a/scripts/collect-postmerge-duration-data.mjs
+++ b/scripts/collect-postmerge-duration-data.mjs
@@ -1,0 +1,176 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { decodeDurationArtifact, validateDurationReports } from './trusted-postmerge-duration-evidence.mjs';
+const { isAllowedReviewFile } = createRequire(import.meta.url)('./ci-impact-policy.cjs');
+const LABELS = ['b', 'c', 'd'];
+const SHA = /^[0-9a-f]{40}$/;
+const fail = (reason) => { throw new Error(`postmerge-duration: ${reason}`); };
+const time = (value) => Date.parse(value || '');
+
+// Metrics provenance is separate from approval/CI reuse. A lint-only rerun does
+// not invalidate successful B/C/D measurements from the same head's earlier attempt.
+export function selectMeasuredDurationArtifacts({ run, pr, jobs, artifacts, repositoryId }) {
+  if (!Number.isSafeInteger(repositoryId) || repositoryId < 1
+      || !Number.isSafeInteger(pr?.number) || pr.number < 1
+      || !Number.isSafeInteger(run?.id) || run.id < 1 || !Number.isSafeInteger(run.run_attempt) || run.run_attempt < 1
+      || run.repository?.id !== repositoryId || pr.base?.repo?.id !== repositoryId
+      || run.head_repository?.id !== pr.head?.repo?.id || run.head_branch !== pr.head?.ref
+      || run.event !== 'pull_request' || run.status !== 'completed' || run.conclusion !== 'success'
+      || run.name !== 'CI' || String(run.path).split('@')[0] !== '.github/workflows/ci.yml'
+      || !SHA.test(run.head_sha) || !Number.isFinite(time(pr.merged_at))
+      || !Number.isFinite(time(pr.created_at))
+      || !Number.isFinite(time(run.run_started_at || run.created_at))
+      || time(run.created_at) < time(pr.created_at) || !Number.isFinite(time(run.created_at))
+      || time(run.run_started_at || run.created_at) > time(pr.merged_at)) fail('invalid successful PR run');
+  if (Array.isArray(run.pull_requests) && run.pull_requests.length
+      && !run.pull_requests.some((entry) => entry.number === pr.number)) fail('run belongs to another PR');
+  if (!Array.isArray(jobs) || !Array.isArray(artifacts)) fail('missing API evidence');
+  const selected = LABELS.map((label) => {
+    const names = [`test-archive-${label}-shard-1`, `test-archive-${label}-shard-1 / Default-feature tests (Archive ${label.toUpperCase()})`];
+    const matches = jobs.filter((job) => names.includes(job.name));
+    if (matches.length !== 1) fail(`missing or duplicate duration worker:${label}`);
+    const job = matches[0];
+    if (!Number.isSafeInteger(job.id) || job.id < 1 || job.status !== 'completed' || job.conclusion !== 'success'
+        || job.run_id !== run.id || job.head_sha !== run.head_sha
+        || !Number.isSafeInteger(job.run_attempt) || job.run_attempt < 1 || job.run_attempt > run.run_attempt
+        || !Number.isFinite(time(job.started_at)) || !Number.isFinite(time(job.completed_at))
+        || time(job.started_at) < time(run.created_at) || time(job.started_at) > time(job.completed_at)
+        || time(job.completed_at) > time(pr.merged_at)) fail(`invalid successful duration worker:${label}`);
+    const name = `nextest-target-durations-${run.id}-attempt-${job.run_attempt}-${label}`;
+    const entries = artifacts.filter((artifact) => artifact.name === name);
+    if (entries.length !== 1) fail(`missing or duplicate measurement:${label}`);
+    const artifact = entries[0];
+    if (!Number.isSafeInteger(artifact.id) || artifact.id < 1 || artifact.expired !== false
+        || !Number.isSafeInteger(artifact.size_in_bytes) || artifact.size_in_bytes < 1 || artifact.size_in_bytes > 8 * 1024 * 1024
+        || !Number.isFinite(time(artifact.created_at)) || time(artifact.created_at) < time(job.started_at)
+        || time(artifact.created_at) > time(job.completed_at)
+        || (artifact.workflow_run && (artifact.workflow_run.id !== run.id
+          || artifact.workflow_run.repository_id !== repositoryId
+          || artifact.workflow_run.head_repository_id !== pr.head.repo.id
+          || artifact.workflow_run.head_sha !== run.head_sha))) fail(`invalid measurement artifact:${label}`);
+    return { label, artifact, attempt: job.run_attempt, jobId: job.id };
+  });
+  if (new Set(selected.map((entry) => entry.artifact.id)).size !== 3) fail('duplicate artifact IDs');
+  return selected;
+}
+
+// GitHub can copy unchanged jobs into a rerun with NEW IDs/run_attempt while
+// retaining their original execution times. Resolve those copies using the
+// attempt-specific endpoint; never substitute a different successful execution.
+export async function resolveMeasuredJobs({ run, jobs, artifacts, listAttemptJobs }) {
+  const result = [...jobs];
+  const cache = new Map();
+  for (const label of LABELS) {
+    const matches = jobs.filter(job => job.name === `test-archive-${label}-shard-1`
+      || job.name === `test-archive-${label}-shard-1 / Default-feature tests (Archive ${label.toUpperCase()})`);
+    if (matches.length !== 1) fail(`missing or duplicate duration worker:${label}`);
+    const latest = matches[0];
+    if (!Number.isSafeInteger(latest.run_attempt) || latest.run_attempt < 1 || latest.run_attempt > run.run_attempt
+        || latest.status !== 'completed' || latest.conclusion !== 'success') fail(`unsuccessful latest worker:${label}`);
+    const currentName = `nextest-target-durations-${run.id}-attempt-${latest.run_attempt}-${label}`;
+    if (artifacts.some(a => a.name === currentName)) continue;
+    const pattern = new RegExp(`^nextest-target-durations-${run.id}-attempt-([1-9][0-9]*)-${label}$`);
+    const attempts = [...new Set(artifacts.map(a => Number(pattern.exec(a.name)?.[1]))
+      .filter(attempt => Number.isSafeInteger(attempt) && attempt > 0 && attempt < latest.run_attempt))]
+      .sort((a, b) => b - a).slice(0, 20);
+    let original;
+    for (const attempt of attempts) {
+      if (!cache.has(attempt)) cache.set(attempt, await listAttemptJobs(attempt));
+      const candidates = cache.get(attempt).filter(job => job.run_attempt === attempt
+        && ['name', 'run_id', 'head_sha', 'status', 'conclusion', 'started_at', 'completed_at']
+          .every(key => job[key] === latest[key]));
+      if (candidates.length === 1) { original = candidates[0]; break; }
+    }
+    if (!original) fail(`original measured worker unavailable:${label}`);
+    result[result.indexOf(latest)] = original;
+  }
+  return result;
+}
+
+export function sameCodeReviewTail(comparison) {
+  return comparison?.status === 'ahead'
+    && comparison.total_commits > 0 && comparison.total_commits <= 250
+    && comparison.commits?.length === comparison.total_commits
+    && comparison.commits.every((commit) => commit.parents?.length === 1)
+    && Array.isArray(comparison.files) && comparison.files.length > 0 && comparison.files.length < 300
+    && comparison.files.every(isAllowedReviewFile);
+}
+
+export async function collectPostmergeDurations({ github, owner, repo, mergeSha, outputDir, notice = () => {} }) {
+  if (!SHA.test(mergeSha)) fail('invalid merge SHA');
+  const repository = (await github.rest.repos.get({ owner, repo })).data;
+  const associations = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
+    owner, repo, commit_sha: mergeSha, per_page: 100,
+  });
+  const merged = associations.filter((pr) => pr.merged_at && pr.merge_commit_sha === mergeSha
+    && pr.base?.ref === 'devel' && pr.base?.repo?.id === repository.id);
+  if (merged.length !== 1) return { ready: false, reason: 'not-one-merged-devel-pr' };
+  const pr = (await github.rest.pulls.get({ owner, repo, pull_number: merged[0].number })).data;
+  if (!pr.merged || pr.merge_commit_sha !== mergeSha || pr.base?.ref !== 'devel'
+      || pr.base?.repo?.id !== repository.id || !SHA.test(pr.head?.sha) || !pr.head?.repo?.id) {
+    return { ready: false, reason: 'merged-pr-identity-unavailable' };
+  }
+  const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+    owner, repo, workflow_id: 'ci.yml', event: 'pull_request', branch: pr.head.ref, per_page: 100,
+  });
+  const candidates = runs.filter((run) => run.head_repository?.id === pr.head.repo.id
+    && run.head_branch === pr.head.ref && run.name === 'CI' && run.status === 'completed'
+    && run.conclusion === 'success' && time(run.created_at) >= time(pr.created_at)
+    && time(run.run_started_at || run.created_at) <= time(pr.merged_at))
+    .sort((a, b) => time(b.created_at) - time(a.created_at) || b.run_attempt - a.run_attempt).slice(0, 20);
+  for (const candidate of candidates) {
+    try {
+      if (candidate.head_sha !== pr.head.sha) {
+        const comparison = (await github.rest.repos.compareCommitsWithBasehead({
+          owner, repo, basehead: `${candidate.head_sha}...${pr.head.sha}`, per_page: 100,
+        })).data;
+        if (!sameCodeReviewTail(comparison)) continue;
+      }
+      const run = (await github.rest.actions.getWorkflowRun({ owner, repo, run_id: candidate.id })).data;
+      // Do not reuse an earlier snapshot if someone reran or replaced the run.
+      if (run.head_sha !== candidate.head_sha || run.run_attempt !== candidate.run_attempt) continue;
+      const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+        owner, repo, run_id: run.id, filter: 'latest', per_page: 100,
+      });
+      const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+        owner, repo, run_id: run.id, per_page: 100,
+      });
+      const measuredJobs = await resolveMeasuredJobs({ run, jobs, artifacts,
+        listAttemptJobs: (attempt_number) => github.paginate(github.rest.actions.listJobsForWorkflowRunAttempt, {
+          owner, repo, run_id: run.id, attempt_number, per_page: 100,
+        }),
+      });
+      const selected = selectMeasuredDurationArtifacts({ run, pr, jobs: measuredJobs, artifacts, repositoryId: repository.id });
+      const reports = [];
+      for (const { label, artifact } of selected) {
+        const response = await github.rest.actions.downloadArtifact({
+          owner, repo, artifact_id: artifact.id, archive_format: 'zip', request: { timeout: 15000 },
+        });
+        reports.push(decodeDurationArtifact(response.data, label));
+      }
+      const testedMergeSha = reports[0]?.sha;
+      if (!SHA.test(testedMergeSha)) fail('invalid tested merge SHA');
+      const tested = (await github.rest.repos.getCommit({ owner, repo, ref: testedMergeSha })).data;
+      if (tested.parents?.length !== 2 || tested.parents[1].sha !== run.head_sha) fail('tested merge/head mismatch');
+      const measurementAttempts = Object.fromEntries(selected.map(({ label, attempt }) => [label, attempt]));
+      const normalized = validateDurationReports(reports, {
+        run, pr, repositoryId: repository.id, testedMergeSha, measurementAttempts,
+      });
+      const final = (await github.rest.actions.getWorkflowRun({ owner, repo, run_id: run.id })).data;
+      if (final.status !== 'completed' || final.conclusion !== 'success'
+          || final.head_sha !== run.head_sha || final.run_attempt !== run.run_attempt) fail('run changed during collection');
+      for (const report of normalized) {
+        const directory = path.join(outputDir, `duration-${report.archive_label}`);
+        fs.mkdirSync(directory, { recursive: true });
+        fs.writeFileSync(path.join(directory, `target-durations-${report.archive_label}.json`), `${JSON.stringify(report)}\n`);
+      }
+      return { ready: true, reason: 'successful-pr-worker-measurements', pullNumber: pr.number,
+        sourceRunId: run.id, latestRunAttempt: run.run_attempt, measurementAttempts, testedMergeSha,
+        sourceHeadSha: run.head_sha, artifactIds: selected.map(({ artifact }) => artifact.id) };
+    } catch (error) {
+      notice(`Duration candidate ${candidate.id} not used: ${error.message}`);
+    }
+  }
+  return { ready: false, reason: 'no-verified-pr-duration-measurements' };
+}

--- a/scripts/tests/ci-impact-policy.test.cjs
+++ b/scripts/tests/ci-impact-policy.test.cjs
@@ -486,7 +486,7 @@ test('mirrored trigger contracts match CI, CodeQL, and Render Diff workflows', (
   const workflows = path.join(__dirname, '..', '..', '.github', 'workflows');
   function triggerItems(filename, start, end) {
     const workflow = fs.readFileSync(path.join(workflows, filename), 'utf8');
-    const block = workflow.split(start, 2)[1].split(end, 1)[0];
+    const block = (workflow.split(start, 2)[1] || '').split(end, 1)[0];
     return Array.from(
       block.matchAll(/^      - ['"]?([^'"\n]+)['"]?$/gm),
       (match) => match[1],
@@ -568,7 +568,6 @@ test('every impact-conditioned CI job is covered by the audit allowlist', () => 
     ...CI_FRONTEND_JOBS,
     'Build & Test',
     'resolve-nextest-duration-policy',
-    'refresh-nextest-target-duration-data',
   ]);
   assert.deepEqual(
     [...new Set(Object.values(CI_AUDITED_JOB_IDS))].sort(),

--- a/scripts/tests/ci-impact-policy.test.cjs
+++ b/scripts/tests/ci-impact-policy.test.cjs
@@ -1107,3 +1107,47 @@ test('CLI writes policy and aggregate audit outputs', (t) => {
   assert.match(outputs, /^audit_conclusion=success$/m);
   assert.equal(JSON.parse(fs.readFileSync(resultPath, 'utf8')).policy.policy_version, '6');
 });
+
+test('#7069 completed workflow with nonterminal lint is pending until evidence converges', () => {
+  const files = [{ filename: 'src/lib.rs', status: 'modified' }];
+  const input = policyInput({ files, classification: classificationFor(files) });
+  const policy = determinePolicy(input);
+  const workflows = workflowEvidence(policy);
+  const lint = workflows.CI.jobs.find((entry) => entry.name === CI_RUST_JOBS[0]);
+  const observed = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/ci-impact-policy/issue7069-lint-snapshot.json'), 'utf8'));
+  assert.equal(observed.run.conclusion, 'success');
+  assert.ok(observed.lint.steps.every((s) => s.status === 'completed' && s.conclusion === 'success'));
+  Object.assign(lint, { status: observed.lint.status, conclusion: observed.lint.conclusion, steps: observed.lint.steps });
+  assert.deepEqual(auditPolicyRuns({ ...input, policy, currentHeadSha: HEAD_SHA, workflows }), {
+    publish: 'true', conclusion: 'pending',
+    reason: 'CI:pending-job:Lint (fmt, clippy, WASM check):in_progress',
+  });
+  lint.status = 'completed'; lint.conclusion = 'success';
+  assert.equal(auditPolicyRuns({ ...input, policy, currentHeadSha: HEAD_SHA, workflows }).conclusion, 'success');
+  for (const conclusion of ['failure', 'cancelled', 'timed_out', 'skipped', '']) {
+    lint.conclusion = conclusion;
+    assert.equal(auditPolicyRuns({ ...input, policy, currentHeadSha: HEAD_SHA, workflows }).conclusion, 'failure');
+  }
+});
+
+test('#7069 completed CodeQL job with a pending analysis step blocks approval', () => {
+  const input = policyInput(); const policy = determinePolicy(input);
+  const workflows = workflowEvidence(policy);
+  const entry = workflows.CodeQL.jobs.find((j) => j.name === CODEQL_JOBS['javascript-typescript']);
+  const analysis = entry.steps.find((s) => s.name === 'Perform CodeQL Analysis');
+  analysis.status = 'in_progress'; analysis.conclusion = '';
+  const result = auditPolicyRuns({ ...input, policy, currentHeadSha: HEAD_SHA, workflows });
+  assert.equal(result.conclusion, 'pending');
+  assert.match(result.reason, /pending-step/);
+});
+
+test('#7069 collection identity failures and exhausted snapshots cannot pass', () => {
+  const input = policyInput(); const policy = determinePolicy(input);
+  for (const [field, value, expected] of [
+    ['collectionFailure', 'job-evidence-identity-mismatch', 'failure'],
+    ['collectionPendingReason', 'workflow-snapshot-changed', 'pending'],
+  ]) {
+    const workflows = workflowEvidence(policy); workflows.CI[field] = value;
+    assert.equal(auditPolicyRuns({ ...input, policy, currentHeadSha: HEAD_SHA, workflows }).conclusion, expected);
+  }
+});

--- a/scripts/tests/ci-workflow-evidence.test.cjs
+++ b/scripts/tests/ci-workflow-evidence.test.cjs
@@ -1,0 +1,68 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { collectWorkflowEvidence } = require('../ci-workflow-evidence.cjs');
+const run = { id: 12, run_attempt: 1, status: 'completed', conclusion: 'success', head_sha: 'a'.repeat(40), head_branch: 'topic', event: 'pull_request', path: '.github/workflows/ci.yml', workflow_id: 2, head_repository: { full_name: 'owner/repo' } };
+const job = { run_id: 12, run_attempt: 1, head_sha: run.head_sha, status: 'completed', conclusion: 'success', steps: [] };
+function fixture(overrides = {}) {
+  const calls = { runs: 0, jobs: 0, sleeps: 0 };
+  return { calls, options: { run, getRun: async () => { calls.runs++; return structuredClone(run); }, listJobs: async () => { calls.jobs++; return [structuredClone(job)]; }, sleep: async () => { calls.sleeps++; }, ...overrides } };
+}
+
+test('stable exact run/job evidence needs no retry', async () => {
+  const { calls, options } = fixture(); const result = await collectWorkflowEvidence(options);
+  assert.equal(result.jobsCollected, true); assert.equal(calls.runs, 2); assert.equal(calls.sleeps, 0);
+});
+test('successful steps never promote nonterminal job to success; later snapshot converges', async () => {
+  let reads = 0;
+  const { calls, options } = fixture({ listJobs: async () => [++reads < 3 ? { ...job, status: 'in_progress', conclusion: null, steps: [{ status: 'completed', conclusion: 'success' }] } : job] });
+  const result = await collectWorkflowEvidence(options);
+  assert.equal(result.jobs[0].status, 'completed'); assert.equal(calls.sleeps, 2);
+});
+test('nonterminal evidence exhausts four reads and remains pending', async () => {
+  const { calls, options } = fixture({ listJobs: async () => [{ ...job, status: 'in_progress', conclusion: null }] });
+  const result = await collectWorkflowEvidence(options);
+  assert.equal(result.collectionAttempts, 4); assert.equal(calls.sleeps, 3);
+  assert.equal(result.collectionPendingReason, 'completed-workflow-nonterminal-evidence');
+  assert.equal(result.jobs[0].status, 'in_progress');
+});
+test('network error cannot retain earlier success evidence', async () => {
+  const { options } = fixture({ listJobs: async () => { throw new Error('unavailable'); } });
+  const result = await collectWorkflowEvidence(options); assert.equal(result.jobsCollected, false); assert.deepEqual(result.jobs, []);
+});
+test('actual terminal failures are returned without retry or rewriting', async () => {
+  for (const conclusion of ['failure', 'cancelled', 'timed_out']) {
+    const { calls, options } = fixture({ listJobs: async () => [{ ...job, conclusion }] });
+    const result = await collectWorkflowEvidence(options); assert.equal(result.jobs[0].conclusion, conclusion); assert.equal(calls.sleeps, 0);
+  }
+});
+test('head/run identity changes cannot be accepted', async () => {
+  for (const change of [{ head_sha: 'b'.repeat(40) }, { id: 13 }, { head_repository: { full_name: 'other/repo' } }]) {
+    const { options } = fixture({ getRun: async () => ({ ...run, ...change }) });
+    assert.equal((await collectWorkflowEvidence(options)).collectionFailure, 'workflow-evidence-identity-mismatch');
+  }
+});
+test('job identity and future attempt are rejected', async () => {
+  for (const change of [{ run_id: 13 }, { head_sha: 'b'.repeat(40) }, { run_attempt: 2 }]) {
+    const { options } = fixture({ listJobs: async () => [{ ...job, ...change }] });
+    assert.equal((await collectWorkflowEvidence(options)).collectionFailure, 'job-evidence-identity-mismatch');
+  }
+});
+test('rerun crossing snapshot boundary discards old jobs, then recollects', async () => {
+  let reads = 0; const second = { ...run, run_attempt: 2 };
+  const { calls, options } = fixture({ getRun: async () => ++reads === 1 ? run : second, listJobs: async () => [{ ...job, run_attempt: 2 }] });
+  const result = await collectWorkflowEvidence(options); assert.equal(result.run.run_attempt, 2); assert.equal(calls.sleeps, 1);
+});
+test('latest jobs may retain earlier attempt successes alongside current rerun', async () => {
+  const { options } = fixture({ getRun: async () => ({ ...run, run_attempt: 2 }), listJobs: async () => [job, { ...job, run_attempt: 2 }] });
+  assert.equal((await collectWorkflowEvidence(options)).jobsCollected, true);
+});
+test('latest jobs missing current attempt remain unavailable', async () => {
+  const { options } = fixture({ getRun: async () => ({ ...run, run_attempt: 2 }) });
+  const result = await collectWorkflowEvidence(options); assert.equal(result.jobsCollected, false); assert.equal(result.collectionPendingReason, 'current-attempt-jobs-unavailable');
+});
+test('elapsed retry budget stops additional waits', async () => {
+  let clock = 0;
+  const { calls, options } = fixture({ now: () => clock, listJobs: async () => { clock += 45000; return [{ ...job, status: 'queued', conclusion: null }]; } });
+  const result = await collectWorkflowEvidence(options); assert.equal(calls.sleeps, 0); assert.equal(result.collectionAttempts, 1);
+});

--- a/scripts/tests/collect-postmerge-duration-data.test.mjs
+++ b/scripts/tests/collect-postmerge-duration-data.test.mjs
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { collectPostmergeDurations, selectMeasuredDurationArtifacts, resolveMeasuredJobs, sameCodeReviewTail } from '../collect-postmerge-duration-data.mjs';
+import { validateDurationReports } from '../trusted-postmerge-duration-evidence.mjs';
+import { durationFixture, reportZip } from './helpers/postmerge-duration-fixtures.mjs';
+
+function fixture(attempts = [1, 1, 1]) {
+  const f = durationFixture({ attempt: 2 });
+  Object.assign(f.pr, { created_at: '2026-09-06T10:00:00Z', merged: true, merge_commit_sha: '4'.repeat(40) });
+  f.pr.head.sha = f.run.head_sha;
+  Object.assign(f.run, { name: 'CI', path: '.github/workflows/ci.yml', head_branch: f.pr.head.ref, head_repository: f.pr.head.repo });
+  f.jobs = f.reports.map((report, i) => ({ id: 200 + i, name: `test-archive-${report.archive_label}-shard-1`,
+    run_id: f.run.id, head_sha: f.run.head_sha, run_attempt: attempts[i], status: 'completed', conclusion: 'success',
+    started_at: '2026-09-06T11:05:00Z', completed_at: '2026-09-06T11:25:00Z' }));
+  f.reports.forEach((r, i) => { r.run_attempt = String(attempts[i]); f.artifacts[i].name = `nextest-target-durations-123-attempt-${attempts[i]}-${r.archive_label}`; });
+  return f;
+}
+for (const attempts of [[1, 1, 1], [1, 2, 1], [2, 2, 2]]) {
+  test(`partial rerun uses actual successful worker attempts ${attempts}`, () => {
+    const f = fixture(attempts);
+    const selected = selectMeasuredDurationArtifacts(f);
+    assert.deepEqual(selected.map(s => s.attempt), attempts);
+    const measurementAttempts = Object.fromEntries(selected.map(s => [s.label, s.attempt]));
+    assert.equal(validateDurationReports(f.reports, { ...f.context, measurementAttempts }).length, 3);
+    if (attempts.includes(1)) assert.throws(() => validateDurationReports(f.reports, f.context));
+  });
+}
+for (const [name, mutate] of Object.entries({
+  'missing worker': f => f.jobs.pop(),
+  'duplicate worker': f => f.jobs.push(f.jobs[0]),
+  'failed worker': f => { f.jobs[0].conclusion = 'failure'; },
+  'pending worker': f => { f.jobs[0].status = 'in_progress'; },
+  'skipped worker': f => { f.jobs[0].conclusion = 'skipped'; },
+  'different head': f => { f.jobs[0].head_sha = 'f'.repeat(40); },
+  'different run': f => { f.jobs[0].run_id++; },
+  'future attempt': f => { f.jobs[0].run_attempt = 3; },
+  'missing attempt': f => { delete f.jobs[0].run_attempt; },
+  'post merge worker': f => { f.jobs[0].completed_at = '2026-09-07T00:00:00Z'; },
+  'invalid job times': f => { f.jobs[0].started_at = '2026-09-06T11:26:00Z'; },
+  'missing artifact': f => f.artifacts.pop(),
+  'duplicate artifact': f => f.artifacts.push(f.artifacts[0]),
+  'expired': f => { f.artifacts[0].expired = true; },
+  'too large': f => { f.artifacts[0].size_in_bytes = 9 * 1024 * 1024; },
+  'old artifact': f => { f.artifacts[0].created_at = '2026-09-06T10:00:00Z'; },
+  'wrong repository': f => { f.artifacts[0].workflow_run.repository_id++; },
+  'wrong fork': f => { f.artifacts[0].workflow_run.head_repository_id++; },
+  'wrong artifact head': f => { f.artifacts[0].workflow_run.head_sha = 'f'.repeat(40); },
+  'wrong workflow': f => { f.run.path = '.github/workflows/other.yml'; },
+  'different PR': f => { f.run.pull_requests = [{ number: 100 }]; },
+  'failed run': f => { f.run.conclusion = 'failure'; },
+  'invalid creation time': f => { delete f.pr.created_at; },
+})) test(`rejects ${name}`, () => { const f = fixture(); mutate(f); assert.throws(() => selectMeasuredDurationArtifacts(f)); });
+
+for (const measurementAttempts of [{}, { b: 1, c: 1 }, { b: 1, c: 1, d: 3 }, { b: 1, c: 1, d: 1, e: 1 }, { b: '1', c: 1, d: 1 }]) {
+  test(`rejects incomplete or invalid attempt map ${JSON.stringify(measurementAttempts)}`, () => {
+    const f = fixture(); assert.throws(() => validateDurationReports(f.reports, { ...f.context, measurementAttempts }));
+  });
+}
+test('review tail requires a complete linear comparison of allowed files', () => {
+  const c = { status: 'ahead', total_commits: 1, commits: [{ parents: [{}] }], files: [{ filename: 'mydocs/report/task.md', status: 'modified' }] };
+  assert.equal(sameCodeReviewTail(c), true);
+  for (const change of [{ status: 'diverged' }, { total_commits: 2 }, { commits: [{ parents: [{}, {}] }] },
+    { files: [{ filename: 'src/lib.rs', status: 'modified' }] }, { files: [] }]) assert.equal(sameCodeReviewTail({ ...c, ...change }), false);
+});
+
+function client(f, options = {}) {
+  let reads = 0;
+  const get = data => async () => ({ data });
+  const actions = {
+    listWorkflowRuns: async () => [f.run], listJobsForWorkflowRun: async () => f.jobs,
+    listWorkflowRunArtifacts: async () => f.artifacts,
+    getWorkflowRun: async () => ({ data: options.changed && ++reads > 1 ? { ...f.run, run_attempt: 3 } : f.run }),
+    downloadArtifact: async ({ artifact_id }) => ({ data: reportZip(f.reports[f.artifacts.findIndex(a => a.id === artifact_id)]) }),
+  };
+  return { rest: { actions, pulls: { get: get(f.pr) }, repos: { get: get({ id: f.repositoryId }),
+    listPullRequestsAssociatedWithCommit: async () => options.noPr ? [] : [f.pr],
+    getCommit: get({ parents: [{ sha: 'a'.repeat(40) }, { sha: options.wrongParent ? 'f'.repeat(40) : f.run.head_sha }] }),
+    compareCommitsWithBasehead: get({ status: 'ahead', total_commits: 1, commits: [{ parents: [{}] }],
+      files: [{ filename: options.codeTail ? 'src/lib.rs' : 'mydocs/report/task.md', status: 'modified' }] }),
+  } }, paginate: async (method, args) => method(args) };
+}
+for (const options of [{}, { changed: true }, { noPr: true }, { wrongParent: true }, { reviewTail: true }, { codeTail: true }, { missing: true }]) {
+  test(`collector publishes only verified measurements ${JSON.stringify(options)}`, async () => {
+    const f = fixture();
+    if (options.reviewTail || options.codeTail) f.pr.head.sha = '5'.repeat(40);
+    if (options.missing) f.artifacts.pop();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhwp-duration-test-'));
+    try {
+      const result = await collectPostmergeDurations({ github: client(f, options), owner: 'edwardkim', repo: 'rhwp', mergeSha: f.pr.merge_commit_sha, outputDir: dir });
+      const expected = Object.keys(options).length === 0 || options.reviewTail === true;
+      assert.equal(result.ready, expected);
+      if (expected) {
+        assert.deepEqual(result.measurementAttempts, { b: 1, c: 1, d: 1 });
+        const saved = JSON.parse(fs.readFileSync(path.join(dir, 'duration-b/target-durations-b.json')));
+        assert.equal(saved.run_attempt, '1');
+      } else assert.deepEqual(fs.readdirSync(dir), []);
+    } finally { fs.rmSync(dir, { recursive: true }); }
+  });
+}
+
+for (const changed of [false, true]) {
+  test(`copied rerun jobs require identical original execution times changed=${changed}`, async () => {
+    const f = fixture();
+    const copies = f.jobs.map(job => ({ ...job, id: job.id + 1000, run_attempt: 2,
+      completed_at: changed ? '2026-09-06T11:26:00Z' : job.completed_at }));
+    const args = { run: f.run, jobs: copies, artifacts: f.artifacts, listAttemptJobs: async attempt => {
+      assert.equal(attempt, 1); return f.jobs;
+    } };
+    if (changed) await assert.rejects(resolveMeasuredJobs(args), /original measured worker unavailable/);
+    else {
+      const jobs = await resolveMeasuredJobs(args);
+      assert.deepEqual(selectMeasuredDurationArtifacts({ ...f, jobs }).map(s => s.attempt), [1, 1, 1]);
+    }
+  });
+}
+
+test('#7068 real API copied job IDs/attempts resolve to original B/C/D artifacts', async () => {
+  const f = JSON.parse(fs.readFileSync(new URL('./fixtures/ci-impact-policy/issue7070-copied-worker-attempts.json', import.meta.url)));
+  assert.ok(f.jobs.every(job => job.run_attempt === 2));
+  assert.ok(f.originalJobs.every(job => job.run_attempt === 1));
+  const jobs = await resolveMeasuredJobs({ ...f, listAttemptJobs: async attempt => {
+    assert.equal(attempt, 1); return f.originalJobs;
+  } });
+  const selected = selectMeasuredDurationArtifacts({ ...f, jobs });
+  assert.deepEqual(selected.map(s => s.artifact.id), [10301251247, 10301655406, 10301346099]);
+});

--- a/scripts/tests/fixtures/ci-impact-policy/issue7069-lint-snapshot.json
+++ b/scripts/tests/fixtures/ci-impact-policy/issue7069-lint-snapshot.json
@@ -1,0 +1,229 @@
+{
+  "source_run_url": "https://github.com/edwardkim/rhwp/actions/runs/34702678657",
+  "run": {
+    "id": 34702678657,
+    "run_attempt": 1,
+    "head_sha": "85f08bda8e1b394e398c404004c27fd4bcd37fca",
+    "status": "completed",
+    "conclusion": "success"
+  },
+  "lint": {
+    "id": 103577273178,
+    "name": "Lint (fmt, clippy, WASM check)",
+    "run_id": 34702678657,
+    "run_attempt": 1,
+    "head_sha": "85f08bda8e1b394e398c404004c27fd4bcd37fca",
+    "status": "in_progress",
+    "conclusion": null,
+    "steps": [
+      {
+        "name": "Set up job",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 1,
+        "started_at": "2026-09-12T15:36:36Z",
+        "completed_at": "2026-09-12T15:36:37Z"
+      },
+      {
+        "name": "Run actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 2,
+        "started_at": "2026-09-12T15:36:37Z",
+        "completed_at": "2026-09-12T15:37:35Z"
+      },
+      {
+        "name": "Install Rust toolchain",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 3,
+        "started_at": "2026-09-12T15:37:35Z",
+        "completed_at": "2026-09-12T15:37:46Z"
+      },
+      {
+        "name": "Rust build cache",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 4,
+        "started_at": "2026-09-12T15:37:46Z",
+        "completed_at": "2026-09-12T15:37:55Z"
+      },
+      {
+        "name": "Prepare derived Rust test suites",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 5,
+        "started_at": "2026-09-12T15:37:55Z",
+        "completed_at": "2026-09-12T15:37:56Z"
+      },
+      {
+        "name": "Format check",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 6,
+        "started_at": "2026-09-12T15:37:56Z",
+        "completed_at": "2026-09-12T15:38:06Z"
+      },
+      {
+        "name": "Validate CI impact classifier",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 7,
+        "started_at": "2026-09-12T15:38:06Z",
+        "completed_at": "2026-09-12T15:38:15Z"
+      },
+      {
+        "name": "Validate Rust test suite manifest",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 8,
+        "started_at": "2026-09-12T15:38:15Z",
+        "completed_at": "2026-09-12T15:38:24Z"
+      },
+      {
+        "name": "Test internal Rust crates",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 9,
+        "started_at": "2026-09-12T15:38:24Z",
+        "completed_at": "2026-09-12T15:38:27Z"
+      },
+      {
+        "name": "Validate LLM verifier tool contracts",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 10,
+        "started_at": "2026-09-12T15:38:27Z",
+        "completed_at": "2026-09-12T15:38:53Z"
+      },
+      {
+        "name": "Validate Render Diff trigger policy",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 11,
+        "started_at": "2026-09-12T15:38:53Z",
+        "completed_at": "2026-09-12T15:38:53Z"
+      },
+      {
+        "name": "Validate canvaskit-parity batch map",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 12,
+        "started_at": "2026-09-12T15:38:53Z",
+        "completed_at": "2026-09-12T15:38:53Z"
+      },
+      {
+        "name": "Validate workflow contracts",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 13,
+        "started_at": "2026-09-12T15:38:53Z",
+        "completed_at": "2026-09-12T15:39:07Z"
+      },
+      {
+        "name": "Validate adoption spine contract",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 14,
+        "started_at": "2026-09-12T15:39:07Z",
+        "completed_at": "2026-09-12T15:39:07Z"
+      },
+      {
+        "name": "Validate planner templates",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 15,
+        "started_at": "2026-09-12T15:39:07Z",
+        "completed_at": "2026-09-12T15:39:07Z"
+      },
+      {
+        "name": "Validate agent org contract",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 16,
+        "started_at": "2026-09-12T15:39:07Z",
+        "completed_at": "2026-09-12T15:39:07Z"
+      },
+      {
+        "name": "Validate agent frame contract",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 17,
+        "started_at": "2026-09-12T15:39:07Z",
+        "completed_at": "2026-09-12T15:39:07Z"
+      },
+      {
+        "name": "Validate external reality check contract",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 18,
+        "started_at": "2026-09-12T15:39:07Z",
+        "completed_at": "2026-09-12T15:39:07Z"
+      },
+      {
+        "name": "Clippy",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 19,
+        "started_at": "2026-09-12T15:39:07Z",
+        "completed_at": "2026-09-12T15:39:51Z"
+      },
+      {
+        "name": "Clippy (WASM32)",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 20,
+        "started_at": "2026-09-12T15:39:51Z",
+        "completed_at": "2026-09-12T15:40:31Z"
+      },
+      {
+        "name": "Check workspace members (FFI bindings, tools)",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 21,
+        "started_at": "2026-09-12T15:40:31Z",
+        "completed_at": "2026-09-12T15:42:49Z"
+      },
+      {
+        "name": "Agent preflight (failure-path sweep + undeclared-command detection)",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 22,
+        "started_at": "2026-09-12T15:42:49Z",
+        "completed_at": "2026-09-12T15:42:53Z"
+      },
+      {
+        "name": "Check WASM target",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 23,
+        "started_at": "2026-09-12T15:42:53Z",
+        "completed_at": "2026-09-12T15:43:17Z"
+      },
+      {
+        "name": "Post Rust build cache",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 45,
+        "started_at": "2026-09-12T15:43:17Z",
+        "completed_at": "2026-09-12T15:43:18Z"
+      },
+      {
+        "name": "Post Run actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 46,
+        "started_at": "2026-09-12T15:43:18Z",
+        "completed_at": "2026-09-12T15:43:18Z"
+      },
+      {
+        "name": "Complete job",
+        "status": "completed",
+        "conclusion": "success",
+        "number": 47,
+        "started_at": "2026-09-12T15:43:18Z",
+        "completed_at": "2026-09-12T15:43:18Z"
+      }
+    ]
+  }
+}

--- a/scripts/tests/fixtures/ci-impact-policy/issue7070-copied-worker-attempts.json
+++ b/scripts/tests/fixtures/ci-impact-policy/issue7070-copied-worker-attempts.json
@@ -1,0 +1,162 @@
+{
+  "repositoryId": 1193345564,
+  "run": {
+    "id": 34702678657,
+    "run_attempt": 2,
+    "name": "CI",
+    "path": ".github/workflows/ci.yml",
+    "head_sha": "85f08bda8e1b394e398c404004c27fd4bcd37fca",
+    "head_branch": "fix/5819-insert-table-options",
+    "event": "pull_request",
+    "status": "completed",
+    "conclusion": "success",
+    "created_at": "2026-09-12T15:35:16Z",
+    "run_started_at": "2026-09-12T15:52:42Z",
+    "pull_requests": [],
+    "repository": {
+      "id": 1193345564,
+      "full_name": "edwardkim/rhwp"
+    },
+    "head_repository": {
+      "id": 1193345564,
+      "full_name": "edwardkim/rhwp"
+    }
+  },
+  "pr": {
+    "number": 7068,
+    "created_at": "2026-09-12T15:29:54Z",
+    "merged_at": "2026-09-12T16:01:27Z",
+    "merged": true,
+    "merge_commit_sha": "3f34869b9c4d15a27b181dd22c63cd0a3730d46a",
+    "base": {
+      "ref": "devel",
+      "sha": "b116c11d0736fb1c105ed64bfc694b43dcd48b7d",
+      "repo": {
+        "id": 1193345564,
+        "full_name": "edwardkim/rhwp"
+      }
+    },
+    "head": {
+      "ref": "fix/5819-insert-table-options",
+      "sha": "85f08bda8e1b394e398c404004c27fd4bcd37fca",
+      "repo": {
+        "id": 1193345564,
+        "full_name": "edwardkim/rhwp"
+      }
+    }
+  },
+  "jobs": [
+    {
+      "id": 103579418249,
+      "name": "test-archive-d-shard-1 / Default-feature tests (Archive D)",
+      "run_id": 34702678657,
+      "run_attempt": 2,
+      "head_sha": "85f08bda8e1b394e398c404004c27fd4bcd37fca",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2026-09-12T15:42:17Z",
+      "completed_at": "2026-09-12T15:47:28Z"
+    },
+    {
+      "id": 103579418341,
+      "name": "test-archive-c-shard-1 / Default-feature tests (Archive C)",
+      "run_id": 34702678657,
+      "run_attempt": 2,
+      "head_sha": "85f08bda8e1b394e398c404004c27fd4bcd37fca",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2026-09-12T15:43:16Z",
+      "completed_at": "2026-09-12T15:47:49Z"
+    },
+    {
+      "id": 103579418376,
+      "name": "test-archive-b-shard-1 / Default-feature tests (Archive B)",
+      "run_id": 34702678657,
+      "run_attempt": 2,
+      "head_sha": "85f08bda8e1b394e398c404004c27fd4bcd37fca",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2026-09-12T15:43:18Z",
+      "completed_at": "2026-09-12T15:48:30Z"
+    }
+  ],
+  "originalJobs": [
+    {
+      "id": 103578018332,
+      "name": "test-archive-d-shard-1 / Default-feature tests (Archive D)",
+      "run_id": 34702678657,
+      "run_attempt": 1,
+      "head_sha": "85f08bda8e1b394e398c404004c27fd4bcd37fca",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2026-09-12T15:42:17Z",
+      "completed_at": "2026-09-12T15:47:28Z"
+    },
+    {
+      "id": 103578144430,
+      "name": "test-archive-c-shard-1 / Default-feature tests (Archive C)",
+      "run_id": 34702678657,
+      "run_attempt": 1,
+      "head_sha": "85f08bda8e1b394e398c404004c27fd4bcd37fca",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2026-09-12T15:43:16Z",
+      "completed_at": "2026-09-12T15:47:49Z"
+    },
+    {
+      "id": 103578147777,
+      "name": "test-archive-b-shard-1 / Default-feature tests (Archive B)",
+      "run_id": 34702678657,
+      "run_attempt": 1,
+      "head_sha": "85f08bda8e1b394e398c404004c27fd4bcd37fca",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2026-09-12T15:43:18Z",
+      "completed_at": "2026-09-12T15:48:30Z"
+    }
+  ],
+  "artifacts": [
+    {
+      "id": 10301655406,
+      "name": "nextest-target-durations-34702678657-attempt-1-c",
+      "expired": false,
+      "size_in_bytes": 41720,
+      "created_at": "2026-09-12T15:47:47Z",
+      "workflow_run": {
+        "id": 34702678657,
+        "repository_id": 1193345564,
+        "head_repository_id": 1193345564,
+        "head_branch": "fix/5819-insert-table-options",
+        "head_sha": "85f08bda8e1b394e398c404004c27fd4bcd37fca"
+      }
+    },
+    {
+      "id": 10301346099,
+      "name": "nextest-target-durations-34702678657-attempt-1-d",
+      "expired": false,
+      "size_in_bytes": 40130,
+      "created_at": "2026-09-12T15:47:26Z",
+      "workflow_run": {
+        "id": 34702678657,
+        "repository_id": 1193345564,
+        "head_repository_id": 1193345564,
+        "head_branch": "fix/5819-insert-table-options",
+        "head_sha": "85f08bda8e1b394e398c404004c27fd4bcd37fca"
+      }
+    },
+    {
+      "id": 10301251247,
+      "name": "nextest-target-durations-34702678657-attempt-1-b",
+      "expired": false,
+      "size_in_bytes": 52325,
+      "created_at": "2026-09-12T15:48:27Z",
+      "workflow_run": {
+        "id": 34702678657,
+        "repository_id": 1193345564,
+        "head_repository_id": 1193345564,
+        "head_branch": "fix/5819-insert-table-options",
+        "head_sha": "85f08bda8e1b394e398c404004c27fd4bcd37fca"
+      }
+    }
+  ]
+}

--- a/scripts/tests/test_ci_impact_policy_workflow.py
+++ b/scripts/tests/test_ci_impact_policy_workflow.py
@@ -87,10 +87,12 @@ class CiImpactPolicyWorkflowTests(unittest.TestCase):
         self.assertIn("'Render Diff': '.github/workflows/render-diff.yml'", self.workflow)
 
     def test_job_collection_errors_are_serialized_as_incomplete_evidence(self) -> None:
-        self.assertIn("let jobsCollected = false;", self.workflow)
-        self.assertIn("jobsCollected = true;", self.workflow)
+        self.assertIn("collectWorkflowEvidence({", self.workflow)
+        self.assertIn("getRun: async (id)", self.workflow)
+        self.assertIn("collectionPendingReason,", self.workflow)
+        self.assertIn("collectionFailure,", self.workflow)
         self.assertIn("jobsCollected,", self.workflow)
-        self.assertIn("audit will remain pending", self.workflow)
+        self.assertIn("trusted-base/scripts/ci-workflow-evidence.cjs", self.workflow)
 
     def test_status_is_exact_head_bound_and_supports_pending_aggregation(self) -> None:
         self.assertEqual(self.workflow.count("context: 'CI Impact Policy'"), 1)

--- a/scripts/tests/test_nextest_archive_workflow.py
+++ b/scripts/tests/test_nextest_archive_workflow.py
@@ -332,9 +332,11 @@ class NextestArchiveWorkflowTests(unittest.TestCase):
         self.assertIn('[profile.ci-duration-observation.junit]\npath = "junit.xml"', nextest)
         self.assertNotIn('path = "target/nextest/ci-duration-observation/junit.xml"', nextest)
         self.assertIn("resolve-nextest-duration-policy:", self.ci)
-        self.assertIn("refresh-nextest-target-duration-data:", self.ci)
-        self.assertIn("ci-metrics/nextest-target-durations", self.ci)
-        self.assertIn("github.ref == 'refs/heads/devel'", self.ci)
+        refresh = (REPO_ROOT / ".github/workflows/refresh-nextest-duration.yml").read_text()
+        self.assertNotIn("refresh-nextest-target-duration-data:", self.ci)
+        self.assertIn("refresh-nextest-target-duration-data:", refresh)
+        self.assertIn("ci-metrics/nextest-target-durations", refresh)
+        self.assertIn("github.ref == 'refs/heads/devel'", refresh)
         self.assertIn("duration_policy_sha:", self.builder)
         self.assertIn(
             "duration_policy_ref='ci-metrics/nextest-target-durations'",

--- a/scripts/tests/test_oracle_public_advisory_workflow.py
+++ b/scripts/tests/test_oracle_public_advisory_workflow.py
@@ -125,11 +125,9 @@ class OraclePublicAdvisoryWorkflowTests(unittest.TestCase):
         active_triggers = self.workflow.split("permissions:\n", maxsplit=1)[0]
         self.assertIn(
             "on:\n"
-            "  # workflow_dispatch identity가 아직 기본 브랜치에 등록되지 않은 후보도\n"
-            "  # workflow 파일 자체를 바꾼 신뢰 push에서 한 번 실실행한다.\n"
+            "  # 후보 브랜치의 명시적 workflow 변경만 검증한다. devel 병합 뒤에는 실행하지 않는다 (#7070).\n"
             "  push:\n"
             "    branches:\n"
-            "      - devel\n"
             "      - 'task_m100_*'\n"
             "    paths:\n"
             "      - '.github/workflows/oracle-public-advisory.yml'\n"

--- a/scripts/tests/test_postmerge_duration_workflow.py
+++ b/scripts/tests/test_postmerge_duration_workflow.py
@@ -9,7 +9,9 @@ WORKFLOWS = ROOT / '.github/workflows'
 class PostmergeDurationWorkflowTests(unittest.TestCase):
     def test_devel_push_subscribers_are_metadata_only(self):
         # An allowlist makes newly introduced implicit/all-branch push triggers fail too.
-        for path in WORKFLOWS.glob('*.yml'):
+        for path in WORKFLOWS.iterdir():
+            if path.suffix not in {'.yml', '.yaml'}:
+                continue
             text = path.read_text()
             match = re.search(r'^  push:(.*?)(?=^  [a-z_]+:|^\S|\Z)', text, re.M | re.S)
             if not match:

--- a/scripts/tests/test_postmerge_duration_workflow.py
+++ b/scripts/tests/test_postmerge_duration_workflow.py
@@ -1,0 +1,48 @@
+"""#7070: no validation workflow may subscribe to devel branch pushes."""
+import pathlib
+import re
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / '.github/workflows'
+
+class PostmergeDurationWorkflowTests(unittest.TestCase):
+    def test_devel_push_subscribers_are_metadata_only(self):
+        # An allowlist makes newly introduced implicit/all-branch push triggers fail too.
+        for path in WORKFLOWS.glob('*.yml'):
+            text = path.read_text()
+            match = re.search(r'^  push:(.*?)(?=^  [a-z_]+:|^\S|\Z)', text, re.M | re.S)
+            if not match:
+                continue
+            block = match[1]
+            if re.search(r'branches:\s*\[main\]', block) or ('tags:' in block and 'branches:' not in block):
+                continue
+            if path.name == 'oracle-public-advisory.yml':
+                self.assertNotIn('devel', block)
+                self.assertIn("'task_m100_*'", block)
+                continue
+            self.assertIn(path.name, ['refresh-nextest-duration.yml', 'close-issues-on-devel-push.yml'])
+
+    def test_pr_checks_and_tag_release_are_preserved(self):
+        for filename in ['ci.yml', 'codeql.yml', 'adapter-diff.yml', 'proptest-roundtrip.yml']:
+            text = (WORKFLOWS / filename).read_text()
+            self.assertIn('  pull_request:', text)
+            self.assertIn('  workflow_dispatch:', text)
+            if filename != 'ci.yml':
+                self.assertNotIn('\n  push:', text)
+        self.assertIn("tags: ['v*']", (WORKFLOWS / 'ci.yml').read_text())
+
+    def test_refresh_has_only_metadata_job_and_no_ci_fallback(self):
+        text = (WORKFLOWS / 'refresh-nextest-duration.yml').read_text()
+        jobs = text.split('\njobs:\n', 1)[1]
+        self.assertEqual(re.findall(r'^  ([\w-]+):', jobs, re.M), ['refresh-nextest-target-duration-data'])
+        for forbidden in ['cargo ', 'npm ', 'workflow_run:', 'actions: write', 'trusted-postmerge-ci-reuse', 'gh run', 'workflow-dispatch', 'pull_request:']:
+            self.assertNotIn(forbidden, text)
+        self.assertIn('branches: [devel]', text)
+        self.assertIn("steps.collect.outputs.ready == 'true'", text)
+        self.assertIn('"${current_devel_sha}" != "${GITHUB_SHA}"', text)
+        self.assertIn('HEAD:refs/heads/${METRICS_BRANCH}', text)
+        self.assertIn('collectPostmergeDurations', text)
+        collector = (ROOT / 'scripts/collect-postmerge-duration-data.mjs').read_text()
+        for forbidden in ['createWorkflowDispatch', 'reRunWorkflow', 'execFile', 'extractall']:
+            self.assertNotIn(forbidden, collector)

--- a/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
+++ b/scripts/tests/test_trusted_postmerge_ci_reuse_workflow.py
@@ -173,8 +173,8 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
         ci = WORKFLOWS["ci"].read_text(encoding="utf-8")
         self.assertIn("require_duration_artifacts: true", ci)
         self.assertIn("postmerge_source_run_id", ci)
-        self.assertIn("Download trusted PR Archive B duration measurement", ci)
-        self.assertIn("Download trusted PR Archive C duration measurement", ci)
+        self.assertNotIn("Download trusted PR Archive B duration measurement", ci)
+        self.assertNotIn("refresh-nextest-target-duration-data:", ci)
 
     def test_fork_upload_remains_read_only_and_attempt_bound(self) -> None:
         runner = (REPO_ROOT / ".github/workflows/run-nextest-archives.yml").read_text(encoding="utf-8")
@@ -187,19 +187,15 @@ class TrustedPostmergeReuseWorkflowTests(unittest.TestCase):
         self.assertIn("contents: read", runner)
         self.assertNotIn("contents: write", runner)
 
-    def test_privileged_refresh_consumes_only_normalized_current_run_data(self) -> None:
-        workflow = REUSABLE.read_text(encoding="utf-8")
-        ci = CI_WORKFLOW.read_text(encoding="utf-8")
-        for label in ("b", "c", "d"):
-            name = f"trusted-postmerge-durations-${{{{ github.run_id }}}}-${{{{ github.run_attempt }}}}-{label}"
-            self.assertIn(name, workflow)
-            self.assertIn(name, ci)
-        self.assertIn("decodeDurationArtifact(response.data, label)", workflow)
-        self.assertIn("scripts/trusted-postmerge-duration-evidence.mjs", workflow)
-        self.assertIn("validated-duration-publication-failed", workflow)
-        self.assertIn("steps.finalize.outputs.reuse", workflow)
-        block = ci.split("- name: Download trusted PR Archive B duration measurement", 1)[1].split("- name: Refresh duration policy data branch", 1)[0]
-        self.assertNotIn("gh run download", block)
+    def test_privileged_refresh_consumes_only_verified_worker_data(self) -> None:
+        root = CI_WORKFLOW.parents[2]
+        refresh = (root / ".github/workflows/refresh-nextest-duration.yml").read_text()
+        collector = (root / "scripts/collect-postmerge-duration-data.mjs").read_text()
+        self.assertIn("collectPostmergeDurations", refresh)
+        self.assertIn("decodeDurationArtifact(response.data, label)", collector)
+        self.assertIn("validateDurationReports(reports", collector)
+        self.assertNotIn("gh run download", refresh)
+        self.assertNotIn("trusted-postmerge-ci-reuse.yml", refresh)
 
     def test_codeql_neutral_is_not_a_substitute_for_language_success(self) -> None:
         workflow = REUSABLE.read_text(encoding="utf-8")
@@ -275,5 +271,4 @@ class FrontendOnlyPostmergeReuseWorkflowTests(frontend_unittest.TestCase):
         self.assertIn('if (result.refreshDurationData !== false)', workflow)
         self.assertIn("core.setOutput('refresh_duration_data'", workflow)
         self.assertIn("postmerge_refresh_duration_data: ${{ needs.trusted_postmerge_reuse.outputs.refresh_duration_data || 'false' }}", ci)
-        self.assertIn("needs.preflight.outputs.postmerge_reuse != 'true'", ci)
-        self.assertIn("needs.preflight.outputs.postmerge_refresh_duration_data == 'true'", ci)
+        self.assertNotIn("  refresh-nextest-target-duration-data:", ci)

--- a/scripts/tests/test_workflow_contract_wiring.py
+++ b/scripts/tests/test_workflow_contract_wiring.py
@@ -59,7 +59,7 @@ class WorkflowContractWiringTests(unittest.TestCase):
         self.assertEqual(
             node_contract_test_files(),
             ["ci-impact-classifier.test.cjs", "ci-impact-policy.test.cjs",
-             "ci-impact-report.test.cjs"],
+             "ci-impact-report.test.cjs", "ci-workflow-evidence.test.cjs"],
         )
 
     def test_every_contract_test_is_invoked_by_ci(self):

--- a/scripts/trusted-postmerge-duration-evidence.mjs
+++ b/scripts/trusted-postmerge-duration-evidence.mjs
@@ -83,12 +83,16 @@ with zipfile.ZipFile(io.BytesIO(sys.stdin.buffer.read(limit+1))) as archive:
   }).toString("utf8"));
 }
 
-export function validateDurationReports(reports, { run, pr, repositoryId, testedMergeSha, legacy = false }) {
+export function validateDurationReports(reports, { run, pr, repositoryId, testedMergeSha, legacy = false, measurementAttempts = null }) {
   if (!Array.isArray(reports) || reports.length !== 3 || !SHA.test(testedMergeSha || "")
     || !SHA.test(run?.head_sha || "") || !ID.test(String(run?.id || ""))
     || !Number.isSafeInteger(pr?.number) || pr.number <= 0
     || !Number.isSafeInteger(run.run_attempt) || run.run_attempt <= 0
     || (legacy && (pr.head?.repo?.id !== repositoryId || run.run_attempt !== 1))) fail("invalid report context");
+  if (measurementAttempts !== null && (legacy || !record(measurementAttempts)
+    || Object.keys(measurementAttempts).sort().join(",") !== "b,c,d"
+    || LABELS.some(label => !Number.isSafeInteger(measurementAttempts[label])
+      || measurementAttempts[label] < 1 || measurementAttempts[label] > run.run_attempt))) fail("invalid measurement attempt map");
   const labels = new Set();
   const keys = { targets: new Set(), cases: new Set(), test_cases: new Set() };
   const schemas = new Set();
@@ -99,7 +103,10 @@ export function validateDurationReports(reports, { run, pr, repositoryId, tested
     schemas.add(report.schema_version);
     if (report.run_id !== String(run.id) || report.ref !== `refs/pull/${pr.number}/merge`
       || report.sha !== testedMergeSha) fail("report run/ref/tested merge SHA mismatch");
-    if (!legacy && (report.run_attempt !== String(run.run_attempt)
+    const expectedAttempt = measurementAttempts?.[report.archive_label] ?? run.run_attempt;
+    if (measurementAttempts && (legacy || !Number.isSafeInteger(expectedAttempt)
+      || expectedAttempt < 1 || expectedAttempt > run.run_attempt)) fail("invalid measurement attempt");
+    if (!legacy && (report.run_attempt !== String(expectedAttempt)
       || report.repository_id !== String(repositoryId) || report.repository !== run.repository.full_name
       || report.pull_number !== String(pr.number) || report.head_repository_id !== String(pr.head.repo.id)
       || report.head_sha !== run.head_sha || report.head_ref !== pr.head.ref)) fail("report PR/repository/attempt/head mismatch");


### PR DESCRIPTION
## 문제와 변경

성공한 CI workflow의 Jobs API가 미완료 상태를 반환하면 CI Impact Policy가 실패했고, 병합 후에는 재사용 증거를 찾지 못한 CI·CodeQL·Adapter·Proptest가 다시 전체 검증을 시작했습니다.

- #7069: 같은 run/head/attempt의 증거를 제한적으로 재조회하고, 미완료 job/step은 pending으로 구분합니다. 실제 실패·누락·중복을 성공으로 바꾸지 않습니다.
- #7070: 검증 workflow의 main/devel branch push와 Oracle advisory의 devel push를 제거합니다. PR 검증은 유지하며, devel 병합 후에는 독립 `Refresh nextest target duration data`에서 메타데이터만 갱신합니다. 증거가 없으면 갱신만 보류하며 Full CI fallback은 없습니다.
- GitHub가 부분 재실행 때 기존 B/C/D job까지 새 ID/attempt로 복사한 #7068 실제 응답을 보존했습니다. attempt별 원본 작업의 실행 시각과 artifact를 대조하여 lint 재실행 뒤에도 원본 attempt 1의 실측을 읽습니다.
- 운영 매뉴얼과 post-merge 절차도 변경했습니다. issue-close 업무 자동화, 명시 수동 실행, release tag/Pages 배포와 독립 보안 schedule은 별도 목적으로 유지합니다.

## 검증

- Node 회귀 450 PASS, Python workflow 계약 240 PASS, exit 0.
- 변경 workflow의 actionlint 구조·expression 검사, 변경 문서 링크·메타데이터, merge simulation 통과.
- ShellCheck SC2016 2건은 기존 CI/Oracle에도 동일하게 존재하며 신규 duration workflow에는 없습니다.
- #7068 run `34702678657`의 실제 artifact 3개를 read-only 검증: latest attempt 2 / B·C·D 측정 attempt 1. 로컬 refresh로 42 target 갱신. 원격 metrics branch 쓰기는 실행하지 않았습니다.
- Rust·renderer 변경이 없어 Cargo/시각 검증은 비해당입니다.

## 적용 경계

push trigger 제거와 새 duration workflow는 devel 병합부터 적용됩니다. #7069 policy 모듈은 live base에서 로드되지만, 기본 branch 전용 controller의 수집 배선은 정상 main release 뒤 활성화됩니다. main 직접 push나 강제 release는 포함하지 않습니다.

Closes #7069
Closes #7070

검토 기록: [self-review](https://github.com/edwardkim/rhwp/blob/6eb724481a1c41165c91fe9c31c959c4c3d0f28d/mydocs/pr/archives/pr_7071_review.md), [#7069 보고서](https://github.com/edwardkim/rhwp/blob/6eb724481a1c41165c91fe9c31c959c4c3d0f28d/mydocs/report/task_m100_7069_report.md), [#7070 보고서](https://github.com/edwardkim/rhwp/blob/6eb724481a1c41165c91fe9c31c959c4c3d0f28d/mydocs/report/task_m100_7070_report.md). 최종 제출 head `54e7ccc3eab789ddb09d50f6698fc650df424a66`의 CI를 확인합니다.

최초 CI에서 발견한 새 테스트의 discovery 기대 목록 누락을 보정했습니다. CI의 `Validate workflow contracts` 명령 전체와 넓힌 `test_*workflow*.py` 240건을 모두 통과한 후 위 최종 head로 갱신했습니다.

## 최종 head CI 결과 — 2026-09-13 KST

`54e7ccc3eab789ddb09d50f6698fc650df424a66` 기준 아래 검증이 모두 성공했고, API 재조회에서 non-draft / `MERGEABLE` / `CLEAN`, 실패·대기 check 없음으로 확인했습니다. 이 검증 직후에는 미병합이었으며, 아래 후속 기록에서 실제 병합 상태를 확인합니다.

- [CI](https://github.com/edwardkim/rhwp/actions/runs/34705958927): success — lint, Archive A~D, Native Skia, frontend, Build & Test.
- [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/34705958841): success — JavaScript/TypeScript, Python, Rust.
- [Adapter inter-diff](https://github.com/edwardkim/rhwp/actions/runs/34705958879): success.
- [Proptest roundtrip](https://github.com/edwardkim/rhwp/actions/runs/34705958890): success.
- [최종 CI Impact Policy audit](https://github.com/edwardkim/rhwp/actions/runs/34706680381): success; PR head의 정책 상태도 success.

이 기록은 PR 본문에 반영하여 검증 완료 후 문서 commit으로 CI를 다시 시작하지 않습니다. 병합 후 새 duration workflow의 운영 결과 확인과 controller의 정상 main release 활성화는 별도 단계입니다.


## 병합 후 확인

2026-09-13 01:58:41 KST, `6eb724481a1c41165c91fe9c31c959c4c3d0f28d`로 병합했습니다. 병합 SHA의 Actions는 duration 갱신과 issue-close 두 개뿐이며 CI/CodeQL/Adapter/Proptest/Oracle 검증 실행은 없습니다. [duration run 34706836993](https://github.com/edwardkim/rhwp/actions/runs/34706836993)이 PR run 34705958927의 B/C/D attempt 1 자료로 42 target을 갱신했고 metrics commit은 `4a330805811985a05cfdce248a797ea644bf64c5`입니다. #7069·#7070 자동 종료와 devel 동기화를 확인했습니다. controller 수집 배선의 main release 활성화 경계는 유지됩니다.
