### PR TITLE
수정: HWP3 선·다각형이 도형 storage 비트를 잃어 한글이 문서를 못 연다 (#4680)

### DIFF
--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -1100,6 +1100,26 @@ fn normalize_picture_geometry_for_hwp(doc: &mut Document, source_is_hwpx: bool) 
                 // 모두 동일한 paragraph container이므로 같은 walker로 재귀한다.
                 if let Some(drawing) = shape.drawing_mut() {
                     walk_drawing(drawing, source_is_hwpx);
+                    // [#4680] 위 사각형 arm 과 같은 storage flip 계약을 선·다각형·
+                    // 타원·호·곡선에도 적용한다. 종전에는 사각형만 세워서 나머지
+                    // 도형이 0 으로 나갔고, 한컴은 그런 도형이 든 문서를 열지 못했다.
+                    //
+                    // 264쪽 HWP3 문서 53쪽(표 칸 안 묶음: `$con` → `$rec`·`$lin`·
+                    // `$pol`)에서 실측했다. 한/글 저장본과 우리 산출물을 레코드
+                    // 단위로 이등분해 `$lin`/`$pol` 의 `SHAPE_COMPONENT` 로 좁히고,
+                    // 다시 바이트 구간으로 좁히면 **이 4바이트 하나**가 갈림점이다
+                    // (그 구간만 한/글 값으로 바꾸면 open=True, 나머지 전부 바꿔도
+                    // 이 구간이 0 이면 open=False). 회전중심은 필요하지 않았다 —
+                    // 근거가 없는 값은 건드리지 않는다.
+                    let has_text_box = drawing.text_box.is_some();
+                    let sa = &mut drawing.shape_attr;
+                    if sa.flip == 0 {
+                        sa.flip = if has_text_box {
+                            0x0108_0000
+                        } else {
+                            0x0008_0000
+                        };
+                    }
                 }
             }
         }

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -2504,6 +2504,31 @@ fn parse_field_control_char(
                         hide.hide_page_num = (flags & 4) != 0;
                         hide.hide_border = (flags & 8) != 0;
                         crate::model::control::Control::PageHide(hide)
+                    } else if kind == 0 {
+                        // [#4680] 제어문자 21 의 종류 0 은 **항상 홀수쪽으로 시작**이다
+                        // (`mydocs/tech/한글문서파일구조3.0.md` §10.15 표 56: 0 = 홀수로
+                        // 시작, 1 = 감춤). 종전에는 이 자리가 catch-all 로 떨어져
+                        // `Control::Unknown { ctrl_id: 21 }` 이 됐다.
+                        //
+                        // 그 21 은 HWP5 저장에서 **구조 오염**이 된다. HWP5 의 ctrl_id 는
+                        // 네 글자 코드('pgct'·'pghd' …)이고, 저장기는 Unknown 을 개체
+                        // 제어문자 자리(0x000B)와 `CTRL_HEADER` 에 그대로 쓴다. 한글은
+                        // 그런 문단을 만나면 문서를 열지 못한다 — 264쪽 HWP3 문서
+                        // `1170000-200500003 독일의 법령체계와 입법심사기준` 이 개방 거부됐고,
+                        // 그 코드가 있는 42쪽 한 장만 뽑아도 같은 거부가 재현된다.
+                        // rhwp 자신은 산출물을 그대로 되읽으므로 자기검증으로는 안 보인다.
+                        //
+                        // 값은 같은 문서의 한/글 HWP5 저장본에서 온다 — `pgct` 4건이
+                        // 모두 payload 2(= 홀수 쪽)이고 개수도 우리 4건과 맞는다. 종류 1
+                        // (감춤)이 `pghd` 인 것도 같은 대조로 확인된다(00472: HWP3 감출
+                        // 대상 7 ↔ 한/글 `pghd` 0x23 = 머리말·꼬리말·쪽번호).
+                        // 코퍼스 HWP3 38건 전수에서 `Control::Unknown` 은 이 4건이 전부다.
+                        // 규격에 종류는 0·1 뿐이므로 그 밖의 값은 종전 경로로 둔다.
+                        crate::model::control::Control::PageNumCtrl(
+                            crate::model::control::PageNumCtrl {
+                                page_starts_on: crate::model::control::PageStartsOn::Odd,
+                            },
+                        )
                     } else {
                         crate::model::control::Control::Unknown(
                             crate::model::control::UnknownControl { ctrl_id: ch as u32 },

--- a/tests/cases/issue_4680_hwp3_odd_page_start.rs
+++ b/tests/cases/issue_4680_hwp3_odd_page_start.rs
@@ -1,0 +1,283 @@
+//! [#4680] HWP3 "항상 홀수쪽으로 시작"(제어문자 21, 종류 0)이 HWP5 저장에서
+//! 구조 오염이 된다 — 한글이 문서를 열지 못한다.
+//!
+//! ## 증상
+//!
+//! 264쪽 HWP3 문서(`1170000-200500003 독일의 법령체계와 입법심사기준`)를
+//! `rhwp convert` 로 저장하면 한글이 **열지 못한다**(open=False). 그 문서에서
+//! 해당 제어문자가 있는 42쪽 한 장만 `extract-pages` 로 뽑아도 같은 거부가
+//! 재현된다. rhwp 자신은 산출물을 원본과 동일하게 되읽으므로 `--verify`
+//! 자기검증으로는 보이지 않는다 — 판정자는 한글뿐이다.
+//!
+//! ## 재현 (코퍼스 문서 — 저장소에는 넣지 않는다)
+//!
+//! ```text
+//! hwpdocs_10k_share/prism_downloads/법제처/
+//!   1170000-200500003_D0150004-1-001_독일의 법령체계와 입법심사기준(최종본).hwp
+//!
+//! rhwp extract-pages <원본> p42.hwp --from 42 --to 42   # 5문단 1쪽
+//! # 한글로 p42.hwp 열기 → 수정 전 open=False / 수정 후 open=True
+//! ```
+//!
+//! ## 근인
+//!
+//! HWP3 파서의 제어문자 18..=21 arm 에서 21 은 종류 1(감춤)만 다루고 종류 0은
+//! catch-all 로 떨어져 `Control::Unknown { ctrl_id: 21 }` 이 됐다. `UnknownControl`
+//! 의 `ctrl_id` 는 **HWP5 의 네 글자 코드**를 실어 나르는 자리인데(알 수 없는 HWP5
+//! 컨트롤의 왕복 보존용), HWP3 파서가 거기에 HWP3 제어문자 코드 21을 넣었다.
+//! HWP5 저장기는 그 값을 개체 제어문자 자리(0x000B)와 `CTRL_HEADER` 에 그대로
+//! 쓰므로, 저장본에는 `ctrl_id = 0x00000015` 라는 존재할 수 없는 컨트롤이 실린다.
+//!
+//! ## 기대값의 출처
+//!
+//! 규격(`mydocs/tech/한글문서파일구조3.0.md` §10.15 표 56)이 종류 0 = "홀수로 시작",
+//! 1 = "감춤" 이라고 적는다. 값은 같은 문서를 한/글이 저장한 HWP5 변환본에서 왔다 —
+//! `pgct`(PageNumCtrl) 4건이 모두 payload 2(= 홀수 쪽)이고 개수가 우리 쪽 4건과
+//! 일치한다.
+//!
+//! ## 이 테스트가 잠그는 것
+//!
+//! 합성 최소 HWP3 문서를 만들어 (1) IR 이 `PageNumCtrl(Odd)` 가 되는지, (2) 저장한
+//! HWP5 의 `CTRL_HEADER` 가 **전부 네 글자 코드**인지를 본다. (2)가 개방 거부의
+//! 실제 형상이다 — 수정 전에는 `0x00000015` 가 실려 깨진다. 반례로 종류 1(감춤)이
+//! 계속 `PageHide` 로 남는 것도 함께 잠근다.
+//!
+//! 합성 문서 골격은 `issue_5557_hwp3_cell_margin` 과 동형이다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::model::control::{Control, PageStartsOn};
+use rhwp::parser::cfb_reader::CfbReader;
+use rhwp::parser::record::Record;
+
+// ---------------------------------------------------------------------------
+// 합성 HWP3 문서 빌더 (최소 골격)
+// ---------------------------------------------------------------------------
+
+fn u16le(v: u16) -> [u8; 2] {
+    v.to_le_bytes()
+}
+
+fn u32le(v: u32) -> [u8; 4] {
+    v.to_le_bytes()
+}
+
+fn hwp3_doc(body: &[u8]) -> Vec<u8> {
+    let mut d = Vec::new();
+    d.extend_from_slice(b"HWP Document File V3.00 \x1a\x01\x02\x03\x04\x05");
+    assert_eq!(d.len(), 30);
+    d.extend_from_slice(&[0u8; 128]); // 문서 정보 (비압축·비암호)
+    d.extend_from_slice(&[0u8; 1008]); // 요약
+    d.extend_from_slice(body);
+    d
+}
+
+fn hwp3_body(paragraphs: &[u8]) -> Vec<u8> {
+    let mut b = Vec::new();
+    for _ in 0..7 {
+        b.extend_from_slice(&u16le(1));
+        let mut name = [0u8; 40];
+        name[..4].copy_from_slice(&[0xB9, 0xD9, 0xC5, 0xC1]); // "바탕" (EUC-KR)
+        b.extend_from_slice(&name);
+    }
+    b.extend_from_slice(&u16le(0)); // nstyles
+    b.extend_from_slice(paragraphs);
+    b.extend_from_slice(&paragraph_list_end());
+    b
+}
+
+fn paragraph_list_end() -> [u8; 43] {
+    [0u8; 43]
+}
+
+fn char_shape31() -> [u8; 31] {
+    let mut cs = [0u8; 31];
+    cs[..2].copy_from_slice(&u16le(250));
+    for r in &mut cs[9..16] {
+        *r = 100;
+    }
+    cs
+}
+
+fn para_shape187() -> [u8; 187] {
+    let mut ps = [0u8; 187];
+    ps[6..8].copy_from_slice(&u16le(160));
+    ps[172] = 1;
+    ps
+}
+
+fn para_header(char_count: u16, line_count: u16) -> Vec<u8> {
+    let mut h = Vec::new();
+    h.push(0u8);
+    h.extend_from_slice(&u16le(char_count));
+    h.extend_from_slice(&u16le(line_count));
+    h.push(0u8); // include_char_shape
+    h.push(0u8); // flags
+    h.extend_from_slice(&u32le(0)); // special_char_flags
+    h.push(0u8); // style_index
+    h.extend_from_slice(&char_shape31());
+    h.extend_from_slice(&para_shape187());
+    h
+}
+
+fn line_info(pgy: u16) -> Vec<u8> {
+    let mut l = Vec::new();
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(400));
+    l.extend_from_slice(&u16le(pgy));
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(0));
+    l
+}
+
+/// 홀수쪽시작/감추기(21) 한 개만 담은 문단 — 규격 §10.15 표 56.
+///
+///   [hchar 21][word 종류][word 감출 대상][hchar 21] = 8바이트 = hchar 4개,
+///   뒤에 문단 끝(0x0D) 1개.
+fn odd_or_hide_paragraph(kind: u16, hide_mask: u16) -> Vec<u8> {
+    let mut p = Vec::new();
+    p.extend_from_slice(&para_header(5, 1));
+    p.extend_from_slice(&line_info(100));
+    p.extend_from_slice(&u16le(21));
+    p.extend_from_slice(&u16le(kind));
+    p.extend_from_slice(&u16le(hide_mask));
+    p.extend_from_slice(&u16le(21));
+    p.extend_from_slice(&u16le(13)); // 문단 끝
+    p
+}
+
+fn parse(kind: u16, hide_mask: u16) -> rhwp::model::document::Document {
+    let bytes = hwp3_doc(&hwp3_body(&odd_or_hide_paragraph(kind, hide_mask)));
+    rhwp::parser::hwp3::parse_hwp3(&bytes).expect("합성 HWP3 파싱 실패")
+}
+
+fn controls(doc: &rhwp::model::document::Document) -> Vec<&Control> {
+    doc.sections
+        .iter()
+        .flat_map(|s| s.paragraphs.iter())
+        .flat_map(|p| p.controls.iter())
+        .collect()
+}
+
+/// 저장한 HWP5 본문의 `CTRL_HEADER` ctrl_id 를 네 글자 코드 문자열로 모은다.
+/// 네 글자 ASCII 가 아니면 `None` 자리에 원값을 16진수로 남긴다.
+fn body_ctrl_ids(doc: &rhwp::model::document::Document) -> Vec<Result<String, u32>> {
+    let bytes = rhwp::serializer::cfb_writer::serialize_hwp(doc).expect("HWP5 직렬화 실패");
+    let mut cfb = CfbReader::open(&bytes).expect("CFB 열기");
+    let file_header = cfb.read_file_header().expect("FileHeader 읽기");
+    let compressed = file_header.get(36).is_some_and(|b| b & 0x01 != 0);
+    let section = cfb
+        .read_body_text_section(0, compressed, false)
+        .expect("Section0 읽기");
+    Record::read_all(&section)
+        .expect("Section0 record 파싱")
+        .into_iter()
+        .filter(|r| r.tag_id == rhwp::parser::tags::HWPTAG_CTRL_HEADER)
+        .filter_map(|r| {
+            let raw = r.data.get(..4)?;
+            let id = u32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]);
+            // HWP5 ctrl_id 는 네 글자 코드를 빅엔디언으로 담는다 ('pgct' → 0x70676374).
+            let code: String = raw.iter().rev().map(|b| *b as char).collect();
+            Some(if code.chars().all(|c| c.is_ascii_graphic() || c == ' ') {
+                Ok(code)
+            } else {
+                Err(id)
+            })
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// 테스트
+// ---------------------------------------------------------------------------
+
+/// 종류 0 = "항상 홀수쪽으로 시작" → `PageNumCtrl(Odd)`.
+/// 한/글 HWP5 변환본이 같은 자리에 `pgct` payload 2 를 쓴다.
+#[test]
+fn hwp3_odd_page_start_becomes_page_num_ctrl() {
+    let doc = parse(0, 0);
+    let ctrls = controls(&doc);
+    let page_num_ctrls: Vec<_> = ctrls
+        .iter()
+        .filter_map(|c| match c {
+            Control::PageNumCtrl(p) => Some(p),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        page_num_ctrls.len(),
+        1,
+        "홀수쪽시작(21/종류 0)은 PageNumCtrl 하나가 되어야 한다 — 실제 컨트롤: {:?}",
+        ctrls
+    );
+    assert_eq!(
+        page_num_ctrls[0].page_starts_on,
+        PageStartsOn::Odd,
+        "규격 §10.15 종류 0 = 홀수로 시작 (한/글 변환본 pgct payload 2)"
+    );
+    assert!(
+        !ctrls.iter().any(|c| matches!(c, Control::Unknown(_))),
+        "HWP3 제어문자 코드가 Unknown 의 ctrl_id 로 새면 안 된다 — {:?}",
+        ctrls
+    );
+}
+
+/// 저장본의 `CTRL_HEADER` 는 전부 네 글자 코드여야 한다. 수정 전에는 여기에
+/// `0x00000015`(HWP3 제어문자 코드 21)가 실렸고, 한글은 그 문서를 열지 못했다.
+#[test]
+fn saved_hwp5_ctrl_ids_are_all_four_char_codes() {
+    let doc = parse(0, 0);
+    let ids = body_ctrl_ids(&doc);
+    let bogus: Vec<_> = ids.iter().filter_map(|r| r.as_ref().err()).collect();
+    assert!(
+        bogus.is_empty(),
+        "네 글자 코드가 아닌 ctrl_id 가 저장본에 실렸다 (한글 개방 거부) — {:?} / 전체 {:?}",
+        bogus,
+        ids
+    );
+    assert!(
+        ids.iter().any(|r| r.as_deref() == Ok("pgct")),
+        "홀수쪽시작은 'pgct' 로 저장되어야 한다 — 전체 {:?}",
+        ids
+    );
+}
+
+/// 반례 — 종류 1(감춤)은 종전대로 `PageHide` 다. 감출 대상 비트도 그대로 옮긴다.
+/// 00472 실측: HWP3 감출 대상 7 ↔ 한/글 `pghd` 0x23(머리말·꼬리말·쪽번호).
+#[test]
+fn hwp3_hide_kind_still_becomes_page_hide() {
+    let doc = parse(1, 0b0000_0111);
+    let ctrls = controls(&doc);
+    let hides: Vec<_> = ctrls
+        .iter()
+        .filter_map(|c| match c {
+            Control::PageHide(h) => Some(h),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        hides.len(),
+        1,
+        "감추기(21/종류 1)는 PageHide 로 남아야 한다 — 실제 컨트롤: {:?}",
+        ctrls
+    );
+    assert_eq!(
+        (
+            hides[0].hide_header,
+            hides[0].hide_footer,
+            hides[0].hide_page_num,
+            hides[0].hide_border
+        ),
+        (true, true, true, false),
+        "감출 대상 비트 0·1·2 만 선다 (규격 §10.15)"
+    );
+    assert!(
+        !ctrls
+            .iter()
+            .any(|c| matches!(c, Control::PageNumCtrl(_) | Control::Unknown(_))),
+        "감추기가 홀수쪽시작으로 새면 안 된다 — {:?}",
+        ctrls
+    );
+}

--- a/tests/cases/issue_4680_hwp3_shape_flip_storage.rs
+++ b/tests/cases/issue_4680_hwp3_shape_flip_storage.rs
@@ -1,0 +1,203 @@
+//! [#4680] HWP3 의 선·다각형이 `SHAPE_COMPONENT` storage flip 을 0 으로 내보내
+//! 한글이 문서를 열지 못한다.
+//!
+//! ## 증상
+//!
+//! 264쪽 HWP3 문서(`1170000-200500003 독일의 법령체계와 입법심사기준`)의 53쪽에는
+//! 표 칸 안에 묶음 개체가 있다(`$con` → `$rec`·`$lin`·`$pol`). 그 쪽 한 장만
+//! `extract-pages` 로 뽑아도 한글이 `open=False` 로 거부한다. 표를 지우면 열린다.
+//!
+//! ## 근인 — 한 필드
+//!
+//! 한/글 저장본과 우리 산출물은 그 표 서브트리에서 레코드 225개의 태그·레벨 시퀀스가
+//! **완전히 같다**. 그래서 레코드 단위로 이등분할 수 있었고, 이등분은 크기가 어긋난
+//! `$lin`/`$pol` 의 `SHAPE_COMPONENT` 로 좁혀졌다. 그 레코드를 다시 바이트 구간으로
+//! 좁히면 갈림점은 **offset 32..36 의 storage flip 4바이트 하나**다:
+//!
+//! - 그 4바이트만 한/글 값으로 바꾸면 `open=True`
+//! - 나머지(행렬·선/채우기 꼬리 전부)를 한/글 값으로 바꿔도 그 4바이트가 0 이면 `open=False`
+//!
+//! `hwpx_to_hwp` 는 이미 같은 계약을 **사각형에만** 걸고 있었다(`#3930` 계열, 주석에
+//! "이 storage 비트가 없으면 한컴이 개체 이후 레코드 스트림을 이어 읽지 못한다"고
+//! 적혀 있다). 선·다각형·타원·호·곡선은 그 arm 을 타지 않아 0 으로 나갔다.
+//!
+//! ## 이 테스트가 잠그는 것
+//!
+//! HWP3 원본 경로(`convert_if_hwpx_source(_, FileFormat::Hwp3)`)를 지난 뒤
+//! (1) 사각형이 아닌 도형도 storage flip 이 서고, (2) 글상자 유무로 값이 갈리며,
+//! (3) 이미 값이 있는 도형(HWP5/HWPX 경로)은 건드리지 않는지를 본다.
+//! 마지막으로 저장 바이트의 `SHAPE_COMPONENT` 해당 4바이트가 0 이 아닌지까지 본다 —
+//! 그게 개방 거부의 실제 형상이다.
+//!
+//! 회전중심은 세우지 않는다. 사각형 arm 은 함께 세우지만, 이 결함에서는 그 구간만
+//! 한/글 값으로 바꿔도 여전히 거부였다(`open=False`) — 근거 없는 값은 쓰지 않는다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::model::control::Control;
+use rhwp::model::document::{Document, Section};
+use rhwp::model::paragraph::Paragraph;
+use rhwp::model::shape::{
+    DrawingObjAttr, GroupShape, LineShape, PolygonShape, ShapeComponentAttr, ShapeObject,
+};
+use rhwp::parser::record::Record;
+use rhwp::parser::tags;
+use rhwp::parser::FileFormat;
+
+/// HWP3 파서가 내놓는 모양 — storage flip 이 0 이고 크기만 있다.
+fn shape_attr(flip: u32) -> ShapeComponentAttr {
+    ShapeComponentAttr {
+        original_width: 2000,
+        original_height: 1000,
+        current_width: 2000,
+        current_height: 1000,
+        flip,
+        ..Default::default()
+    }
+}
+
+fn line(flip: u32) -> ShapeObject {
+    ShapeObject::Line(LineShape {
+        drawing: DrawingObjAttr {
+            shape_attr: shape_attr(flip),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+
+fn polygon_with_text_box() -> ShapeObject {
+    let mut drawing = DrawingObjAttr {
+        shape_attr: shape_attr(0),
+        ..Default::default()
+    };
+    drawing.text_box = Some(Default::default());
+    ShapeObject::Polygon(PolygonShape {
+        drawing,
+        ..Default::default()
+    })
+}
+
+/// 실제 결함 자리와 같은 모양으로 담는다 — 도형은 **묶음 자식**이다.
+/// 최상위 도형은 `SHAPE_COMPONENT` 가 ctrl_id 를 두 번 쓰므로 바이트 오프셋이 다르다.
+fn doc_with(shapes: Vec<ShapeObject>) -> Document {
+    let mut para = Paragraph::default();
+    let group = ShapeObject::Group(GroupShape {
+        children: shapes,
+        ..Default::default()
+    });
+    para.controls.push(Control::Shape(Box::new(group)));
+    let mut section = Section::default();
+    section.paragraphs.push(para);
+    let mut doc = Document::default();
+    doc.sections.push(section);
+    doc
+}
+
+/// CLI `convert` 가 HWP3 원본에 적용하는 것과 같은 경로.
+fn convert_as_hwp3(doc: &mut Document) {
+    rhwp::document_core::converters::hwpx_to_hwp::convert_if_hwpx_source(doc, FileFormat::Hwp3);
+}
+
+fn flips(doc: &Document) -> Vec<u32> {
+    doc.sections
+        .iter()
+        .flat_map(|s| s.paragraphs.iter())
+        .flat_map(|p| p.controls.iter())
+        .filter_map(|c| match c {
+            Control::Shape(s) => match s.as_ref() {
+                ShapeObject::Group(g) => Some(g.children.iter().map(|c| c.shape_attr().flip)),
+                _ => None,
+            },
+            _ => None,
+        })
+        .flatten()
+        .collect()
+}
+
+/// 저장 바이트의 `SHAPE_COMPONENT` storage flip(offset 32..36)을 모은다.
+fn saved_storage_flips(doc: &Document) -> Vec<u32> {
+    let bytes = rhwp::serializer::cfb_writer::serialize_hwp(doc).expect("HWP5 직렬화 실패");
+    let mut cfb = rhwp::parser::cfb_reader::CfbReader::open(&bytes).expect("CFB 열기");
+    let file_header = cfb.read_file_header().expect("FileHeader 읽기");
+    let compressed = file_header.get(36).is_some_and(|b| b & 0x01 != 0);
+    let section = cfb
+        .read_body_text_section(0, compressed, false)
+        .expect("Section0 읽기");
+    Record::read_all(&section)
+        .expect("Section0 record 파싱")
+        .into_iter()
+        .filter(|r| r.tag_id == tags::HWPTAG_SHAPE_COMPONENT)
+        // 묶음 자식만 본다 — 최상위(묶음 자신)는 ctrl_id 를 두 번 써서 오프셋이 4 밀린다.
+        .filter(|r| r.data.get(0..4) != r.data.get(4..8))
+        .filter_map(|r| {
+            let raw = r.data.get(32..36)?;
+            Some(u32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]))
+        })
+        .collect()
+}
+
+/// 글상자 없는 선은 `0x0008_0000` 을 받는다 — 사각형 arm 과 같은 값.
+#[test]
+fn hwp3_line_gets_storage_flip() {
+    let mut doc = doc_with(vec![line(0)]);
+    convert_as_hwp3(&mut doc);
+    assert_eq!(
+        flips(&doc),
+        vec![0x0008_0000],
+        "사각형이 아닌 도형도 storage flip 을 받아야 한다 (한글 개방 조건)"
+    );
+}
+
+/// 글상자가 있는 다각형은 글상자 비트까지 받는다.
+#[test]
+fn hwp3_polygon_with_text_box_gets_text_box_bit() {
+    let mut doc = doc_with(vec![polygon_with_text_box()]);
+    convert_as_hwp3(&mut doc);
+    assert_eq!(
+        flips(&doc),
+        vec![0x0108_0000],
+        "글상자가 있으면 글상자 비트(0x0100_0000)까지 선다"
+    );
+}
+
+/// 반례 — 이미 값이 있는 도형(HWP5·HWPX 경로)은 건드리지 않는다.
+#[test]
+fn existing_storage_flip_is_preserved() {
+    let mut doc = doc_with(vec![line(0x0002_0000)]);
+    convert_as_hwp3(&mut doc);
+    assert_eq!(
+        flips(&doc),
+        vec![0x0002_0000],
+        "원본이 준 flip 은 덮어쓰지 않는다"
+    );
+}
+
+/// 반례 — HWP3 원본이 아니면 이 보정은 걸리지 않는다.
+#[test]
+fn non_hwp3_source_is_untouched() {
+    let mut doc = doc_with(vec![line(0)]);
+    rhwp::document_core::converters::hwpx_to_hwp::convert_if_hwpx_source(&mut doc, FileFormat::Hwp);
+    assert_eq!(
+        flips(&doc),
+        vec![0],
+        "HWP5(Hwp) 원본 경로는 storage 보정 대상이 아니다"
+    );
+}
+
+/// 개방 거부의 실제 형상 — 저장 바이트의 해당 4바이트가 0 이면 안 된다.
+#[test]
+fn saved_shape_component_storage_flip_is_not_zero() {
+    let mut doc = doc_with(vec![line(0), polygon_with_text_box()]);
+    convert_as_hwp3(&mut doc);
+    let saved = saved_storage_flips(&doc);
+    assert!(
+        !saved.is_empty(),
+        "SHAPE_COMPONENT 가 저장되지 않았다 — 테스트 전제가 깨졌다"
+    );
+    assert!(
+        saved.iter().all(|v| *v != 0),
+        "storage flip 0 인 SHAPE_COMPONENT 가 저장본에 남았다 (한글 개방 거부) — {:?}",
+        saved
+    );
+}


### PR DESCRIPTION
> **#7075 위에 쌓인 PR 이다.** 첫 커밋 `2f41f46f1` 은 그 PR 과 같은 것이고,
> 그것이 머지되면 여기에는 두 번째 커밋만 남는다. 검토는 `85b8726dd` 만 보면 된다.

## 무엇이 문제인가

`hwpx_to_hwp` 는 HWP3 원본 경로에서 `SHAPE_COMPONENT` 의 storage flip 비트를 채워 준다.
그 자리가 0 이면 한컴이 개체 이후 레코드 스트림을 이어 읽지 못하는 케이스가 있어서다
(#3930 계열 — 기존 주석이 그렇게 적고 있다). 그런데 그 보정이 **사각형 arm 에만**
걸려 있었고 선·다각형·타원·호·곡선은 `_` arm 이라 0 으로 나갔다.

264쪽 HWP3 문서 `1170000-200500003 독일의 법령체계와 입법심사기준` 53쪽은 표 칸 안에
묶음 개체를 담는다(`$con` → `$rec`·`$lin`·`$pol`). 그 쪽 **한 장만 뽑아도** 한글이
`open=False` 로 거부했다. rhwp 자신은 산출물을 그대로 되읽으므로 `--verify` 로는
보이지 않는다.

## 어떻게 한 필드까지 좁혔나

한/글 저장본과 우리 산출물은 그 표 서브트리에서 **레코드 225개의 (태그, 레벨) 시퀀스가
완전히 같다**. 인덱스가 1:1 로 대응하므로 부분 이식이 인공 결함을 만들지 않는다.
양쪽 대조군을 먼저 잡았다 — 전량 이식 `open=True` / 무이식 `open=False`.

| 실험 | 결과 | 읽은 것 |
|---|---|---|
| 접두 이등분 `[0,84)` / `[0,83)` | 열림 / 거부 | 83번 레코드가 필요조건 |
| `[83,84)` 단독 | 거부 | 필요조건이 **하나가 아니다** |
| 접미 이등분 `[10,84)` / `[21,84)` | 열림 / 거부 | 두 번째 자리는 `[15,21)` |
| 술어 이식 — "크기 어긋난 `SHAPE_COMPONENT` 17건만" | **열림** | 둘 다 `$lin`/`$pol` |
| 그 레코드의 head `[0,288)` / tail `[288,)` | 열림 / 거부 | 꼬리(선·채우기)는 무죄 |
| head 안에서 `[32,36)` / `[38,46)` | **열림** / 거부 | **4바이트 하나가 갈림점** |

> 헛다리 셋도 기록해 둔다(전부 실제 차이지만 개방 거부의 원인이 아니다): 표
> `borderFillId` 0 · `$pol`/`$lin` 선·채우기 꼬리 13바이트 차(344 vs 331) ·
> HWP3 no-fill sentinel `0x1000_0000` 이 단색 채우기로 새는 것.

## 수정

`_` arm 에 사각형 arm 과 같은 계약을 건다 — 글상자가 있으면 `0x0108_0000`,
없으면 `0x0008_0000`. **회전중심은 세우지 않는다.** 사각형 arm 은 함께 세우지만,
이 결함에서는 그 구간만 한/글 값으로 바꿔도 여전히 `open=False` 였다.
근거가 없는 값은 쓰지 않는다.

## 실측 (한글 2024 COM, 문서 1건당 프로세스 1개, 직렬)

| 대상 | 수정 전 | 수정 후 |
|---|---|---|
| 07615 53쪽 1장 (`extract-pages`) | `open=False` | **`open=True` · 2쪽 · 1,400자** |
| 07615 전체 `convert` 산출물 | `open=False` | **`open=True` · 327쪽 · 278,600자** |

전체 문서가 열리는 것은 부모 커밋(#7075, 홀수쪽시작)과 **둘 다** 있어야 한다.
이것으로 #4680 의 `07615 264쪽 → 0쪽` 이 **개방 축에서는 해소**된다.
쪽수 327 대 원본 264 는 조판 축이라 이 PR 의 범위가 아니다.

## 폭발반경

코퍼스 HWP3 38건 중 이 보정이 닿는 문서는 **2건**이다(COM 없이 센 값 — 묶음 자식
`SHAPE_COMPONENT` 의 `d[32..36]` 비0 개수).

| docid | 도형 수 | 개방 판정 |
|---|---|---|
| 07615 | 136 | `open=False` → **`open=True`** |
| 03908 | 4 | `open=True` → `open=True` (1쪽 90자, 전후 동일) |

## 회귀 고정

`tests/cases/issue_4680_hwp3_shape_flip_storage.rs` 5건. 도형을 **묶음 자식**으로 담아
실제 결함 자리와 오프셋을 맞췄다 — 최상위 도형은 `SHAPE_COMPONENT` 가 ctrl_id 를 두 번
써서 4바이트가 밀리고, 그걸 놓치면 수정 전에도 통과한다(실제로 한 번 겪었다).

- 수정 전 실패 3건: 선·다각형의 flip, 그리고 **저장 바이트의 해당 4바이트가 0 이 아닐 것**
- 반례 2건(전후 모두 통과): 이미 값이 있는 도형은 덮어쓰지 않는다 · HWP3 가 아닌 원본
  경로는 보정 대상이 아니다

## 검증

검증 head `85b8726dd`. 격리 worktree 에서 실행했다.

```
node scripts/rust-test-suite-manifest.mjs --prepare
cargo fmt --all ; cargo fmt --all -- --check
cargo clippy --locked --target-dir target/pr-review -- -D warnings
cargo clippy --locked -p rhwp --lib --target wasm32-unknown-unknown   --target-dir target/pr-review -- -D warnings
cargo build --locked --workspace --target-dir target/pr-review
cargo clippy --locked --workspace --all-targets --target-dir target/pr-review -- -D warnings
node scripts/rust-test-suite-manifest.mjs --check
cargo nextest run --cargo-profile release-test --no-fail-fast
  → 9,534건 전건 통과 (403s)
```

한글 개방 판정은 로컬 COM(한글 2024)에서 수동으로 했다 — CI 에서는 돌지 않는다.

## 남은 것

- 묶음 자식의 **그룹 깊이**가 IR 에 안 실린다. 한/글 저장본과 우리 재저장(o2h)은
  `(깊이, 행렬 쌍 수)` census 가 완전히 일치하는데(1→2 · 2→3 · 3→4), HWP3 산출물은
  전부 `(0, 1)` 이다. 개방에는 필요하지 않아 이 PR 에서 뺐다(별도 축).
- 07615 쪽수 327 대 264.

관련: #4680, #7075

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ngNq2bF2ZdqUyFNeTVnXr
