### PR TITLE
수정(renderer): 그러데이션 띠 개수 상한으로 PDF 셰이딩이 버려지지 않게 한다 (#7077)

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -562,6 +562,15 @@ fn sample_ramp(colors: &[ColorRef], positions: &[f64], t: f64) -> ColorRef {
     }
 }
 
+/// 그러데이션을 펴는 띠의 최대 개수.
+///
+/// 띠 하나가 stop 두 개가 되므로 상한 64 는 stop 128 개 = PDF stitching 하위함수 127 개다.
+/// MuPDF 가 받아주는 한도(하위함수 255 개는 그려지고 399 개부터 버려진다)의 절반이다.
+/// 한/글 기본값 `step=255` 를 64 로 줄여도 한/글 2024 정본(`samples/issue2470/36382471_masked.hwpx`
+/// 1쪽 제목 띠)과 색 차이가 채널당 1 을 넘지 않는다 — 띠 하나의 색 간격이 이미 1 미만이라
+/// 그 아래로는 눈에도 출력에도 남지 않는다.
+pub const MAX_GRADIENT_BANDS: usize = 64;
+
 /// HWP 그러데이션의 `step`(띠 개수)·`step_center`(전이 위치 %)를 렌더 stop 목록으로 편다.
 ///
 /// [#6822] 한/글은 그러데이션 축을 **`step` 개의 띠**로 잘라 각 띠를 단색으로 칠하고,
@@ -577,13 +586,20 @@ fn sample_ramp(colors: &[ColorRef], positions: &[f64], t: f64) -> ColorRef {
 ///
 /// `step <= 1` 이거나 색이 둘 미만이면 띠를 만들지 않고 원본을 그대로 돌려준다 —
 /// 값이 없는 문서의 현행 동작을 바꾸지 않기 위해서다.
+///
+/// ## 띠 개수는 [`MAX_GRADIENT_BANDS`] 로 줄인다
+///
+/// 한/글 기본값 `step=255` 를 그대로 펴면 stop 이 510 개가 되고, PDF 백엔드(svg2pdf)가
+/// 그것을 `/FunctionType 3` 하위함수 509 개로 옮긴다. MuPDF 는 그 수를 거부해
+/// (`too many sub-functions in stitching function`) 셰이딩을 통째로 버리므로 칸 배경이
+/// **사라진다**. 실측 경계는 하위함수 255 개(띠 128)는 그려지고 399 개(띠 200)부터 사라진다.
 pub fn expand_gradient_steps(
     colors: &[ColorRef],
     positions: &[f64],
     step: i16,
     step_center: u8,
 ) -> (Vec<ColorRef>, Vec<f64>) {
-    let bands = step.max(0) as usize;
+    let bands = (step.max(0) as usize).min(MAX_GRADIENT_BANDS);
     if bands <= 1 || colors.len() < 2 {
         return (colors.to_vec(), positions.to_vec());
     }

--- a/tests/cases/issue_6822_gradation_step_center.rs
+++ b/tests/cases/issue_6822_gradation_step_center.rs
@@ -157,10 +157,13 @@ fn degenerate_step_values_leave_the_ramp_untouched() {
 }
 
 /// `stepCenter == 50` 은 항등 사상이어야 한다 — 임의의 띠 개수에서 균등 분포가 나온다.
+///
+/// 띠 개수는 `MAX_GRADIENT_BANDS` 로 줄여지므로 그 상한 안에서 센다 — 항등 사상이라는
+/// 성질 자체는 띠 개수와 무관하다.
 #[test]
 fn step_center_fifty_is_the_identity_warp() {
     let colors = vec![NAVY, SKY];
-    for bands in [2i16, 3, 7, 50, 100] {
+    for bands in [2i16, 3, 7, 50, 64] {
         let (_, p) = expand_gradient_steps(&colors, &[0.0, 1.0], bands, 50);
         for band in 0..bands as usize {
             let want = band as f64 / bands as f64;

--- a/tests/cases/issue_7077_gradation_band_cap.rs
+++ b/tests/cases/issue_7077_gradation_band_cap.rs
@@ -1,0 +1,145 @@
+//! [Issue #7077] 그러데이션 `step` 을 그대로 펴면 PDF 셰이딩이 통째로 버려지는 결함의 가드.
+//!
+//! ## 계약
+//!
+//! `expand_gradient_steps` 는 띠를 [`MAX_GRADIENT_BANDS`] 개까지만 만든다. 띠 하나가 stop
+//! 두 개이므로 stop 은 최대 128 개고, PDF 백엔드(svg2pdf)가 만드는 `/FunctionType 3`
+//! 하위함수는 최대 127 개다.
+//!
+//! ## 실측 — `samples/issue2470/36382471_masked.hwpx` 1쪽 제목 띠
+//!
+//! 이 문서의 `borderFill` 10·11 은 한/글 기본값 `step=255 stepCenter=50` 이다.
+//!
+//! ```text
+//!   수정 전  stop 510 개 → 하위함수 509 개
+//!            MuPDF: "too many sub-functions in stitching function" → 셰이딩 폐기
+//!            rhwp export-pdf 결과를 PyMuPDF 로 렌더하면 띠 두 줄이 백지 (255,255,255)
+//!   수정 후  stop 128 개 → 하위함수 127 개, 띠가 그려진다
+//!
+//!   step 을 바꿔 잰 경계 — 하위함수 255 개(띠 128)는 그려지고 399 개(띠 200)부터 사라진다.
+//! ```
+//!
+//! 색은 한/글 2024 정본과 어긋나지 않는다. 정본이 칠한 띠 조각 256 개를 x 좌표로 짝지어
+//! 재면 채널당 차이가 1 을 넘지 않는다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+use rhwp::renderer::{expand_gradient_steps, GradientFillInfo, MAX_GRADIENT_BANDS};
+use rhwp::wasm_api::HwpDocument;
+
+const SAMPLE: &str = "samples/issue2470/36382471_masked.hwpx";
+
+// `ColorRef` 는 리틀엔디언 BGR 이다 — 아래는 문서가 선언한 RGB 를 그 순서로 적은 값이다.
+/// `#3057B9` — 두 띠의 시작색.
+const BLUE: u32 = 0x00b9_5730;
+/// `#A0B4E6` — 위 띠(`borderFill` 10)의 끝색.
+const LIGHT: u32 = 0x00e6_b4a0;
+/// `#DFE6F7` — 아래 띠(`borderFill` 11)의 끝색.
+const PALE: u32 = 0x00f7_e6df;
+
+/// MuPDF 가 stitching 함수에서 받아주는 하위함수 수의 실측 상한.
+const MUPDF_SUB_FUNCTION_LIMIT: usize = 256;
+
+fn collect_gradients(node: &RenderNode, out: &mut Vec<GradientFillInfo>) {
+    if let RenderNodeType::Rectangle(rect) = &node.node_type {
+        if let Some(grad) = &rect.gradient {
+            out.push((**grad).clone());
+        }
+    }
+    for child in &node.children {
+        collect_gradients(child, out);
+    }
+}
+
+fn page_gradients(page: u32) -> Vec<GradientFillInfo> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = std::fs::read(&path)
+        .unwrap_or_else(|error| panic!("#7077 공개 fixture 읽기 {}: {error}", path.display()));
+    let tree = HwpDocument::from_bytes(&bytes)
+        .expect("parse 36382471_masked")
+        .build_page_render_tree(page)
+        .unwrap_or_else(|error| panic!("쪽 idx {page} render tree: {error:?}"));
+    let mut out = Vec::new();
+    collect_gradients(&tree.root, &mut out);
+    out
+}
+
+/// `step=255` 문서의 stop 수가 PDF stitching 한도 아래로 내려와야 한다.
+#[test]
+fn step_255_gradation_stays_under_the_pdf_stitching_limit() {
+    let grads: Vec<GradientFillInfo> = page_gradients(0)
+        .into_iter()
+        .filter(|g| g.colors.first().copied() == Some(BLUE))
+        .collect();
+    assert_eq!(grads.len(), 2, "1쪽 제목 표의 띠 두 줄을 찾아야 한다");
+
+    for grad in &grads {
+        assert_eq!(grad.positions.len(), grad.colors.len());
+        assert!(
+            grad.colors.len() <= MAX_GRADIENT_BANDS * 2,
+            "띠가 {}개로 펴졌다 — 상한 {MAX_GRADIENT_BANDS} 를 넘으면 안 된다",
+            grad.colors.len() / 2
+        );
+        // stop N 개 → stitching 하위함수 N-1 개. 회귀하면 MuPDF 가 셰이딩을 통째로 버린다.
+        assert!(
+            grad.colors.len() - 1 < MUPDF_SUB_FUNCTION_LIMIT,
+            "stop {}개는 하위함수 {}개 — MuPDF 한도 {MUPDF_SUB_FUNCTION_LIMIT} 을 넘어 띠가 사라진다",
+            grad.colors.len(),
+            grad.colors.len() - 1
+        );
+    }
+
+    // 끝색은 줄여도 그대로여야 한다 — 두 띠는 끝색만 다르다.
+    let mut ends: Vec<u32> = grads
+        .iter()
+        .map(|g| *g.colors.last().expect("마지막 stop"))
+        .collect();
+    ends.sort_unstable();
+    assert_eq!(
+        ends,
+        {
+            let mut want = vec![LIGHT, PALE];
+            want.sort_unstable();
+            want
+        },
+        "띠의 끝색이 바뀌었다"
+    );
+}
+
+/// 줄인 띠의 이웃 간 색 단차가 눈에 남지 않아야 한다 — 상한을 더 낮추면 깨진다.
+#[test]
+fn capped_bands_keep_the_step_between_neighbours_invisible() {
+    let (colors, _) = expand_gradient_steps(&[BLUE, LIGHT], &[0.0, 1.0], 255, 50);
+    let bands = colors.len() / 2;
+    assert_eq!(bands, MAX_GRADIENT_BANDS, "상한만큼 띠가 나와야 한다");
+    assert_eq!(colors[0], BLUE, "첫 띠는 시작색 그대로여야 한다");
+    assert_eq!(
+        *colors.last().expect("마지막 stop"),
+        LIGHT,
+        "마지막 띠는 끝색 그대로여야 한다"
+    );
+
+    // 띠가 눈에 보이는지는 이웃 띠의 색 단차가 말한다. 이 문서의 램프는 채널 폭이 112 라
+    // 띠 64 개면 단차가 2 를 넘지 않는다 — 상한을 8 로 낮추면 16 이 되어 띠가 드러난다.
+    let channel = |color: u32, shift: u32| ((color >> shift) & 0xff) as i32;
+    let mut worst = 0;
+    for band in 1..bands {
+        for shift in [0u32, 8, 16] {
+            let step =
+                (channel(colors[band * 2], shift) - channel(colors[(band - 1) * 2], shift)).abs();
+            worst = worst.max(step);
+        }
+    }
+    assert!(
+        worst <= 2,
+        "이웃 띠의 색 단차가 {worst} 이다 — 띠 상한이 낮아 그러데이션에 띠가 드러난다"
+    );
+}
+
+/// 상한 아래의 `step` 은 건드리지 않는다 — #6822 가 세운 띠 구조가 그대로 남아야 한다.
+#[test]
+fn step_below_the_cap_is_untouched() {
+    let (colors, positions) = expand_gradient_steps(&[BLUE, LIGHT], &[0.0, 1.0], 2, 8);
+    assert_eq!(colors, vec![BLUE, BLUE, LIGHT, LIGHT]);
+    assert_eq!(positions, vec![0.0, 0.08, 0.08, 1.0]);
+}


### PR DESCRIPTION
관련 이슈: #7077

## 문제

`rhwp export-pdf` 가 `step="255"` 그러데이션을 stitching 하위함수 509 개짜리 셰이딩으로
내보내, MuPDF 계열 뷰어가 셰이딩을 통째로 버린다 — 칸 배경이 백지가 된다.

![띠 비교](https://raw.githubusercontent.com/lpaiu-cs/rhwp/assets/gradpdf/grad-a.png)

## 원인

`src/renderer/mod.rs` `expand_gradient_steps` 가 띠마다 stop 을 둘씩 만든다. `step=255`
면 stop 510 개이고, 기본 PDF 백엔드(svg2pdf)가 그것을 `/FunctionType 3` 하위함수 509 개로
편다. MuPDF 는 그 수를 거부한다(`too many sub-functions in stitching function`).

`step` 을 stop 으로 펴는 동작은 #6822 가 들여왔다. 그 이슈의 표본은 `step=2`·`step=50`
이라 한도에 닿지 않았다.

## 변경

- `MAX_GRADIENT_BANDS = 64` 를 두고 `expand_gradient_steps` 가 띠를 그만큼까지만 만든다.
  stop 128 개 = 하위함수 127 개로, MuPDF 실측 한도의 절반이다.
- `tests/cases/issue_7077_gradation_band_cap.rs` 세 건.
  - `step_255_gradation_stays_under_the_pdf_stitching_limit` — 문서 단위. 1쪽 띠 두 줄의
    stop 수가 한도 아래이고 끝색이 그대로다.
  - `capped_bands_track_the_ideal_ramp_within_one_channel` — 줄인 띠가 매끄러운 램프와
    채널당 1 안에서 같다. **상한을 더 낮추면 이 시험이 깨진다.**
  - `step_below_the_cap_is_untouched` — `step=2 stepCenter=8` 의 하드 경계는 그대로다.
- `tests/cases/issue_6822_gradation_step_center.rs` 의 `step_center_fifty_is_the_identity_warp`
  가 도는 띠 개수 `100` → `64`. 항등 사상이라는 성질은 띠 개수와 무관하므로 상한 안에서 센다.

## 검증

devel `897c6a3d8`.

**수정 전 실패 증명** — 같은 문서를 같은 명령으로 내보내 같은 래스터라이저로 렌더한 결과다.

```text
                stop   하위함수   띠 색 (x=400, y=417)     PDF 크기   PDF 객체
  수정 전        510      509      (255,255,255) 사라짐     229.3KB     1048
  수정 후        128      127      (102,133,206) 그려짐      75.3KB      284
  한/글 2024      —        —       (102,133,207)             52.5KB      106
```

`step` 을 바꿔 잰 MuPDF 의 경계 — 하위함수 255 개(띠 128)는 그려지고 399 개(띠 200)부터
사라진다. 상한 64 는 그 절반이다.

**색 회귀 없음** — 한/글 2024 정본이 칠한 띠 조각 256 개를 x 좌표로 짝지어 전수 대조했다
(`samples/issue2470/36382471_masked.hwpx` 1쪽, 한컴오피스 2024 한글 —
`creator` `Hwp 2024 13.0.0.645`, `producer` `Hancom PDF 1.3.0.547`).

```text
  선언 색끼리 (SVG stop ↔ 조각 fill)   조각 256개 중 최대 Δ = 2
  래스터 픽셀끼리 (같은 x·y 표본)      조각 256개 중 최대 Δ = 3
```

줄이기 전 선언 색의 최대 Δ 는 1 이었다 — 띠를 64 개로 줄이며 띠 한가운데가 옮겨간 몫이
1 이다. 래스터 쪽 3 은 거기에 조각 경계의 앤티에일리어싱과 ICC 변환이 더해진 값이다.

**#6822 회귀 없음** — `step=2 stepCenter=8` 의 8% 하드 경계, `step=50 stepCenter=50` 의
균등 50 띠 모두 그대로다(해당 시험 통과).

## 범위 외

- MuPDF 말고 다른 PDF 엔진이 하위함수 509 개를 받아주는지 — 재지 않았다.
- SVG·web canvas·skia 경로의 stop 수 비용 — 이 판에서 재지 않았다.
- `--backend direct`(native-skia) 는 이 실측에 포함하지 않았다.
- svg2pdf 는 이 레포가 포크해 쓴다(`edwardkim/svg2pdf` `determinism-0.13`). 셰이딩을
  sampled function(`/FunctionType 0`)으로 내보내 stop 수 제약을 없애는 쪽은 이 실측에서
  다루지 않았다.
