### PR TITLE
수정(renderer): 칸 세로 정렬용 콘텐츠 높이를 줄별 중첩 표 그룹으로 센다 (#7066)

### DIFF
--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -8372,7 +8372,12 @@ impl LayoutEngine {
                 // 조건**(호스트가 칸의 마지막 문단)으로 싣는다 — 뒤 형제 문단이 있을 때
                 // 그 몫을 싣지 않는 계약(59043 `□ 편익`)은 그대로다.
                 let host_is_cell_last_para = pidx + 1 == paragraphs.len();
-                let nested_h: f64 = p
+                // [#7066] 저장 줄별 그룹은 측정(`height_measurer::cell_nested_controls_bottom`)
+                // 과 **같은 함수**로 낸다. 한 줄에 나란히 놓인 표는 그 줄이 합이 아니라
+                // 최댓값만 차지하므로, 합산하면 정렬용 콘텐츠 높이가 칸보다 커져 여유가
+                // `0` 으로 깎이고 `Center`·`Bottom` 이 상단정렬로 무너진다.
+                let groups = crate::renderer::float_placement::nested_table_groups(p);
+                let heights: Vec<f64> = p
                     .controls
                     .iter()
                     .map(|ctrl| {
@@ -8387,7 +8392,29 @@ impl LayoutEngine {
                             0.0
                         }
                     })
-                    .sum();
+                    .collect();
+                let para_top_hu = p.line_segs.first().map_or(0, |s| s.vertical_pos);
+                let mut nested_h = 0.0f64;
+                for group in groups {
+                    let height = if group.side_by_side {
+                        group
+                            .controls
+                            .iter()
+                            .map(|&ci| heights[ci])
+                            .fold(0.0, f64::max)
+                    } else {
+                        group.controls.iter().map(|&ci| heights[ci]).sum()
+                    };
+                    let bottom = if let Some(line) = group.line {
+                        let seg = &p.line_segs[line];
+                        let top =
+                            hwpunit_to_px(seg.vertical_pos.saturating_sub(para_top_hu), self.dpi);
+                        top + height
+                    } else {
+                        height
+                    };
+                    nested_h = nested_h.max(bottom);
+                }
                 if nested_h <= 0.0 {
                     0.0
                 } else {

--- a/tests/cases/issue_7066_cell_valign_nested_line_group.rs
+++ b/tests/cases/issue_7066_cell_valign_nested_line_group.rs
@@ -1,0 +1,126 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! [Issue #7066] 칸 안 중첩 표가 있으면 칸 **세로 정렬**이 무효가 되어 내용이 상단에 붙던
+//! 결함의 가드.
+//!
+//! ## 계약
+//!
+//! 세로 정렬이 쓰는 콘텐츠 높이(`calc_nested_controls_bottom_height`)는 한 줄에 나란히
+//! 놓인 중첩 표를 **합이 아니라 최댓값**으로 세야 한다. 합하면 콘텐츠가 칸보다 크다고
+//! 판정되어 정렬 여유가 `0` 으로 깎이고 `Center`·`Bottom` 이 상단정렬로 무너진다.
+//!
+//! `#7008` 이 측정(`height_measurer::cell_nested_controls_bottom`)의 같은 합산을 줄 단위로
+//! 고쳤다. 이 판은 배치 쪽 형제가 같은 `float_placement::nested_table_groups` 를 쓰게 한다.
+//!
+//! ## 실측 — 결재 서식 3문서, 한/글 2022 정본
+//!
+//! ```text
+//!                            수정 전    수정 후    한/글    정본
+//!   issue2470  문서번호표 상단   157.60    179.10   177.73   pdf/issue2470/36382471_masked-2022.pdf
+//!              결재표 하단      272.80    294.30   292.80   (Hwp 2022 12.0.0.4547)
+//!   issue2083  문서번호표 상단   208.40    242.20   240.70   pdf/issue2083_hide_fill_page-hwpx-2020.pdf
+//!              결재표 하단      361.10    395.00   393.17   (Hwp 2022 0.0.0.0)
+//!   21_언어    중첩 상자 상단    254.70    262.90   266.60   pdf/21_언어_기출_편집가능본-2022.pdf
+//!                                                           (Hwp 2022 12.0.0.4426)
+//! ```
+//!
+//! 글자로 재면 결재 블록 전체가 균일하게 움직인다 — `issue2470` 은 `Δy +20.07 → −1.41`,
+//! `issue2083` 은 `+32.32 → −1.54` (낱말 17·20개, `Δx` 는 둘 다 `0.8px` 안).
+//!
+//! ⚠ 남는 `1.4~1.8px` 는 기준선 경로의 균일 오프셋이라 이 이슈 밖이다(`#7058` 에서
+//! 독립적으로 같은 크기가 관측됐다). `21_언어` 의 `3.7px` 은 상자 외곽선만의 몫이다 —
+//! 그 안의 글자는 한/글과 `Δy −0.19` 로 맞는다. 둘 다 이 판에서 재지 않았다.
+
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::render_tree::{PageRenderTree, RenderNode, RenderNodeType};
+
+/// 정본과의 남은 차 `1.4~1.8px` 를 담되 수정 전(`20~32px`)은 분명히 걸러내는 폭.
+const TOL: f64 = 2.5;
+
+fn page0(sample: &str) -> PageRenderTree {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(sample);
+    let bytes = std::fs::read(&path)
+        .unwrap_or_else(|error| panic!("#7066 공개 fixture 읽기 {}: {error}", path.display()));
+    DocumentCore::from_bytes(&bytes)
+        .expect("문서 로드")
+        .build_page_render_tree(0)
+        .expect("1쪽 render tree")
+}
+
+fn tables(node: &RenderNode, out: &mut Vec<(f64, f64, f64, f64)>) {
+    if matches!(node.node_type, RenderNodeType::Table { .. }) {
+        out.push((node.bbox.x, node.bbox.y, node.bbox.width, node.bbox.height));
+    }
+    for child in &node.children {
+        tables(child, out);
+    }
+}
+
+/// 너비로 표를 집는다 — 각 쪽에서 그 폭을 가진 표는 하나뿐이다.
+fn table_by_width(tree: &PageRenderTree, want: f64) -> (f64, f64, f64, f64) {
+    let mut all = Vec::new();
+    tables(&tree.root, &mut all);
+    let mut hit: Vec<_> = all
+        .into_iter()
+        .filter(|&(_, _, w, _)| (w - want).abs() < 1.0)
+        .collect();
+    assert_eq!(hit.len(), 1, "폭 {want} 인 표가 정확히 하나여야 한다");
+    hit.pop().expect("대상 표")
+}
+
+/// `valign=Center` 칸 — 결재 블록이 칸 가운데로 내려와야 한다.
+#[test]
+fn center_aligned_cell_recovers_its_slack_in_36382471() {
+    let tree = page0("samples/issue2470/36382471_masked.hwpx");
+    let (_, doc_no_y, _, _) = table_by_width(&tree, 252.3);
+    let (_, approval_y, _, approval_h) = table_by_width(&tree, 358.2);
+
+    assert!(
+        (doc_no_y - 177.73).abs() < TOL,
+        "문서번호 표 상단이 {doc_no_y} — 한/글 177.73, 수정 전 157.60"
+    );
+    let approval_bottom = approval_y + approval_h;
+    assert!(
+        (approval_bottom - 292.80).abs() < TOL,
+        "결재 표 하단이 {approval_bottom} — 한/글 292.80, 수정 전 272.80"
+    );
+}
+
+/// 같은 결함의 다른 서식 — 여기서는 `32px` 어긋났다.
+#[test]
+fn center_aligned_cell_recovers_its_slack_in_issue2083() {
+    let tree = page0("samples/issue2083_hide_fill_page.hwpx");
+    let (_, doc_no_y, _, _) = table_by_width(&tree, 237.2);
+    let (_, approval_y, _, approval_h) = table_by_width(&tree, 385.9);
+
+    assert!(
+        (doc_no_y - 240.70).abs() < TOL,
+        "문서번호 표 상단이 {doc_no_y} — 한/글 240.70, 수정 전 208.40"
+    );
+    let approval_bottom = approval_y + approval_h;
+    assert!(
+        (approval_bottom - 393.17).abs() < TOL,
+        "결재 표 하단이 {approval_bottom} — 한/글 393.17, 수정 전 361.10"
+    );
+}
+
+/// `valign=Bottom` 칸 — `#7008` 이 세운 "두 상자는 같은 줄" 계약도 함께 지켜야 한다.
+#[test]
+fn bottom_aligned_cell_keeps_the_two_boxes_on_one_line_in_21_language() {
+    let tree = page0("samples/21_언어_기출_편집가능본.hwp");
+    let (_, name_y, _, _) = table_by_width(&tree, 189.0);
+    let (_, number_y, _, _) = table_by_width(&tree, 285.1);
+
+    assert!(
+        (name_y - number_y).abs() < 0.5,
+        "두 상자가 같은 줄이 아니다 — {name_y} vs {number_y}"
+    );
+    // 상자 외곽선에는 별도 축의 3.7px 이 남아 있다(본문 주석 참조) — 수정 전 11.9px 과는
+    // 분명히 갈린다.
+    assert!(
+        (name_y - 266.60).abs() < 4.5,
+        "중첩 상자 상단이 {name_y} — 한/글 266.60, 수정 전 254.70"
+    );
+}


### PR DESCRIPTION
관련 이슈: #7066

## 문제

칸 안에 중첩 표가 있으면 그 칸의 **세로 정렬**이 무효가 되어 내용이 칸 상단에 붙는다.
결재 서식 세 문서에서 결재 블록 전체가 `8~32px` 위로 뜬다.

![36382471_masked 1쪽](https://raw.githubusercontent.com/lpaiu-cs/rhwp/assets/cellvalign-7066b/valign-a.png)

![issue2083 1쪽](https://raw.githubusercontent.com/lpaiu-cs/rhwp/assets/cellvalign-7066b/valign-b.png)

## 원인

`src/renderer/layout/table_layout.rs` `calc_nested_controls_bottom_height` 가 한 문단의
중첩 표 높이를 **합산**한다.

```rust
let nested_h: f64 = p.controls.iter()
    .map(|ctrl| if let Control::Table(t) = ctrl { self.calc_nested_table_height(t, styles) + … } else { 0.0 })
    .sum();
```

같은 줄에 나란히 놓인 표는 그 줄이 합이 아니라 **최댓값**만 차지한다. 합하면 정렬용
콘텐츠 높이가 칸보다 커져 여유가 `0` 으로 깎이고, `Center`·`Bottom` 이 상단정렬로 무너진다.

`#7008` 이 측정 쪽 형제(`height_measurer::cell_nested_controls_bottom`)의 같은 합산을
`float_placement::nested_table_groups` 로 고쳤는데, 배치 쪽 이 함수만 그 줄 구성을 쓰지
않고 있었다.

## 변경

- `calc_nested_controls_bottom_height` 가 측정과 **같은 함수**
  (`float_placement::nested_table_groups`)로 저장 줄별 그룹을 내고, 나란한 그룹은 최댓값·
  아닌 그룹은 합으로 세며 그룹이 속한 줄의 top 만큼 내려 잡는다. 측정 쪽 구현의 문자 그대로의
  거울이다.
- 회귀 시험 `tests/cases/issue_7066_cell_valign_nested_line_group.rs` 세 건 — `Center` 두
  서식과 `Bottom` 한 서식. `Bottom` 건은 `#7008` 이 세운 "두 상자는 같은 줄" 계약도 함께 센다.

## 검증

devel `897c6a3d8`.

**수정 전 실패 증명** — 새 시험 3건이 수정 전 트리에서 전부 실패한다(아래 좌표).

```text
                              수정 전    수정 후    한/글    정본
  issue2470  문서번호표 상단    157.60    179.10   177.73   pdf/issue2470/36382471_masked-2022.pdf
             결재표 하단       272.80    294.30   292.80   (Hwp 2022 12.0.0.4547)
  issue2083  문서번호표 상단    208.40    242.20   240.70   pdf/issue2083_hide_fill_page-hwpx-2020.pdf
             결재표 하단       361.10    395.00   393.17   (Hwp 2022 0.0.0.0)
  21_언어    중첩 상자 상단     254.70    262.90   266.60   pdf/21_언어_기출_편집가능본-2022.pdf
                                                           (Hwp 2022 12.0.0.4426)
```

**글자로 잰 이동** — rhwp `export-pdf` 와 정본 PDF 에서 같은 낱말을 짝지어 `Δy` 를 냈다.

```text
              낱말   수정 전 Δy      수정 후 Δy     Δx
  issue2470    17     +20.07        -1.41        0.7 안
  issue2083    20     +32.32        -1.54        0.8 안
  21_언어     129     +7.97         -0.19        (수험번호·성명)
```

**쪽 나눔 회귀 없음** — 이 함수는 호출부가 5곳이라 칸 높이 전반에 닿는다. 수정 전/후
바이너리로 `samples/` 의 문서 **985개** 쪽수를 대조했다.

```text
  985개 중 쪽수가 달라진 문서 0개
```

**넘침 래칫** — `body_overflow_baseline` 16개 구획 전부 통과.

## 범위 외

- 남는 `1.4~1.8px`. 기준선 경로의 균일 오프셋으로 보인다 — `#7058` 에서 planet6897 이
  독립적으로 같은 크기(`+1.6px`)를 측정했다. 이 판에서 재지 않았다.
- `21_언어` 상자 외곽선의 `3.7px`. 상자 **안의 글자**는 정본과 `Δy -0.19` 로 맞으므로
  외곽선만의 몫이고, 그 문서만 저장 `baseline_distance` 가 `0.4998 × lh` 로 이례적이다.
  별도 축이라 재지 않았다.
- `36382471_masked` 의 꼬리말 `-8.04px`, `21_언어` 의 쪽번호 `-12.98px` — 수정 전후가
  같다. 다른 축이라 이 판에서 재지 않았다.
