### PR TITLE
수정: HWP3 묶음 자식이 그룹 깊이를 잃어 rendering 행렬이 모자란다 (#6874)

### DIFF
--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -1100,6 +1100,26 @@ fn normalize_picture_geometry_for_hwp(doc: &mut Document, source_is_hwpx: bool) 
                 // 모두 동일한 paragraph container이므로 같은 walker로 재귀한다.
                 if let Some(drawing) = shape.drawing_mut() {
                     walk_drawing(drawing, source_is_hwpx);
+                    // [#4680] 위 사각형 arm 과 같은 storage flip 계약을 선·다각형·
+                    // 타원·호·곡선에도 적용한다. 종전에는 사각형만 세워서 나머지
+                    // 도형이 0 으로 나갔고, 한컴은 그런 도형이 든 문서를 열지 못했다.
+                    //
+                    // 264쪽 HWP3 문서 53쪽(표 칸 안 묶음: `$con` → `$rec`·`$lin`·
+                    // `$pol`)에서 실측했다. 한/글 저장본과 우리 산출물을 레코드
+                    // 단위로 이등분해 `$lin`/`$pol` 의 `SHAPE_COMPONENT` 로 좁히고,
+                    // 다시 바이트 구간으로 좁히면 **이 4바이트 하나**가 갈림점이다
+                    // (그 구간만 한/글 값으로 바꾸면 open=True, 나머지 전부 바꿔도
+                    // 이 구간이 0 이면 open=False). 회전중심은 필요하지 않았다 —
+                    // 근거가 없는 값은 건드리지 않는다.
+                    let has_text_box = drawing.text_box.is_some();
+                    let sa = &mut drawing.shape_attr;
+                    if sa.flip == 0 {
+                        sa.flip = if has_text_box {
+                            0x0108_0000
+                        } else {
+                            0x0008_0000
+                        };
+                    }
                 }
             }
         }

--- a/src/parser/hwp3/drawing.rs
+++ b/src/parser/hwp3/drawing.rs
@@ -672,12 +672,29 @@ pub fn parse_drawing_object_tree(
         });
     }
 
-    if root_nodes.len() == 1 {
-        Ok(root_nodes.remove(0))
+    let mut root = if root_nodes.len() == 1 {
+        root_nodes.remove(0)
     } else {
         let mut group = GroupShape::default();
         group.children = root_nodes;
-        Ok(ShapeObject::Group(group))
+        ShapeObject::Group(group)
+    };
+    assign_group_levels(&mut root, 0);
+    Ok(root)
+}
+
+/// [#4680] 묶음 자식의 그룹 깊이를 매긴다 — 최상위 0, 그 자식 1, 손자 2 …
+///
+/// HWP5 `SHAPE_COMPONENT` 는 이 깊이로 rendering 행렬 쌍 개수(`group_level + 1`)를
+/// 정한다. HWP3 파서가 깊이를 안 매기면 모든 자식이 0 이 되어 저장기가 쌍을 하나만
+/// 쓰고, 레코드가 한컴이 기대하는 길이보다 96바이트씩 짧아진다. 한글은 그런 문서를
+/// 열지 못한다. 같은 문서의 한/글 HWP5 저장본은 깊이 1·2·3 에 각각 쌍 2·3·4 를 쓴다.
+fn assign_group_levels(node: &mut ShapeObject, level: u16) {
+    node.shape_attr_mut().group_level = level;
+    if let ShapeObject::Group(group) = node {
+        for child in &mut group.children {
+            assign_group_levels(child, level + 1);
+        }
     }
 }
 

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -2504,6 +2504,31 @@ fn parse_field_control_char(
                         hide.hide_page_num = (flags & 4) != 0;
                         hide.hide_border = (flags & 8) != 0;
                         crate::model::control::Control::PageHide(hide)
+                    } else if kind == 0 {
+                        // [#4680] 제어문자 21 의 종류 0 은 **항상 홀수쪽으로 시작**이다
+                        // (`mydocs/tech/한글문서파일구조3.0.md` §10.15 표 56: 0 = 홀수로
+                        // 시작, 1 = 감춤). 종전에는 이 자리가 catch-all 로 떨어져
+                        // `Control::Unknown { ctrl_id: 21 }` 이 됐다.
+                        //
+                        // 그 21 은 HWP5 저장에서 **구조 오염**이 된다. HWP5 의 ctrl_id 는
+                        // 네 글자 코드('pgct'·'pghd' …)이고, 저장기는 Unknown 을 개체
+                        // 제어문자 자리(0x000B)와 `CTRL_HEADER` 에 그대로 쓴다. 한글은
+                        // 그런 문단을 만나면 문서를 열지 못한다 — 264쪽 HWP3 문서
+                        // `1170000-200500003 독일의 법령체계와 입법심사기준` 이 개방 거부됐고,
+                        // 그 코드가 있는 42쪽 한 장만 뽑아도 같은 거부가 재현된다.
+                        // rhwp 자신은 산출물을 그대로 되읽으므로 자기검증으로는 안 보인다.
+                        //
+                        // 값은 같은 문서의 한/글 HWP5 저장본에서 온다 — `pgct` 4건이
+                        // 모두 payload 2(= 홀수 쪽)이고 개수도 우리 4건과 맞는다. 종류 1
+                        // (감춤)이 `pghd` 인 것도 같은 대조로 확인된다(00472: HWP3 감출
+                        // 대상 7 ↔ 한/글 `pghd` 0x23 = 머리말·꼬리말·쪽번호).
+                        // 코퍼스 HWP3 38건 전수에서 `Control::Unknown` 은 이 4건이 전부다.
+                        // 규격에 종류는 0·1 뿐이므로 그 밖의 값은 종전 경로로 둔다.
+                        crate::model::control::Control::PageNumCtrl(
+                            crate::model::control::PageNumCtrl {
+                                page_starts_on: crate::model::control::PageStartsOn::Odd,
+                            },
+                        )
                     } else {
                         crate::model::control::Control::Unknown(
                             crate::model::control::UnknownControl { ctrl_id: ch as u32 },

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -2175,34 +2175,28 @@ fn parse_object_control_char(
                 )));
             }
         } else if parsed_obj_type == 3 {
-            let mut form = crate::model::control::FormObject::default();
-            form.form_type = crate::model::control::FormType::PushButton;
-            form.enabled = true;
             if let Some(table) = parsed_table {
-                // [#6266] 원본 개체의 배치(기준·정렬·어울림·오프셋)를 그대로 옮긴다.
-                // 종전에는 width/height 만 읽어 배치를 버렸고, 그 결과 렌더러가 이
-                // 개체를 인라인 말고는 놓을 수 없었다.
-                form.common = table.common.clone();
-                form.width = table.common.width;
-                form.height = table.common.height;
-                if let Some(cell) = table.cells.first() {
-                    let mut text = String::new();
-                    for para in &cell.paragraphs {
-                        text.push_str(&para.text);
-                        text.push('\n');
-                    }
-                    form.caption = text.trim().to_string();
-                    form.name = form.caption.clone();
-                    if let Some(bf) =
-                        doc_border_fills.get(cell.border_fill_id.saturating_sub(1) as usize)
-                    {
-                        if let Some(ref solid) = bf.fill.solid {
-                            form.back_color = solid.background_color;
-                        }
-                    }
-                }
+                // [#6874] HWP3 obj_type=3 은 캡션을 담은 1x1 표 구조로 저장되고,
+                // 한글도 그것을 **표로** 만든다(정본 HWP3 -> HWPX 대조:
+                // `hp:tbl 2 / hp:btn 0`, 현행은 `hp:tbl 1 / hp:btn 1`).
+                //
+                // 종전에는 그 표를 버리고 `FormObject{PushButton}` 만 남겨, 캡션이
+                // 본문 글자가 아니라 개체 속성이 됐다. 코퍼스 `2955289` 는 그 때문에
+                // 표 하나와 본문 12자(`- 581-13 -`)를 통째로 잃었고, 한글이 원본에서
+                // 보여 주는 그 글자가 저장본에 없다. 바로 위 `obj_type == 1`(글상자)이
+                // 같은 이유로 이미 Table IR 을 보존한다 — `obj_type = 3` 만 버렸다.
+                //
+                // 배치는 `#6266` 이 한글 2024 COM PDF 로 잠근 계약이다. 표로 두면
+                // 세로 기준이 `VertRelTo::Paper` 경로로 가므로, 그 기준 높이를 실제
+                // 용지 높이로 바로잡는 수정(`renderer/layout/table_layout.rs` 의 같은
+                // 이슈 주석)이 **함께** 있어야 그 계약이 산다.
+                controls.push(crate::model::control::Control::Table(Box::new(table)));
+            } else {
+                let mut form = crate::model::control::FormObject::default();
+                form.form_type = crate::model::control::FormType::PushButton;
+                form.enabled = true;
+                controls.push(crate::model::control::Control::Form(Box::new(form)));
             }
-            controls.push(crate::model::control::Control::Form(Box::new(form)));
         } else if let Some(table) = parsed_table {
             controls.push(crate::model::control::Control::Table(Box::new(table)));
         } else {

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -4898,7 +4898,21 @@ impl LayoutEngine {
                     let base_y = para_stored_anchor_y.unwrap_or(anchor_y);
                     (base_y, col_area.height - (base_y - col_area.y).max(0.0))
                 }
-                crate::model::shape::VertRelTo::Paper => (0.0, page_h_approx),
+                crate::model::shape::VertRelTo::Paper => {
+                    // [#6874] 용지 기준 표의 세로 기준 높이는 **실제 용지 높이**다.
+                    // `page_h_approx` 는 상·하 여백이 같다고 가정하는데 코퍼스 10k 의
+                    // 48.0%(4,779건)가 그렇지 않다. 어긋난 문서에서는 `Bottom` 정렬이
+                    // `ref_y + ref_h - …` 로 그대로 아래로 밀린다 — 위 30mm·아래 20mm
+                    // 문서에서 1160.3px 대 실제 1122.5px = +37.8px(#6266 실측).
+                    // 가로축은 이미 같은 자리에서 실제 용지 너비를 쓴다(`HorzRelTo::Paper`).
+                    //
+                    // ⚠ 아래 쪽 맞춤 가드(`pushed + table_height <= page_h_approx`)는
+                    // 자리차지·글뒤로·글앞으로 **모든 표**가 타므로 건드리지 않는다.
+                    // 이 기준 높이를 실제로 소비하는 `VertRelTo::Paper` 표는 10k 중
+                    // 113문서·637개뿐이고, 그중 상≠하 문서는 6건(표 26개)이다.
+                    let ph = self.current_page_height.get();
+                    (0.0, if ph > 0.0 { ph } else { page_h_approx })
+                }
             };
             // Top 캡션: 표 위치를 캡션 높이만큼 아래로 이동
             let caption_top_offset = if let Some(ref cap) = table.caption {

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -2549,8 +2549,11 @@ fn write_shape_component_base(
     } else if has_explicit_rendering_matrix(attr) {
         write_parsed_rendering_matrix(w, attr);
     } else {
-        let is_group_child = attr.group_level > 0;
-        let cnt: u16 = if is_group_child { 2 } else { 1 };
+        // [#4680] 쌍 개수는 그룹 깊이 + 1 이다. 한/글 HWP5 저장본 실측(264쪽 HWP3
+        // 변환본 대조): 깊이 0 → 1쌍, 1 → 2쌍, 2 → 3쌍, 3 → 4쌍. 종전에는 깊이와
+        // 무관하게 2 를 써서 두 겹 이상 중첩된 묶음의 레코드가 96바이트씩 짧았고,
+        // 한글은 그런 문서를 열지 못했다.
+        let cnt: u16 = attr.group_level.saturating_add(1);
         w.write_u16(cnt).unwrap();
         // translation matrix = identity [1, 0, 0, 0, 1, 0].
         // 그룹 자식 위치의 단일 권위는 render_tx/ty 다 (렌더러 layout_group_child_*,
@@ -2576,22 +2579,10 @@ fn write_shape_component_base(
         // rotation matrix. Hancom applies visible picture rotation from the
         // rendering rotMatrix, not only from ShapeComponentAttr.rotation_angle.
         write_matrix(w, shape_rotation_matrix(attr));
-        // 그룹 자식 (cnt=2): 두 번째 scale + rotation 세트 (identity)
-        if is_group_child {
-            // scale2 = identity
-            w.write_f64(1.0).unwrap();
-            w.write_f64(0.0).unwrap();
-            w.write_f64(0.0).unwrap();
-            w.write_f64(0.0).unwrap();
-            w.write_f64(1.0).unwrap();
-            w.write_f64(0.0).unwrap();
-            // rotation2 = identity
-            w.write_f64(1.0).unwrap();
-            w.write_f64(0.0).unwrap();
-            w.write_f64(0.0).unwrap();
-            w.write_f64(0.0).unwrap();
-            w.write_f64(1.0).unwrap();
-            w.write_f64(0.0).unwrap();
+        // 그룹 깊이만큼 남은 scale + rotation 쌍 (identity)
+        for _ in 0..attr.group_level {
+            write_matrix(w, [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
+            write_matrix(w, [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
         }
     }
 }
@@ -2675,8 +2666,8 @@ fn shape_rotation_matrix(attr: &ShapeComponentAttr) -> [f64; 6] {
 }
 
 fn write_generated_rendering_matrix(w: &mut ByteWriter, attr: &ShapeComponentAttr) {
-    let is_group_child = attr.group_level > 0;
-    let cnt: u16 = if is_group_child { 2 } else { 1 };
+    // [#6874] 쌍 개수는 그룹 깊이 + 1 이다 — 아래 폴백 경로와 같은 규칙.
+    let cnt: u16 = attr.group_level.saturating_add(1);
     w.write_u16(cnt).unwrap();
     write_matrix(
         w,
@@ -2691,7 +2682,7 @@ fn write_generated_rendering_matrix(w: &mut ByteWriter, attr: &ShapeComponentAtt
     );
     write_matrix(w, shape_scale_matrix(attr));
     write_matrix(w, shape_rotation_matrix(attr));
-    if is_group_child {
+    for _ in 0..attr.group_level {
         write_matrix(w, [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
         write_matrix(w, [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
     }
@@ -2703,7 +2694,10 @@ fn write_parsed_rendering_matrix(w: &mut ByteWriter, attr: &ShapeComponentAttr) 
     //
     // Store the parsed affine transform so reload reconstructs exactly:
     // [sx, b, tx; c, sy, ty] = [1,0,tx;0,1,ty] x I x [sx,b,0;c,sy,0]
-    w.write_u16(1).unwrap();
+    //
+    // [#6874] 쌍 개수는 그룹 깊이 + 1 이다. 종전에는 깊이와 무관하게 1 을 써서, 명시
+    // 변환을 가진 묶음 자식의 레코드가 한/글 저장본보다 96바이트씩 짧았다.
+    w.write_u16(attr.group_level.saturating_add(1)).unwrap();
     write_matrix(w, [1.0, 0.0, attr.render_tx, 0.0, 1.0, attr.render_ty]);
     write_matrix(
         w,
@@ -2717,6 +2711,10 @@ fn write_parsed_rendering_matrix(w: &mut ByteWriter, attr: &ShapeComponentAttr) 
         ],
     );
     write_matrix(w, [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
+    for _ in 0..attr.group_level {
+        write_matrix(w, [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
+        write_matrix(w, [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
+    }
 }
 
 /// 도형 채우기 직렬화 (SHAPE_COMPONENT 내부 — parse_fill과 동일한 형식)

--- a/tests/cases/issue_4680_hwp3_odd_page_start.rs
+++ b/tests/cases/issue_4680_hwp3_odd_page_start.rs
@@ -1,0 +1,283 @@
+//! [#4680] HWP3 "항상 홀수쪽으로 시작"(제어문자 21, 종류 0)이 HWP5 저장에서
+//! 구조 오염이 된다 — 한글이 문서를 열지 못한다.
+//!
+//! ## 증상
+//!
+//! 264쪽 HWP3 문서(`1170000-200500003 독일의 법령체계와 입법심사기준`)를
+//! `rhwp convert` 로 저장하면 한글이 **열지 못한다**(open=False). 그 문서에서
+//! 해당 제어문자가 있는 42쪽 한 장만 `extract-pages` 로 뽑아도 같은 거부가
+//! 재현된다. rhwp 자신은 산출물을 원본과 동일하게 되읽으므로 `--verify`
+//! 자기검증으로는 보이지 않는다 — 판정자는 한글뿐이다.
+//!
+//! ## 재현 (코퍼스 문서 — 저장소에는 넣지 않는다)
+//!
+//! ```text
+//! hwpdocs_10k_share/prism_downloads/법제처/
+//!   1170000-200500003_D0150004-1-001_독일의 법령체계와 입법심사기준(최종본).hwp
+//!
+//! rhwp extract-pages <원본> p42.hwp --from 42 --to 42   # 5문단 1쪽
+//! # 한글로 p42.hwp 열기 → 수정 전 open=False / 수정 후 open=True
+//! ```
+//!
+//! ## 근인
+//!
+//! HWP3 파서의 제어문자 18..=21 arm 에서 21 은 종류 1(감춤)만 다루고 종류 0은
+//! catch-all 로 떨어져 `Control::Unknown { ctrl_id: 21 }` 이 됐다. `UnknownControl`
+//! 의 `ctrl_id` 는 **HWP5 의 네 글자 코드**를 실어 나르는 자리인데(알 수 없는 HWP5
+//! 컨트롤의 왕복 보존용), HWP3 파서가 거기에 HWP3 제어문자 코드 21을 넣었다.
+//! HWP5 저장기는 그 값을 개체 제어문자 자리(0x000B)와 `CTRL_HEADER` 에 그대로
+//! 쓰므로, 저장본에는 `ctrl_id = 0x00000015` 라는 존재할 수 없는 컨트롤이 실린다.
+//!
+//! ## 기대값의 출처
+//!
+//! 규격(`mydocs/tech/한글문서파일구조3.0.md` §10.15 표 56)이 종류 0 = "홀수로 시작",
+//! 1 = "감춤" 이라고 적는다. 값은 같은 문서를 한/글이 저장한 HWP5 변환본에서 왔다 —
+//! `pgct`(PageNumCtrl) 4건이 모두 payload 2(= 홀수 쪽)이고 개수가 우리 쪽 4건과
+//! 일치한다.
+//!
+//! ## 이 테스트가 잠그는 것
+//!
+//! 합성 최소 HWP3 문서를 만들어 (1) IR 이 `PageNumCtrl(Odd)` 가 되는지, (2) 저장한
+//! HWP5 의 `CTRL_HEADER` 가 **전부 네 글자 코드**인지를 본다. (2)가 개방 거부의
+//! 실제 형상이다 — 수정 전에는 `0x00000015` 가 실려 깨진다. 반례로 종류 1(감춤)이
+//! 계속 `PageHide` 로 남는 것도 함께 잠근다.
+//!
+//! 합성 문서 골격은 `issue_5557_hwp3_cell_margin` 과 동형이다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::model::control::{Control, PageStartsOn};
+use rhwp::parser::cfb_reader::CfbReader;
+use rhwp::parser::record::Record;
+
+// ---------------------------------------------------------------------------
+// 합성 HWP3 문서 빌더 (최소 골격)
+// ---------------------------------------------------------------------------
+
+fn u16le(v: u16) -> [u8; 2] {
+    v.to_le_bytes()
+}
+
+fn u32le(v: u32) -> [u8; 4] {
+    v.to_le_bytes()
+}
+
+fn hwp3_doc(body: &[u8]) -> Vec<u8> {
+    let mut d = Vec::new();
+    d.extend_from_slice(b"HWP Document File V3.00 \x1a\x01\x02\x03\x04\x05");
+    assert_eq!(d.len(), 30);
+    d.extend_from_slice(&[0u8; 128]); // 문서 정보 (비압축·비암호)
+    d.extend_from_slice(&[0u8; 1008]); // 요약
+    d.extend_from_slice(body);
+    d
+}
+
+fn hwp3_body(paragraphs: &[u8]) -> Vec<u8> {
+    let mut b = Vec::new();
+    for _ in 0..7 {
+        b.extend_from_slice(&u16le(1));
+        let mut name = [0u8; 40];
+        name[..4].copy_from_slice(&[0xB9, 0xD9, 0xC5, 0xC1]); // "바탕" (EUC-KR)
+        b.extend_from_slice(&name);
+    }
+    b.extend_from_slice(&u16le(0)); // nstyles
+    b.extend_from_slice(paragraphs);
+    b.extend_from_slice(&paragraph_list_end());
+    b
+}
+
+fn paragraph_list_end() -> [u8; 43] {
+    [0u8; 43]
+}
+
+fn char_shape31() -> [u8; 31] {
+    let mut cs = [0u8; 31];
+    cs[..2].copy_from_slice(&u16le(250));
+    for r in &mut cs[9..16] {
+        *r = 100;
+    }
+    cs
+}
+
+fn para_shape187() -> [u8; 187] {
+    let mut ps = [0u8; 187];
+    ps[6..8].copy_from_slice(&u16le(160));
+    ps[172] = 1;
+    ps
+}
+
+fn para_header(char_count: u16, line_count: u16) -> Vec<u8> {
+    let mut h = Vec::new();
+    h.push(0u8);
+    h.extend_from_slice(&u16le(char_count));
+    h.extend_from_slice(&u16le(line_count));
+    h.push(0u8); // include_char_shape
+    h.push(0u8); // flags
+    h.extend_from_slice(&u32le(0)); // special_char_flags
+    h.push(0u8); // style_index
+    h.extend_from_slice(&char_shape31());
+    h.extend_from_slice(&para_shape187());
+    h
+}
+
+fn line_info(pgy: u16) -> Vec<u8> {
+    let mut l = Vec::new();
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(400));
+    l.extend_from_slice(&u16le(pgy));
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(0));
+    l
+}
+
+/// 홀수쪽시작/감추기(21) 한 개만 담은 문단 — 규격 §10.15 표 56.
+///
+///   [hchar 21][word 종류][word 감출 대상][hchar 21] = 8바이트 = hchar 4개,
+///   뒤에 문단 끝(0x0D) 1개.
+fn odd_or_hide_paragraph(kind: u16, hide_mask: u16) -> Vec<u8> {
+    let mut p = Vec::new();
+    p.extend_from_slice(&para_header(5, 1));
+    p.extend_from_slice(&line_info(100));
+    p.extend_from_slice(&u16le(21));
+    p.extend_from_slice(&u16le(kind));
+    p.extend_from_slice(&u16le(hide_mask));
+    p.extend_from_slice(&u16le(21));
+    p.extend_from_slice(&u16le(13)); // 문단 끝
+    p
+}
+
+fn parse(kind: u16, hide_mask: u16) -> rhwp::model::document::Document {
+    let bytes = hwp3_doc(&hwp3_body(&odd_or_hide_paragraph(kind, hide_mask)));
+    rhwp::parser::hwp3::parse_hwp3(&bytes).expect("합성 HWP3 파싱 실패")
+}
+
+fn controls(doc: &rhwp::model::document::Document) -> Vec<&Control> {
+    doc.sections
+        .iter()
+        .flat_map(|s| s.paragraphs.iter())
+        .flat_map(|p| p.controls.iter())
+        .collect()
+}
+
+/// 저장한 HWP5 본문의 `CTRL_HEADER` ctrl_id 를 네 글자 코드 문자열로 모은다.
+/// 네 글자 ASCII 가 아니면 `None` 자리에 원값을 16진수로 남긴다.
+fn body_ctrl_ids(doc: &rhwp::model::document::Document) -> Vec<Result<String, u32>> {
+    let bytes = rhwp::serializer::cfb_writer::serialize_hwp(doc).expect("HWP5 직렬화 실패");
+    let mut cfb = CfbReader::open(&bytes).expect("CFB 열기");
+    let file_header = cfb.read_file_header().expect("FileHeader 읽기");
+    let compressed = file_header.get(36).is_some_and(|b| b & 0x01 != 0);
+    let section = cfb
+        .read_body_text_section(0, compressed, false)
+        .expect("Section0 읽기");
+    Record::read_all(&section)
+        .expect("Section0 record 파싱")
+        .into_iter()
+        .filter(|r| r.tag_id == rhwp::parser::tags::HWPTAG_CTRL_HEADER)
+        .filter_map(|r| {
+            let raw = r.data.get(..4)?;
+            let id = u32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]);
+            // HWP5 ctrl_id 는 네 글자 코드를 빅엔디언으로 담는다 ('pgct' → 0x70676374).
+            let code: String = raw.iter().rev().map(|b| *b as char).collect();
+            Some(if code.chars().all(|c| c.is_ascii_graphic() || c == ' ') {
+                Ok(code)
+            } else {
+                Err(id)
+            })
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// 테스트
+// ---------------------------------------------------------------------------
+
+/// 종류 0 = "항상 홀수쪽으로 시작" → `PageNumCtrl(Odd)`.
+/// 한/글 HWP5 변환본이 같은 자리에 `pgct` payload 2 를 쓴다.
+#[test]
+fn hwp3_odd_page_start_becomes_page_num_ctrl() {
+    let doc = parse(0, 0);
+    let ctrls = controls(&doc);
+    let page_num_ctrls: Vec<_> = ctrls
+        .iter()
+        .filter_map(|c| match c {
+            Control::PageNumCtrl(p) => Some(p),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        page_num_ctrls.len(),
+        1,
+        "홀수쪽시작(21/종류 0)은 PageNumCtrl 하나가 되어야 한다 — 실제 컨트롤: {:?}",
+        ctrls
+    );
+    assert_eq!(
+        page_num_ctrls[0].page_starts_on,
+        PageStartsOn::Odd,
+        "규격 §10.15 종류 0 = 홀수로 시작 (한/글 변환본 pgct payload 2)"
+    );
+    assert!(
+        !ctrls.iter().any(|c| matches!(c, Control::Unknown(_))),
+        "HWP3 제어문자 코드가 Unknown 의 ctrl_id 로 새면 안 된다 — {:?}",
+        ctrls
+    );
+}
+
+/// 저장본의 `CTRL_HEADER` 는 전부 네 글자 코드여야 한다. 수정 전에는 여기에
+/// `0x00000015`(HWP3 제어문자 코드 21)가 실렸고, 한글은 그 문서를 열지 못했다.
+#[test]
+fn saved_hwp5_ctrl_ids_are_all_four_char_codes() {
+    let doc = parse(0, 0);
+    let ids = body_ctrl_ids(&doc);
+    let bogus: Vec<_> = ids.iter().filter_map(|r| r.as_ref().err()).collect();
+    assert!(
+        bogus.is_empty(),
+        "네 글자 코드가 아닌 ctrl_id 가 저장본에 실렸다 (한글 개방 거부) — {:?} / 전체 {:?}",
+        bogus,
+        ids
+    );
+    assert!(
+        ids.iter().any(|r| r.as_deref() == Ok("pgct")),
+        "홀수쪽시작은 'pgct' 로 저장되어야 한다 — 전체 {:?}",
+        ids
+    );
+}
+
+/// 반례 — 종류 1(감춤)은 종전대로 `PageHide` 다. 감출 대상 비트도 그대로 옮긴다.
+/// 00472 실측: HWP3 감출 대상 7 ↔ 한/글 `pghd` 0x23(머리말·꼬리말·쪽번호).
+#[test]
+fn hwp3_hide_kind_still_becomes_page_hide() {
+    let doc = parse(1, 0b0000_0111);
+    let ctrls = controls(&doc);
+    let hides: Vec<_> = ctrls
+        .iter()
+        .filter_map(|c| match c {
+            Control::PageHide(h) => Some(h),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        hides.len(),
+        1,
+        "감추기(21/종류 1)는 PageHide 로 남아야 한다 — 실제 컨트롤: {:?}",
+        ctrls
+    );
+    assert_eq!(
+        (
+            hides[0].hide_header,
+            hides[0].hide_footer,
+            hides[0].hide_page_num,
+            hides[0].hide_border
+        ),
+        (true, true, true, false),
+        "감출 대상 비트 0·1·2 만 선다 (규격 §10.15)"
+    );
+    assert!(
+        !ctrls
+            .iter()
+            .any(|c| matches!(c, Control::PageNumCtrl(_) | Control::Unknown(_))),
+        "감추기가 홀수쪽시작으로 새면 안 된다 — {:?}",
+        ctrls
+    );
+}

--- a/tests/cases/issue_4680_hwp3_shape_flip_storage.rs
+++ b/tests/cases/issue_4680_hwp3_shape_flip_storage.rs
@@ -1,0 +1,203 @@
+//! [#4680] HWP3 의 선·다각형이 `SHAPE_COMPONENT` storage flip 을 0 으로 내보내
+//! 한글이 문서를 열지 못한다.
+//!
+//! ## 증상
+//!
+//! 264쪽 HWP3 문서(`1170000-200500003 독일의 법령체계와 입법심사기준`)의 53쪽에는
+//! 표 칸 안에 묶음 개체가 있다(`$con` → `$rec`·`$lin`·`$pol`). 그 쪽 한 장만
+//! `extract-pages` 로 뽑아도 한글이 `open=False` 로 거부한다. 표를 지우면 열린다.
+//!
+//! ## 근인 — 한 필드
+//!
+//! 한/글 저장본과 우리 산출물은 그 표 서브트리에서 레코드 225개의 태그·레벨 시퀀스가
+//! **완전히 같다**. 그래서 레코드 단위로 이등분할 수 있었고, 이등분은 크기가 어긋난
+//! `$lin`/`$pol` 의 `SHAPE_COMPONENT` 로 좁혀졌다. 그 레코드를 다시 바이트 구간으로
+//! 좁히면 갈림점은 **offset 32..36 의 storage flip 4바이트 하나**다:
+//!
+//! - 그 4바이트만 한/글 값으로 바꾸면 `open=True`
+//! - 나머지(행렬·선/채우기 꼬리 전부)를 한/글 값으로 바꿔도 그 4바이트가 0 이면 `open=False`
+//!
+//! `hwpx_to_hwp` 는 이미 같은 계약을 **사각형에만** 걸고 있었다(`#3930` 계열, 주석에
+//! "이 storage 비트가 없으면 한컴이 개체 이후 레코드 스트림을 이어 읽지 못한다"고
+//! 적혀 있다). 선·다각형·타원·호·곡선은 그 arm 을 타지 않아 0 으로 나갔다.
+//!
+//! ## 이 테스트가 잠그는 것
+//!
+//! HWP3 원본 경로(`convert_if_hwpx_source(_, FileFormat::Hwp3)`)를 지난 뒤
+//! (1) 사각형이 아닌 도형도 storage flip 이 서고, (2) 글상자 유무로 값이 갈리며,
+//! (3) 이미 값이 있는 도형(HWP5/HWPX 경로)은 건드리지 않는지를 본다.
+//! 마지막으로 저장 바이트의 `SHAPE_COMPONENT` 해당 4바이트가 0 이 아닌지까지 본다 —
+//! 그게 개방 거부의 실제 형상이다.
+//!
+//! 회전중심은 세우지 않는다. 사각형 arm 은 함께 세우지만, 이 결함에서는 그 구간만
+//! 한/글 값으로 바꿔도 여전히 거부였다(`open=False`) — 근거 없는 값은 쓰지 않는다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::model::control::Control;
+use rhwp::model::document::{Document, Section};
+use rhwp::model::paragraph::Paragraph;
+use rhwp::model::shape::{
+    DrawingObjAttr, GroupShape, LineShape, PolygonShape, ShapeComponentAttr, ShapeObject,
+};
+use rhwp::parser::record::Record;
+use rhwp::parser::tags;
+use rhwp::parser::FileFormat;
+
+/// HWP3 파서가 내놓는 모양 — storage flip 이 0 이고 크기만 있다.
+fn shape_attr(flip: u32) -> ShapeComponentAttr {
+    ShapeComponentAttr {
+        original_width: 2000,
+        original_height: 1000,
+        current_width: 2000,
+        current_height: 1000,
+        flip,
+        ..Default::default()
+    }
+}
+
+fn line(flip: u32) -> ShapeObject {
+    ShapeObject::Line(LineShape {
+        drawing: DrawingObjAttr {
+            shape_attr: shape_attr(flip),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+
+fn polygon_with_text_box() -> ShapeObject {
+    let mut drawing = DrawingObjAttr {
+        shape_attr: shape_attr(0),
+        ..Default::default()
+    };
+    drawing.text_box = Some(Default::default());
+    ShapeObject::Polygon(PolygonShape {
+        drawing,
+        ..Default::default()
+    })
+}
+
+/// 실제 결함 자리와 같은 모양으로 담는다 — 도형은 **묶음 자식**이다.
+/// 최상위 도형은 `SHAPE_COMPONENT` 가 ctrl_id 를 두 번 쓰므로 바이트 오프셋이 다르다.
+fn doc_with(shapes: Vec<ShapeObject>) -> Document {
+    let mut para = Paragraph::default();
+    let group = ShapeObject::Group(GroupShape {
+        children: shapes,
+        ..Default::default()
+    });
+    para.controls.push(Control::Shape(Box::new(group)));
+    let mut section = Section::default();
+    section.paragraphs.push(para);
+    let mut doc = Document::default();
+    doc.sections.push(section);
+    doc
+}
+
+/// CLI `convert` 가 HWP3 원본에 적용하는 것과 같은 경로.
+fn convert_as_hwp3(doc: &mut Document) {
+    rhwp::document_core::converters::hwpx_to_hwp::convert_if_hwpx_source(doc, FileFormat::Hwp3);
+}
+
+fn flips(doc: &Document) -> Vec<u32> {
+    doc.sections
+        .iter()
+        .flat_map(|s| s.paragraphs.iter())
+        .flat_map(|p| p.controls.iter())
+        .filter_map(|c| match c {
+            Control::Shape(s) => match s.as_ref() {
+                ShapeObject::Group(g) => Some(g.children.iter().map(|c| c.shape_attr().flip)),
+                _ => None,
+            },
+            _ => None,
+        })
+        .flatten()
+        .collect()
+}
+
+/// 저장 바이트의 `SHAPE_COMPONENT` storage flip(offset 32..36)을 모은다.
+fn saved_storage_flips(doc: &Document) -> Vec<u32> {
+    let bytes = rhwp::serializer::cfb_writer::serialize_hwp(doc).expect("HWP5 직렬화 실패");
+    let mut cfb = rhwp::parser::cfb_reader::CfbReader::open(&bytes).expect("CFB 열기");
+    let file_header = cfb.read_file_header().expect("FileHeader 읽기");
+    let compressed = file_header.get(36).is_some_and(|b| b & 0x01 != 0);
+    let section = cfb
+        .read_body_text_section(0, compressed, false)
+        .expect("Section0 읽기");
+    Record::read_all(&section)
+        .expect("Section0 record 파싱")
+        .into_iter()
+        .filter(|r| r.tag_id == tags::HWPTAG_SHAPE_COMPONENT)
+        // 묶음 자식만 본다 — 최상위(묶음 자신)는 ctrl_id 를 두 번 써서 오프셋이 4 밀린다.
+        .filter(|r| r.data.get(0..4) != r.data.get(4..8))
+        .filter_map(|r| {
+            let raw = r.data.get(32..36)?;
+            Some(u32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]))
+        })
+        .collect()
+}
+
+/// 글상자 없는 선은 `0x0008_0000` 을 받는다 — 사각형 arm 과 같은 값.
+#[test]
+fn hwp3_line_gets_storage_flip() {
+    let mut doc = doc_with(vec![line(0)]);
+    convert_as_hwp3(&mut doc);
+    assert_eq!(
+        flips(&doc),
+        vec![0x0008_0000],
+        "사각형이 아닌 도형도 storage flip 을 받아야 한다 (한글 개방 조건)"
+    );
+}
+
+/// 글상자가 있는 다각형은 글상자 비트까지 받는다.
+#[test]
+fn hwp3_polygon_with_text_box_gets_text_box_bit() {
+    let mut doc = doc_with(vec![polygon_with_text_box()]);
+    convert_as_hwp3(&mut doc);
+    assert_eq!(
+        flips(&doc),
+        vec![0x0108_0000],
+        "글상자가 있으면 글상자 비트(0x0100_0000)까지 선다"
+    );
+}
+
+/// 반례 — 이미 값이 있는 도형(HWP5·HWPX 경로)은 건드리지 않는다.
+#[test]
+fn existing_storage_flip_is_preserved() {
+    let mut doc = doc_with(vec![line(0x0002_0000)]);
+    convert_as_hwp3(&mut doc);
+    assert_eq!(
+        flips(&doc),
+        vec![0x0002_0000],
+        "원본이 준 flip 은 덮어쓰지 않는다"
+    );
+}
+
+/// 반례 — HWP3 원본이 아니면 이 보정은 걸리지 않는다.
+#[test]
+fn non_hwp3_source_is_untouched() {
+    let mut doc = doc_with(vec![line(0)]);
+    rhwp::document_core::converters::hwpx_to_hwp::convert_if_hwpx_source(&mut doc, FileFormat::Hwp);
+    assert_eq!(
+        flips(&doc),
+        vec![0],
+        "HWP5(Hwp) 원본 경로는 storage 보정 대상이 아니다"
+    );
+}
+
+/// 개방 거부의 실제 형상 — 저장 바이트의 해당 4바이트가 0 이면 안 된다.
+#[test]
+fn saved_shape_component_storage_flip_is_not_zero() {
+    let mut doc = doc_with(vec![line(0), polygon_with_text_box()]);
+    convert_as_hwp3(&mut doc);
+    let saved = saved_storage_flips(&doc);
+    assert!(
+        !saved.is_empty(),
+        "SHAPE_COMPONENT 가 저장되지 않았다 — 테스트 전제가 깨졌다"
+    );
+    assert!(
+        saved.iter().all(|v| *v != 0),
+        "storage flip 0 인 SHAPE_COMPONENT 가 저장본에 남았다 (한글 개방 거부) — {:?}",
+        saved
+    );
+}

--- a/tests/cases/issue_6266_form_object_placement.rs
+++ b/tests/cases/issue_6266_form_object_placement.rs
@@ -15,6 +15,20 @@
 //!
 //! 배치 산식의 마지막 조각은 **바깥 여백**이다 — 이 개체의 `margin.bottom` 은
 //! 4252HWPUNIT(42.5pt)이고, 한글은 용지 하단에서 정확히 그만큼 위에 둔다.
+//!
+//! ## [#6874] 개체 종류가 Form -> Table 로 바뀌었다 — 수치 계약은 그대로다
+//!
+//! HWP3 `obj_type=3` 은 캡션을 담은 1x1 표 구조로 저장되고 한글도 그것을 표로 만든다
+//! (정본 HWP3 -> HWPX 대조: `hp:tbl 2 / hp:btn 0`). 종전 파서는 그 표를 버리고
+//! `FormObject{PushButton}` 만 남겨 `- 581-13 -` 이 본문 글자가 아니라 개체 속성이
+//! 됐고, 저장본에서 그 12자가 사라졌다. 이제 표로 보존하므로 이 테스트도 **개체 종류가
+//! 아니라 배치**를 본다 — 기대 좌표(1052.5px / 396.7px)는 한글 2024 COM PDF 실측
+//! 그대로이고 바꾸지 않았다.
+//!
+//! 표로 두면 세로 기준이 `VertRelTo::Paper` 경로로 가는데, 그 기준 높이가
+//! `col_area.y * 2 + col_area.height`(상·하 여백이 같다는 가정)이면 이 문서
+//! (위 30mm·아래 20mm)에서 +37.8px 아래로 밀린다. 같은 커밋이 그 기준을 실제 용지
+//! 높이로 바로잡아 두 계약이 함께 산다.
 #![cfg(not(target_arch = "wasm32"))]
 
 use std::path::Path;
@@ -86,71 +100,47 @@ fn form_object_is_not_inlined_into_the_title_line() {
 
 #[test]
 fn form_object_lands_at_paper_bottom_center() {
-    let out = Command::new(rhwp_bin())
-        .args(["export-render-tree", &sample(), "-p", "0", "--stdout"])
-        .output()
-        .unwrap();
-    let json = if out.status.success() && !out.stdout.is_empty() {
-        String::from_utf8_lossy(&out.stdout).into_owned()
-    } else {
-        // `--stdout` 미지원 빌드 대비 — 임시 폴더로 내보내 읽는다.
-        let dir = std::env::temp_dir().join(format!("rhwp-6266-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let out = Command::new(rhwp_bin())
-            .args([
-                "export-render-tree",
-                &sample(),
-                "-p",
-                "0",
-                "-o",
-                &dir.to_string_lossy(),
-            ])
-            .output()
-            .unwrap();
-        assert_eq!(out.status.code(), Some(0), "{out:?}");
-        let path = std::fs::read_dir(&dir)
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .map(|e| e.path())
-            .find(|p| p.extension().is_some_and(|x| x == "json"))
-            .expect("render tree JSON 이 없다");
-        std::fs::read_to_string(path).unwrap()
-    };
-
-    // `"Form"` 노드의 bbox 를 찾는다.
-    let idx = json
-        .find("\"Form\"")
-        .expect("Form 노드가 없다 — 개체가 소실됐다");
-    let tail = &json[idx..];
-    let bbox = tail.find("\"bbox\"").expect("Form bbox 가 없다");
-    let seg = &tail[bbox..(bbox + 200).min(tail.len())];
+    // 개체는 1x1 표로 보존된다(#6874). `dump-extents` 의 표 줄은
+    //   `Table  y=A..B h=H x=X w=W  pi=P ci=C RxC`
+    // 꼴이라, 이 문서에서 유일한 `1x1` 표가 그 개체다(본문 표는 16x8).
+    let text = extents();
+    let line = text
+        .lines()
+        .map(str::trim)
+        .find(|l| l.starts_with("Table") && l.ends_with("1x1"))
+        .expect("1x1 표 노드가 없다 — 개체가 소실됐다");
+    // `y=A..B` 의 범위 표기를 공백으로 풀어 앞 값만 읽는다.
+    let flat = line.replace("..", " ");
     let num = |key: &str| -> f64 {
-        seg.split(&format!("\"{key}\""))
+        flat.split(&format!("{key}="))
             .nth(1)
-            .and_then(|r| r.trim_start().strip_prefix(':'))
-            .map(|r| {
-                r.trim_start()
-                    .trim_end_matches(|c: char| !c.is_ascii_digit() && c != '.' && c != '-')
-            })
             .and_then(|r| {
-                r.split(|c: char| !c.is_ascii_digit() && c != '.' && c != '-')
+                r.trim_start()
+                    .split(|c: char| !c.is_ascii_digit() && c != '.' && c != '-')
                     .find(|s| !s.is_empty())
                     .and_then(|s| s.parse::<f64>().ok())
             })
-            .unwrap_or_else(|| panic!("bbox.{key} 를 읽지 못했다: {seg}"))
+            .unwrap_or_else(|| panic!("{key} 를 읽지 못했다: {flat}"))
     };
     let (x, y, w) = (num("x"), num("y"), num("w"));
 
-    // 세로: 용지 하단에서 바깥 여백(4252HU = 56.7px)만큼 위 → 1052.5px.
+    // 세로: 용지 하단에서 바깥 여백(4252HU = 56.7px)만큼 위 -> 1052.5px.
     // 인라인이던 종전에는 제목 줄(161px)에 있었다.
     assert!(
         (y - 1052.5).abs() <= 6.0,
-        "양식 개체가 쪽 하단에 놓이지 않았다: y={y:.1} (기대 1052.5)"
+        "개체가 쪽 하단에 놓이지 않았다: y={y:.1} (기대 1052.5)"
     );
-    // 가로: 용지 가운데 → 중심 396.7px (한글 297.47pt).
+    // 가로: 용지 가운데 -> 중심 396.7px (한글 297.47pt).
     let center = x + w / 2.0;
     assert!(
         (center - 396.7).abs() <= 4.0,
-        "양식 개체가 용지 가운데가 아니다: center={center:.1} (기대 396.7)"
+        "개체가 용지 가운데가 아니다: center={center:.1} (기대 396.7)"
+    );
+
+    // [#6874] 캡션이 **본문 글자**로 남는다 — 종전에는 개체 속성이라 저장본에서 사라졌다.
+    assert!(
+        text.lines()
+            .any(|l| l.contains("TextRun") && l.contains("- 581-13 -")),
+        "일련번호가 본문 글자로 남지 않았다"
     );
 }

--- a/tests/cases/issue_6874_group_depth_matrix_pairs.rs
+++ b/tests/cases/issue_6874_group_depth_matrix_pairs.rs
@@ -1,0 +1,129 @@
+//! [#6874] 묶음 자식의 **그룹 깊이**가 IR 에 실리고, `SHAPE_COMPONENT` 의 rendering
+//! 행렬 쌍 개수가 그 깊이를 따른다.
+//!
+//! ## 규칙의 출처
+//!
+//! 한/글이 같은 HWP3 원본을 저장한 HWP5 변환본에서 **행렬 쌍 개수 = 그룹 깊이 + 1**
+//! 이다. 두 문서에서 깊이별 개수까지 전부 일치한다(이 값은 구현이 아니라 변환본에서 왔다):
+//!
+//! ```text
+//!   samples/hwp3-sample11.hwp   (1,2):76 (2,3):195 (3,4):99 (4,5):145 (5,6):112
+//!                               (6,7):140 (7,8):184 (8,9):224 (9,10):192
+//!   코퍼스 1170000-200500003    (1,2):186 (2,3):142 (3,4):20
+//! ```
+//!
+//! 우리 자신의 HWP5 재저장(o2h)도 같은 census 를 낸다 — HWP5 를 읽어 다시 쓸 때는
+//! 원본 rendering 바이트를 그대로 보존하기 때문이다. 어긋나던 것은 **HWP3 읽기 경로**
+//! 하나였다.
+//!
+//! ## 근인 둘
+//!
+//! 1. `parser/hwp3/drawing.rs::parse_drawing_object_tree` 가 `shape_attr.group_level`
+//!    을 매기지 않아 모든 자식이 0 이었다.
+//! 2. `serializer/control.rs` 의 세 rendering 경로가 깊이를 안 봤다 — 폴백은
+//!    `group_level > 0` 이면 무조건 2쌍, 명시 변환 경로는 깊이와 무관하게 1쌍.
+//!
+//! 그래서 HWP3 변환본의 묶음 자식 레코드가 한/글 저장본보다 깊이당 96바이트씩 짧았다.
+//!
+//! ## 이 테스트가 잠그는 것
+//!
+//! 저장 바이트에서 `(그룹 깊이, 행렬 쌍 개수)` 를 직접 읽어 `쌍 = 깊이 + 1` 을 단언한다.
+//! 최상위 도형(`SHAPE_COMPONENT` 가 ctrl_id 를 두 번 쓰는 것)은 오프셋이 4 밀리므로
+//! 제외한다 — 그걸 놓치면 엉뚱한 바이트를 보고 수정 전에도 통과한다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::parser::cfb_reader::CfbReader;
+use rhwp::parser::record::Record;
+use rhwp::parser::tags;
+use std::path::Path;
+
+fn sample(name: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples")
+        .join(name)
+}
+
+/// HWP3 를 CLI `convert` 와 같은 경로로 HWP5 바이트로 만든다.
+fn convert_hwp3(name: &str) -> Option<Vec<u8>> {
+    let raw = std::fs::read(sample(name)).ok()?;
+    let mut doc = rhwp::parser::hwp3::parse_hwp3(&raw).ok()?;
+    rhwp::document_core::converters::hwpx_to_hwp::convert_if_hwpx_source(
+        &mut doc,
+        rhwp::parser::FileFormat::Hwp3,
+    );
+    rhwp::serializer::cfb_writer::serialize_hwp(&doc).ok()
+}
+
+/// 저장 바이트의 묶음 자식 `SHAPE_COMPONENT` 에서 (그룹 깊이, 행렬 쌍 개수)를 모은다.
+fn depth_and_pairs(bytes: &[u8]) -> Vec<(u16, u16)> {
+    let mut cfb = CfbReader::open(bytes).expect("CFB 열기");
+    let file_header = cfb.read_file_header().expect("FileHeader 읽기");
+    let compressed = file_header.get(36).is_some_and(|b| b & 0x01 != 0);
+    let mut out = Vec::new();
+    for index in 0..64u32 {
+        let Ok(section) = cfb.read_body_text_section(index, compressed, false) else {
+            break;
+        };
+        let Ok(records) = Record::read_all(&section) else {
+            break;
+        };
+        for r in records {
+            if r.tag_id != tags::HWPTAG_SHAPE_COMPONENT || r.data.len() < 48 {
+                continue;
+            }
+            // 최상위 도형은 ctrl_id 를 두 번 쓴다 — 그때는 오프셋이 4 밀린다.
+            if r.data[0..4] == r.data[4..8] {
+                continue;
+            }
+            let depth = u16::from_le_bytes([r.data[12], r.data[13]]);
+            let pairs = u16::from_le_bytes([r.data[46], r.data[47]]);
+            out.push((depth, pairs));
+        }
+    }
+    out
+}
+
+/// 깊이 1~9 가 모두 나오는 실문서 — 한/글 변환본과 깊이별 개수까지 맞는다.
+#[test]
+fn hwp3_group_children_get_depth_matched_matrix_pairs() {
+    let Some(bytes) = convert_hwp3("hwp3-sample11.hwp") else {
+        panic!("samples/hwp3-sample11.hwp 변환 실패 — 표본 배치를 확인하라");
+    };
+    let rows = depth_and_pairs(&bytes);
+    assert!(
+        rows.len() > 100,
+        "묶음 자식 SHAPE_COMPONENT 가 너무 적다 ({}) — 전제가 깨졌다",
+        rows.len()
+    );
+    let bad: Vec<_> = rows
+        .iter()
+        .filter(|(depth, pairs)| *pairs != depth.saturating_add(1))
+        .take(8)
+        .collect();
+    assert!(
+        bad.is_empty(),
+        "행렬 쌍 개수가 그룹 깊이 + 1 이 아니다 (한/글 변환본 규칙) — {:?}",
+        bad
+    );
+    let max_depth = rows.iter().map(|(d, _)| *d).max().unwrap_or(0);
+    assert!(
+        max_depth >= 3,
+        "중첩 깊이가 얕아 규칙을 시험하지 못한다: 최대 {max_depth}"
+    );
+}
+
+/// 최상위 도형(깊이 0)은 종전대로 1쌍이다 — 반례.
+#[test]
+fn top_level_shapes_keep_a_single_matrix_pair() {
+    let Some(bytes) = convert_hwp3("hwp3-sample11.hwp") else {
+        panic!("samples/hwp3-sample11.hwp 변환 실패");
+    };
+    let rows = depth_and_pairs(&bytes);
+    let zero_depth: Vec<_> = rows.iter().filter(|(d, _)| *d == 0).collect();
+    assert!(
+        zero_depth.iter().all(|(_, pairs)| *pairs == 1),
+        "깊이 0 인데 쌍이 1 이 아니다 — {:?}",
+        zero_depth.iter().take(8).collect::<Vec<_>>()
+    );
+}

--- a/tests/cases/issue_6874_hwp3_objtype3_is_a_table.rs
+++ b/tests/cases/issue_6874_hwp3_objtype3_is_a_table.rs
@@ -1,0 +1,240 @@
+//! [#6874] HWP3 `obj_type=3` 을 표로 보존한다 — 종전에는 표를 버리고 버튼만 남겼다.
+//!
+//! ## 증상
+//!
+//! 코퍼스 `2955289`(HWP3)를 `convert` 하면 표 2개 중 1개와 본문 12자(`- 581-13 -`)를
+//! 잃는다. 둘은 **같은 개체 하나**다. 한글은 원본에서 그 글자를 보여 주는데 저장본에는
+//! 없다(한글 2024 추출 텍스트 372자 대 362자).
+//!
+//! ## 근인
+//!
+//! HWP3 제어문자 10(표/글상자/수식/버튼)의 `obj_type=3` 은 **캡션을 담은 1x1 표**
+//! 구조로 저장되고, 한글도 그것을 표로 만든다 — 정본 HWP3 -> HWPX 대조에서
+//! `hp:tbl 2 / hp:btn 0` 이다(현행은 `hp:tbl 1 / hp:btn 1`). 파서는 그 표를 버리고
+//! `FormObject{PushButton}` 만 남겨, 캡션이 본문 글자가 아니라 **개체 속성**이 됐다.
+//!
+//! 바로 위 `obj_type == 1`(글상자)은 같은 이유로 이미 Table IR 을 보존한다 —
+//! `obj_type = 3` 만 버렸다.
+//!
+//! ## 배치 계약과의 관계
+//!
+//! 표로 두면 세로 기준이 `VertRelTo::Paper` 경로로 간다. 그 경로의 기준 높이가
+//! 상·하 여백이 같다는 가정(`col_area.y * 2 + col_area.height`)이면 `#6266` 이 한글
+//! 2024 COM PDF 로 잠근 배치가 +37.8px 아래로 밀린다. 같은 커밋이 그 기준을 실제 용지
+//! 높이로 바로잡는다 — 실문서 계약은 `issue_6266_form_object_placement` 가 잠근다.
+//! 이 파일은 **파서 축만** 합성 최소 문서로 잠근다.
+//!
+//! 합성 문서 골격은 `issue_5557_hwp3_cell_margin` 과 동형이다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::model::control::Control;
+
+// ---------------------------------------------------------------------------
+// 합성 HWP3 문서 빌더
+// ---------------------------------------------------------------------------
+
+fn u16le(v: u16) -> [u8; 2] {
+    v.to_le_bytes()
+}
+
+fn u32le(v: u32) -> [u8; 4] {
+    v.to_le_bytes()
+}
+
+fn hwp3_doc(body: &[u8]) -> Vec<u8> {
+    let mut d = Vec::new();
+    d.extend_from_slice(b"HWP Document File V3.00 \x1a\x01\x02\x03\x04\x05");
+    assert_eq!(d.len(), 30);
+    d.extend_from_slice(&[0u8; 128]);
+    d.extend_from_slice(&[0u8; 1008]);
+    d.extend_from_slice(body);
+    d
+}
+
+fn hwp3_body(paragraphs: &[u8]) -> Vec<u8> {
+    let mut b = Vec::new();
+    for _ in 0..7 {
+        b.extend_from_slice(&u16le(1));
+        let mut name = [0u8; 40];
+        name[..4].copy_from_slice(&[0xB9, 0xD9, 0xC5, 0xC1]); // "바탕" (EUC-KR)
+        b.extend_from_slice(&name);
+    }
+    b.extend_from_slice(&u16le(0));
+    b.extend_from_slice(paragraphs);
+    b.extend_from_slice(&paragraph_list_end());
+    b
+}
+
+fn paragraph_list_end() -> [u8; 43] {
+    [0u8; 43]
+}
+
+fn char_shape31() -> [u8; 31] {
+    let mut cs = [0u8; 31];
+    cs[..2].copy_from_slice(&u16le(250));
+    for r in &mut cs[9..16] {
+        *r = 100;
+    }
+    cs
+}
+
+fn para_shape187() -> [u8; 187] {
+    let mut ps = [0u8; 187];
+    ps[6..8].copy_from_slice(&u16le(160));
+    ps[172] = 1;
+    ps
+}
+
+fn para_header(char_count: u16, line_count: u16) -> Vec<u8> {
+    let mut h = Vec::new();
+    h.push(0u8); // follow_prev_para_shape
+    h.extend_from_slice(&u16le(char_count));
+    h.extend_from_slice(&u16le(line_count));
+    h.push(0u8); // include_char_shape
+    h.push(0u8); // flags
+    h.extend_from_slice(&u32le(0)); // special_char_flags
+    h.push(0u8); // style_index
+    h.extend_from_slice(&char_shape31());
+    h.extend_from_slice(&para_shape187());
+    h
+}
+
+fn line_info(pgy: u16) -> Vec<u8> {
+    let mut l = Vec::new();
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(400));
+    l.extend_from_slice(&u16le(pgy));
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(0));
+    l
+}
+
+/// 글자만 담은 셀 문단 하나 + 리스트 끝.
+fn cell_paragraph_list(text: &str) -> Vec<u8> {
+    let chars: Vec<u16> = text.chars().map(|c| c as u16).collect();
+    let mut p = Vec::new();
+    p.extend_from_slice(&para_header(chars.len() as u16 + 1, 1));
+    p.extend_from_slice(&line_info(0));
+    for c in &chars {
+        p.extend_from_slice(&u16le(*c));
+    }
+    p.extend_from_slice(&u16le(13)); // 문단 끝
+    p.extend_from_slice(&paragraph_list_end());
+    p
+}
+
+/// 제어문자 10 개체 문단 — `box_type` 이 표(0)/글상자(1)/수식(2)/버튼(3)을 가른다.
+fn object_paragraph(box_type: u16, cell_text: &str) -> Vec<u8> {
+    let mut p = Vec::new();
+    p.extend_from_slice(&para_header(5, 1));
+    p.extend_from_slice(&line_info(100));
+    // 식별 정보: [hchar 10][dword 예약][hchar 10]
+    p.extend_from_slice(&u16le(10));
+    p.extend_from_slice(&u32le(0));
+    p.extend_from_slice(&u16le(10));
+    // 개체 정보 84B
+    let mut info = [0u8; 84];
+    info[16..18].copy_from_slice(&u16le(10)); // 특수 문자 코드
+    for k in 0..4 {
+        info[34 + k * 2..36 + k * 2].copy_from_slice(&u16le(35)); // 셀 여백
+    }
+    info[42..44].copy_from_slice(&u16le(2000)); // 박스 가로
+    info[44..46].copy_from_slice(&u16le(400)); // 박스 세로
+    info[78..80].copy_from_slice(&u16le(box_type)); // 박스 종류
+    info[80..82].copy_from_slice(&u16le(1)); // 셀 개수
+    p.extend_from_slice(&info);
+    // 셀 정보 27B
+    let mut cell = [0u8; 27];
+    cell[8..10].copy_from_slice(&u16le(2000));
+    cell[10..12].copy_from_slice(&u16le(400));
+    p.extend_from_slice(&cell);
+    p.extend_from_slice(&cell_paragraph_list(cell_text)); // 셀 문단 리스트
+    p.extend_from_slice(&paragraph_list_end()); // 캡션 문단 리스트
+    p.extend_from_slice(&u16le(13)); // 문단 끝
+    p
+}
+
+fn parse(box_type: u16, cell_text: &str) -> rhwp::model::document::Document {
+    let bytes = hwp3_doc(&hwp3_body(&object_paragraph(box_type, cell_text)));
+    rhwp::parser::hwp3::parse_hwp3(&bytes).expect("합성 HWP3 파싱 실패")
+}
+
+fn controls(doc: &rhwp::model::document::Document) -> Vec<&Control> {
+    doc.sections
+        .iter()
+        .flat_map(|s| s.paragraphs.iter())
+        .flat_map(|p| p.controls.iter())
+        .collect()
+}
+
+/// 문서 전체에서 표 셀 안 글자를 모은다.
+fn table_cell_text(doc: &rhwp::model::document::Document) -> String {
+    let mut out = String::new();
+    for c in controls(doc) {
+        if let Control::Table(t) = c {
+            for cell in &t.cells {
+                for para in &cell.paragraphs {
+                    out.push_str(&para.text);
+                }
+            }
+        }
+    }
+    out
+}
+
+fn kinds(doc: &rhwp::model::document::Document) -> Vec<&'static str> {
+    controls(doc)
+        .into_iter()
+        .filter_map(|c| match c {
+            Control::Table(_) => Some("Table"),
+            Control::Form(_) => Some("Form"),
+            Control::Shape(_) => Some("Shape"),
+            _ => None,
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// 테스트
+// ---------------------------------------------------------------------------
+
+/// `obj_type=3`(버튼)은 표로 보존된다 — 한글도 같은 개체를 표로 만든다.
+#[test]
+fn hwp3_objtype3_becomes_a_table() {
+    let doc = parse(3, "581");
+    assert_eq!(
+        kinds(&doc),
+        vec!["Table"],
+        "obj_type=3 은 Table 이어야 한다 (정본 HWP3->HWPX: hp:tbl 2 / hp:btn 0)"
+    );
+}
+
+/// 캡션이 **본문 글자**로 남는다 — 종전에는 개체 속성이라 저장본에서 사라졌다.
+#[test]
+fn hwp3_objtype3_keeps_its_caption_as_body_text() {
+    let doc = parse(3, "581");
+    assert!(
+        table_cell_text(&doc).contains("581"),
+        "표 셀 글자가 사라졌다 — 실제 문서에서 본문 12자가 없어지던 결함"
+    );
+}
+
+/// 반례 — 표(0)와 글상자(1)는 종전 그대로 Table 이다.
+#[test]
+fn hwp3_table_and_textbox_are_unchanged() {
+    for box_type in [0u16, 1u16] {
+        let doc = parse(box_type, "581");
+        assert_eq!(
+            kinds(&doc),
+            vec!["Table"],
+            "obj_type={box_type} 의 종전 동작이 바뀌면 안 된다"
+        );
+        assert!(
+            table_cell_text(&doc).contains("581"),
+            "obj_type={box_type} 의 셀 글자가 사라졌다"
+        );
+    }
+}


### PR DESCRIPTION
> **#7088 위에 쌓인 PR 이다.** 앞 세 커밋은 #7075·#7082·#7088 과 같은 것이고,
> 그것들이 머지되면 여기에는 마지막 커밋만 남는다.

## 규칙은 한/글 변환본이 말한다

한/글이 같은 HWP3 원본을 저장한 HWP5 변환본에서 `SHAPE_COMPONENT` 의 rendering
**행렬 쌍 개수 = 그룹 깊이 + 1** 이다. 두 문서에서 깊이별 개수까지 전부 일치한다.

| 문서 | 한/글 변환본 (깊이, 쌍):개수 |
|---|---|
| `samples/hwp3-sample11.hwp` | `(1,2):76 (2,3):195 (3,4):99 (4,5):145 (5,6):112 (6,7):140 (7,8):184 (8,9):224 (9,10):192` |
| 코퍼스 `1170000-200500003` | `(1,2):186 (2,3):142 (3,4):20` |

우리 자신의 HWP5 재저장(o2h)도 같은 census 를 낸다 — HWP5 를 읽어 다시 쓸 때는 원본
rendering 바이트를 그대로 보존하기 때문이다. **어긋나던 것은 HWP3 읽기 경로 하나**이고,
그 산출물은 전부 `(깊이 0, 1쌍)` 이었다. 묶음 자식 레코드가 한/글 저장본보다 깊이당
96바이트씩 짧다.

## 근인 둘 — ②를 빠뜨리면 절반만 고쳐진다

1. `parser/hwp3/drawing.rs::parse_drawing_object_tree` 가 `shape_attr.group_level` 을
   매기지 않아 모든 자식이 0.
2. `serializer/control.rs` 의 **세** rendering 경로가 깊이를 안 봤다 — 폴백은
   `group_level > 0` 이면 무조건 2쌍, 명시 변환 경로(`write_parsed_rendering_matrix`)는
   깊이와 무관하게 1쌍.

`07615` 는 묶음 자식이 전부 폴백 경로라 ①만으로도 맞아 보인다. `sample11`(깊이 1~9)을
한/글 변환본과 대조하면 드러난다 — ①만 넣은 중간 상태에서 `(2,2):38` `(3,2):20`
`(6,2):48` `(9,2):192` … 가 남았다. **문서 하나만 봤다면 못 잡았을 결함이다.**

## 실측

수정 후 두 문서 모두 census 가 한/글 변환본과 **완전 일치**한다. 레코드가 깊이당
96바이트 길어졌지만 한글 개방은 정상이다.

| | 개방 | 쪽수 | 글자수 |
|---|---|---|---|
| `07615` 변환본 | `open=True` | 327 | 278,600 |
| `sample11` 변환본 | `open=True` | 151 | 206,913 |

## 검증

- **쪽수 A/B**: 용지기준 표 114문서 + HWP3 38건(중복 제거 **150문서**) 전후
  **전건 동일(변화 0)**
- fmt(실차이 0) · clippy 3종(native·wasm·workspace all-targets) · workspace build ·
  manifest `--check` · **nextest 9,539건 전건 통과**

한글 개방 판정은 로컬 COM(한글 2024)에서 수동으로 했다 — CI 에서는 돌지 않는다.

## 회귀 고정

저장 바이트에서 `(그룹 깊이, 행렬 쌍 개수)` 를 직접 읽어 `쌍 = 깊이 + 1` 을 단언한다
(`issue_6874_group_depth_matrix_pairs`, 실문서 `sample11` 기준). 수정 전에는 최대 깊이가
0 이라 실패한다. 반례로 깊이 0 이 1쌍인 것도 잠근다.

> ⚠ 최상위 도형은 `SHAPE_COMPONENT` 가 ctrl_id 를 **두 번** 써서 오프셋이 4 밀린다.
> 그걸 놓치면 엉뚱한 바이트를 보고 수정 전에도 통과한다 — 테스트가 그 레코드를 제외한다.

관련: #6874, #4680

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ngNq2bF2ZdqUyFNeTVnXr
